### PR TITLE
Enable wheel

### DIFF
--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -20,7 +20,10 @@ jobs:
     runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Win11-ARM-CPU"]
     steps:
       - uses: actions/checkout@v2
-
+      - name: Install Python Wheel
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade setuptools wheel
       - name: Setup Visual Studio 2022
         uses: microsoft/setup-msbuild@v1.1
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if(BUILD_WHEEL)
     configure_file("${filename}" "${WHEEL_FILES_DIR}/${TARGET_NAME}" COPYONLY)
   endforeach(filename)
 
-  add_custom_target(PyPackageBuild ALL
+  add_custom_target(PyPackageBuild
      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:python> ${WHEEL_FILES_DIR}/${TARGET_NAME}
      COMMAND "${PYTHON_EXECUTABLE}" -m pip wheel .
      WORKING_DIRECTORY "${WHEEL_FILES_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ if(BUILD_WHEEL)
     configure_file("${filename}" "${WHEEL_FILES_DIR}/${TARGET_NAME}" COPYONLY)
   endforeach (filename)
 
-  add_custom_target(PyPackageBuild
+  add_custom_target(PyPackageBuild ALL
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:python> ${WHEEL_FILES_DIR}/${TARGET_NAME}
     COMMAND "${PYTHON_EXECUTABLE}" -m pip wheel .
     WORKING_DIRECTORY "${WHEEL_FILES_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,10 +188,10 @@ if(BUILD_WHEEL)
   endforeach(filename)
 
   add_custom_target(PyPackageBuild ALL
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:python> ${WHEEL_FILES_DIR}/${TARGET_NAME}
-    COMMAND "${PYTHON_EXECUTABLE}" -m pip wheel .
-    WORKING_DIRECTORY "${WHEEL_FILES_DIR}"
-    COMMENT "Building wheel"
+     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:python> ${WHEEL_FILES_DIR}/${TARGET_NAME}
+     COMMAND "${PYTHON_EXECUTABLE}" -m pip wheel .
+     WORKING_DIRECTORY "${WHEEL_FILES_DIR}"
+     COMMENT "Building wheel"
   )
 
   add_dependencies(PyPackageBuild python)

--- a/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_centos.sh
@@ -4,5 +4,10 @@ set -e -x
 os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for CentOS version : $os_major_version"
-dnf install -y python39-devel glibc-langpack-\* glibc-locale-source which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel java-11-openjdk-devel graphviz gcc-toolset-12-binutils gcc-toolset-12-gcc gcc-toolset-12-gcc-c++ gcc-toolset-12-gcc-gfortran
+dnf install -y \
+  python311-devel python311-pip python311-wheel\
+  glibc-langpack-\* glibc-locale-source which redhat-lsb-core \
+  expat-devel tar unzip zlib-devel make bzip2 bzip2-devel \
+  java-11-openjdk-devel graphviz \
+  gcc-toolset-12-binutils gcc-toolset-12-gcc gcc-toolset-12-gcc-c++ gcc-toolset-12-gcc-gfortran
 locale

--- a/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_centos.sh
@@ -5,7 +5,7 @@ os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for CentOS version : $os_major_version"
 dnf install -y \
-  python311-devel python311-pip python311-wheel\
+  python3-devel python3-pip python3-wheel\
   glibc-langpack-\* glibc-locale-source which redhat-lsb-core \
   expat-devel tar unzip zlib-devel make bzip2 bzip2-devel \
   java-11-openjdk-devel graphviz \

--- a/tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_centos.sh
@@ -4,5 +4,10 @@ set -e -x
 os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for CentOS version : $os_major_version"
-dnf install -y python39-devel glibc-langpack-\* glibc-locale-source which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel java-11-openjdk-devel graphviz gcc-toolset-12-binutils gcc-toolset-12-gcc gcc-toolset-12-gcc-c++ gcc-toolset-12-gcc-gfortran
+dnf install -y \
+  python311-devel python311-pip python311-wheel\
+  glibc-langpack-\* glibc-locale-source which redhat-lsb-core \
+  expat-devel tar unzip zlib-devel make bzip2 bzip2-devel \
+  java-11-openjdk-devel graphviz \
+  gcc-toolset-12-binutils gcc-toolset-12-gcc gcc-toolset-12-gcc-c++ gcc-toolset-12-gcc-gfortran
 locale

--- a/tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_centos.sh
@@ -5,7 +5,7 @@ os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for CentOS version : $os_major_version"
 dnf install -y \
-  python311-devel python311-pip python311-wheel\
+  python3-devel python3-pip python3-wheel\
   glibc-langpack-\* glibc-locale-source which redhat-lsb-core \
   expat-devel tar unzip zlib-devel make bzip2 bzip2-devel \
   java-11-openjdk-devel graphviz \


### PR DESCRIPTION
This pull request primarily focuses on improving the build and installation process for the project. The changes involve the addition of Python wheel installation in the GitHub workflow file, and the modification of installation commands in two CentOS scripts.

* GitHub Workflow Changes:
  * [`.github/workflows/win-cpu-arm64-build.yml`](diffhunk://#diff-df45fc531e16b591e484e29a3a4c836e876f3c8136137ffa39bb6979af6b1c79L23-R26): Added a new step to install Python Wheel which upgrades pip and setuptools wheel before setting up Visual Studio 2022.

* CentOS Installation Changes:
  * [`tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_centos.sh`](diffhunk://#diff-e5579681efa0741a6293dd5b310cb756f92c664229aa879cb93c9ab5d9e64671L7-R12): Modified the installation command to include python3-devel, python3-pip, and python3-wheel packages.
  * [`tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_centos.sh`](diffhunk://#diff-e5579681efa0741a6293dd5b310cb756f92c664229aa879cb93c9ab5d9e64671L7-R12): Similar changes as above, with the addition of python3-devel, python3-pip, and python3-wheel to the installation command.