### PR TITLE
Add support for generating ONNX Runtime GenAI files only in model builder

### DIFF
--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -11,6 +11,7 @@ This folder contains the model builder tool, which greatly accelerates creating 
    - [Customized or Finetuned PyTorch Model](#customized-or-finetuned-pytorch-model)
    - [GGUF Model](#gguf-model)
    - [Extra Options](#extra-options)
+   - [Config Only](#config-only)
    - [Unit Testing Models](#unit-testing-models)
      - [Option 1: Use the model builder tool directly](#option-1-use-the-model-builder-tool-directly)
      - [Option 2: Edit the config.json file](#option-2-edit-the-configjson-file-on-disk-and-then-run-the-model-builder-tool)
@@ -85,6 +86,18 @@ python3 -m onnxruntime_genai.models.builder -m model_name -o path_to_output_fold
 python3 builder.py -m model_name -o path_to_output_folder -p precision -e execution_provider -c cache_dir_for_hf_files --extra_options filename=decoder.onnx
 ```
 To see all available options through `--extra_options`, please use the `help` commands in the `Full Usage` section above.
+
+### Config Only
+This scenario is for when you already have your optimized and/or quantized ONNX model and you need to create the config files to run with ONNX Runtime GenAI.
+```
+# From wheel:
+python3 -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p precision -e execution_provider -c cache_dir_for_hf_files --extra_options config_only=true
+
+# From source:
+python3 builder.py -m model_name -o path_to_output_folder -p precision -e execution_provider -c cache_dir_for_hf_files --extra_options config_only=true
+```
+
+Afterwards, please open the `genai_config.json` file in the output folder and modify the fields as needed for your model. You should store your ONNX model in the output folder as well.
 
 ### Unit Testing Models
 This scenario is where your PyTorch model is already downloaded locally (either in the default Hugging Face cache directory or in a local folder on disk). If it is not already downloaded locally, here is an example of how you can download it.


### PR DESCRIPTION
### Description

This PR adds support for generating the config and tokenizer files that are needed for ONNX Runtime GenAI.

### Motivation and Context

This is for when users already have their optimized and/or quantized ONNX models. By generating the config and tokenizer files only, users can run their own models with ONNX Runtime GenAI.