### PR TITLE
Replace gdn with .config\tsaoptions.json

### DIFF
--- a/.gdn/.gdntsa
+++ b/.gdn/.gdntsa
@@ -1,3 +1,0 @@
-{
-    "codebaseName": "onnxruntime_genai_main"
-}

--- a/.pipelines/stages/jobs/py-win-cpu-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-win-cpu-packaging-job.yml
@@ -134,7 +134,7 @@ jobs:
     condition: and(and (succeeded(), and(eq(variables['buildArch'], 'x64'), eq(variables['PythonVersion'], '3.8'))), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     inputs:
       GdnPublishTsaOnboard: false
-      GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.gdn\.gdntsa'
+      GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.config\tsaoptions.json'
     continueOnError: true
 
   - template: steps/component-governance-component-detection-step.yml

--- a/.pipelines/stages/jobs/py-win-gpu-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-win-gpu-packaging-job.yml
@@ -141,7 +141,7 @@ jobs:
     condition: and(and (succeeded(), eq(variables['PythonVersion'], '3.8')), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     inputs:
       GdnPublishTsaOnboard: false
-      GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.gdn\.gdntsa'
+      GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.config\tsaoptions.json'
     continueOnError: true
 
   - template: steps/component-governance-component-detection-step.yml


### PR DESCRIPTION
This pull request primarily involves changes in the configuration of the Guardian (Gdn) tool used for threat detection. The main changes include the removal of the `.gdntsa` file and updates to the `GdnPublishTsaConfigFile` path in two job files.

Here are the key changes:

* File removal:
  * [`.gdn/.gdntsa`](diffhunk://#diff-b4fbb94e5e0cd5b2aae8fa62763e8099598170a5478d9e610bdced711de09de1L1-L3): This file was completely removed from the project. It previously contained the name of the codebase for the Guardian tool.

* Configuration updates:
  * [`.pipelines/stages/jobs/py-win-cpu-packaging-job.yml`](diffhunk://#diff-d83fb863912a20250c78a0ba8d76f9fd49914a23b11faa9aa7654a92921dacebL137-R137): Updated the `GdnPublishTsaConfigFile` path from `$(Build.sourcesDirectory)\.gdn\.gdntsa` to `$(Build.sourcesDirectory)\.config\tsaoptions.json`. This change means the Guardian tool will now use the new `tsaoptions.json` file for its configuration.
  * [`.pipelines/stages/jobs/py-win-gpu-packaging-job.yml`](diffhunk://#diff-db7ba42cb4be9cdc07b17473c451fad2b6d98dcf672f2f78599544099a711473L144-R144): Similar to the above, the `GdnPublishTsaConfigFile` path was updated to use the `tsaoptions.json` file.