### PR TITLE
All model tensor inputs/outputs are now auto detected

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2,7 +2,7 @@
 #include "json.h"
 #include <fstream>
 #include <sstream>
-#include <iostream> // std::cout warnings
+#include <iostream>  // std::cout warnings
 
 namespace Generators {
 
@@ -131,7 +131,7 @@ struct Model_Element : JSON::Element {
     if (name == "type") {
       v_.type = value;
     } else if (name == "logits_type") {
-      std::cout << "genai-config.json warning: logits_type is deprecated" << std::endl; // TODO: Remove once removed from model builder
+      std::cout << "genai-config.json warning: logits_type is deprecated" << std::endl;  // TODO: Remove once removed from model builder
     } else if (name == "kv_type") {
       std::cout << "genai-config.json warning: kv_type is deprecated" << std::endl;  // TODO: Remove once removed from model builder
     } else

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -130,10 +130,6 @@ struct Model_Element : JSON::Element {
   void OnString(std::string_view name, std::string_view value) override {
     if (name == "type") {
       v_.type = value;
-    } else if (name == "logits_type") {
-      std::cout << "genai-config.json warning: logits_type is deprecated" << std::endl;  // TODO: Remove once removed from model builder
-    } else if (name == "kv_type") {
-      std::cout << "genai-config.json warning: kv_type is deprecated" << std::endl;  // TODO: Remove once removed from model builder
     } else
       throw JSON::unknown_value_error{};
   }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2,6 +2,7 @@
 #include "json.h"
 #include <fstream>
 #include <sstream>
+#include <iostream> // std::cout warnings
 
 namespace Generators {
 
@@ -130,9 +131,9 @@ struct Model_Element : JSON::Element {
     if (name == "type") {
       v_.type = value;
     } else if (name == "logits_type") {
-      v_.logits_type = TranslateTensorType(value);
+      std::cout << "genai-config.json warning: logits_type is deprecated" << std::endl; // TODO: Remove once removed from model builder
     } else if (name == "kv_type") {
-      v_.kv_type = TranslateTensorType(value);
+      std::cout << "genai-config.json warning: kv_type is deprecated" << std::endl;  // TODO: Remove once removed from model builder
     } else
       throw JSON::unknown_value_error{};
   }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2,7 +2,6 @@
 #include "json.h"
 #include <fstream>
 #include <sstream>
-#include <iostream>  // std::cout warnings
 
 namespace Generators {
 

--- a/src/config.h
+++ b/src/config.h
@@ -10,9 +10,6 @@ struct Config {
   struct Model {
     std::string type;
 
-    ONNXTensorElementDataType logits_type{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT};  // float16/float32 are the valid types
-    ONNXTensorElementDataType kv_type{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT};      // float16/float32 are the valid types
-
     int pad_token_id{};            // The id of the padding token.
     int eos_token_id{};            // The id of the end-of-stream token.
     int bos_token_id{};            // The id of the beginning-of-stream token.

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -84,16 +84,18 @@ void GeneratorParams::SetInputSequences(const TokenSequences& sequences) {
 
 ProviderOptions GetDefaultProviderOptions([[maybe_unused]] DeviceType device_type) {
   ProviderOptions options;
-#if USE_CUDA
   if (device_type == DeviceType::CUDA) {
+#if USE_CUDA
     cudaStream_t cuda_stream;
     cudaStreamCreate(&cuda_stream);
 
     auto& cuda_options = options.emplace<OrtCUDAProviderOptions>();
     cuda_options.has_user_compute_stream = true;
     cuda_options.user_compute_stream = cuda_stream;
-  }
+#else
+    throw std::runtime_error("Trying to use cuda with the non cuda version of onnxruntime-genai");
 #endif
+  }
 
   return options;
 }

--- a/src/generators.h
+++ b/src/generators.h
@@ -14,6 +14,7 @@
 #include <set>
 #include <stdexcept>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <variant>
 #include <vector>

--- a/src/models/gpt.cpp
+++ b/src/models/gpt.cpp
@@ -6,7 +6,6 @@ namespace Generators {
 Gpt_Model::Gpt_Model(std::unique_ptr<Config> config, OrtEnv& ort_env, const ProviderOptions* provider_options)
     : Model{std::move(config), provider_options} {
   session_decoder_ = OrtSession::Create(ort_env, (config_->config_path / config_->model.decoder.filename).c_str(), session_options_.get());
-
   InitDeviceAllocator(*session_decoder_);
 }
 

--- a/src/models/gpt.h
+++ b/src/models/gpt.h
@@ -25,9 +25,9 @@ struct Gpt_State : State {
   const Gpt_Model& model_;
   bool first_run_{true};
 
-  InputIDs<int32_t> input_ids_{model_, *this};
+  InputIDs input_ids_{model_, *this};
   Logits logits_{model_, *this};
   KV_Cache_Combined kv_cache_{model_, *this};
-  PositionIDs<int32_t> position_ids_;
+  PositionIDs position_ids_;
 };
 }  // namespace Generators

--- a/src/models/input_ids.cpp
+++ b/src/models/input_ids.cpp
@@ -5,49 +5,48 @@
 
 namespace Generators {
 
-template <typename T>
-InputIDs<T>::InputIDs(const Model& model, State& state)
+InputIDs::InputIDs(const Model& model, State& state)
     : model_{model},
       state_{state} {
   name_ = model_.config_->model.decoder.inputs.input_ids.c_str();
   shape_ = {state_.search_params_.batch_size, state_.search_params_.sequence_length};
+  type_ = model_.session_info_->GetInputDataType(name_);
 
   // If 64-bit, convert from 32-bit to 64-bit
-  if constexpr (std::is_same_v<T, int64_t>) {
-    value_ = OrtValue::CreateTensor<int64_t>(model.allocator_cpu_, shape_);
-    auto* p_data = value_->GetTensorMutableData<T>();
+  if(type_==Ort::TypeToTensorType<int64_t>::type) {
+    value_ = OrtValue::CreateTensor(model.allocator_cpu_, shape_, type_);
+    auto* p_data = value_->GetTensorMutableData<int64_t>();
     for (auto v : state_.search_params_.input_ids) {
       *p_data++ = v;
     }
   } else {
-    static_assert(std::is_same_v<T, int32_t>);
-    value_ = OrtValue::CreateTensor<T>(model.allocator_cpu_.GetInfo(), std::span<T>(const_cast<T*>(state_.search_params_.input_ids.data()), shape_[0] * shape_[1]), shape_);
+    if (type_ != Ort::TypeToTensorType<int32_t>::type)
+      throw std::runtime_error("InputIDs must be int64 or int32");
+    value_ = OrtValue::CreateTensor<int32_t>(model.allocator_cpu_.GetInfo(), std::span<int32_t>(const_cast<int32_t*>(state_.search_params_.input_ids.data()), shape_[0] * shape_[1]), shape_);
   }
 
   value_ = model_.ExpandInputs(value_, state_.search_params_.num_beams);
   shape_[0] *= state_.search_params_.num_beams;
 }
 
-template <typename T>
-void InputIDs<T>::Add() {
+void InputIDs::Add() {
   input_index_ = state_.inputs_.size();
 
   state_.inputs_.push_back(value_.get());
   state_.input_names_.push_back(name_);
 }
 
-template <typename T>
-void InputIDs<T>::Update(RoamingArray<int32_t> next_tokens_unk) {
+void InputIDs::Update(RoamingArray<int32_t> next_tokens_unk) {
   // Resize input_ids shape once if it doesn't match the decoder shape
   if (shape_[1] != 1) {
     shape_[1] = 1;
-    value_ = OrtValue::CreateTensor<T>(*model_.allocator_device_, shape_);
+    value_ = OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_);
     state_.inputs_[input_index_] = value_.get();
   }
 
-  auto* data = value_->GetTensorMutableData<T>();
   // Update input_ids with next tokens, converting from 32-bit to 64-bit
-  if constexpr (std::is_same_v<T, int64_t>) {
+  if(type_ == Ort::TypeToTensorType<int64_t>::type) {
+    auto* data = value_->GetTensorMutableData<int64_t>();
 #if USE_CUDA
     if (model_.device_type_ == DeviceType::CUDA) {
       auto next_tokens = next_tokens_unk.GetGPU();
@@ -61,17 +60,14 @@ void InputIDs<T>::Update(RoamingArray<int32_t> next_tokens_unk) {
       }
     }
   } else {
-    static_assert(std::is_same_v<T, int32_t>);
+    auto* data = value_->GetTensorMutableData<int32_t>();
 #if USE_CUDA
     if (model_.device_type_ == DeviceType::CUDA)
-      cudaMemcpyAsync(data, next_tokens_unk.GetGPU().data(), shape_[0] * sizeof(T), cudaMemcpyDeviceToDevice, model_.cuda_stream_);
+      cudaMemcpyAsync(data, next_tokens_unk.GetGPU().data(), shape_[0] * sizeof(int32_t), cudaMemcpyDeviceToDevice, model_.cuda_stream_);
     else
 #endif
-      memcpy(data, next_tokens_unk.GetCPU().data(), shape_[0] * sizeof(T));
+      memcpy(data, next_tokens_unk.GetCPU().data(), shape_[0] * sizeof(int32_t));
   }
 }
-
-template struct InputIDs<int32_t>;
-template struct InputIDs<int64_t>;
 
 }  // namespace Generators

--- a/src/models/input_ids.cpp
+++ b/src/models/input_ids.cpp
@@ -13,7 +13,7 @@ InputIDs::InputIDs(const Model& model, State& state)
   type_ = model_.session_info_->GetInputDataType(name_);
 
   // If 64-bit, convert from 32-bit to 64-bit
-  if(type_==Ort::TypeToTensorType<int64_t>::type) {
+  if (type_ == Ort::TypeToTensorType<int64_t>::type) {
     value_ = OrtValue::CreateTensor(model.allocator_cpu_, shape_, type_);
     auto* p_data = value_->GetTensorMutableData<int64_t>();
     for (auto v : state_.search_params_.input_ids) {
@@ -45,7 +45,7 @@ void InputIDs::Update(RoamingArray<int32_t> next_tokens_unk) {
   }
 
   // Update input_ids with next tokens, converting from 32-bit to 64-bit
-  if(type_ == Ort::TypeToTensorType<int64_t>::type) {
+  if (type_ == Ort::TypeToTensorType<int64_t>::type) {
     auto* data = value_->GetTensorMutableData<int64_t>();
 #if USE_CUDA
     if (model_.device_type_ == DeviceType::CUDA) {

--- a/src/models/input_ids.h
+++ b/src/models/input_ids.h
@@ -2,7 +2,6 @@
 
 namespace Generators {
 
-template <typename T>
 struct InputIDs {
   InputIDs(const Model& model, State& state);
 
@@ -18,6 +17,7 @@ struct InputIDs {
   size_t input_index_{~0U};
 
   std::array<int64_t, 2> shape_{};
+  ONNXTensorElementDataType type_;
   std::unique_ptr<OrtValue> value_;
 };
 

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -8,21 +8,27 @@ KV_Cache_Combined::KV_Cache_Combined(const Model& model, State& state)
     : model_{model},
       state_{state},
       layer_count_{model.config_->model.decoder.num_hidden_layers},
-      shape_{2, static_cast<int64_t>(state_.search_params_.batch_size) * state_.search_params_.num_beams, model.config_->model.decoder.num_key_value_heads, 0, model.config_->model.decoder.head_size},
-      empty_past_{OrtValue::CreateTensor(*model_.allocator_device_, shape_, model_.config_->model.kv_type)} {
+      shape_{2, static_cast<int64_t>(state_.search_params_.batch_size) * state_.search_params_.num_beams, model.config_->model.decoder.num_key_value_heads, 0, model.config_->model.decoder.head_size} {
   pasts_.resize(layer_count_);
   presents_.reserve(layer_count_);
 
-  shape_[3] = state_.search_params_.sequence_length;
   for (int i = 0; i < layer_count_; ++i) {
-    presents_.push_back(OrtValue::CreateTensor(*model.allocator_device_, shape_, model_.config_->model.kv_type));
-
     char string[64];
     snprintf(string, std::size(string), model.config_->model.decoder.inputs.past_names.c_str(), i);
     input_name_strings_.emplace_back(string);
 
     snprintf(string, std::size(string), model.config_->model.decoder.outputs.present_names.c_str(), i);
     output_name_strings_.emplace_back(string);
+  }
+
+  // Derive the KV data type from the KV input 0
+  type_ = model_.session_info_->GetInputDataType(input_name_strings_[0]);
+
+  empty_past_ = OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_);
+  shape_[3] = state_.search_params_.sequence_length;
+
+  for (int i = 0; i < layer_count_; ++i) {
+    presents_.push_back(OrtValue::CreateTensor(*model.allocator_device_, shape_, type_));
   }
 }
 
@@ -51,7 +57,7 @@ void KV_Cache_Combined::Update(std::span<const int32_t> beam_indices, int curren
 
   shape_[3] = current_length;
   for (int i = 0; i < layer_count_; i++) {
-    presents_[i] = OrtValue::CreateTensor(*model_.allocator_device_, shape_, model_.config_->model.kv_type);
+    presents_[i] = OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_);
     state_.inputs_[input_index_ + i] = pasts_[i].get();
     state_.outputs_[output_index_ + i] = presents_[i].get();
   }
@@ -100,7 +106,7 @@ void KV_Cache_Combined::PickPastState(std::span<const int32_t> beam_indices, int
 }
 
 void KV_Cache_Combined::PickPastState(std::span<const int32_t> beam_indices, int index) {
-  if (model_.config_->model.kv_type == Ort::TypeToTensorType<float>::type) {
+  if (type_ == Ort::TypeToTensorType<float>::type) {
     PickPastState<float>(beam_indices, index);
   } else {
     PickPastState<Ort::Float16_t>(beam_indices, index);
@@ -111,17 +117,11 @@ KV_Cache::KV_Cache(const Model& model, State& state)
     : model_{model},
       state_{state},
       layer_count_{model_.config_->model.decoder.num_hidden_layers},
-      shape_{static_cast<int64_t>(state_.search_params_.batch_size) * state_.search_params_.num_beams, model.config_->model.decoder.num_key_value_heads, 0, model.config_->model.decoder.head_size},
-      empty_past_{OrtValue::CreateTensor(*model_.allocator_device_, shape_, model_.config_->model.kv_type)} {
+      shape_{static_cast<int64_t>(state_.search_params_.batch_size) * state_.search_params_.num_beams, model.config_->model.decoder.num_key_value_heads, 0, model.config_->model.decoder.head_size} {
   pasts_.resize(layer_count_ * 2);
   presents_.reserve(layer_count_ * 2);
 
-  shape_[2] = state_.search_params_.sequence_length;  // Set this after empty_past_ has been created with 0 for this field
-
   for (int i = 0; i < layer_count_; ++i) {
-    presents_.push_back(OrtValue::CreateTensor(*model_.allocator_device_, shape_, model_.config_->model.kv_type));
-    presents_.push_back(OrtValue::CreateTensor(*model_.allocator_device_, shape_, model_.config_->model.kv_type));
-
     char string[64];
     snprintf(string, std::size(string), model.config_->model.decoder.inputs.past_key_names.c_str(), i);
     input_name_strings_.emplace_back(string);
@@ -132,6 +132,17 @@ KV_Cache::KV_Cache(const Model& model, State& state)
     output_name_strings_.emplace_back(string);
     snprintf(string, std::size(string), model.config_->model.decoder.outputs.present_value_names.c_str(), i);
     output_name_strings_.emplace_back(string);
+  }
+
+  // Derive the KV data type from the KV input 0
+  type_ = model_.session_info_->GetInputDataType(input_name_strings_[0]);
+
+  empty_past_ = OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_);
+  shape_[2] = state_.search_params_.sequence_length;  // Set this after empty_past_ has been created with 0 for this field
+
+  for (int i = 0; i < layer_count_; ++i) {
+    presents_.push_back(OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_));
+    presents_.push_back(OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_));
   }
 }
 
@@ -168,7 +179,7 @@ void KV_Cache::Update(std::span<const int32_t> beam_indices, int current_length)
 
   shape_[2] = current_length;
   for (int i = 0; i < layer_count_ * 2; i++) {
-    presents_[i] = OrtValue::CreateTensor(*model_.allocator_device_, shape_, model_.config_->model.kv_type);
+    presents_[i] = OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_);
     state_.outputs_[output_index_ + i] = presents_[i].get();
   }
 }
@@ -207,7 +218,7 @@ void KV_Cache::PickPastState(std::span<const int32_t> beam_indices, int index) {
 }
 
 void KV_Cache::PickPastState(std::span<const int32_t> beam_indices, int index) {
-  if (model_.config_->model.kv_type == Ort::TypeToTensorType<float>::type) {
+  if (type_ == Ort::TypeToTensorType<float>::type) {
     PickPastState<float>(beam_indices, index);
   } else {
     PickPastState<Ort::Float16_t>(beam_indices, index);
@@ -222,9 +233,6 @@ Cross_Cache::Cross_Cache(const Model& model, State& state)
   values_.reserve(layer_count_ * 2);
 
   for (int i = 0; i < layer_count_; ++i) {
-    values_.push_back(OrtValue::CreateTensor(*model_.allocator_device_, shape_, model_.config_->model.kv_type));
-    values_.push_back(OrtValue::CreateTensor(*model_.allocator_device_, shape_, model_.config_->model.kv_type));
-
     char string[64];
     snprintf(string, std::size(string), model.config_->model.decoder.inputs.cross_past_key_names.c_str(), i);
     input_name_strings_.emplace_back(string);
@@ -235,6 +243,14 @@ Cross_Cache::Cross_Cache(const Model& model, State& state)
     output_name_strings_.emplace_back(string);
     snprintf(string, std::size(string), model.config_->model.decoder.outputs.cross_present_value_names.c_str(), i);
     output_name_strings_.emplace_back(string);
+  }
+
+  // Derive the KV data type from the KV input 0
+  type_ = model_.session_info_->GetInputDataType(input_name_strings_[0]);
+
+  for (int i = 0; i < layer_count_; ++i) {
+    values_.push_back(OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_));
+    values_.push_back(OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_));
   }
 }
 

--- a/src/models/kv_cache.h
+++ b/src/models/kv_cache.h
@@ -19,6 +19,7 @@ struct KV_Cache_Combined {
   size_t input_index_{~0U}, output_index_{~0U};
 
   std::array<int64_t, 5> shape_;
+  ONNXTensorElementDataType type_;
 
   std::unique_ptr<OrtValue> empty_past_;
   std::vector<std::unique_ptr<OrtValue>> pasts_, presents_;
@@ -42,6 +43,7 @@ struct KV_Cache {
   size_t input_index_{~0U}, output_index_{~0U};
 
   std::array<int64_t, 4> shape_;
+  ONNXTensorElementDataType type_;
 
   std::unique_ptr<OrtValue> empty_past_;
   std::vector<std::unique_ptr<OrtValue>> pasts_, presents_;
@@ -61,6 +63,7 @@ struct Cross_Cache {
   int layer_count_;
 
   std::array<int64_t, 4> shape_;
+  ONNXTensorElementDataType type_;
 
   std::vector<std::unique_ptr<OrtValue>> values_;
   std::vector<std::string> input_name_strings_, output_name_strings_;

--- a/src/models/llama.h
+++ b/src/models/llama.h
@@ -25,10 +25,10 @@ struct Llama_State : State {
   const Llama_Model& model_;
   bool first_run_{true};
 
-  InputIDs<int64_t> input_ids_{model_, *this};
+  InputIDs input_ids_{model_, *this};
   Logits logits_{model_, *this};
   KV_Cache kv_cache_{model_, *this};
-  PositionIDs<int64_t> position_ids_;
+  PositionIDs position_ids_;
 };
 
 }  // namespace Generators

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -9,7 +9,6 @@ Logits::Logits(const Model& model, State& state)
       state_{state},
       shape_{state_.search_params_.batch_size * state_.search_params_.num_beams, state_.search_params_.sequence_length, state_.search_params_.vocab_size},
       type_{model_.session_info_->GetOutputDataType(model_.config_->model.decoder.outputs.logits)} {
-
   value_ = OrtValue::CreateTensor(*model.allocator_device_, shape_, type_);
 
   if (model_.device_type_ == DeviceType::CPU && type_ != Ort::TypeToTensorType<float>::type)

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -6,43 +6,45 @@ namespace Generators {
 
 Logits::Logits(const Model& model, State& state)
     : model_{model},
-      state_{state} {
-  logits_shape_ = {state_.search_params_.batch_size * state_.search_params_.num_beams, state_.search_params_.sequence_length, state_.search_params_.vocab_size};
-  logits_ = OrtValue::CreateTensor(*model.allocator_device_, logits_shape_, model_.config_->model.logits_type);
+      state_{state},
+      shape_{state_.search_params_.batch_size * state_.search_params_.num_beams, state_.search_params_.sequence_length, state_.search_params_.vocab_size},
+      type_{model_.session_info_->GetOutputDataType(model_.config_->model.decoder.outputs.logits)} {
 
-  if (model_.device_type_ == DeviceType::CPU && model_.config_->model.logits_type != Ort::TypeToTensorType<float>::type)
+  value_ = OrtValue::CreateTensor(*model.allocator_device_, shape_, type_);
+
+  if (model_.device_type_ == DeviceType::CPU && type_ != Ort::TypeToTensorType<float>::type)
     throw std::runtime_error("Model logits_type can only be float32 on CPU");
 }
 
 RoamingArray<float> Logits::Get() {
-  auto element_count = logits_->GetTensorTypeAndShapeInfo()->GetElementCount();
+  size_t element_count = shape_[0] * shape_[1] * shape_[2];
 
 #if USE_CUDA
   if (model_.device_type_ == DeviceType::CUDA) {
-    if (model_.config_->model.logits_type == Ort::TypeToTensorType<Ort::Float16_t>::type) {
-      ConvertFp16ToFp32(*model_.allocator_device_, model_.cuda_stream_, *logits_, logits32_);
-      return gpu_span<float>{logits32_->GetTensorMutableData<float>(), element_count};
+    if (type_ == Ort::TypeToTensorType<Ort::Float16_t>::type) {
+      ConvertFp16ToFp32(*model_.allocator_device_, model_.cuda_stream_, *value_, value32_);
+      return gpu_span<float>{value32_->GetTensorMutableData<float>(), element_count};
     }
-    return gpu_span<float>{logits_->GetTensorMutableData<float>(), element_count};
+    return gpu_span<float>{value_->GetTensorMutableData<float>(), element_count};
   }
 #endif
 
-  return cpu_span<float>{logits_->GetTensorMutableData<float>(), element_count};
+  return cpu_span<float>{value_->GetTensorMutableData<float>(), element_count};
 }
 
 void Logits::Add() {
   output_index_ = state_.outputs_.size();
 
   state_.output_names_.push_back(model_.config_->model.decoder.outputs.logits.c_str());
-  state_.outputs_.push_back(logits_.get());
+  state_.outputs_.push_back(value_.get());
 }
 
 void Logits::Update() {
   // Resize the logits shape once if it doesn't match the decoder shape
-  if (logits_shape_[1] != 1) {
-    logits_shape_[1] = 1;
-    logits_ = OrtValue::CreateTensor(*model_.allocator_device_, logits_shape_, model_.config_->model.logits_type);
-    state_.outputs_[output_index_] = logits_.get();
+  if (shape_[1] != 1) {
+    shape_[1] = 1;
+    value_ = OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_);
+    state_.outputs_[output_index_] = value_.get();
   }
 }
 

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -7,7 +7,7 @@ namespace Generators {
 Logits::Logits(const Model& model, State& state)
     : model_{model},
       state_{state},
-      shape_{state_.search_params_.batch_size * state_.search_params_.num_beams, state_.search_params_.sequence_length, state_.search_params_.vocab_size},
+      shape_{static_cast<int64_t>(state_.search_params_.batch_size) * state_.search_params_.num_beams, state_.search_params_.sequence_length, state_.search_params_.vocab_size},
       type_{model_.session_info_->GetOutputDataType(model_.config_->model.decoder.outputs.logits)} {
   value_ = OrtValue::CreateTensor(*model.allocator_device_, shape_, type_);
 

--- a/src/models/logits.h
+++ b/src/models/logits.h
@@ -14,9 +14,10 @@ struct Logits {
   State& state_;
   size_t output_index_{~0U};
 
-  std::array<int64_t, 3> logits_shape_{};
-  std::unique_ptr<OrtValue> logits_;
-  std::unique_ptr<OrtValue> logits32_;  // When model output is fp16, this holds the fp32 conversion of them
+  std::array<int64_t, 3> shape_{};
+  ONNXTensorElementDataType type_;
+  std::unique_ptr<OrtValue> value_;
+  std::unique_ptr<OrtValue> value32_;  // When model output is fp16, this holds the fp32 conversion of them
 };
 
 }  // namespace Generators

--- a/src/models/mistral.h
+++ b/src/models/mistral.h
@@ -25,10 +25,10 @@ struct Mistral_State : State {
   const Mistral_Model& model_;
   bool first_run_{true};
 
-  InputIDs<int64_t> input_ids_{model_, *this};
+  InputIDs input_ids_{model_, *this};
   Logits logits_{model_, *this};
   KV_Cache kv_cache_{model_, *this};
-  PositionIDs<int64_t> position_ids_;
+  PositionIDs position_ids_;
 };
 
 }  // namespace Generators

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -139,7 +139,6 @@ Ort::Allocator* GetCudaAllocator(OrtSession& session) {
 #endif
 
 SessionInfo::SessionInfo(OrtSession& session) {
-
   auto input_names = session.GetInputNames();
   std::vector<ONNXTensorElementDataType> input_types(input_names.size());
   for (size_t i = 0; i < input_types.size(); i++) {
@@ -156,11 +155,11 @@ SessionInfo::SessionInfo(OrtSession& session) {
 }
 
 ONNXTensorElementDataType SessionInfo::GetInputDataType(const std::string& name) const {
-    return inputs_.find(name)->second;
+  return inputs_.find(name)->second;
 }
 
 ONNXTensorElementDataType SessionInfo::GetOutputDataType(const std::string& name) const {
-    return outputs_.find(name)->second;
+  return outputs_.find(name)->second;
 }
 
 Model::Model(std::unique_ptr<Config> config, const ProviderOptions* provider_options) : config_{std::move(config)} {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -138,17 +138,44 @@ Ort::Allocator* GetCudaAllocator(OrtSession& session) {
 }
 #endif
 
+SessionInfo::SessionInfo(OrtSession& session) {
+
+  auto input_names = session.GetInputNames();
+  std::vector<ONNXTensorElementDataType> input_types(input_names.size());
+  for (size_t i = 0; i < input_types.size(); i++) {
+    auto input_type = session.GetInputTypeInfo(i)->GetTensorTypeAndShapeInfo().GetElementType();
+    inputs_.emplace(std::make_pair(std::move(input_names[i]), input_type));
+  }
+
+  auto output_names = session.GetOutputNames();
+  std::vector<ONNXTensorElementDataType> output_types(output_names.size());
+  for (size_t i = 0; i < output_types.size(); i++) {
+    auto output_type = session.GetOutputTypeInfo(i)->GetTensorTypeAndShapeInfo().GetElementType();
+    outputs_.emplace(std::make_pair(std::move(output_names[i]), output_type));
+  }
+}
+
+ONNXTensorElementDataType SessionInfo::GetInputDataType(const std::string& name) const {
+    return inputs_.find(name)->second;
+}
+
+ONNXTensorElementDataType SessionInfo::GetOutputDataType(const std::string& name) const {
+    return outputs_.find(name)->second;
+}
+
 Model::Model(std::unique_ptr<Config> config, const ProviderOptions* provider_options) : config_{std::move(config)} {
   session_options_ = OrtSessionOptions::Create();
 
   if (provider_options != nullptr) {
-#if USE_CUDA
     if (auto* options = std::get_if<OrtCUDAProviderOptions>(provider_options)) {
+#if USE_CUDA
       cuda_stream_ = reinterpret_cast<cudaStream_t>(options->user_compute_stream);
       session_options_->AppendExecutionProvider_CUDA(*options);
       device_type_ = DeviceType::CUDA;
-    }
+#else
+      throw std::runtime_error("Trying to use cuda with the non cuda version of onnxruntime-genai");
 #endif
+    }
   }
 }
 
@@ -161,6 +188,7 @@ void Model::InitDeviceAllocator([[maybe_unused]] OrtSession& session) {
     allocator_device_ = GetCudaAllocator(session);
   }
 #endif
+  session_info_ = std::make_unique<SessionInfo>(session);
 }
 
 std::unique_ptr<Tokenizer> Model::CreateTokenizer() const {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -166,15 +166,13 @@ Model::Model(std::unique_ptr<Config> config, const ProviderOptions* provider_opt
   session_options_ = OrtSessionOptions::Create();
 
   if (provider_options != nullptr) {
-    if (auto* options = std::get_if<OrtCUDAProviderOptions>(provider_options)) {
 #if USE_CUDA
+    if (auto* options = std::get_if<OrtCUDAProviderOptions>(provider_options)) {
       cuda_stream_ = reinterpret_cast<cudaStream_t>(options->user_compute_stream);
       session_options_->AppendExecutionProvider_CUDA(*options);
       device_type_ = DeviceType::CUDA;
-#else
-      throw std::runtime_error("Trying to use cuda with the non cuda version of onnxruntime-genai");
-#endif
     }
+#endif
   }
 }
 

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -78,6 +78,16 @@ struct Tokenizer {
 };
 #endif
 
+struct SessionInfo {
+  SessionInfo(OrtSession& session);
+
+  ONNXTensorElementDataType GetInputDataType(const std::string& name) const;
+  ONNXTensorElementDataType GetOutputDataType(const std::string& name) const;
+
+ private:
+  std::unordered_map<std::string, ONNXTensorElementDataType> inputs_, outputs_;
+};
+
 struct Model {
   Model(std::unique_ptr<Config> config, const ProviderOptions* provider_options);
   virtual ~Model();
@@ -94,6 +104,8 @@ struct Model {
   DeviceType device_type_{DeviceType::CPU};
   Ort::Allocator& allocator_cpu_{Ort::Allocator::GetWithDefaultOptions()};
   Ort::Allocator* allocator_device_{};  // Can be CUDA or CPU based on the DeviceType in the model
+
+  std::unique_ptr<SessionInfo> session_info_;
 
  protected:
   void InitDeviceAllocator(OrtSession& session);

--- a/src/models/phi.h
+++ b/src/models/phi.h
@@ -25,8 +25,8 @@ struct Phi2_State : State {
   const Phi2_Model& model_;
   bool first_run_{true};
 
-  InputIDs<int64_t> input_ids_{model_, *this};
-  PositionIDs<int64_t> position_ids_;
+  InputIDs input_ids_{model_, *this};
+  PositionIDs position_ids_;
   Logits logits_{model_, *this};
   KV_Cache kv_cache_{model_, *this};
 };

--- a/src/models/position_ids.cpp
+++ b/src/models/position_ids.cpp
@@ -5,17 +5,123 @@
 
 namespace Generators {
 
-template <typename T>
-PositionIDs<T>::PositionIDs(const Model& model, State& state, RoamingArray<int32_t>& sequence_lengths_unk)
+PositionIDs::PositionIDs(const Model& model, State& state, RoamingArray<int32_t>& sequence_lengths_unk)
     : model_{model},
       state_{state} {
-  cpu_span<int32_t> const sequence_lengths = sequence_lengths_unk;
+  type_ = model_.session_info_->GetInputDataType(model_.config_->model.decoder.inputs.position_ids);
+  if (type_ != Ort::TypeToTensorType<int32_t>::type && type_ != Ort::TypeToTensorType<int64_t>::type)
+    throw std::runtime_error("position_ids & attention_mask only support int32 or int64 types");
+
   std::array<int64_t, 2> shape{state_.search_params_.batch_size, state_.search_params_.sequence_length};  // Only batch_size initially, as we haven't expanded over the beams yet
-  position_ids_ = OrtValue::CreateTensor<T>(model.allocator_cpu_, shape);
-  attention_mask_ = OrtValue::CreateTensor<T>(model.allocator_cpu_, shape);
+  position_ids_ = OrtValue::CreateTensor(model.allocator_cpu_, shape, type_);
+  attention_mask_ = OrtValue::CreateTensor(model.allocator_cpu_, shape, type_);
 
   initial_sequence_lengths_.resize(state_.search_params_.batch_size * state_.search_params_.num_beams);
 
+  if (type_ == Ort::TypeToTensorType<int32_t>::type)
+    InitializeTensors<int32_t>(shape, sequence_lengths_unk);
+  else
+    InitializeTensors<int64_t>(shape, sequence_lengths_unk);
+
+  position_ids_ = model_.ExpandInputs(position_ids_, state_.search_params_.num_beams);
+  attention_mask_ = model_.ExpandInputs(attention_mask_, state_.search_params_.num_beams);
+  shape[0] *= state_.search_params_.num_beams;
+  position_ids_shape_ = shape;
+  attention_mask_shape_ = shape;
+}
+
+void PositionIDs::Add() {
+  input_index_ = state_.inputs_.size();
+
+  state_.inputs_.push_back(position_ids_.get());
+  state_.input_names_.push_back(model_.config_->model.decoder.inputs.position_ids.c_str());
+
+  state_.inputs_.push_back(attention_mask_.get());
+  state_.input_names_.push_back(model_.config_->model.decoder.inputs.attention_mask.c_str());
+}
+
+void PositionIDs::Update(int current_length) {
+  // Reallocate position_ids for the 2nd and onward shape
+  if (initial_sequence_lengths_.size()) {
+    position_ids_shape_[1] = 1;
+    position_ids_ = OrtValue::CreateTensor(*model_.allocator_device_, position_ids_shape_, type_);
+    state_.inputs_[input_index_] = position_ids_.get();
+
+    // Copy the initial values over to the device specific tensor
+    switch (model_.device_type_) {
+      case DeviceType::CPU:
+        if (type_ == Ort::TypeToTensorType<int32_t>::type)
+          std::copy(initial_sequence_lengths_.begin(), initial_sequence_lengths_.end(), position_ids_->GetTensorMutableData<int32_t>());
+        else
+          std::copy(initial_sequence_lengths_.begin(), initial_sequence_lengths_.end(), position_ids_->GetTensorMutableData<int64_t>());
+        break;
+#if USE_CUDA
+      case DeviceType::CUDA:
+        if (type_ == Ort::TypeToTensorType<int32_t>::type)
+          cudaMemcpyAsync(position_ids_->GetTensorMutableRawData(), initial_sequence_lengths_.data(), sizeof(int32_t) * initial_sequence_lengths_.size(), cudaMemcpyHostToDevice, model_.cuda_stream_);
+        else
+          cudaMemcpyAsync(position_ids_->GetTensorMutableRawData(), initial_sequence_lengths_.data(), sizeof(int64_t) * initial_sequence_lengths_.size(), cudaMemcpyHostToDevice, model_.cuda_stream_);
+        break;
+#endif
+      default:
+        throw std::runtime_error("PositionIDs::Update - Unsupported device type");
+    }
+    initial_sequence_lengths_.clear();
+  } else {  // Just incrementing existing position IDs
+    switch (model_.device_type_) {
+      case DeviceType::CPU: {
+        if (type_ == Ort::TypeToTensorType<int32_t>::type)
+          UpdatePositionIDs<int32_t>();
+        else
+          UpdatePositionIDs<int64_t>();
+        break;
+      }
+#if USE_CUDA
+      case DeviceType::CUDA:
+        if (type_ == Ort::TypeToTensorType<int32_t>::type)
+          cuda::Launch_UpdatePositionIds(position_ids_->GetTensorMutableData<int32_t>(), static_cast<int>(position_ids_shape_[0]), model_.cuda_stream_);
+        else
+          cuda::Launch_UpdatePositionIds(position_ids_->GetTensorMutableData<int64_t>(), static_cast<int>(position_ids_shape_[0]), model_.cuda_stream_);
+        break;
+#endif
+      default:
+        throw std::runtime_error("PositionIDs::Update - Unsupported device type");
+    }
+  }
+
+  {
+    // Update attention mask
+    assert(attention_mask_shape_[1] == current_length - 1);  // We should always be growing by 1
+    attention_mask_shape_[1] = current_length;
+
+    std::unique_ptr<OrtValue> next_attention_mask = OrtValue::CreateTensor(*model_.allocator_device_, attention_mask_shape_, type_);
+
+    switch (model_.device_type_) {
+      case DeviceType::CPU: {
+        if (type_ == Ort::TypeToTensorType<int32_t>::type)
+          UpdateAttentionMask(next_attention_mask->GetTensorMutableData<int32_t>(), attention_mask_->GetTensorData<int32_t>(), current_length);
+        else
+          UpdateAttentionMask(next_attention_mask->GetTensorMutableData<int64_t>(), attention_mask_->GetTensorData<int64_t>(), current_length);
+        break;
+      }
+#if USE_CUDA
+      case DeviceType::CUDA:
+        if (type_ == Ort::TypeToTensorType<int32_t>::type)
+          cuda::Launch_UpdateAttentionMask(next_attention_mask->GetTensorMutableData<int32_t>(), attention_mask_->GetTensorData<int32_t>(), static_cast<int>(attention_mask_shape_[0]), current_length, model_.cuda_stream_);
+        else
+          cuda::Launch_UpdateAttentionMask(next_attention_mask->GetTensorMutableData<int64_t>(), attention_mask_->GetTensorData<int64_t>(), static_cast<int>(attention_mask_shape_[0]), current_length, model_.cuda_stream_);
+        break;
+#endif
+      default:
+        throw std::runtime_error("PositionIDs::Update - Unsupported device type");
+    }
+    attention_mask_ = std::move(next_attention_mask);
+    state_.inputs_[input_index_ + 1] = attention_mask_.get();
+  }
+}
+
+template <typename T>
+void PositionIDs::InitializeTensors(std::array<int64_t, 2> shape, cpu_span<int32_t> sequence_lengths) {
   // Set attention mask to be 0 for pad tokens, and 1 for all other tokens.
   // Set position id to be 0 for pad tokens, and accumulated sum of mask in a batch for other tokens
   auto* mask_data = attention_mask_->GetTensorMutableData<T>();
@@ -37,102 +143,28 @@ PositionIDs<T>::PositionIDs(const Model& model, State& state, RoamingArray<int32
 
     for (int k = 0; k < state_.search_params_.num_beams; k++) {
       sequence_lengths[i * state_.search_params_.num_beams + k] = static_cast<int32_t>(abs_position);
-      initial_sequence_lengths_[i * state_.search_params_.num_beams + k] = abs_position;
+      initial_sequence_lengths_[i * state_.search_params_.num_beams + k] = static_cast<int32_t>(abs_position);
     }
   }
-
-  position_ids_ = model_.ExpandInputs(position_ids_, state_.search_params_.num_beams);
-  attention_mask_ = model_.ExpandInputs(attention_mask_, state_.search_params_.num_beams);
-  shape[0] *= state_.search_params_.num_beams;
-  position_ids_shape_ = shape;
-  attention_mask_shape_ = shape;
 }
 
 template <typename T>
-void PositionIDs<T>::Add() {
-  input_index_ = state_.inputs_.size();
-
-  state_.inputs_.push_back(position_ids_.get());
-  state_.input_names_.push_back(model_.config_->model.decoder.inputs.position_ids.c_str());
-
-  state_.inputs_.push_back(attention_mask_.get());
-  state_.input_names_.push_back(model_.config_->model.decoder.inputs.attention_mask.c_str());
-}
+void PositionIDs::UpdatePositionIDs() {
+  // Increment position IDs
+  auto* data = position_ids_->GetTensorMutableData<T>();
+  for (int i = 0; i < position_ids_shape_[0]; i++) {
+    data[i]++;
+  }
+};
 
 template <typename T>
-void PositionIDs<T>::Update(int current_length) {
-  // Reallocate position_ids for the 2nd and onward shape
-  if (initial_sequence_lengths_.size()) {
-    position_ids_shape_[1] = 1;
-    position_ids_ = OrtValue::CreateTensor<T>(*model_.allocator_device_, position_ids_shape_);
-    state_.inputs_[input_index_] = position_ids_.get();
-
-    // Copy the initial values over to the device specific tensor
-    switch (model_.device_type_) {
-      case DeviceType::CPU:
-        std::copy(initial_sequence_lengths_.begin(), initial_sequence_lengths_.end(), position_ids_->GetTensorMutableData<T>());
-        break;
-#if USE_CUDA
-      case DeviceType::CUDA:
-        cudaMemcpyAsync(position_ids_->GetTensorMutableRawData(), initial_sequence_lengths_.data(), sizeof(T) * initial_sequence_lengths_.size(), cudaMemcpyHostToDevice, model_.cuda_stream_);
-        break;
-#endif
-      default:
-        throw std::runtime_error("PositionIDs::Update - Unsupported device type");
+void PositionIDs::UpdateAttentionMask(T* data, const T* old_data, int current_length) {
+  for (int i = 0; i < attention_mask_shape_[0]; i++) {
+    for (int j = 0; j < current_length - 1; j++) {
+      data[i * current_length + j] = old_data[i * (current_length - 1) + j];
     }
-    initial_sequence_lengths_.clear();
-  } else {  // Just incrementing existing position IDs
-    switch (model_.device_type_) {
-      case DeviceType::CPU: {
-        // Increment position IDs
-        auto* data = position_ids_->GetTensorMutableData<T>();
-        for (int i = 0; i < position_ids_shape_[0]; i++) {
-          data[i]++;
-        }
-        break;
-      }
-#if USE_CUDA
-      case DeviceType::CUDA:
-        cuda::Launch_UpdatePositionIds(position_ids_->GetTensorMutableData<T>(), static_cast<int>(position_ids_shape_[0]), model_.cuda_stream_);
-        break;
-#endif
-      default:
-        throw std::runtime_error("PositionIDs::Update - Unsupported device type");
-    }
+    data[i * current_length + current_length - 1] = 1;
   }
-
-  {
-    // Update attention mask
-    assert(attention_mask_shape_[1] == current_length - 1);  // We should always be growing by 1
-    attention_mask_shape_[1] = current_length;
-
-    const auto* old_data = attention_mask_->GetTensorData<T>();
-    std::unique_ptr<OrtValue> attention_mask = OrtValue::CreateTensor<T>(*model_.allocator_device_, attention_mask_shape_);
-    auto* data = attention_mask->GetTensorMutableData<T>();
-
-    switch (model_.device_type_) {
-      case DeviceType::CPU:
-        for (int i = 0; i < attention_mask_shape_[0]; i++) {
-          for (int j = 0; j < current_length - 1; j++) {
-            data[i * current_length + j] = old_data[i * (current_length - 1) + j];
-          }
-          data[i * current_length + current_length - 1] = 1;
-        }
-        break;
-#if USE_CUDA
-      case DeviceType::CUDA:
-        cuda::Launch_UpdateAttentionMask(data, old_data, static_cast<int>(attention_mask_shape_[0]), current_length, model_.cuda_stream_);
-        break;
-#endif
-      default:
-        throw std::runtime_error("PositionIDs::Update - Unsupported device type");
-    }
-    attention_mask_ = std::move(attention_mask);
-    state_.inputs_[input_index_ + 1] = attention_mask_.get();
-  }
-}
-
-template struct PositionIDs<int32_t>;
-template struct PositionIDs<int64_t>;
+};
 
 }  // namespace Generators

--- a/src/models/position_ids.h
+++ b/src/models/position_ids.h
@@ -2,7 +2,6 @@
 
 namespace Generators {
 
-template <typename T>
 struct PositionIDs {
   PositionIDs(const Model& model, State& state, RoamingArray<int32_t>& sequence_lengths);
 
@@ -10,16 +9,25 @@ struct PositionIDs {
   void Update(int current_length);
 
  private:
+  template <typename T>
+  void InitializeTensors(std::array<int64_t, 2> shape, cpu_span<int32_t> sequence_lengths);
+
+  template <typename T>
+  void UpdatePositionIDs();
+  template <typename T>
+  void UpdateAttentionMask(T* data, const T* old_data, int current_length);
+
   const Model& model_;
   State& state_;
   size_t input_index_{~0U};
+  ONNXTensorElementDataType type_;  // Common type for position_ids and attention_mask
 
   std::array<int64_t, 2> position_ids_shape_{};  // {search_params.batch_size*search_params.beam_size, search_params.sequence_length}
   std::unique_ptr<OrtValue> position_ids_;
   std::array<int64_t, 2> attention_mask_shape_{};  // {search_params.batch_size*search_params.beam_size, search_params.sequence_length}
   std::unique_ptr<OrtValue> attention_mask_;
 
-  std::vector<T> initial_sequence_lengths_;
+  std::vector<int32_t> initial_sequence_lengths_;
 };
 
 }  // namespace Generators

--- a/src/models/whisper.h
+++ b/src/models/whisper.h
@@ -24,7 +24,7 @@ struct Whisper_State : State {
   const Whisper_Model& model_;
   bool first_run_{true};
 
-  InputIDs<int32_t> decoder_input_ids_{model_, *this};
+  InputIDs decoder_input_ids_{model_, *this};
   Logits logits_{model_, *this};
   KV_Cache kv_cache_{model_, *this};
   Cross_Cache cross_cache_{model_, *this};

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -149,8 +149,6 @@ class Model:
                     "num_key_value_heads": self.num_kv_heads,
                 },
                 "eos_token_id": config.eos_token_id,
-                "logits_type": "float32" if self.io_dtype == TensorProto.FLOAT else "float16",
-                "kv_type": "float32" if self.io_dtype == TensorProto.FLOAT else "float16",
                 "pad_token_id": config.pad_token_id if hasattr(config, "pad_token_id") and config.pad_token_id != None else config.eos_token_id,
                 "type": self.model_type[ : self.model_type.find("For")].lower(),
                 "vocab_size": self.vocab_size,

--- a/test/test_models/hf-internal-testing/tiny-random-gpt2-fp16/genai_config.json
+++ b/test/test_models/hf-internal-testing/tiny-random-gpt2-fp16/genai_config.json
@@ -5,8 +5,6 @@
     "bos_token_id": 98,
     "eos_token_id": 98,
     "vocab_size": 1000,
-    "logits_type": "float16",
-    "kv_type": "float16",
     "decoder": {
       "filename" : "past.onnx",
       "num_key_value_heads": 4,


### PR DESCRIPTION
Removed templates from Model PositionIDs/InputIDs handlers

Remove logits type and kv type from genai-config.json
Config file will output a warning that the logits_type and kv_type are deprecated. We'll remove all traces once we update builder.py

Also detects requesting CUDA device type when not built for CUDA and report an early error