### PR TITLE
Update options.cmake to utilize CUDAToolkit_FOUND

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,6 +1,6 @@
 include(CMakeDependentOption)
 
-option(USE_CUDA "Build with CUDA support" ON)
+option(USE_CUDA "Build with CUDA support" CUDAToolkit_FOUND)
 option(NO_TOKENIZER "Don't include the Tokenizer" OFF)
 option(ENABLE_PYTHON "Build the Python API." ON)
 option(ENABLE_TESTS "Enable tests" ON)


### PR DESCRIPTION
Use `CUDAToolkit_FOUND` forged by [FindCUDAToolkit](https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html#) (available in CMake 3.17+)

The use case is to automatically fallback to CPU build if CUDA toolkit is not found.

