### PR TITLE
Remove clang from CI pipeline.

### DIFF
--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -10,9 +10,6 @@ env:
 
 jobs:
   linux_cpu_x64:
-    strategy:
-      matrix:
-        compiler: [ gcc, clang ]
     runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-AMD-CPU" ]
     steps:
       - name: Checkout OnnxRuntime GenAI repo
@@ -37,12 +34,12 @@ jobs:
         run: |
           set -e -x
           rm -rf build
-          cmake --preset linux_${{ matrix.compiler }}_cpu_release
-          cmake --build --preset linux_${{ matrix.compiler }}_cpu_release
+          cmake --preset linux_gcc_cpu_release
+          cmake --build --preset linux_gcc_cpu_release
 
       - name: Install the python wheel and test dependencies
         run: |
-          python3 -m pip install build/${{ matrix.compiler }}_cpu/release/wheel/onnxruntime_genai*.whl
+          python3 -m pip install build/gcc_cpu/release/wheel/onnxruntime_genai*.whl
           python3 -m pip install -r test/python/requirements-nightly-cpu.txt --user
 
       - name: Get HuggingFace Token
@@ -60,16 +57,9 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          ls -l ${{ github.workspace }}/build/${{ matrix.compiler }}_cpu/release
+          ls -l ${{ github.workspace }}/build/gcc_cpu/release
 
       - name: Run tests
         run: |
           set -e -x
-          ./build/${{ matrix.compiler }}_cpu/release/test/unit_tests
-
-      - name: Upload Build Artifacts
-        if: ${{ matrix.compiler == 'gcc'}}
-        uses: actions/upload-artifact@v3
-        with:
-          name: onnxruntime-genai-linux-cpu-x64
-          path: ${{ github.workspace }}/build/**/*.a
+          ./build/gcc_cpu/release/test/unit_tests


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/linux-cpu-x64-build.yml` file. The changes simplify the build process by removing the matrix strategy for different compilers and standardizing on the gcc compiler. This has resulted in changes to the build and test commands, and the removal of an artifact upload step that was specific to the gcc build.

Changes to build process:

* Removed the matrix strategy for different compilers, standardizing on the gcc compiler. This change affects the `env:` section of the `jobs:` block.
* Updated the build and test commands to remove references to the matrix strategy and use the gcc compiler directly. This change is reflected in several places in the `jobs:` block. [[1]](diffhunk://#diff-e758ed36b14737d7c89353329cb735a6d081f5fa288b809d49e47bfc0ade96c3L40-R42) [[2]](diffhunk://#diff-e758ed36b14737d7c89353329cb735a6d081f5fa288b809d49e47bfc0ade96c3L63-R65)
* Removed the artifact upload step that was specific to the gcc build. This change is also in the `jobs:` block.
* Clang will be used for nightly build