### PR TITLE
using preset for windows gha

### DIFF
--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Install the Python Wheel and Test Dependencies
       run: |
-        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\Release\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
         python -m pip install -r test\python\requirements.txt
 
     - name: Run the Python Tests

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -73,5 +73,5 @@ jobs:
 
     - name: Run tests
       run: |
-        .\build\test\Release\unit_tests.exe
+        .\unit_tests.exe
       working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\Release'

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -47,8 +47,8 @@ jobs:
 
       - name: Build with CMake
         run: |
-          cmake -G "Visual Studio 17 2022" -A arm64 -S . -B $env:cmake_build_dir -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=OFF
-          cmake --build $env:cmake_build_dir --config Release --parallel
+          cmake --preset windows_arm64_cpu_release
+          cmake --build --preset windows_arm64_cpu_release
 
       - name: Install the Python Wheel and Test Dependencies
         run: |
@@ -74,9 +74,3 @@ jobs:
       - name: Run tests
         run: |
           .\build\test\Release\unit_tests.exe
-
-      - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: onnxruntime-genai-win-cpu-arm64
-          path: Release/*.lib

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -3,8 +3,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
-      - rel-*
+    - main
+    - rel-*
   pull_request:
 
 concurrency:
@@ -14,63 +14,64 @@ env:
   ort_dir: "onnxruntime-win-arm64-1.17.0"
   ort_zip: "$(ort_dir).zip"
   ort_url: "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/$(ort_zip)"
-  cmake_build_dir: build
+  cmake_build_dir: 'build/release/cpu_default'
 
 jobs:
   windows-cpu-arm64-build:
     runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Win11-ARM-CPU" ]
     steps:
-      - name: Checkout OnnxRuntime GenAI repo
-        uses: actions/checkout@v4
-        with:
-          submodules: true
+    - name: Checkout OnnxRuntime GenAI repo
+      uses: actions/checkout@v4
+      with:
+        submodules: true
 
-      - name: Setup Visual Studio 2022
-        uses: microsoft/setup-msbuild@v1.1
-        with:
-          vs-version: '17.4'
-          msbuild-architecture: arm64
+    - name: Setup Visual Studio 2022
+      uses: microsoft/setup-msbuild@v1.1
+      with:
+        vs-version: '17.4'
+        msbuild-architecture: arm64
 
-      - name: Download OnnxRuntime
-        run: |
-          $env:ort_url = "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-arm64-1.17.0.zip"
-          Invoke-WebRequest -Uri $env:ort_url -OutFile $env:ort_zip
+    - name: Download OnnxRuntime
+      run: |
+        $env:ort_url = "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-arm64-1.17.0.zip"
+        Invoke-WebRequest -Uri $env:ort_url -OutFile $env:ort_zip
 
-      - name: Unzip OnnxRuntime
-        run: |
-          Expand-Archive $env:ort_zip -DestinationPath .
-          Remove-Item -Path $env:ort_zip
+    - name: Unzip OnnxRuntime
+      run: |
+        Expand-Archive $env:ort_zip -DestinationPath .
+        Remove-Item -Path $env:ort_zip
 
-      - name: Rename OnnxRuntime to ort
-        run: |
-          Rename-Item -Path $env:ort_dir -NewName ort
+    - name: Rename OnnxRuntime to ort
+      run: |
+        Rename-Item -Path $env:ort_dir -NewName ort
 
-      - name: Build with CMake
-        run: |
-          cmake --preset windows_arm64_cpu_release
-          cmake --build --preset windows_arm64_cpu_release --parallel
+    - name: Build with CMake
+      run: |
+        cmake --preset windows_arm64_cpu_release
+        cmake --build --preset windows_arm64_cpu_release --parallel
 
-      - name: Install the Python Wheel and Test Dependencies
-        run: |
-          python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
-          python -m pip install -r test\python\requirements.txt
+    - name: Install the Python Wheel and Test Dependencies
+      run: |
+        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
+        python -m pip install -r test\python\requirements.txt
 
-      - name: Run the Python Tests
-        run: |
-          python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
+    - name: Run the Python Tests
+      run: |
+        python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
 
-      - name: Build the C# API and Run the C# Tests
-        run: |
-          cd test\csharp
-          dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\Release"
+    - name: Build the C# API and Run the C# Tests
+      run: |
+        cd test\csharp
+        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir"
 
-      - name: Verify Build Artifacts
-        if: always()
-        continue-on-error: true
-        run: |
-          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\Release -Recurse
-          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\Release -Recurse
+    - name: Verify Build Artifacts
+      if: always()
+      continue-on-error: true
+      run: |
+        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir -Recurse
+        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\test -Recurse
 
-      - name: Run tests
-        run: |
-          .\build\test\Release\unit_tests.exe
+    - name: Run tests
+      run: |
+        .\build\test\Release\unit_tests.exe
+      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test'

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -73,5 +73,4 @@ jobs:
 
     - name: Run tests
       run: |
-        .\unit_tests.exe
-      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\Release'
+        $env:GITHUB_WORKSPACE\\$env:cmake_build_dir\test\Release\unit_tests.exe

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Install the Python Wheel and Test Dependencies
       run: |
-        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\Release\*.whl"))
         python -m pip install -r test\python\requirements.txt
 
     - name: Run the Python Tests
@@ -62,7 +62,7 @@ jobs:
     - name: Build the C# API and Run the C# Tests
       run: |
         cd test\csharp
-        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir"
+        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\Release"
 
     - name: Verify Build Artifacts
       if: always()
@@ -74,4 +74,4 @@ jobs:
     - name: Run tests
       run: |
         .\build\test\Release\unit_tests.exe
-      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test'
+      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\Release'

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -73,4 +73,4 @@ jobs:
 
     - name: Run tests
       run: |
-        $env:GITHUB_WORKSPACE\\$env:cmake_build_dir\test\Release\unit_tests.exe
+        .\build\release\cpu_default\test\Release\unit_tests.exe

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build with CMake
         run: |
           cmake --preset windows_arm64_cpu_release
-          cmake --build --preset windows_arm64_cpu_release
+          cmake --build --preset windows_arm64_cpu_release --parallel
 
       - name: Install the Python Wheel and Test Dependencies
         run: |

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Install the python wheel and test dependencies
       run: |
-        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\Release\*.whl"))
         python -m pip install -r test\python\requirements-nightly-cpu.txt
 
     - name: Get HuggingFace Token
@@ -76,7 +76,7 @@ jobs:
     - name: Build the C# API and Run the C# Tests
       run: |
         cd test\csharp
-        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir"
+        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\Release"
 
     - name: Verify Build Artifacts
       if: always()
@@ -88,7 +88,7 @@ jobs:
     - name: Run tests
       run: |
         .\unit_tests.exe
-      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test'
+      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\Release'
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -87,8 +87,7 @@ jobs:
 
     - name: Run tests
       run: |
-        .\unit_tests.exe
-      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\Release'
+        $env:GITHUB_WORKSPACE\\$env:cmake_build_dir\test\Release\unit_tests.exe
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -3,8 +3,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
-      - rel-*
+    - main
+    - rel-*
   pull_request:
 
 concurrency:
@@ -23,77 +23,72 @@ jobs:
       security-events: write
       actions: read
     steps:
-      - name: Checkout OnnxRuntime GenAI repo
-        uses: actions/checkout@v4
-        with:
-          submodules: true
+    - name: Checkout OnnxRuntime GenAI repo
+      uses: actions/checkout@v4
+      with:
+        submodules: true
 
-      - name: Setup Visual Studio 2022
-        uses: microsoft/setup-msbuild@v1.1
-        with:
-          vs-version: '17.5'
+    - name: Setup Visual Studio 2022
+      uses: microsoft/setup-msbuild@v1.1
+      with:
+        vs-version: '17.5'
 
-      - name: Download OnnxRuntime
-        run: |
-          $env:ort_url = "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-1.17.0.zip"
-          Invoke-WebRequest -Uri $env:ort_url -OutFile $env:ort_zip
+    - name: Download OnnxRuntime
+      run: |
+        $env:ort_url = "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-1.17.0.zip"
+        Invoke-WebRequest -Uri $env:ort_url -OutFile $env:ort_zip
 
-      - name: Unzip OnnxRuntime
-        run: |
-          Expand-Archive $env:ort_zip -DestinationPath .
-          Remove-Item -Path $env:ort_zip
+    - name: Unzip OnnxRuntime
+      run: |
+        Expand-Archive $env:ort_zip -DestinationPath .
+        Remove-Item -Path $env:ort_zip
 
-      - name: Rename OnnxRuntime to ort
-        run: |
-          Rename-Item -Path $env:ort_dir -NewName ort
+    - name: Rename OnnxRuntime to ort
+      run: |
+        Rename-Item -Path $env:ort_dir -NewName ort
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: 'cpp'
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: 'cpp'
 
-      - name: Build with CMake
-        run: |
-          cmake -G "Visual Studio 17 2022" -A x64 -S . -B $env:cmake_build_dir -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=OFF
-          cmake --build $env:cmake_build_dir --config Release --parallel
+    - name: Build with CMake
+      run: |
+        cmake --preset windows_x64_cpu_release
+        cmake --build --preset windows_x64_cpu_release
 
-      - name: Install the python wheel and test dependencies
-        run: |
-          python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
-          python -m pip install -r test\python\requirements-nightly-cpu.txt
+    - name: Install the python wheel and test dependencies
+      run: |
+        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
+        python -m pip install -r test\python\requirements-nightly-cpu.txt
 
-      - name: Get HuggingFace Token
-        run: |
-          az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
-          $HF_TOKEN = (az keyvault secret show --vault-name anubissvcsecret --name ANUBIS-HUGGINGFACE-TOKEN --query value)
-          Write-Output "::add-mask::$HF_TOKEN"
-          Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=$HF_TOKEN"
+    - name: Get HuggingFace Token
+      run: |
+        az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
+        $HF_TOKEN = (az keyvault secret show --vault-name anubissvcsecret --name ANUBIS-HUGGINGFACE-TOKEN --query value)
+        Write-Output "::add-mask::$HF_TOKEN"
+        Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=$HF_TOKEN"
 
-      - name: Run the Python Tests
-        run: |
-          python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
+    - name: Run the Python Tests
+      run: |
+        python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
 
-      - name: Build the C# API and Run the C# Tests
-        run: |
-          cd test\csharp
-          dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\Release"
+    - name: Build the C# API and Run the C# Tests
+      run: |
+        cd test\csharp
+        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\release"
 
-      - name: Verify Build Artifacts
-        if: always()
-        continue-on-error: true
-        run: |
-          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\Release -Recurse
-          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\Release -Recurse
+    - name: Verify Build Artifacts
+      if: always()
+      continue-on-error: true
+      run: |
+        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\release -Recurse
+        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\release -Recurse
 
-      - name: Run tests
-        run: |
-          .\build\test\Release\unit_tests.exe
+    - name: Run tests
+      run: |
+        .\build\test\release\unit_tests.exe
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
 
-      - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: onnxruntime-genai-win-cpu-x64
-          path: Release/*.lib

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Build with CMake
       run: |
         cmake --preset windows_x64_cpu_release
-        cmake --build --preset windows_x64_cpu_release
+        cmake --build --preset windows_x64_cpu_release --parallel
 
     - name: Install the python wheel and test dependencies
       run: |

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Install the python wheel and test dependencies
       run: |
-        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\Release\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
         python -m pip install -r test\python\requirements-nightly-cpu.txt
 
     - name: Get HuggingFace Token

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -87,7 +87,7 @@ jobs:
 
     - name: Run tests
       run: |
-        $env:GITHUB_WORKSPACE\\$env:cmake_build_dir\test\Release\unit_tests.exe
+        .\build\release\cpu_default\test\Release\unit_tests.exe
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -14,7 +14,7 @@ env:
   ort_dir: "onnxruntime-win-x64-1.17.0"
   ort_zip: "$(ort_dir).zip"
   ort_url: "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/$(ort_zip)"
-  cmake_build_dir: build
+  cmake_build_dir: 'build/release/cpu_default'
 
 jobs:
   windows-cpu-x64-build:
@@ -76,18 +76,19 @@ jobs:
     - name: Build the C# API and Run the C# Tests
       run: |
         cd test\csharp
-        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\release"
+        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir"
 
     - name: Verify Build Artifacts
       if: always()
       continue-on-error: true
       run: |
-        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\release -Recurse
-        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\release -Recurse
+        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir -Recurse
+        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir\test -Recurse
 
     - name: Run tests
       run: |
-        .\build\test\release\unit_tests.exe
+        .\unit_tests.exe
+      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test'
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/win-gpu-x64-build.yml
+++ b/.github/workflows/win-gpu-x64-build.yml
@@ -11,12 +11,12 @@ env:
   ort_dir: "onnxruntime-win-x64-gpu-1.17.0"
   ort_zip: "onnxruntime-win-x64-gpu-1.17.0.zip"
   ort_url: "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-gpu-1.17.0.zip"
-#  ort_dir: "onnxruntime-win-x64-cuda-1.17.0"
-#  ort_zip: "onnxruntime-win-x64-cuda12-1.17.0.zip"
-#  ort_url: "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-cuda12-1.17.0.zip"
+  #  ort_dir: "onnxruntime-win-x64-cuda-1.17.0"
+  #  ort_zip: "onnxruntime-win-x64-cuda12-1.17.0.zip"
+  #  ort_url: "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-cuda12-1.17.0.zip"
   cuda_dir: "${{ github.workspace }}\\cuda_sdk"
-#  cuda_version: "12.2"
-#  CUDA_PATH: "${{ github.workspace }}\\cuda_sdk\\v12.2"
+  #  cuda_version: "12.2"
+  #  CUDA_PATH: "${{ github.workspace }}\\cuda_sdk\\v12.2"
   cuda_version: "11.8"
   CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v11.8
   cmake_build_dir: build
@@ -26,76 +26,70 @@ jobs:
   windows-gpu-x64-build:
     runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-GPU-A10" ]
     steps:
-      - name: Checkout OnnxRuntime GenAI repo
-        uses: actions/checkout@v4
-        with:
-          submodules: true
+    - name: Checkout OnnxRuntime GenAI repo
+      uses: actions/checkout@v4
+      with:
+        submodules: true
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.x'
-          architecture: 'x64'
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.x'
+        architecture: 'x64'
 
-      - name: Download cuda
-        run: |
-          azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ env.cuda_version }}" ${{ env.cuda_dir}}
+    - name: Download cuda
+      run: |
+        azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ env.cuda_version }}" ${{ env.cuda_dir}}
 
-      - name: Download OnnxRuntime
-        run: |
-          Invoke-WebRequest -Uri $env:ort_url -OutFile $env:ort_zip
+    - name: Download OnnxRuntime
+      run: |
+        Invoke-WebRequest -Uri $env:ort_url -OutFile $env:ort_zip
 
-      - name: Unzip OnnxRuntime
-        run: |
-          Expand-Archive $env:ort_zip -DestinationPath .
-          Remove-Item -Path $env:ort_zip
-      - name: Rename OnnxRuntime to ort
-        run: |
-          Rename-Item -Path $env:ort_dir -NewName ort
+    - name: Unzip OnnxRuntime
+      run: |
+        Expand-Archive $env:ort_zip -DestinationPath .
+        Remove-Item -Path $env:ort_zip
+    - name: Rename OnnxRuntime to ort
+      run: |
+        Rename-Item -Path $env:ort_dir -NewName ort
 
-      - name: Build with CMake
-        run: |
-          cmake -G "Visual Studio 17 2022" -S . -B build -A x64 -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }} -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=TRUE -DTEST_PHI2=False
-          cmake --build build --config Release --parallel
+    - name: Build with CMake
+      run: |
+        cmake --preset windows_x64_cuda_release -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }} -DTEST_PHI2=False
+        cmake --build --preset windows_x64_cuda_release
 
-      - name: Install the Python Wheel and Test Dependencies
-        run: |
-          python -m pip install (Get-ChildItem ("build\wheel\*.whl"))
-          python -m pip install -r test\python\requirements-nightly-cpu.txt
+    - name: Install the Python Wheel and Test Dependencies
+      run: |
+        python -m pip install (Get-ChildItem ("build\wheel\*.whl"))
+        python -m pip install -r test\python\requirements-nightly-cpu.txt
 
-      - name: Get HuggingFace Token
-        run: |
-          az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
-          $HF_TOKEN = (az keyvault secret show --vault-name anubissvcsecret --name ANUBIS-HUGGINGFACE-TOKEN --query value)
-          Write-Output "::add-mask::$HF_TOKEN"
-          Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=$HF_TOKEN"
+    - name: Get HuggingFace Token
+      run: |
+        az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
+        $HF_TOKEN = (az keyvault secret show --vault-name anubissvcsecret --name ANUBIS-HUGGINGFACE-TOKEN --query value)
+        Write-Output "::add-mask::$HF_TOKEN"
+        Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=$HF_TOKEN"
 
-      - name: Run the Python Tests
-        run: |
-          python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
+    - name: Run the Python Tests
+      run: |
+        python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
 
-      - name: Add CUDA to PATH
-        run: |
-          echo "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Add CUDA to PATH
+      run: |
+        echo "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Build the C# API and Run the C# Tests
-        run: |
-          cd test\csharp
-          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\Release"
+    - name: Build the C# API and Run the C# Tests
+      run: |
+        cd test\csharp
+        dotnet test /p:Configuration=release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\release"
 
-      - name: Verify Build Artifacts
-        if: always()
-        continue-on-error: true
-        run: |
-          Get-ChildItem -Path $env:GITHUB_WORKSPACE\build\test\Release -Recurse
+    - name: Verify Build Artifacts
+      if: always()
+      continue-on-error: true
+      run: |
+        Get-ChildItem -Path $env:GITHUB_WORKSPACE\build\test\release -Recurse
 
-      - name: Prepend CUDA to PATH and Run tests
-        run: |
-          $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
-          echo "Current PATH variable is: $env:PATH" 
-          .\build\test\Release\unit_tests.exe
-
-      - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: onnxruntime-genai-win-cpu-x64
-          path: build/Release/*.lib
+    - name: Prepend CUDA to PATH and Run tests
+      run: |
+        $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
+        echo "Current PATH variable is: $env:PATH" 
+        .\build\test\release\unit_tests.exe

--- a/.github/workflows/win-gpu-x64-build.yml
+++ b/.github/workflows/win-gpu-x64-build.yml
@@ -81,11 +81,11 @@ jobs:
       if: always()
       continue-on-error: true
       run: |
+        
         Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir -Recurse
 
     - name: Prepend CUDA to PATH and Run tests
       run: |
         $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
         echo "Current PATH variable is: $env:PATH" 
-        .\unit_tests.exe
-      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\Release'
+        $env:GITHUB_WORKSPACE\\$env:cmake_build_dir\test\Release\unit_tests.exe

--- a/.github/workflows/win-gpu-x64-build.yml
+++ b/.github/workflows/win-gpu-x64-build.yml
@@ -11,15 +11,10 @@ env:
   ort_dir: "onnxruntime-win-x64-gpu-1.17.0"
   ort_zip: "onnxruntime-win-x64-gpu-1.17.0.zip"
   ort_url: "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-gpu-1.17.0.zip"
-  #  ort_dir: "onnxruntime-win-x64-cuda-1.17.0"
-  #  ort_zip: "onnxruntime-win-x64-cuda12-1.17.0.zip"
-  #  ort_url: "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-cuda12-1.17.0.zip"
   cuda_dir: "${{ github.workspace }}\\cuda_sdk"
-  #  cuda_version: "12.2"
-  #  CUDA_PATH: "${{ github.workspace }}\\cuda_sdk\\v12.2"
   cuda_version: "11.8"
   CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v11.8
-  cmake_build_dir: 'build/release/gpu_default'
+  cmake_build_dir: 'build/release/cuda_default'
 
 
 jobs:
@@ -86,7 +81,7 @@ jobs:
       if: always()
       continue-on-error: true
       run: |
-        Get-ChildItem -Path "$env:GITHUB_WORKSPACE\$env:cmake_build_dir" -Recurse
+        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:cmake_build_dir -Recurse
 
     - name: Prepend CUDA to PATH and Run tests
       run: |

--- a/.github/workflows/win-gpu-x64-build.yml
+++ b/.github/workflows/win-gpu-x64-build.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Install the Python Wheel and Test Dependencies
       run: |
-        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\Release\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
         python -m pip install -r test\python\requirements-nightly-cpu.txt
 
     - name: Get HuggingFace Token
@@ -86,7 +86,7 @@ jobs:
       if: always()
       continue-on-error: true
       run: |
-        Get-ChildItem -Path '$env:GITHUB_WORKSPACE\$env:cmake_build_dir' -Recurse
+        Get-ChildItem -Path "$env:GITHUB_WORKSPACE\$env:cmake_build_dir" -Recurse
 
     - name: Prepend CUDA to PATH and Run tests
       run: |

--- a/.github/workflows/win-gpu-x64-build.yml
+++ b/.github/workflows/win-gpu-x64-build.yml
@@ -88,4 +88,4 @@ jobs:
       run: |
         $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
         echo "Current PATH variable is: $env:PATH" 
-        $env:GITHUB_WORKSPACE\\$env:cmake_build_dir\test\Release\unit_tests.exe
+        .\build\release\cuda_default\test\Release\unit_tests.exe

--- a/.github/workflows/win-gpu-x64-build.yml
+++ b/.github/workflows/win-gpu-x64-build.yml
@@ -19,7 +19,7 @@ env:
   #  CUDA_PATH: "${{ github.workspace }}\\cuda_sdk\\v12.2"
   cuda_version: "11.8"
   CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v11.8
-  cmake_build_dir: build
+  cmake_build_dir: 'build/release/gpu_default'
 
 
 jobs:
@@ -80,16 +80,17 @@ jobs:
     - name: Build the C# API and Run the C# Tests
       run: |
         cd test\csharp
-        dotnet test /p:Configuration=release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\release"
+        dotnet test /p:Configuration=release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir"
 
     - name: Verify Build Artifacts
       if: always()
       continue-on-error: true
       run: |
-        Get-ChildItem -Path $env:GITHUB_WORKSPACE\build\test\release -Recurse
+        Get-ChildItem -Path '$env:GITHUB_WORKSPACE\$env:cmake_build_dir' -Recurse
 
     - name: Prepend CUDA to PATH and Run tests
       run: |
         $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
         echo "Current PATH variable is: $env:PATH" 
-        .\build\test\release\unit_tests.exe
+        .\unit_tests.exe
+      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test'

--- a/.github/workflows/win-gpu-x64-build.yml
+++ b/.github/workflows/win-gpu-x64-build.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Install the Python Wheel and Test Dependencies
       run: |
-        python -m pip install (Get-ChildItem ("build\wheel\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
         python -m pip install -r test\python\requirements-nightly-cpu.txt
 
     - name: Get HuggingFace Token

--- a/.github/workflows/win-gpu-x64-build.yml
+++ b/.github/workflows/win-gpu-x64-build.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Build with CMake
       run: |
         cmake --preset windows_x64_cuda_release -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }} -DTEST_PHI2=False
-        cmake --build --preset windows_x64_cuda_release
+        cmake --build --preset windows_x64_cuda_release --parallel
 
     - name: Install the Python Wheel and Test Dependencies
       run: |

--- a/.github/workflows/win-gpu-x64-build.yml
+++ b/.github/workflows/win-gpu-x64-build.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Install the Python Wheel and Test Dependencies
       run: |
-        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:cmake_build_dir\wheel\Release\*.whl"))
         python -m pip install -r test\python\requirements-nightly-cpu.txt
 
     - name: Get HuggingFace Token
@@ -80,7 +80,7 @@ jobs:
     - name: Build the C# API and Run the C# Tests
       run: |
         cd test\csharp
-        dotnet test /p:Configuration=release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir"
+        dotnet test /p:Configuration=release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:cmake_build_dir\Release"
 
     - name: Verify Build Artifacts
       if: always()
@@ -93,4 +93,4 @@ jobs:
         $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
         echo "Current PATH variable is: $env:PATH" 
         .\unit_tests.exe
-      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test'
+      working-directory: '$env:GITHUB_WORKSPACE\$env:cmake_build_dir\test\Release'

--- a/cmake/presets/CMakeLinuxBuildPresets.json
+++ b/cmake/presets/CMakeLinuxBuildPresets.json
@@ -7,122 +7,98 @@
   "buildPresets": [
     {
       "name": "linux_gcc_cpu_release_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_release_asan"
     },
     {
       "name": "linux_gcc_cpu_debug_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_debug_asan"
     },
     {
       "name": "linux_gcc_cpu_relwithdebinfo_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_relwithdebinfo_asan"
     },
     {
       "name": "linux_gcc_cpu_minsizerel_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_minsizerel_asan"
     },
     {
       "name": "linux_gcc_cpu_release",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_release"
     },
     {
       "name": "linux_gcc_cpu_debug",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_debug"
     },
     {
       "name": "linux_gcc_cpu_relwithdebinfo",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_relwithdebinfo"
     },
     {
       "name": "linux_gcc_cpu_minsizerel",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_minsizerel"
     },
     {
       "name": "linux_clang_cpu_release_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_release_asan"
     },
     {
       "name": "linux_clang_cpu_debug_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_debug_asan"
     },
     {
       "name": "linux_clang_cpu_relwithdebinfo_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_relwithdebinfo_asan"
     },
     {
       "name": "linux_clang_cpu_minsizerel_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_minsizerel_asan"
     },
     {
       "name": "linux_clang_cpu_release",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_release"
     },
     {
       "name": "linux_clang_cpu_debug",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_debug"
     },
     {
       "name": "linux_clang_cpu_relwithdebinfo",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_relwithdebinfo"
     },
     {
       "name": "linux_clang_cpu_minsizerel",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_minsizerel"
     },
     {
       "name": "linux_gcc_cuda_release_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_release_asan"
     },
     {
       "name": "linux_gcc_cuda_debug_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_debug_asan"
     },
     {
       "name": "linux_gcc_cuda_relwithdebinfo_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_relwithdebinfo_asan"
     },
     {
       "name": "linux_gcc_cuda_minsizerel_asan",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_minsizerel_asan"
     },
     {
       "name": "linux_gcc_cuda_release",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_release"
     },
     {
       "name": "linux_gcc_cuda_debug",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_debug"
     },
     {
       "name": "linux_gcc_cuda_relwithdebinfo",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_relwithdebinfo"
     },
     {
       "name": "linux_gcc_cuda_minsizerel",
-      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_minsizerel"
     }
   ]

--- a/cmake/presets/CMakeLinuxBuildPresets.json
+++ b/cmake/presets/CMakeLinuxBuildPresets.json
@@ -7,98 +7,122 @@
   "buildPresets": [
     {
       "name": "linux_gcc_cpu_release_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cpu_release_asan"
     },
     {
       "name": "linux_gcc_cpu_debug_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cpu_debug_asan"
     },
     {
       "name": "linux_gcc_cpu_relwithdebinfo_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cpu_relwithdebinfo_asan"
     },
     {
       "name": "linux_gcc_cpu_minsizerel_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cpu_minsizerel_asan"
     },
     {
       "name": "linux_gcc_cpu_release",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cpu_release"
     },
     {
       "name": "linux_gcc_cpu_debug",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cpu_debug"
     },
     {
       "name": "linux_gcc_cpu_relwithdebinfo",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cpu_relwithdebinfo"
     },
     {
       "name": "linux_gcc_cpu_minsizerel",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cpu_minsizerel"
     },
     {
       "name": "linux_clang_cpu_release_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_clang_cpu_release_asan"
     },
     {
       "name": "linux_clang_cpu_debug_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_clang_cpu_debug_asan"
     },
     {
       "name": "linux_clang_cpu_relwithdebinfo_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_clang_cpu_relwithdebinfo_asan"
     },
     {
       "name": "linux_clang_cpu_minsizerel_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_clang_cpu_minsizerel_asan"
     },
     {
       "name": "linux_clang_cpu_release",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_clang_cpu_release"
     },
     {
       "name": "linux_clang_cpu_debug",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_clang_cpu_debug"
     },
     {
       "name": "linux_clang_cpu_relwithdebinfo",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_clang_cpu_relwithdebinfo"
     },
     {
       "name": "linux_clang_cpu_minsizerel",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_clang_cpu_minsizerel"
     },
     {
       "name": "linux_gcc_cuda_release_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cuda_release_asan"
     },
     {
       "name": "linux_gcc_cuda_debug_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cuda_debug_asan"
     },
     {
       "name": "linux_gcc_cuda_relwithdebinfo_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cuda_relwithdebinfo_asan"
     },
     {
       "name": "linux_gcc_cuda_minsizerel_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cuda_minsizerel_asan"
     },
     {
       "name": "linux_gcc_cuda_release",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cuda_release"
     },
     {
       "name": "linux_gcc_cuda_debug",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cuda_debug"
     },
     {
       "name": "linux_gcc_cuda_relwithdebinfo",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cuda_relwithdebinfo"
     },
     {
       "name": "linux_gcc_cuda_minsizerel",
+      "jobs": "${env.NPROC}",
       "configurePreset": "linux_gcc_cuda_minsizerel"
     }
   ]

--- a/cmake/presets/CMakeLinuxBuildPresets.json
+++ b/cmake/presets/CMakeLinuxBuildPresets.json
@@ -7,122 +7,122 @@
   "buildPresets": [
     {
       "name": "linux_gcc_cpu_release_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_release_asan"
     },
     {
       "name": "linux_gcc_cpu_debug_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_debug_asan"
     },
     {
       "name": "linux_gcc_cpu_relwithdebinfo_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_relwithdebinfo_asan"
     },
     {
       "name": "linux_gcc_cpu_minsizerel_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_minsizerel_asan"
     },
     {
       "name": "linux_gcc_cpu_release",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_release"
     },
     {
       "name": "linux_gcc_cpu_debug",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_debug"
     },
     {
       "name": "linux_gcc_cpu_relwithdebinfo",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_relwithdebinfo"
     },
     {
       "name": "linux_gcc_cpu_minsizerel",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cpu_minsizerel"
     },
     {
       "name": "linux_clang_cpu_release_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_release_asan"
     },
     {
       "name": "linux_clang_cpu_debug_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_debug_asan"
     },
     {
       "name": "linux_clang_cpu_relwithdebinfo_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_relwithdebinfo_asan"
     },
     {
       "name": "linux_clang_cpu_minsizerel_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_minsizerel_asan"
     },
     {
       "name": "linux_clang_cpu_release",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_release"
     },
     {
       "name": "linux_clang_cpu_debug",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_debug"
     },
     {
       "name": "linux_clang_cpu_relwithdebinfo",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_relwithdebinfo"
     },
     {
       "name": "linux_clang_cpu_minsizerel",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_clang_cpu_minsizerel"
     },
     {
       "name": "linux_gcc_cuda_release_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_release_asan"
     },
     {
       "name": "linux_gcc_cuda_debug_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_debug_asan"
     },
     {
       "name": "linux_gcc_cuda_relwithdebinfo_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_relwithdebinfo_asan"
     },
     {
       "name": "linux_gcc_cuda_minsizerel_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_minsizerel_asan"
     },
     {
       "name": "linux_gcc_cuda_release",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_release"
     },
     {
       "name": "linux_gcc_cuda_debug",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_debug"
     },
     {
       "name": "linux_gcc_cuda_relwithdebinfo",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_relwithdebinfo"
     },
     {
       "name": "linux_gcc_cuda_minsizerel",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{nproc}",
       "configurePreset": "linux_gcc_cuda_minsizerel"
     }
   ]

--- a/cmake/presets/CMakeWinBuildPresets.json
+++ b/cmake/presets/CMakeWinBuildPresets.json
@@ -6,92 +6,92 @@
   "buildPresets": [
     {
       "name": "windows_x64_cpu_release_asan",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cpu_release_asan"
     },
     {
       "name": "windows_x64_cpu_debug_asan",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cpu_debug_asan"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo_asan",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cpu_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cpu_minsizerel_asan",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cpu_minsizerel_asan"
     },
     {
       "name": "windows_x64_cpu_release",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cpu_release"
     },
     {
       "name": "windows_x64_cpu_debug",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cpu_debug"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cpu_relwithdebinfo"
     },
     {
       "name": "windows_x64_cpu_minsizerel",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cpu_minsizerel"
     },
     {
       "name": "windows_x64_cuda_release_asan",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cuda_release_asan"
     },
     {
       "name": "windows_x64_cuda_debug_asan",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cuda_debug_asan"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo_asan",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cuda_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cuda_minsizerel_asan",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cuda_minsizerel_asan"
     },
     {
       "name": "windows_x64_cuda_release",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cuda_release"
     },
     {
       "name": "windows_x64_cuda_debug",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cuda_debug"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cuda_relwithdebinfo"
     },
     {
       "name": "windows_x64_cuda_minsizerel",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_x64_cuda_minsizerel"
     },
     {
       "name": "windows_arm64_cpu_relwithdebinfo",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_arm64_cpu_relwithdebinfo"
     },
     {
       "name": "windows_arm64_cpu_release",
-      "jobs": "$env{NUMBER_OF_PROCESSORS}",
+      "jobs": 4,
       "configurePreset": "windows_arm64_cpu_release"
     }
   ]

--- a/cmake/presets/CMakeWinBuildPresets.json
+++ b/cmake/presets/CMakeWinBuildPresets.json
@@ -6,92 +6,74 @@
   "buildPresets": [
     {
       "name": "windows_x64_cpu_release_asan",
-      "jobs": 4,
       "configurePreset": "windows_x64_cpu_release_asan"
     },
     {
       "name": "windows_x64_cpu_debug_asan",
-      "jobs": 4,
       "configurePreset": "windows_x64_cpu_debug_asan"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo_asan",
-      "jobs": 4,
       "configurePreset": "windows_x64_cpu_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cpu_minsizerel_asan",
-      "jobs": 4,
       "configurePreset": "windows_x64_cpu_minsizerel_asan"
     },
     {
       "name": "windows_x64_cpu_release",
-      "jobs": 4,
       "configurePreset": "windows_x64_cpu_release"
     },
     {
       "name": "windows_x64_cpu_debug",
-      "jobs": 4,
       "configurePreset": "windows_x64_cpu_debug"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo",
-      "jobs": 4,
       "configurePreset": "windows_x64_cpu_relwithdebinfo"
     },
     {
       "name": "windows_x64_cpu_minsizerel",
-      "jobs": 4,
       "configurePreset": "windows_x64_cpu_minsizerel"
     },
     {
       "name": "windows_x64_cuda_release_asan",
-      "jobs": 4,
       "configurePreset": "windows_x64_cuda_release_asan"
     },
     {
       "name": "windows_x64_cuda_debug_asan",
-      "jobs": 4,
       "configurePreset": "windows_x64_cuda_debug_asan"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo_asan",
-      "jobs": 4,
       "configurePreset": "windows_x64_cuda_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cuda_minsizerel_asan",
-      "jobs": 4,
       "configurePreset": "windows_x64_cuda_minsizerel_asan"
     },
     {
       "name": "windows_x64_cuda_release",
-      "jobs": 4,
       "configurePreset": "windows_x64_cuda_release"
     },
     {
       "name": "windows_x64_cuda_debug",
-      "jobs": 4,
       "configurePreset": "windows_x64_cuda_debug"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo",
-      "jobs": 4,
       "configurePreset": "windows_x64_cuda_relwithdebinfo"
     },
     {
       "name": "windows_x64_cuda_minsizerel",
-      "jobs": 4,
       "configurePreset": "windows_x64_cuda_minsizerel"
     },
     {
       "name": "windows_arm64_cpu_relwithdebinfo",
-      "jobs": 4,
       "configurePreset": "windows_arm64_cpu_relwithdebinfo"
     },
     {
       "name": "windows_arm64_cpu_release",
-      "jobs": 4,
       "configurePreset": "windows_arm64_cpu_release"
     }
   ]

--- a/cmake/presets/CMakeWinBuildPresets.json
+++ b/cmake/presets/CMakeWinBuildPresets.json
@@ -7,7 +7,7 @@
     {
       "name": "windows_x64_cpu_release_asan",
       "jobs": "${env.NPROC}",
-      "configurePreset": "windows_x64_cpu_release_asan",
+      "configurePreset": "windows_x64_cpu_release_asan"
     },
     {
       "name": "windows_x64_cpu_debug_asan",

--- a/cmake/presets/CMakeWinBuildPresets.json
+++ b/cmake/presets/CMakeWinBuildPresets.json
@@ -6,67 +6,93 @@
   "buildPresets": [
     {
       "name": "windows_x64_cpu_release_asan",
-      "configurePreset": "windows_x64_cpu_release_asan"
+      "jobs": "${env.NPROC}",
+      "configurePreset": "windows_x64_cpu_release_asan",
     },
     {
       "name": "windows_x64_cpu_debug_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cpu_debug_asan"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cpu_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cpu_minsizerel_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cpu_minsizerel_asan"
     },
     {
       "name": "windows_x64_cpu_release",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cpu_release"
     },
     {
       "name": "windows_x64_cpu_debug",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cpu_debug"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cpu_relwithdebinfo"
     },
     {
       "name": "windows_x64_cpu_minsizerel",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cpu_minsizerel"
     },
     {
       "name": "windows_x64_cuda_release_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cuda_release_asan"
     },
     {
       "name": "windows_x64_cuda_debug_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cuda_debug_asan"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cuda_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cuda_minsizerel_asan",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cuda_minsizerel_asan"
     },
     {
       "name": "windows_x64_cuda_release",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cuda_release"
     },
     {
       "name": "windows_x64_cuda_debug",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cuda_debug"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cuda_relwithdebinfo"
     },
     {
       "name": "windows_x64_cuda_minsizerel",
+      "jobs": "${env.NPROC}",
       "configurePreset": "windows_x64_cuda_minsizerel"
+    },
+    {
+      "name": "windows_arm64_cpu_relwithdebinfo",
+      "jobs": "${env.NPROC}",
+      "configurePreset": "windows_arm64_cpu_relwithdebinfo"
+    },
+    {
+      "name": "windows_arm64_cpu_release",
+      "jobs": "${env.NPROC}",
+      "configurePreset": "windows_arm64_cpu_release"
     }
   ]
 }

--- a/cmake/presets/CMakeWinBuildPresets.json
+++ b/cmake/presets/CMakeWinBuildPresets.json
@@ -6,92 +6,92 @@
   "buildPresets": [
     {
       "name": "windows_x64_cpu_release_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cpu_release_asan"
     },
     {
       "name": "windows_x64_cpu_debug_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cpu_debug_asan"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cpu_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cpu_minsizerel_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cpu_minsizerel_asan"
     },
     {
       "name": "windows_x64_cpu_release",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cpu_release"
     },
     {
       "name": "windows_x64_cpu_debug",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cpu_debug"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cpu_relwithdebinfo"
     },
     {
       "name": "windows_x64_cpu_minsizerel",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cpu_minsizerel"
     },
     {
       "name": "windows_x64_cuda_release_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cuda_release_asan"
     },
     {
       "name": "windows_x64_cuda_debug_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cuda_debug_asan"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cuda_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cuda_minsizerel_asan",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cuda_minsizerel_asan"
     },
     {
       "name": "windows_x64_cuda_release",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cuda_release"
     },
     {
       "name": "windows_x64_cuda_debug",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cuda_debug"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cuda_relwithdebinfo"
     },
     {
       "name": "windows_x64_cuda_minsizerel",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_x64_cuda_minsizerel"
     },
     {
       "name": "windows_arm64_cpu_relwithdebinfo",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_arm64_cpu_relwithdebinfo"
     },
     {
       "name": "windows_arm64_cpu_release",
-      "jobs": "${env.NPROC}",
+      "jobs": "$env{NUMBER_OF_PROCESSORS}",
       "configurePreset": "windows_arm64_cpu_release"
     }
   ]

--- a/cmake/presets/CMakeWinBuildPresets.json
+++ b/cmake/presets/CMakeWinBuildPresets.json
@@ -6,74 +6,92 @@
   "buildPresets": [
     {
       "name": "windows_x64_cpu_release_asan",
+      "configuration": "Release",
       "configurePreset": "windows_x64_cpu_release_asan"
     },
     {
       "name": "windows_x64_cpu_debug_asan",
+      "configuration": "Debug",
       "configurePreset": "windows_x64_cpu_debug_asan"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo_asan",
+      "configuration": "Relwithdebinfo",
       "configurePreset": "windows_x64_cpu_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cpu_minsizerel_asan",
+      "configuration": "Minsizerel",
       "configurePreset": "windows_x64_cpu_minsizerel_asan"
     },
     {
       "name": "windows_x64_cpu_release",
+      "configuration": "Release",
       "configurePreset": "windows_x64_cpu_release"
     },
     {
       "name": "windows_x64_cpu_debug",
+      "configuration": "Debug",
       "configurePreset": "windows_x64_cpu_debug"
     },
     {
       "name": "windows_x64_cpu_relwithdebinfo",
+      "configuration": "Relwithdebinfo",
       "configurePreset": "windows_x64_cpu_relwithdebinfo"
     },
     {
       "name": "windows_x64_cpu_minsizerel",
+      "configuration": "Minsizerel",
       "configurePreset": "windows_x64_cpu_minsizerel"
     },
     {
       "name": "windows_x64_cuda_release_asan",
+      "configuration": "Release",
       "configurePreset": "windows_x64_cuda_release_asan"
     },
     {
       "name": "windows_x64_cuda_debug_asan",
+      "configuration": "Debug",
       "configurePreset": "windows_x64_cuda_debug_asan"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo_asan",
+      "configuration": "Relwithdebinfo",
       "configurePreset": "windows_x64_cuda_relwithdebinfo_asan"
     },
     {
       "name": "windows_x64_cuda_minsizerel_asan",
+      "configuration": "Minsizerel",
       "configurePreset": "windows_x64_cuda_minsizerel_asan"
     },
     {
       "name": "windows_x64_cuda_release",
+      "configuration": "Release",
       "configurePreset": "windows_x64_cuda_release"
     },
     {
       "name": "windows_x64_cuda_debug",
+      "configuration": "Debug",
       "configurePreset": "windows_x64_cuda_debug"
     },
     {
       "name": "windows_x64_cuda_relwithdebinfo",
+      "configuration": "Relwithdebinfo",
       "configurePreset": "windows_x64_cuda_relwithdebinfo"
     },
     {
       "name": "windows_x64_cuda_minsizerel",
+      "configuration": "Minsizerel",
       "configurePreset": "windows_x64_cuda_minsizerel"
     },
     {
       "name": "windows_arm64_cpu_relwithdebinfo",
+      "configuration": "Relwithdebinfo",
       "configurePreset": "windows_arm64_cpu_relwithdebinfo"
     },
     {
       "name": "windows_arm64_cpu_release",
+      "configuration": "Release",
       "configurePreset": "windows_arm64_cpu_release"
     }
   ]

--- a/cmake/presets/CMakeWinConfigPresets.json
+++ b/cmake/presets/CMakeWinConfigPresets.json
@@ -200,6 +200,18 @@
       "cacheVariables": {
         "USE_CUDA": "ON"
       }
+    },
+    {
+      "name": "windows_arm64_cpu_relwithdebinfo",
+      "inherits": "windows_x64_cpu_relwithdebinfo",
+      "displayName": "windows arm64 cpu relwithdebinfo",
+      "architecture": "arm64"
+    },
+    {
+      "name": "windows_arm64_cpu_release",
+      "inherits": "windows_x64_cpu_release",
+      "displayName": "windows arm64 cpu release",
+      "architecture": "arm64"
     }
   ]
 }

--- a/cmake/presets/CMakeWinConfigPresets.json
+++ b/cmake/presets/CMakeWinConfigPresets.json
@@ -21,7 +21,6 @@
       "name": "windows_release_default",
       "inherits": "windows_cpu_default",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG",
         "CMAKE_CXX_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG"
       }
@@ -30,7 +29,6 @@
       "name": "windows_debug_default",
       "inherits": "windows_cpu_default",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_C_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /Ob0 /Od /RTC1",
         "CMAKE_CXX_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /Ob0 /Od /RTC1"
       }
@@ -39,7 +37,6 @@
       "name": "windows_relwithdebinfo_default",
       "inherits": "windows_cpu_default",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_C_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob1 /DNDEBUG",
         "CMAKE_CXX_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob1 /DNDEBUG"
       }
@@ -48,7 +45,6 @@
       "name": "windows_minsizerel_default",
       "inherits": "windows_cpu_default",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "MinSizeRel",
         "CMAKE_C_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O1 /Ob1 /DNDEBUG",
         "CMAKE_CXX_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O1 /Ob1 /DNDEBUG"
       }

--- a/cmake/presets/CMakeWinConfigPresets.json
+++ b/cmake/presets/CMakeWinConfigPresets.json
@@ -21,6 +21,7 @@
       "name": "windows_release_default",
       "inherits": "windows_cpu_default",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG",
         "CMAKE_CXX_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG"
       }
@@ -29,6 +30,7 @@
       "name": "windows_debug_default",
       "inherits": "windows_cpu_default",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_C_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /Ob0 /Od /RTC1",
         "CMAKE_CXX_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /Ob0 /Od /RTC1"
       }
@@ -37,6 +39,7 @@
       "name": "windows_relwithdebinfo_default",
       "inherits": "windows_cpu_default",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_C_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob1 /DNDEBUG",
         "CMAKE_CXX_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob1 /DNDEBUG"
       }
@@ -45,6 +48,7 @@
       "name": "windows_minsizerel_default",
       "inherits": "windows_cpu_default",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel",
         "CMAKE_C_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O1 /Ob1 /DNDEBUG",
         "CMAKE_CXX_FLAGS": "/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O1 /Ob1 /DNDEBUG"
       }


### PR DESCRIPTION
This pull request primarily focuses on refactoring the build process in the GitHub Actions workflows for Windows CPU and GPU builds. The changes streamline the build process by utilizing CMake presets and modifying the build directory structure. The changes also add support for ARM64 architecture in the CMake presets. 

Here are the most important changes:

Changes to GitHub Actions workflows:

* `.github/workflows/win-cpu-arm64-build.yml`, `.github/workflows/win-cpu-x64-build.yml`, `.github/workflows/win-gpu-x64-build.yml`: Changed the `cmake_build_dir` environment variable to point to a new directory structure (`'build/release/cpu_default'` and `'build/release/cuda_default'`). The build commands were updated to use CMake presets instead of manual CMake configuration and build commands. The commands to list build artifacts and run unit tests were updated to match the new directory structure. The step to upload build artifacts was removed. [[1]](diffhunk://#diff-df45fc531e16b591e484e29a3a4c836e876f3c8136137ffa39bb6979af6b1c79L17-R17) [[2]](diffhunk://#diff-df45fc531e16b591e484e29a3a4c836e876f3c8136137ffa39bb6979af6b1c79L50-R51) [[3]](diffhunk://#diff-df45fc531e16b591e484e29a3a4c836e876f3c8136137ffa39bb6979af6b1c79L71-R77) [[4]](diffhunk://#diff-14c154d7bf4d7c90f647475b0340d0840319223d91faa598c4756739555bd863L17-R17) [[5]](diffhunk://#diff-14c154d7bf4d7c90f647475b0340d0840319223d91faa598c4756739555bd863L57-R58) [[6]](diffhunk://#diff-14c154d7bf4d7c90f647475b0340d0840319223d91faa598c4756739555bd863L85-L99) [[7]](diffhunk://#diff-0989dea22643962b5f5d6f36719798b1975f96bf0537ff0053c57c5e9a774e95L14-R17) [[8]](diffhunk://#diff-0989dea22643962b5f5d6f36719798b1975f96bf0537ff0053c57c5e9a774e95L57-R57) [[9]](diffhunk://#diff-0989dea22643962b5f5d6f36719798b1975f96bf0537ff0053c57c5e9a774e95L83-R91)

Changes to CMake presets:

* [`cmake/presets/CMakeWinBuildPresets.json`](diffhunk://#diff-e6809155b4fb7e3187cc69020a0b550bb34b790b8b31b2a6b7194ec406857ba4R9-R95): Added the `configuration` property to all existing build presets. Also, new build presets were added for ARM64 architecture.
* [`cmake/presets/CMakeWinConfigPresets.json`](diffhunk://#diff-c17ad8704155d1da02335c7a9e25a28457e424be60873cbf24f171f744d76c82R203-R214): New configuration presets were added for ARM64 architecture.