### PR TITLE
Change bash to powershell

### DIFF
--- a/.pipelines/stages/jobs/nuget-win-packaging-job.yml
+++ b/.pipelines/stages/jobs/nuget-win-packaging-job.yml
@@ -36,7 +36,7 @@ jobs:
       ep: ${{ parameters.ep }}
       cuda_version: ${{ parameters.cuda_version }}
 
-  - bash:
+  - powershell: |
       dotnet build Microsoft.ML.OnnxRuntimeGenAI.csproj -p:Configuration="$(build_config)" -p:NativeBuildOutputDir="$(build_dir)\$(build_config)"
     displayName: 'Build CSharp'
     workingDirectory: '$(Build.SourcesDirectory)\src\csharp'

--- a/.pipelines/stages/jobs/py-win-cpu-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-win-cpu-packaging-job.yml
@@ -78,7 +78,7 @@ jobs:
     displayName: Rename Onnxruntime to ort
     workingDirectory: '$(Build.SourcesDirectory)'
 
-  - bash: |
+  - powershell: |
       cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=$(BuildConfig) -DUSE_CUDA=OFF -DENABLE_TESTS=OFF -S . -B build
       cmake --build build --config $(BuildConfig)  --parallel --target python
     displayName: 'Build pybind with CMake'
@@ -95,7 +95,7 @@ jobs:
       DoEsrp: true
       Pattern: '*.pyd,*.dll'
   #
-  - bash: |
+  - powershell: |
       cmake --build build --config $(BuildConfig) --parallel --target PyPackageBuild
     displayName: 'Build Python Wheel'
 

--- a/.pipelines/stages/jobs/py-win-gpu-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-win-gpu-packaging-job.yml
@@ -104,7 +104,7 @@ jobs:
       DoEsrp: true
       Pattern: '*.pyd,*.dll'
 
-  - bash: |
+  - powershell: |
       cmake --build build --config $(BuildConfig) --parallel --target PyPackageBuild
     displayName: 'Build Python Wheel'
 

--- a/.pipelines/stages/jobs/steps/capi-win-build-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-build-step.yml
@@ -58,22 +58,21 @@ steps:
   condition: and(eq('${{ parameters.ep }}', 'gpu'), eq('${{ parameters.cuda_version }}', '12.2'))
   workingDirectory: '$(Build.SourcesDirectory)'
 
-- bash: |
+- powershell: |
     set -e -x
     azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.cuda_version }}" '$(Build.SourcesDirectory)\cuda_sdk'
   displayName: 'Download CUDA'
   condition: eq('${{ parameters.ep }}', 'gpu')
   workingDirectory: '$(Build.SourcesDirectory)'
-- bash: |
-    set -e -x
+
+- powershell: |
     cmake --preset windows_x64_cuda_release -T cuda='$(Build.SourcesDirectory)\cuda_sdk\v${{ parameters.cuda_version }}'
     cmake --build --preset windows_x64_cuda_release --parallel
   displayName: 'Configure CMake C API with CUDA'
   condition: eq('${{ parameters.ep }}', 'gpu')
   workingDirectory: '$(Build.SourcesDirectory)'
 
-- bash: |
-    set -e -x
+- powershell: |
     cmake --preset windows_x64_cpu_release
     cmake --build --preset windows_x64_cpu_release --parallel
   displayName: 'Configure CMake C API without CUDA'

--- a/.pipelines/stages/jobs/steps/capi-win-build-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-build-step.yml
@@ -59,7 +59,6 @@ steps:
   workingDirectory: '$(Build.SourcesDirectory)'
 
 - powershell: |
-    set -e -x
     azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.cuda_version }}" '$(Build.SourcesDirectory)\cuda_sdk'
   displayName: 'Download CUDA'
   condition: eq('${{ parameters.ep }}', 'gpu')


### PR DESCRIPTION
This pull request includes changes primarily aimed at switching the scripting language in various build and packaging jobs from `bash` to `Powershell`. These changes affect several `.yml` files in the `.pipelines/stages/jobs` directory and are expected to improve the compatibility and efficiency of the build process on Windows platforms.

Changes to build and packaging jobs:

* [`.pipelines/stages/jobs/nuget-win-packaging-job.yml`](diffhunk://#diff-97390677658d875cbd41773aa78037661f27d91cd3d878db42a9073d3764db51L39-R39): Switched from `bash` to `Powershell` for the 'Build CSharp' job.
* [`.pipelines/stages/jobs/py-win-cpu-packaging-job.yml`](diffhunk://#diff-d83fb863912a20250c78a0ba8d76f9fd49914a23b11faa9aa7654a92921dacebL81-R81): Replaced `bash` with `Powershell` for the 'Build pybind with CMake' and 'Build Python Wheel' jobs. [[1]](diffhunk://#diff-d83fb863912a20250c78a0ba8d76f9fd49914a23b11faa9aa7654a92921dacebL81-R81) [[2]](diffhunk://#diff-d83fb863912a20250c78a0ba8d76f9fd49914a23b11faa9aa7654a92921dacebL98-R98)
* [`.pipelines/stages/jobs/py-win-gpu-packaging-job.yml`](diffhunk://#diff-db7ba42cb4be9cdc07b17473c451fad2b6d98dcf672f2f78599544099a711473L107-R107): Changed the scripting language from `bash` to `Powershell` in the 'Build Python Wheel' job.
* [`.pipelines/stages/jobs/steps/capi-win-build-step.yml`](diffhunk://#diff-65ac9358424b4d21e9538ad015df2e3e167077222dba7ea6944d75cc0252dcf3L61-R75): Replaced `bash` with `Powershell` in several steps including 'Download CUDA', 'Configure CMake C API with CUDA', and 'Configure CMake C API without CUDA'.