### PR TITLE
Disable USE_CUDA if CMAKE_CUDA_COMPILER is not found instead of ERROR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ file(GLOB generator_srcs CONFIGURE_DEPENDS
   "${MODELS_ROOT}/*.h"
   "${MODELS_ROOT}/*.cpp"
 )
+file(GLOB generator_cuda_exclude_srcs "${GENERATORS_ROOT}/*_cuda*.*")
+# Remove the cuda files from the generator_srcs unless we are using cuda
+list(REMOVE_ITEM generator_srcs ${generator_cuda_exclude_srcs})
 
 if(USE_CUDA AND CMAKE_CUDA_COMPILER)
   # Don't let cmake set a default value for CMAKE_CUDA_ARCHITECTURES
@@ -58,15 +61,13 @@ if(USE_CUDA AND CMAKE_CUDA_COMPILER)
     "${MODELS_ROOT}/*.cu"
     "${MODELS_ROOT}/*.cuh"
   )
-  list(APPEND generator_srcs ${generator_cuda_srcs})
+  list(APPEND generator_srcs ${generator_cuda_srcs} ${generator_cuda_exclude_srcs})
   add_compile_definitions(USE_CUDA=1)
   include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
 elseif(USE_CUDA)
   # USE_CUDA is true but cmake could not find the cuda compiler
-  message(FATAL_ERROR "USE_CUDA is ON but no cuda compiler was found.")
-else()
-  file(GLOB generator_cuda_srcs "${GENERATORS_ROOT}/*_cuda*.*")
-  list(REMOVE_ITEM generator_srcs ${generator_cuda_srcs})
+  message(WARNING "USE_CUDA is ON but no cuda compiler was found. Disabling CUDA support.")
+  set(USE_CUDA OFF)
 endif()
 
 add_library(onnxruntime-genai SHARED ${generator_srcs})
@@ -117,7 +118,7 @@ if(NOT EXISTS "${ORT_LIB_DIR}/${ONNXRUNTIME_LIB}")
   message(FATAL_ERROR "Expected the ONNX Runtime library to be found at ${ORT_LIB_DIR}/${ONNXRUNTIME_LIB}. Actual: Not found.")
 endif()
 if(NOT EXISTS "${ORT_HEADER_DIR}/onnxruntime_c_api.h")
-  message(FATAL_ERROR "Expected the ONNX Runtime C API header to be found at "${ORT_HEADER_DIR}/onnxruntime_c_api.h". Actual: Not found.")
+  message(FATAL_ERROR "Expected the ONNX Runtime C API header to be found at " ${ORT_HEADER_DIR}/onnxruntime_c_api.h". Actual: Not found.")
 endif()
 if(USE_CUDA AND NOT EXISTS "${ORT_LIB_DIR}/${ONNXRUNTIME_PROVIDERS_CUDA_LIB}")
   message(FATAL_ERROR "Expected the ONNX Runtime providers cuda library to be found at ${ORT_LIB_DIR}/${ONNXRUNTIME_PROVIDERS_CUDA_LIB}. Actual: Not found.")


### PR DESCRIPTION
This pull request primarily focuses on changes in the `CMakeLists.txt` file to improve the handling of CUDA-related files during the build process. The changes ensure that CUDA files are only included when CUDA is available and properly configured. Additionally, the error message when CUDA is not found has been modified to a warning, and CUDA support is disabled instead of terminating the build process.

Changes to CUDA file handling:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR47-R49): Added a new glob pattern to exclude CUDA files from `generator_srcs` unless CUDA is being used. This is done by creating a new list `generator_cuda_exclude_srcs` that matches all CUDA files, and then removing these files from `generator_srcs`.

Changes to CUDA availability checks:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL61-R70): Modified the `if(USE_CUDA AND CMAKE_CUDA_COMPILER)` condition to append the excluded CUDA files to `generator_srcs` only when CUDA is available and properly configured. If CUDA is requested but the compiler is not found, a warning message is now displayed and CUDA support is disabled, instead of terminating the build process with a fatal error.