### PR TITLE
Separating test CMakeLists.txt from root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,6 @@ option(ENABLE_PYTHON "Enable python buildings" ON)
 cmake_dependent_option(BUILD_WHEEL "Build the python wheel" ON "ENABLE_PYTHON" OFF)
 
 include(cmake/external/onnxruntime_external_deps.cmake)
-
-
 # Checking if CUDA is supported
 include(CheckLanguage)
 if(USE_CUDA)
@@ -34,8 +32,8 @@ endif()
 set(GENERATORS_ROOT ${PROJECT_SOURCE_DIR}/src)
 set(MODELS_ROOT ${PROJECT_SOURCE_DIR}/src/models)
 set(PYTHON_ROOT ${PROJECT_SOURCE_DIR}/src/python)
-set (ORT_HEADER_DIR ${CMAKE_SOURCE_DIR}/ort/include)
-set (ORT_LIB_DIR ${CMAKE_SOURCE_DIR}/ort/lib)
+set(ORT_HEADER_DIR ${CMAKE_SOURCE_DIR}/ort/include)
+set(ORT_LIB_DIR ${CMAKE_SOURCE_DIR}/ort/lib)
 
 # CUDA Being enabled will make it not a debug build without this option, so all of the C++ headers will complain
 # about a mismatch with the actual debug headers and it'll fail to link. I don't know why this happens, or if this is the best fix.
@@ -46,15 +44,15 @@ endif()
 message(STATUS "Adding source files")
 
 file(GLOB generator_srcs CONFIGURE_DEPENDS
-   "${GENERATORS_ROOT}/*.h"
-   "${GENERATORS_ROOT}/*.cpp"
-   "${MODELS_ROOT}/*.h"
-   "${MODELS_ROOT}/*.cpp"
+  "${GENERATORS_ROOT}/*.h"
+  "${GENERATORS_ROOT}/*.cpp"
+  "${MODELS_ROOT}/*.h"
+  "${MODELS_ROOT}/*.cpp"
 )
 
 file(GLOB python_srcs CMAKE_CONFIGURE_DEPENDS
-   "${PYTHON_ROOT}/*.h"
-   "${PYTHON_ROOT}/*.cpp"
+  "${PYTHON_ROOT}/*.h"
+  "${PYTHON_ROOT}/*.cpp"
 )
 
 if(USE_CUDA AND CMAKE_CUDA_COMPILER)
@@ -65,10 +63,10 @@ if(USE_CUDA AND CMAKE_CUDA_COMPILER)
   # set(CUDA_PROPAGATE_HOST_FLAGS ON)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=2803 --expt-relaxed-constexpr")
   file(GLOB generator_cuda_srcs CONFIGURE_DEPENDS
-     "${GENERATORS_ROOT}/*.cu"
-     "${GENERATORS_ROOT}/*.cuh"
-     "${MODELS_ROOT}/*.cu"
-     "${MODELS_ROOT}/*.cuh"
+    "${GENERATORS_ROOT}/*.cu"
+    "${GENERATORS_ROOT}/*.cuh"
+    "${MODELS_ROOT}/*.cu"
+    "${MODELS_ROOT}/*.cuh"
   )
   list(APPEND generator_srcs ${generator_cuda_srcs})
   add_compile_definitions(USE_CUDA=1)
@@ -86,13 +84,10 @@ add_library(onnxruntime-genai-static STATIC ${generator_srcs})
 target_include_directories(onnxruntime-genai PRIVATE ${ORT_HEADER_DIR})
 target_include_directories(onnxruntime-genai-static PRIVATE ${ORT_HEADER_DIR})
 
-
 if(USE_TOKENIZER)
   add_subdirectory("${CMAKE_SOURCE_DIR}/src/tokenizer")
   message("Using Tokenizer")
 endif()
-
-
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set_target_properties(onnxruntime-genai-static PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -117,8 +112,6 @@ if(ENABLE_TESTS)
   add_subdirectory("${CMAKE_SOURCE_DIR}/test")
   message("Enabling tests")
 endif()
-
-#
 
 if(ENABLE_PYTHON)
   pybind11_add_module(python ${python_srcs})
@@ -155,8 +148,8 @@ endif()
 file(GLOB onnxruntime_libs "${ORT_LIB_DIR}/${ONNXRUNTIME_FILES}")
 foreach(DLL_FILE ${onnxruntime_libs})
   add_custom_command(
-     TARGET onnxruntime-genai POST_BUILD
-     COMMAND ${CMAKE_COMMAND} -E copy_if_different  ${DLL_FILE} $<TARGET_FILE_DIR:onnxruntime-genai>
+    TARGET onnxruntime-genai POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DLL_FILE} $<TARGET_FILE_DIR:onnxruntime-genai>
   )
 endforeach()
 
@@ -182,12 +175,10 @@ if(BUILD_WHEEL)
   file(GLOB onnxruntime_libs "${CMAKE_SOURCE_DIR}/ort/${ONNXRUNTIME_FILES}")
   foreach(DLL_FILE ${onnxruntime_libs})
     add_custom_command(
-       TARGET onnxruntime-genai-static
-       COMMAND ${CMAKE_COMMAND} -E copy ${DLL_FILE} ${WHEEL_FILES_DIR}/${TARGET_NAME}/${DLL_FILE_NAME}
+      TARGET onnxruntime-genai-static
+      COMMAND ${CMAKE_COMMAND} -E copy ${DLL_FILE} ${WHEEL_FILES_DIR}/${TARGET_NAME}/${DLL_FILE_NAME}
     )
   endforeach()
-
-
   # Copy over any additional python files
   file(GLOB pyfiles "${PYTHON_ROOT}/py/*.py")
   foreach(filename ${pyfiles})
@@ -195,14 +186,12 @@ if(BUILD_WHEEL)
     message(STATUS "Copying ${filename} to ${target}")
     configure_file("${filename}" "${WHEEL_FILES_DIR}/${TARGET_NAME}" COPYONLY)
   endforeach(filename)
-
   add_custom_target(PyPackageBuild ALL
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:python> ${WHEEL_FILES_DIR}/${TARGET_NAME}
     COMMAND "${PYTHON_EXECUTABLE}" -m pip wheel .
     WORKING_DIRECTORY "${WHEEL_FILES_DIR}"
     COMMENT "Building wheel"
   )
-
   add_dependencies(PyPackageBuild python)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(CMakeDependentOption)
 project(Generators LANGUAGES C CXX)
 option(USE_CUDA "Build with CUDA support" ON)
 option(USE_TOKENIZER "Build with Tokenizer support" ON)
+option(ENABLE_TESTS "Enable tests" ON)
 option(ENABLE_PYTHON "Enable python buildings" ON)
 cmake_dependent_option(BUILD_WHEEL "Build the python wheel" ON "ENABLE_PYTHON" OFF)
 
@@ -32,8 +33,9 @@ endif()
 
 set(GENERATORS_ROOT ${PROJECT_SOURCE_DIR}/src)
 set(MODELS_ROOT ${PROJECT_SOURCE_DIR}/src/models)
-set(TESTS_ROOT ${PROJECT_SOURCE_DIR}/test)
 set(PYTHON_ROOT ${PROJECT_SOURCE_DIR}/src/python)
+set (ORT_HEADER_DIR ${CMAKE_SOURCE_DIR}/ort/include)
+set (ORT_LIB_DIR ${CMAKE_SOURCE_DIR}/ort/lib)
 
 # CUDA Being enabled will make it not a debug build without this option, so all of the C++ headers will complain
 # about a mismatch with the actual debug headers and it'll fail to link. I don't know why this happens, or if this is the best fix.
@@ -48,11 +50,6 @@ file(GLOB generator_srcs CONFIGURE_DEPENDS
    "${GENERATORS_ROOT}/*.cpp"
    "${MODELS_ROOT}/*.h"
    "${MODELS_ROOT}/*.cpp"
-)
-
-file(GLOB test_srcs CONFIGURE_DEPENDS
-   "${TESTS_ROOT}/*.h"
-   "${TESTS_ROOT}/*.cpp"
 )
 
 file(GLOB python_srcs CMAKE_CONFIGURE_DEPENDS
@@ -86,14 +83,16 @@ endif()
 
 add_library(onnxruntime-genai SHARED ${generator_srcs})
 add_library(onnxruntime-genai-static STATIC ${generator_srcs})
-target_include_directories(onnxruntime-genai PRIVATE ${CMAKE_SOURCE_DIR}/ort/include)
-target_include_directories(onnxruntime-genai-static PRIVATE ${CMAKE_SOURCE_DIR}/ort/include)
+target_include_directories(onnxruntime-genai PRIVATE ${ORT_HEADER_DIR})
+target_include_directories(onnxruntime-genai-static PRIVATE ${ORT_HEADER_DIR})
 
 
 if(USE_TOKENIZER)
   add_subdirectory("${CMAKE_SOURCE_DIR}/src/tokenizer")
   message("Using Tokenizer")
 endif()
+
+
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set_target_properties(onnxruntime-genai-static PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -114,25 +113,24 @@ else()
   set(ONNXRUNTIME_EXTENSIONS_LIB "tfmtok_c.so")
 endif()
 
-add_executable(unit_tests ${test_srcs})
-target_include_directories(unit_tests PRIVATE ${CMAKE_SOURCE_DIR}/ort/include)
-target_link_directories(unit_tests PRIVATE ${CMAKE_SOURCE_DIR}/ort/lib)
-target_link_libraries(unit_tests PRIVATE onnxruntime-genai-static ${ONNXRUNTIME_LIB})
+if(ENABLE_TESTS)
+  add_subdirectory("${CMAKE_SOURCE_DIR}/test")
+  message("Enabling tests")
+endif()
+
 #
 
 if(ENABLE_PYTHON)
   pybind11_add_module(python ${python_srcs})
-  target_include_directories(python PRIVATE ${CMAKE_SOURCE_DIR}/ort/include)
-  target_link_directories(python PRIVATE ${CMAKE_SOURCE_DIR}/ort/lib)
+  target_include_directories(python PRIVATE ${ORT_HEADER_DIR})
+  target_link_directories(python PRIVATE ${ORT_LIB_DIR})
   target_link_libraries(python PRIVATE onnxruntime-genai-static ${ONNXRUNTIME_LIB})
   set_target_properties(python PROPERTIES OUTPUT_NAME "onnxruntime_genai")
 endif()
 
 if(USE_CUDA AND CMAKE_CUDA_COMPILER)
   set_target_properties(onnxruntime-genai PROPERTIES LINKER_LANGUAGE CUDA)
-  set_target_properties(unit_tests PROPERTIES LINKER_LANGUAGE CUDA)
   target_link_libraries(onnxruntime-genai PRIVATE cublasLt cublas cudnn curand cufft cudart)
-  target_link_libraries(unit_tests PRIVATE cublasLt cublas cudnn curand cufft cudart)
   #  onnxruntime-genai-static is statically linked under Windows
   if(NOT WIN32)
     set_target_properties(onnxruntime-genai-static PROPERTIES LINKER_LANGUAGE CUDA)
@@ -154,7 +152,7 @@ if(MSVC)
 endif()
 
 # Copy the onnxruntime binaries into the build folder so it's found on launch
-file(GLOB onnxruntime_libs "${CMAKE_SOURCE_DIR}/ort/lib/${ONNXRUNTIME_FILES}")
+file(GLOB onnxruntime_libs "${ORT_LIB_DIR}/${ONNXRUNTIME_FILES}")
 foreach(DLL_FILE ${onnxruntime_libs})
   add_custom_command(
      TARGET onnxruntime-genai POST_BUILD
@@ -166,7 +164,6 @@ if(USE_TOKENIZER)
   add_compile_definitions(USE_TOKENIZER=1)
   target_include_directories(onnxruntime-genai PRIVATE ${TOKENIZER_ROOT})
   target_include_directories(onnxruntime-genai-static PRIVATE ${TOKENIZER_ROOT})
-  target_include_directories(unit_tests PRIVATE ${TOKENIZER_ROOT})
   target_link_libraries(onnxruntime-genai PRIVATE tokenizer)
   target_link_libraries(onnxruntime-genai-static PRIVATE tokenizer)
   if(ENABLE_PYTHON)
@@ -211,25 +208,7 @@ endif()
 
 # Have visual studio put all files into one single folder vs the default split of header files into a separate folder
 source_group(TREE ${GENERATORS_ROOT} FILES ${generator_srcs})
-source_group("Sources" FILES ${test_srcs})
 source_group("Sources" FILES ${python_srcs})
 
-set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT unit_tests)
-
-enable_testing()
-
-target_include_directories (
-  unit_tests
-  PRIVATE
-  ${CMAKE_SOURCE_DIR}/src
-)
 
 
-target_link_libraries(
-  unit_tests
-  PRIVATE
-  GTest::gtest_main
-)
-
-#include(GoogleTest)
-#gtest_discover_tests(unit_tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,36 +1,25 @@
+enable_testing()
 set(TESTS_ROOT ${CMAKE_CURRENT_SOURCE_DIR} PARENT_SCOPE)
 file(GLOB test_srcs CONFIGURE_DEPENDS
   "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
 )
 add_executable(unit_tests ${test_srcs})
-target_include_directories(unit_tests PRIVATE ${ORT_HEADER_DIR})
+target_include_directories(unit_tests PRIVATE
+  ${ORT_HEADER_DIR}
+  ${CMAKE_SOURCE_DIR}/src
+)
 target_link_directories(unit_tests PRIVATE ${ORT_LIB_DIR})
-message(ONNXRUNTIME_LIB: ${ONNXRUNTIME_LIB})
-target_link_libraries(unit_tests PRIVATE onnxruntime-genai-static ${ONNXRUNTIME_LIB})
-
+target_link_libraries(unit_tests PRIVATE
+  onnxruntime-genai-static
+  ${ONNXRUNTIME_LIB}
+  GTest::gtest_main
+)
 if(USE_CUDA AND CMAKE_CUDA_COMPILER)
   set_target_properties(unit_tests PROPERTIES LINKER_LANGUAGE CUDA)
   target_link_libraries(unit_tests PRIVATE cublasLt cublas cudnn curand cufft cudart)
 endif()
 
-if(USE_TOKENIZER)
-  target_include_directories(unit_tests PRIVATE ${TOKENIZER_ROOT})
-endif()
-
-enable_testing()
-
-target_include_directories(
-  unit_tests
-  PRIVATE
-  ${CMAKE_SOURCE_DIR}/src
-)
-
-target_link_libraries(
-  unit_tests
-  PRIVATE
-  GTest::gtest_main
-)
 source_group("Sources" FILES ${test_srcs})
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT unit_tests)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,38 @@
+set(TESTS_ROOT ${CMAKE_CURRENT_SOURCE_DIR} PARENT_SCOPE)
+file(GLOB test_srcs CONFIGURE_DEPENDS
+  "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+)
+add_executable(unit_tests ${test_srcs})
+target_include_directories(unit_tests PRIVATE ${ORT_HEADER_DIR})
+target_link_directories(unit_tests PRIVATE ${ORT_LIB_DIR})
+message(ONNXRUNTIME_LIB: ${ONNXRUNTIME_LIB})
+target_link_libraries(unit_tests PRIVATE onnxruntime-genai-static ${ONNXRUNTIME_LIB})
+
+if(USE_CUDA AND CMAKE_CUDA_COMPILER)
+  set_target_properties(unit_tests PROPERTIES LINKER_LANGUAGE CUDA)
+  target_link_libraries(unit_tests PRIVATE cublasLt cublas cudnn curand cufft cudart)
+endif()
+
+if(USE_TOKENIZER)
+  target_include_directories(unit_tests PRIVATE ${TOKENIZER_ROOT})
+endif()
+
+enable_testing()
+
+target_include_directories(
+  unit_tests
+  PRIVATE
+  ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(
+  unit_tests
+  PRIVATE
+  GTest::gtest_main
+)
+source_group("Sources" FILES ${test_srcs})
+set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT unit_tests)
+
+#include(GoogleTest)
+#gtest_discover_tests(unit_tests)


### PR DESCRIPTION
This pull request primarily modifies the `CMakeLists.txt` file to improve code organization and enable testing. The changes include the addition of a new option to enable tests, the reorganization of test related code into a separate `CMakeLists.txt` file in the `test` directory, and the replacement of hardcoded paths with variables for better maintainability.

Code organization and testing:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR10): Added a new option `ENABLE_TESTS` to enable or disable tests.
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL35-R38): Removed the hard-coded paths for the `ORT_HEADER_DIR` and `ORT_LIB_DIR` and replaced them with variables. This makes the code more maintainable and less prone to errors. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL35-R38) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL89-R96) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL157-R155)
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL117-L135): Removed the `unit_tests` target and related code from this file. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL117-L135) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL169) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL214-L235)
* [`test/CMakeLists.txt`](diffhunk://#diff-33394812ba204689144fd2f80832db83853ba1cb32403edb4e15fe4893e675fdR1-R38): Added a new `CMakeLists.txt` file in the `test` directory. This file now contains all the test related code, making the main `CMakeLists.txt` file cleaner and easier to read. This also makes it easier to manage test related code separately from the main build code.
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL53-L57): Removed the `test_srcs` from the `file(GLOB` command as the test sources are now handled separately in the `test/CMakeLists.txt` file.