### PR TITLE
Fix BFCArena crash when deleting an OrtValue

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -89,6 +89,23 @@ std::string Tokenizer::Decode(std::span<const int32_t> tokens) const {
 }
 #endif
 
+#if USE_CUDA
+// Since Python/Others can and will hold onto a generator object past the model object's lifetime we need to ensure
+// the allocator used is not destroyed until last. This keeps the allocator around until exit, after all other memory
+// has been destroyed. Without this, we will crash in the Onnxruntime BFCArena code when deleting tensors due to the
+// arena already being destroyed.
+Ort::Allocator* GetCudaAllocator(OrtSession& session) {
+  static std::unique_ptr<OrtMemoryInfo> memory_info_cuda_;
+  static std::unique_ptr<Ort::Allocator> allocator_cuda_;
+
+  if (!allocator_cuda_) {
+    memory_info_cuda_ = OrtMemoryInfo::Create("Cuda", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+    allocator_cuda_ = Ort::Allocator::Create(session, *memory_info_cuda_);
+  }
+  return allocator_cuda_.get();
+}
+#endif
+
 Model::Model(std::unique_ptr<Config> config, const ProviderOptions* provider_options) : config_{std::move(config)} {
   session_options_ = OrtSessionOptions::Create();
 
@@ -109,9 +126,7 @@ void Model::InitDeviceAllocator([[maybe_unused]] OrtSession& session) {
   allocator_device_ = &allocator_cpu_;
 #if USE_CUDA
   if (device_type_ == DeviceType::CUDA) {
-    memory_info_cuda_ = OrtMemoryInfo::Create("Cuda", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
-    allocator_cuda_ = Ort::Allocator::Create(session, *memory_info_cuda_);
-    allocator_device_ = allocator_cuda_.get();
+    allocator_device_ = GetCudaAllocator(session);
   }
 #endif
 }

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -88,9 +88,6 @@ struct Model {
   cudaStream_t cuda_stream_{};
   DeviceType device_type_{DeviceType::CPU};
   Ort::Allocator& allocator_cpu_{Ort::Allocator::GetWithDefaultOptions()};
-
-  std::unique_ptr<OrtMemoryInfo> memory_info_cuda_;
-  std::unique_ptr<Ort::Allocator> allocator_cuda_;
   Ort::Allocator* allocator_device_{};  // Can be CUDA or CPU based on the DeviceType in the model
 
  protected:


### PR DESCRIPTION
The problem was that Python was destroying the Generator object after the Model object was destroyed, this caused the OrtAllocator the cuda memory was in to already be destroyed before other OrtValues were destroyed.

This is not legal and crashed in the now deleted allocator. Discussed the fix with Ort core team.