### PR TITLE
Add CUDA_PATH to the dll search paths on windows if import fails

### DIFF
--- a/src/python/py/__init__.py.in
+++ b/src/python/py/__init__.py.in
@@ -1,1 +1,15 @@
-from .@TARGET_NAME@ import *
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License
+
+from onnxruntime_genai import _dll_directory
+
+try:
+    # Try importing onnxruntime_genai. If an ImportError is raised,
+    # it could be because the cuda dlls could not be found on windows.
+    # Try adding the cuda dlls path to the dll search directory
+    # and import onnxruntime_genai again.
+    from onnxruntime_genai.@TARGET_NAME@ import *
+except ImportError:
+    _dll_directory.add_dll_directory()
+
+from onnxruntime_genai.@TARGET_NAME@ import *

--- a/src/python/py/_dll_directory.py
+++ b/src/python/py/_dll_directory.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License
+
+import os
+import sys
+
+def _is_windows():
+    return sys.platform.startswith("win")
+
+
+def add_dll_directory():
+    """Add the CUDA DLL directory to the DLL search path.
+    
+    This function is a no-op on non-Windows platforms.
+    """
+    if _is_windows():
+        cuda_path = os.getenv("CUDA_PATH", None)
+        if cuda_path:
+            os.add_dll_directory(os.path.join(cuda_path, "bin"))
+        else:
+            raise ImportError("Could not find the CUDA libraries. Please set the CUDA_PATH environment variable.")


### PR DESCRIPTION
Since Python 3.8, Python does not by default add the PATH to the directory where it searches for DLLs on Windows.

This causes a problem because onnxruntime-genai depends on cudart64_12.dll and this dll cannot be found by Python. The error message reported is:

```python
>>> import onnxruntime_genai
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\bmeswani\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\onnxruntime_genai\__init__.py", line 2, in <module>
    from .onnxruntime_genai import Model
ImportError: DLL load failed while importing onnxruntime_genai: The specified module could not be found.
```

To work around this issue, this PR tries to search for `"CUDA_PATH"` in the users env and adds the `<CUDA_PATH>/bin` folder to directory where dlls are searched for.