### PR TITLE
Add kv_shared_past_present option

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -107,6 +107,13 @@ struct Decoder_Element : JSON::Element {
       throw JSON::unknown_value_error{};
   }
 
+  void OnBool(std::string_view name, bool value) override {
+    if (name == "kv_shared_past_present") {
+      v_.kv_shared_past_present = value;
+    } else
+      throw JSON::unknown_value_error{};
+  }
+
   Element& OnObject(std::string_view name) override {
     if (name == "inputs") {
       return inputs_;

--- a/src/config.h
+++ b/src/config.h
@@ -31,6 +31,7 @@ struct Config {
       int num_key_value_heads{};
       int num_hidden_layers{};
       int head_size{};
+      bool kv_shared_past_present{};
 
       struct Inputs {
         std::string input_ids{"input_ids"};

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -117,6 +117,7 @@ KV_Cache::KV_Cache(const Model& model, State& state)
     : model_{model},
       state_{state},
       layer_count_{model_.config_->model.decoder.num_hidden_layers},
+      shared_past_present_{model_.config_->model.decoder.kv_shared_past_present && state_.params_.search.num_beams == 1 && model_.device_type_ == DeviceType::CUDA},
       shape_{state_.params_.BatchBeamSize(), model.config_->model.decoder.num_key_value_heads, 0, model.config_->model.decoder.head_size} {
   pasts_.resize(layer_count_ * 2);
   presents_.reserve(layer_count_ * 2);
@@ -138,7 +139,12 @@ KV_Cache::KV_Cache(const Model& model, State& state)
   type_ = model_.session_info_->GetInputDataType(input_name_strings_[0]);
 
   empty_past_ = OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_);
-  shape_[2] = state_.params_.sequence_length;  // Set this after empty_past_ has been created with 0 for this field
+
+  // Set the size after empty_past_ has been created with 0 for this field
+  if (shared_past_present_)
+    shape_[2] = state_.params_.search.max_length;
+  else
+    shape_[2] = state_.params_.sequence_length;
 
   for (int i = 0; i < layer_count_; ++i) {
     presents_.push_back(OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_));
@@ -165,9 +171,19 @@ void KV_Cache::Add() {
     state_.outputs_.push_back(presents_[i].get());
     state_.output_names_.push_back(output_name_strings_[i].c_str());
   }
+
+  // For shared_past_present, the past & presents never change, so set the inputs to the present values (outputs are already set above)
+  if (shared_past_present_) {
+    for (int i = 0; i < layer_count_ * 2; ++i) {
+      state_.inputs_[input_index_ + i] = presents_[i].get();
+    }
+  }
 }
 
 void KV_Cache::Update(std::span<const int32_t> beam_indices, int current_length) {
+  if (shared_past_present_)
+    return;
+
   for (int i = 0; i < layer_count_ * 2; i++) {
     if (beam_indices.empty()) {
       pasts_[i] = std::move(presents_[i]);

--- a/src/models/kv_cache.h
+++ b/src/models/kv_cache.h
@@ -41,7 +41,7 @@ struct KV_Cache {
   State& state_;
   int layer_count_;
   size_t input_index_{~0U}, output_index_{~0U};
-  bool shared_past_present_; // True if model.decoder.kv_shared_past_present is set to true, and we're using cuda, and not beam search
+  bool shared_past_present_;  // True if model.decoder.kv_shared_past_present is set to true, and we're using cuda, and not beam search
 
   std::array<int64_t, 4> shape_;
   ONNXTensorElementDataType type_;

--- a/src/models/kv_cache.h
+++ b/src/models/kv_cache.h
@@ -41,6 +41,7 @@ struct KV_Cache {
   State& state_;
   int layer_count_;
   size_t input_index_{~0U}, output_index_{~0U};
+  bool shared_past_present_; // True if model.decoder.kv_shared_past_present is set to true, and we're using cuda, and not beam search
 
   std::array<int64_t, 4> shape_;
   ONNXTensorElementDataType type_;


### PR DESCRIPTION
In the config, there is a new bool option: `{ "model": { "decoder": { "kv_shared_past_present": true } } }` that will cause the KV cache buffers to be allocated once to the max size, and to have the past & present buffers be the same buffers (so no memory allocations after the first iteration, and only half of the max memory).

Does not apply to KV_Cache_Combined.

Tested with phi2 model on cuda