### PR TITLE
Add Gemma to model builder tool

### DIFF
--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -5,6 +5,7 @@ This folder contains the model builder tool, which greatly accelerates creating 
 ## Current Support
 The tool currently supports the following model architectures.
 
+- Gemma
 - LLaMA
 - Mistral
 - Phi

--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -16,50 +16,50 @@ The tool currently supports the following model architectures.
 For all available options, please use the `-h/--help` flag.
 ```
 # From wheel:
-python -m onnxruntime_genai.models.builder --help
+python3 -m onnxruntime_genai.models.builder --help
 
 # From source:
-python builder.py --help
+python3 builder.py --help
 ```
 
 ### Original Model From Hugging Face
 This scenario is where your PyTorch model is not downloaded locally (either in the default Hugging Face cache directory or in a local folder on disk).
 ```
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_to_save_hf_files
+python3 -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_to_save_hf_files
 
 # From source:
-python builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_to_save_hf_files
+python3 builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_to_save_hf_files
 ```
 
 ### Original Model From Disk
 This scenario is where your PyTorch model is already downloaded locally (either in the default Hugging Face cache directory or in a local folder on disk).
 ```
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_where_hf_files_are_saved
+python3 -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_where_hf_files_are_saved
 
 # From source:
-python builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_where_hf_files_are_saved
+python3 builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_where_hf_files_are_saved
 ```
 
 ### Customized or Finetuned Model
 This scenario is where your PyTorch model has been customized or finetuned for one of the currently supported model architectures and your model can be loaded in Hugging Face.
 ```
 # From wheel:
-python -m onnxruntime_genai.models.builder -m path_to_local_folder_on_disk -o /path/to/output/folder -p precision -e execution_provider
+python3 -m onnxruntime_genai.models.builder -m path_to_local_folder_on_disk -o /path/to/output/folder -p precision -e execution_provider
 
 # From source:
-python builder.py -m path_to_local_folder_on_disk -o /path/to/output/folder -p precision -e execution_provider
+python3 builder.py -m path_to_local_folder_on_disk -o /path/to/output/folder -p precision -e execution_provider
 ```
 
 ### Extra Options
 This scenario is for when you want to have control over some specific settings. The below example shows how you can pass key-value arguments to `--extra_options`.
 ```
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_to_save_hf_files --extra_options filename=decoder.onnx
+python3 -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_to_save_hf_files --extra_options filename=decoder.onnx
 
 # From source:
-python builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_to_save_hf_files --extra_options filename=decoder.onnx
+python3 builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_to_save_hf_files --extra_options filename=decoder.onnx
 ```
 To see all available options through `--extra_options`, please use the `help` commands in the `Full Usage` section above.
 
@@ -83,10 +83,10 @@ tokenizer.save_pretrained(cache_dir)
 This option is the simplest but it will download another copy of the PyTorch model onto disk to accommodate the change in the number of hidden layers.
 ```
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider --extra_options num_hidden_layers=4
+python3 -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider --extra_options num_hidden_layers=4
 
 # From source:
-python builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider --extra_options num_hidden_layers=4
+python3 builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider --extra_options num_hidden_layers=4
 ```
 
 #### Option 2: Edit the config.json file on disk and then run the model builder tool
@@ -97,8 +97,8 @@ python builder.py -m model_name -o /path/to/output/folder -p precision -e execut
 
 ```
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_where_hf_files_are_saved
+python3 -m onnxruntime_genai.models.builder -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_where_hf_files_are_saved
 
 # From source:
-python builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_where_hf_files_are_saved
+python3 builder.py -m model_name -o /path/to/output/folder -p precision -e execution_provider -c cache_dir_where_hf_files_are_saved
 ```

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -1359,7 +1359,7 @@ def create_model(model_name_or_path, output_dir, precision, execution_provider, 
     # Set input/output precision of ONNX model
     io_dtype = TensorProto.FLOAT if precision in {"int8", "fp32"} or (precision == "int4" and execution_provider == "cpu") else TensorProto.FLOAT16
 
-    # List options in alphabetical order
+    # List architecture options in alphabetical order
     if config.architectures[0] == "GemmaForCausalLM":
         onnx_model = GemmaModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
     elif config.architectures[0] == "LlamaForCausalLM":

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -1398,7 +1398,7 @@ def get_args():
         "-o",
         "--output",
         required=True,
-        help="Path to folder containing ONNX model and additional files (e.g. GenAI config, external data files, etc.)",
+        help="Path to folder to store ONNX model and additional files (e.g. GenAI config, external data files, etc.)",
     )
 
     parser.add_argument(
@@ -1422,7 +1422,7 @@ def get_args():
         "--cache_dir",
         required=False,
         type=str,
-        default=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'cache_dir'),
+        default=os.path.join('.', 'cache_dir'),
         help="Model cache directory (if providing model name and not folder path)",
     )
 


### PR DESCRIPTION
### Description

This PR adds [Google's Gemma](https://blog.google/technology/developers/gemma-open-models/) models to the model builder tool.

### Motivation and Context

Google's Gemma is a family of foundation models that shares components with [Google's Gemini](https://blog.google/technology/ai/google-gemini-ai/) models.