### PR TITLE
Accelerate CUDA Top 1 Select

### DIFF
--- a/src/cuda_sampling.cu
+++ b/src/cuda_sampling.cu
@@ -553,13 +553,13 @@ void GetTopKSubset(SamplingData* data, cudaStream_t stream, float* scores_in, fl
   std::span<float> scores_softmaxed{data->scores_softmaxed.get(), static_cast<size_t>(vocab_size * batch_size)};
   DispatchBlockwiseSoftmaxForward<false>(&stream, scores_softmaxed.data(), const_cast<const float*>(scores_in), vocab_size, vocab_size, vocab_size, batch_size, temperature);
   // Get top k subset
-  #define GetTopK(max_k)                       \
+  #define GetTopK(max_k)                              \
   LaunchGetTopKSubset<max_k>(stream,                  \
                              scores_softmaxed.data(), \
-                             scores_out,       \
-                             indices_out,      \
-                             vocab_size,       \
-                             batch_size,       \
+                             scores_out,              \
+                             indices_out,             \
+                             vocab_size,              \
+                             batch_size,              \
                              k)
 
   if (k <= 4) {

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -158,9 +158,9 @@ void BeamSearch_Cuda::SelectTop() {
 }
 
 void GreedySearch_Cuda::SelectTop() {
-  auto next_token_scores = next_token_scores_.data();
-  cuda::Launch_ArgMax(argmaxdata_, next_tokens_.data(), next_token_scores, params_.batch_size, params_.vocab_size, params_.cuda_stream);
-
+  std::span<float> scores = next_token_scores_.subspan(0, params_.batch_size * params_.vocab_size);
+  cuda::GetSample(samplingdata_.get(), params_.cuda_stream, next_tokens_.data(), scores.data(), int(scores.size() / params_.batch_size),
+                  params_.batch_size, 1, 0.0, 1.0);
   CheckForEOS();
   AppendNextTokensToSequences();
 }

--- a/src/search_cuda.cuh
+++ b/src/search_cuda.cuh
@@ -6,7 +6,6 @@ struct ArgMaxData {
   virtual ~ArgMaxData() = default;
 };
 
-void Launch_ArgMax(std::unique_ptr<ArgMaxData>& data, int32_t* next_tokens, const float* next_token_scores, int batch_size, int vocab_size, cudaStream_t stream);
 void Launch_CheckForEOS(int32_t* next_tokens, int next_tokens_count, bool* eos_meet, int eos_token_id, int pad_token_id, bool* done_cpu, cudaStream_t stream);
 void LaunchAddProbsKernel(float* log_probs, float* cum_log_probs, const int batch_size, const int num_beams, const int vocab_size, cudaStream_t stream);
 void LaunchRepetitionPenaltyProcessor(const int32_t* sequences, float* next_token_scores, int batch_size, int num_beams, int vocab_size, int max_sequence_length, int current_sequence_length, float repetition_penalty, cudaStream_t stream);

--- a/test/sampling_benchmark.cpp
+++ b/test/sampling_benchmark.cpp
@@ -263,4 +263,46 @@ TEST(Benchmarks, BenchmarkRandomizedSamplingTopPAndKCuda) {
             << average_time << " microseconds" << std::endl;
 }
 
+TEST(Benchmarks, BenchmarkRandomizedSelectTopCuda) {
+  std::unique_ptr<OrtEnv> g_ort_env;
+  Ort::InitApi();
+  g_ort_env = OrtEnv::Create();
+  auto model = Generators::CreateModel(*g_ort_env, MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  int vocab_size = 32000;  // vocab size of llama
+  int batch_size = 12;
+  std::vector<int32_t> input_ids{0, 1, 2, 3, 4};
+  Generators::GeneratorParams params = Generators::GeneratorParams{};
+  params.max_length = 10;
+  params.batch_size = batch_size;
+  params.sequence_length = 1;
+  params.vocab_size = vocab_size;
+  params.input_ids = input_ids;
+  params.device_type = Generators::DeviceType::CUDA;
+  auto logits_gpu = Generators::CudaMallocArray<float>(vocab_size * batch_size);
+  auto indices_buffer = Generators::CudaMallocArray<int>(vocab_size * batch_size);
+  float* cpu_logits = new float[vocab_size * batch_size];
+  std::random_device rd;
+  std::mt19937 engine(rd());
+  std::uniform_int_distribution<> dist(1, 25);
+  double total_time = 0.0;
+  int num_iter = 1000;
+  for (int i = 0; i < num_iter; i++) {
+    int num_large = dist(engine);
+    auto generator = Generators::CreateGenerator(*model, params);
+    LaunchGeometricDecayKernel(logits_gpu.get(), vocab_size, batch_size, num_large, 20.0f, params.cuda_stream);
+    LaunchFisherYatesKernel(logits_gpu.get(), indices_buffer.get(), vocab_size, batch_size, params.cuda_stream);
+    cudaMemcpy(cpu_logits, logits_gpu.get(), vocab_size * batch_size * sizeof(float), cudaMemcpyDeviceToHost);
+    generator->search_->SetLogits(Generators::gpu_span<float>(logits_gpu.get(), vocab_size * batch_size));
+    cudaStreamSynchronize(params.cuda_stream);
+    auto start = std::chrono::high_resolution_clock::now();
+    generator->search_->SelectTop();
+    auto stop = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
+    total_time += duration.count();
+  }
+  double average_time = total_time / double(num_iter);
+  std::cout << "Average time taken by Top1: "
+            << average_time << " microseconds" << std::endl;
+}
+
 #endif

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -435,4 +435,43 @@ TEST(SamplingTests, RandomizedSamplingTopPAndKCuda) {
   }
 }
 
+TEST(SamplingTests, RandomizedSamplingSelectTopCuda) {
+  auto model = Generators::CreateModel(*g_ort_env, MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  int vocab_size = 32000;  // vocab size of llama
+  int batch_size = 5;
+  std::vector<int32_t> input_ids{0, 1, 2, 3, 4};
+  Generators::GeneratorParams params = Generators::GeneratorParams{};
+  params.max_length = 10;
+  params.batch_size = batch_size;
+  params.sequence_length = 1;
+  params.vocab_size = vocab_size;
+  params.input_ids = input_ids;
+  params.device_type = Generators::DeviceType::CUDA;
+  auto logits_gpu = Generators::CudaMallocArray<float>(vocab_size * batch_size);
+  auto indices_buffer = Generators::CudaMallocHostArray<int>(vocab_size * batch_size);
+  float* cpu_logits = new float[vocab_size * batch_size];
+  std::random_device rd;
+  std::mt19937 engine(rd());
+  std::uniform_int_distribution<> dist(1, 25);
+  int num_iter = 100;
+  for (int i = 0; i < num_iter; i++) {
+    int num_large = dist(engine);
+    LaunchGeometricDecayKernel(logits_gpu.get(), vocab_size, batch_size, num_large, 20.0f, params.cuda_stream);
+    LaunchFisherYatesKernel(logits_gpu.get(), indices_buffer.get(), vocab_size, batch_size, params.cuda_stream);
+    cudaMemcpyAsync(cpu_logits, logits_gpu.get(), vocab_size * batch_size * sizeof(float), cudaMemcpyDeviceToHost, params.cuda_stream);
+    auto generator = Generators::CreateGenerator(*model, params);
+    generator->search_->SetLogits(Generators::gpu_span<float>(logits_gpu.get(), vocab_size * batch_size));
+    generator->search_->SelectTop();
+    auto next_tokens = generator->search_->GetNextTokens().GetCPU();
+    cudaStreamSynchronize(params.cuda_stream);
+    // Verify outputs match expected outputs
+    for (int b = 0; b < batch_size; b++) {
+      float max_score = *std::max_element(cpu_logits + vocab_size * b, cpu_logits + vocab_size * (b + 1));
+      auto next_token = next_tokens[b];
+      auto next_token_score = cpu_logits[next_token + vocab_size * b];
+      EXPECT_EQ(next_token_score, max_score);
+    }
+  }
+}
+
 #endif


### PR DESCRIPTION
Previous implementation did not parallelize across logits in a batch. Average performance measured on RTX 4090 over 1000 iterations using vocab size 32000.

| Average performance per batch size | Cuda Argmax (unbatched) | Custom Sampling Kernel (batched) |
|--------------------|---------------|--------------|
| Batch Size 1          | 24.62μs          | 22.86μs        |
| Batch Size 5       | 63.30μs         | 25.55μs        |
| Batch Size 12          | 120.35μs           | 23.6μs          |