### PR TITLE
64-bit position IDs were being initialized incorrectly

### DIFF
--- a/src/models/position_ids.h
+++ b/src/models/position_ids.h
@@ -27,7 +27,7 @@ struct PositionIDs {
   std::array<int64_t, 2> attention_mask_shape_{};  // {params.batch_size*params.beam_size, params.sequence_length}
   std::unique_ptr<OrtValue> attention_mask_;
 
-  std::vector<int32_t> initial_sequence_lengths_;
+  std::unique_ptr<OrtValue> position_ids_next_;  // Replaces position_ids_ after the first Run() call
 };
 
 }  // namespace Generators


### PR DESCRIPTION
64-bit position IDs were being initialized with 32-bit data, which led to garbage values in memory, plus accessing CPU memory off the end of the array.