### PR TITLE
  update  cuda_version: '11.8'

### DIFF
--- a/.pipelines/stages/jobs/py-win-gpu-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-win-gpu-packaging-job.yml
@@ -20,7 +20,7 @@ jobs:
         PythonVersion: '3.12'
   variables:
     BuildConfig: 'RelWithDebInfo'
-    cuda_version: '12.2'
+    cuda_version: '11.8'
     cuda_dir: '$(Build.SourcesDirectory)\cuda_sdk'
   timeoutInMinutes: 180
   workspace:


### PR DESCRIPTION
This pull request includes a change to the `cuda_version` variable in the `jobs:` section of the `.pipelines/stages/jobs/py-win-gpu-packaging-job.yml` file. The `cuda_version` was updated from '12.2' to '11.8'. This change might affect the compatibility and performance of the GPU packaging job, so it's important to test the impact of this change thoroughly.