### PR TITLE
Update win-cpu-x64-build.yml: add permission setting

### DIFF
--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -18,6 +18,9 @@ env:
 jobs:
   job:
     runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-CPU"]
+    permissions:
+      security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This change is needed because the default GITHUB_TOKEN became readonly recently.