### PR TITLE
Install various version of pythons on Docker images

### DIFF
--- a/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
 ADD scripts /tmp/scripts
-RUN cd /tmp/scripts && /tmp/scripts/install_centos.sh && /tmp/scripts/install_deps.sh && rm -rf /tmp/scripts
+RUN cd /tmp/scripts && /tmp/scripts/install_python.sh && /tmp/scripts/install_centos.sh && /tmp/scripts/install_deps.sh && rm -rf /tmp/scripts
 
 ARG BUILD_UID=1001
 ARG BUILD_USER=onnxruntimedev

--- a/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_centos.sh
@@ -5,7 +5,6 @@ os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for CentOS version : $os_major_version"
 dnf install -y \
-  python3-devel python3-pip python3-wheel\
   glibc-langpack-\* glibc-locale-source which redhat-lsb-core \
   expat-devel tar unzip zlib-devel make bzip2 bzip2-devel \
   java-11-openjdk-devel graphviz \

--- a/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_python.sh
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_python.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e -x
+os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
+echo "installing Python for CentOS version : $os_major_version"
+
+dnf install -y \
+  python3.8-devel python3.8-pip python3.8-wheel\
+  python3.9-devel python3.9-pip python3.9-wheel\
+  python3.10-devel python3.10-pip python3.10-wheel\
+  python3.11-devel python3.11-pip python3.11-wheel\
+  python3.12-devel python3.12-pip python3.12-wheel

--- a/tools/ci_build/github/linux/docker/inference/x64/default/gpu/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/x64/default/gpu/Dockerfile
@@ -13,7 +13,8 @@ ENV CUDNN_HOME=/usr/lib/x86_64-linux-gnu/
 ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
 ENV CUDAHOSTCXX=/opt/rh/gcc-toolset-12/root/usr/bin/g++
 ADD scripts /tmp/scripts
-RUN cd /tmp/scripts && /tmp/scripts/install_centos.sh && /tmp/scripts/install_deps.sh && rm -rf /tmp/scripts
+RUN cd /tmp/scripts && /tmp/scripts/install_python.sh && /tmp/scripts/install_centos.sh && /tmp/scripts/install_deps.sh && rm -rf /tmp/scripts
+
 
 ARG BUILD_UID=1001
 ARG BUILD_USER=onnxruntimedev

--- a/tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_centos.sh
@@ -5,7 +5,6 @@ os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for CentOS version : $os_major_version"
 dnf install -y \
-  python3-devel python3-pip python3-wheel\
   glibc-langpack-\* glibc-locale-source which redhat-lsb-core \
   expat-devel tar unzip zlib-devel make bzip2 bzip2-devel \
   java-11-openjdk-devel graphviz \

--- a/tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_python.sh
+++ b/tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_python.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e -x
+os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
+echo "installing Python for CentOS version : $os_major_version"
+
+dnf install -y \
+  python3.8-devel python3.8-pip python3.8-wheel\
+  python3.9-devel python3.9-pip python3.9-wheel\
+  python3.10-devel python3.10-pip python3.10-wheel\
+  python3.11-devel python3.11-pip python3.11-wheel\
+  python3.12-devel python3.12-pip python3.12-wheel


### PR DESCRIPTION
This pull request primarily focuses on improving the Python installation process in the Docker build scripts for both CPU and GPU configurations. The changes include the creation of a new `install_python.sh` script, modification of the `install_centos.sh` script, and updates to the Dockerfiles to incorporate the new Python installation script.

Python Installation Changes:

* `tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_python.sh` and `tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_python.sh`: New scripts were added to handle the installation of multiple Python versions (3.8 to 3.12). The scripts determine the CentOS version and install the appropriate Python packages.

CentOS Installation Adjustments:

* `tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_centos.sh` and `tools/ci_build/github/linux/docker/inference/x64/default/gpu/scripts/install_centos.sh`: The Python installation commands were removed from these scripts as the new `install_python.sh` script now handles this process.

Dockerfile Updates:

* `tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile` and `tools/ci_build/github/linux/docker/inference/x64/default/gpu/Dockerfile`: The Dockerfiles were updated to call the new `install_python.sh` script in addition to the existing `install_centos.sh` and `install_deps.sh` scripts. [[1]](diffhunk://#diff-1705e7912b27bb54625f9d4e9487beea5c1c25262cfb217c244860286789d560L13-R13) [[2]](diffhunk://#diff-76161a284e73a26825dc2fe6120ff79ddeb132532ed0071e6012d5a79705b683L16-R17)