### PR TITLE
Add enable_profiling to session_options

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -58,9 +58,11 @@ struct SessionOptions_Element : JSON::Element {
   explicit SessionOptions_Element(Config::SessionOptions& v) : v_{v} {}
 
   void OnString(std::string_view name, std::string_view value) override {
-    if (name == "log_id") {
+    if (name == "log_id")
       v_.log_id = value;
-    } else
+    else if (name == "enable_profiling")
+      v_.enable_profiling = value;
+    else
       throw JSON::unknown_value_error{};
   }
 

--- a/src/config.h
+++ b/src/config.h
@@ -21,6 +21,7 @@ struct Config {
     std::optional<bool> enable_mem_pattern;
     std::optional<std::string> log_id;
     std::optional<int> log_severity_level;
+    std::optional<std::string> enable_profiling;
 
     std::vector<ProviderOptions> provider_options;
   };

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -259,6 +259,11 @@ void Model::CreateSessionOptions() {
     ort_options.SetLogSeverityLevel(options.log_severity_level.value());
   }
 
+  if (options.enable_profiling.has_value()) {
+    std::filesystem::path profile_file_prefix{options.enable_profiling.value()};
+    ort_options.EnableProfiling(profile_file_prefix.c_str());
+  }
+
   for (auto& provider_options : options.provider_options) {
     if (provider_options.name == "cuda") {
       auto ort_provider_options = OrtCUDAProviderOptionsV2::Create();


### PR DESCRIPTION
Example usage in genai_config.json:

```
{
    "model": {
        "bos_token_id": 50256,
        "context_length": 2048,
        "decoder": {
            "session_options": {
                "enable_profiling": "Test prefix",
                "provider_options": [
                    {
                        "cuda": {}
                    }
                ]
            },
...
```