### PR TITLE
Windows x64 CPU CI fail fast

### DIFF
--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -70,7 +70,7 @@ jobs:
         uses: github/codeql-action/analyze@v3
 
       - name: Upload Build Artifacts
-        if: matrix.additional_steps == 'with_static_analysis'
+        if: matrix.additional_steps == 'build_only'
         uses: actions/upload-artifact@v3
         with:
           name: onnxruntime-genai-win-cpu-x64

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         additional_steps: [ build_only, with_static_analysis ]
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-CPU" ]
+    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-CPU"]
     permissions:
       security-events: write
       actions: read
@@ -49,7 +49,7 @@ jobs:
         run: |
           Rename-Item -Path $env:ort_dir -NewName ort
 
-      - name: Install additional_steps
+      - name: Install CodeQL
         if: matrix.additional_steps == 'with_static_analysis'
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           Get-ChildItem -Path $env:GITHUB_WORKSPACE\Release -Recurse
 
-      - name: Perform CodeQL Analysis\
+      - name: Perform CodeQL Analysis
         if: matrix.additional_steps == 'with_static_analysis'
         uses: github/codeql-action/analyze@v3
 

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -16,13 +16,19 @@ env:
   ort_url: "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/$(ort_zip)"
 
 jobs:
-  job:
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-CPU"]
+  win_cpu_x64:
+    strategy:
+      matrix:
+        additional_steps: [ build_only, with_static_analysis ]
+    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-CPU" ]
     permissions:
       security-events: write
       actions: read
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout OnnxRuntime GenAI repo
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
 
       - name: Setup Visual Studio 2022
         uses: microsoft/setup-msbuild@v1.1
@@ -43,12 +49,9 @@ jobs:
         run: |
           Rename-Item -Path $env:ort_dir -NewName ort
 
-      - name: Git Submodule Update
-        run: |
-          git submodule update --init --recursive
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+      - name: Install additional_steps
+        if: matrix.additional_steps == 'with_static_analysis'
+        uses: github/additional_steps-action/init@v3
         with:
           languages: 'cpp'
 
@@ -58,14 +61,16 @@ jobs:
           cmake --build . --config Release --parallel
 
       - name: Verify Build Artifacts
-        if: always()
+        if: matrix.additional_steps == 'build_only' && always()
         run: |
           Get-ChildItem -Path $env:GITHUB_WORKSPACE\Release -Recurse
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+      - name: Perform additional_steps Analysis\
+        if: matrix.additional_steps == 'with_static_analysis'
+        uses: github/additional_steps-action/analyze@v3
 
       - name: Upload Build Artifacts
+        if: matrix.additional_steps == 'with_static_analysis'
         uses: actions/upload-artifact@v3
         with:
           name: onnxruntime-genai-win-cpu-x64

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         additional_steps: [ build_only, with_static_analysis ]
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-CPU"]
+    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-CPU" ]
     permissions:
       security-events: write
       actions: read
@@ -49,7 +49,7 @@ jobs:
         run: |
           Rename-Item -Path $env:ort_dir -NewName ort
 
-      - name: Install CodeQL
+      - name: Initialize CodeQL
         if: matrix.additional_steps == 'with_static_analysis'
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install additional_steps
         if: matrix.additional_steps == 'with_static_analysis'
-        uses: github/additional_steps-action/init@v3
+        uses: github/codeql-action/init@v3
         with:
           languages: 'cpp'
 
@@ -65,9 +65,9 @@ jobs:
         run: |
           Get-ChildItem -Path $env:GITHUB_WORKSPACE\Release -Recurse
 
-      - name: Perform additional_steps Analysis\
+      - name: Perform CodeQL Analysis\
         if: matrix.additional_steps == 'with_static_analysis'
-        uses: github/additional_steps-action/analyze@v3
+        uses: github/codeql-action/analyze@v3
 
       - name: Upload Build Artifacts
         if: matrix.additional_steps == 'with_static_analysis'


### PR DESCRIPTION
# Motivation
This PR is to reduce all future CI pipeline iteration by enabling parallelization and fail-fast. With fail-fast, If one of the step failures, such as build, it will fail all other steps are running in parallel.
This way, when a build fails, it will fail 6 to 7 mins sooner than before. 

# Summary.
This pull request mainly focuses on refining the GitHub Actions workflow in the `.github/workflows/win-cpu-x64-build.yml` file. The changes include renaming the job, adding a matrix strategy for different steps, upgrading the checkout action, removing the Git Submodule Update step, and adding conditions for CodeQL analysis and artifact uploading.

Changes to the GitHub Actions workflow:

* [`.github/workflows/win-cpu-x64-build.yml`](diffhunk://#diff-14c154d7bf4d7c90f647475b0340d0840319223d91faa598c4756739555bd863L19-R31): Renamed the job and added a matrix strategy to allow for different additional steps - 'build_only' and 'with_static_analysis'.
* [`.github/workflows/win-cpu-x64-build.yml`](diffhunk://#diff-14c154d7bf4d7c90f647475b0340d0840319223d91faa598c4756739555bd863L19-R31): Upgraded the checkout action to version 4 and added a parameter to checkout submodules.
* [`.github/workflows/win-cpu-x64-build.yml`](diffhunk://#diff-14c154d7bf4d7c90f647475b0340d0840319223d91faa598c4756739555bd863L46-R53): Removed the Git Submodule Update step as it's now covered by the checkout action.
* [`.github/workflows/win-cpu-x64-build.yml`](diffhunk://#diff-14c154d7bf4d7c90f647475b0340d0840319223d91faa598c4756739555bd863L46-R53): Added conditions to the CodeQL analysis, artifact uploading, and build artifact verification steps based on the matrix strategy. [[1]](diffhunk://#diff-14c154d7bf4d7c90f647475b0340d0840319223d91faa598c4756739555bd863L46-R53) [[2]](diffhunk://#diff-14c154d7bf4d7c90f647475b0340d0840319223d91faa598c4756739555bd863L61-R73)