### PR TITLE
Remove pip install wheel.

### DIFF
--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -20,10 +20,6 @@ jobs:
     runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Win11-ARM-CPU"]
     steps:
       - uses: actions/checkout@v2
-      - name: Install Python Wheel
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade setuptools wheel
       - name: Setup Visual Studio 2022
         uses: microsoft/setup-msbuild@v1.1
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if(BUILD_WHEEL)
     configure_file("${filename}" "${WHEEL_FILES_DIR}/${TARGET_NAME}" COPYONLY)
   endforeach(filename)
 
-  add_custom_target(PyPackageBuild ALL
+  add_custom_target(PyPackageBuild
      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:python> ${WHEEL_FILES_DIR}/${TARGET_NAME}
      COMMAND "${PYTHON_EXECUTABLE}" -m pip wheel .
      WORKING_DIRECTORY "${WHEEL_FILES_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if(BUILD_WHEEL)
     configure_file("${filename}" "${WHEEL_FILES_DIR}/${TARGET_NAME}" COPYONLY)
   endforeach(filename)
 
-  add_custom_target(PyPackageBuild
+  add_custom_target(PyPackageBuild ALL
      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:python> ${WHEEL_FILES_DIR}/${TARGET_NAME}
      COMMAND "${PYTHON_EXECUTABLE}" -m pip wheel .
      WORKING_DIRECTORY "${WHEEL_FILES_DIR}"


### PR DESCRIPTION
Since python wheel package installation is added to docker image building. The step to install it from GHA is no longer necessary.