### PR TITLE
Change Nuget extension from gpu to cuda

### DIFF
--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -12,12 +12,12 @@ parameters:
 - name: enable_linux_cpu
   displayName: 'Whether Linux CPU package is built.'
   type: boolean
-  default: false
+  default: true
 
 - name: enable_linux_cuda
   displayName: 'Whether Linux CUDA package is built.'
   type: boolean
-  default: false
+  default: true
 
 
 - name: ort_version

--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -4,8 +4,8 @@ parameters:
   type: boolean
   default: true
 
-- name: enable_win_gpu
-  displayName: 'Whether Windows GPU package is built.'
+- name: enable_win_cuda
+  displayName: 'Whether Windows CUDA package is built.'
   type: boolean
   default: true
 
@@ -14,8 +14,8 @@ parameters:
   type: boolean
   default: false
 
-- name: enable_linux_gpu
-  displayName: 'Whether Linux GPU package is built.'
+- name: enable_linux_cuda
+  displayName: 'Whether Linux CUDA package is built.'
   type: boolean
   default: false
 
@@ -46,9 +46,9 @@ stages:
 - template: stages/nuget-packaging-stage.yml
   parameters:
     enable_win_cpu: ${{ parameters.enable_win_cpu }}
-    enable_win_gpu: ${{ parameters.enable_win_gpu }}
+    enable_win_cuda: ${{ parameters.enable_win_cuda }}
     enable_linux_cpu: ${{ parameters.enable_linux_cpu }}
-    enable_linux_gpu: ${{ parameters.enable_linux_gpu }}
+    enable_linux_cuda: ${{ parameters.enable_linux_cuda }}
     ort_version: ${{ parameters.ort_version }}
     cuda_version: ${{ parameters.cuda_version }}
 

--- a/.pipelines/pypl-publishing.yml
+++ b/.pipelines/pypl-publishing.yml
@@ -4,8 +4,8 @@ parameters:
   type: boolean
   default: true
 
-- name: enable_win_gpu
-  displayName: 'Whether Windows GPU package is built.'
+- name: enable_win_cuda
+  displayName: 'Whether Windows CUDA package is built.'
   type: boolean
   default: true
 
@@ -14,8 +14,8 @@ parameters:
   type: boolean
   default: true
 
-- name: enable_linux_gpu
-  displayName: 'Whether Linux GPU package is built.'
+- name: enable_linux_cuda
+  displayName: 'Whether Linux CUDA package is built.'
   type: boolean
   default: true
 
@@ -45,8 +45,8 @@ stages:
 - template: stages/py-packaging-stage.yml
   parameters:
     enable_linux_cpu: ${{ parameters.enable_linux_cpu }}
-    enable_linux_gpu: ${{ parameters.enable_linux_gpu }}
+    enable_linux_cuda: ${{ parameters.enable_linux_cuda }}
     enable_win_cpu: ${{ parameters.enable_win_cpu }}
-    enable_win_gpu: ${{ parameters.enable_win_gpu }}
+    enable_win_cuda: ${{ parameters.enable_win_cuda }}
     ort_version: ${{ parameters.ort_version }}
     cuda_version: ${{ parameters.cuda_version }}

--- a/.pipelines/stages/jobs/nuget-win-packaging-job.yml
+++ b/.pipelines/stages/jobs/nuget-win-packaging-job.yml
@@ -45,7 +45,7 @@ jobs:
     ${{ if eq(parameters.ep, 'cpu') }}:
       value: ''
     ${{ if eq(parameters.ep, 'cuda') }}:
-      value: 'Gpu'
+      value: 'Cuda'
   workspace:
     clean: all
   steps:

--- a/.pipelines/stages/jobs/nuget-win-packaging-job.yml
+++ b/.pipelines/stages/jobs/nuget-win-packaging-job.yml
@@ -41,11 +41,16 @@ jobs:
         value: 'onnxruntime-win-${{ parameters.arch }}-gpu-${{ parameters.ort_version }}'
       ${{ else }}:
         value: 'onnxruntime-win-${{ parameters.arch }}-cuda12-${{ parameters.ort_version }}'
-  - name: ext
+  - name: genai_nuget_ext
     ${{ if eq(parameters.ep, 'cpu') }}:
       value: ''
     ${{ if eq(parameters.ep, 'cuda') }}:
       value: '.Cuda'
+  - name: ort_nuget_ext
+    ${{ if eq(parameters.ep, 'cpu') }}:
+      value: ''
+    ${{ if eq(parameters.ep, 'cuda') }}:
+      value: '.Gpu'
   workspace:
     clean: all
   steps:

--- a/.pipelines/stages/jobs/nuget-win-packaging-job.yml
+++ b/.pipelines/stages/jobs/nuget-win-packaging-job.yml
@@ -45,7 +45,7 @@ jobs:
     ${{ if eq(parameters.ep, 'cpu') }}:
       value: ''
     ${{ if eq(parameters.ep, 'cuda') }}:
-      value: 'Cuda'
+      value: '.Cuda'
   workspace:
     clean: all
   steps:

--- a/.pipelines/stages/jobs/py-linux-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-linux-packaging-job.yml
@@ -35,6 +35,8 @@ jobs:
   # The build machine pool doesn't have dotnet, so it can't run CG.
   - name: skipComponentGovernanceDetection
     value: true
+  - name: arch
+    value: ${{ parameters.arch }}
   - name: ep
     value: ${{ parameters.ep }}
   - name: cuda_version

--- a/.pipelines/stages/jobs/py-win-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-win-packaging-job.yml
@@ -38,7 +38,7 @@ jobs:
       value: 'onnxruntime-win-${{ parameters.arch }}-${{ parameters.ort_version }}'
     ${{ else}}:
       ${{if eq(parameters.cuda_version, '11.8') }}:
-        value: 'onnxruntime-win-${{ parameters.arch }}-gpu-${{ parameters.ort_version }}'
+        value: 'onnxruntime-win-${{ parameters.arch }}-vriables['ep']-${{ parameters.ort_version }}'
       ${{ else }}:
         value: 'onnxruntime-win-${{ parameters.arch }}-cuda12-${{ parameters.ort_version }}'
   workspace:

--- a/.pipelines/stages/jobs/py-win-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-win-packaging-job.yml
@@ -38,7 +38,7 @@ jobs:
       value: 'onnxruntime-win-${{ parameters.arch }}-${{ parameters.ort_version }}'
     ${{ else}}:
       ${{if eq(parameters.cuda_version, '11.8') }}:
-        value: 'onnxruntime-win-${{ parameters.arch }}-vriables['ep']-${{ parameters.ort_version }}'
+        value: 'onnxruntime-win-${{ parameters.arch }}-gpu-${{ parameters.ort_version }}'
       ${{ else }}:
         value: 'onnxruntime-win-${{ parameters.arch }}-cuda12-${{ parameters.ort_version }}'
   workspace:

--- a/.pipelines/stages/jobs/steps/nuget-win-step.yml
+++ b/.pipelines/stages/jobs/steps/nuget-win-step.yml
@@ -19,7 +19,9 @@ steps:
     $VERSION = '0.1.0-rc1'
     nuget.exe pack Microsoft.ML.OnnxRuntimeGenAI.nuspec `
       -Prop version=$VERSION `
-      -Prop ext=$(ext) `
+      -Prop genai_nuget_ext=$(genai_nuget_ext) `
+      -Prop ort_nuget_ext=$(ort_nuget_ext) `
+      -Prop ort_version=$(ort_version) `
       -Prop configuration=$(buildConfig) `
       -Prop buildPath=$(buildDir)
     nuget.exe pack Microsoft.ML.OnnxRuntimeGenAI.Managed.nuspec `

--- a/.pipelines/stages/nuget-packaging-stage.yml
+++ b/.pipelines/stages/nuget-packaging-stage.yml
@@ -1,11 +1,11 @@
 parameters:
 - name: enable_win_cpu
   type: boolean
-- name: enable_win_gpu
+- name: enable_win_cuda
   type: boolean
 - name: enable_linux_cpu
   type: boolean
-- name: enable_linux_gpu
+- name: enable_linux_cuda
   type: boolean
 - name: ort_version
   type: string
@@ -23,7 +23,7 @@ stages:
         arch: 'x64'
         ep: 'cpu'
         ort_version: ${{ parameters.ort_version }}
-  - ${{ if eq(parameters.enable_win_gpu, true) }}:
+  - ${{ if eq(parameters.enable_win_cuda, true) }}:
     - template: jobs/nuget-win-packaging-job.yml
       parameters:
         arch: 'x64'
@@ -37,7 +37,7 @@ stages:
         arch: 'x64'
         ep: 'cpu'
         ort_version: ${{ parameters.ort_version }}
-  - ${{ if eq(parameters.enable_linux_gpu, true) }}:
+  - ${{ if eq(parameters.enable_linux_cuda, true) }}:
     - template: jobs/nuget-linux-packaging-job.yml
       parameters:
         arch: 'x64'

--- a/.pipelines/stages/py-packaging-stage.yml
+++ b/.pipelines/stages/py-packaging-stage.yml
@@ -1,11 +1,11 @@
 parameters:
 - name: enable_win_cpu
   type: boolean
-- name: enable_win_gpu
+- name: enable_win_cuda
   type: boolean
 - name: enable_linux_cpu
   type: boolean
-- name: enable_linux_gpu
+- name: enable_linux_cuda
   type: boolean
 - name: ort_version
   type: string
@@ -21,7 +21,7 @@ stages:
         arch: 'x64'
         ep: 'cpu'
         ort_version: ${{ parameters.ort_version }}
-  - ${{ if eq(parameters.enable_win_gpu, true) }}:
+  - ${{ if eq(parameters.enable_win_cuda, true) }}:
     - template: jobs/py-win-packaging-job.yml
       parameters:
         arch: 'x64'
@@ -36,7 +36,7 @@ stages:
         arch: 'x64'
         ep: 'cpu'
         ort_version: ${{ parameters.ort_version }}
-  - ${{ if eq(parameters.enable_linux_gpu, true) }}:
+  - ${{ if eq(parameters.enable_linux_cuda, true) }}:
     - template: jobs/py-linux-packaging-job.yml
       parameters:
         arch: 'x64'

--- a/nuget/Microsoft.ML.OnnxRuntimeGenAI.nuspec
+++ b/nuget/Microsoft.ML.OnnxRuntimeGenAI.nuspec
@@ -17,15 +17,15 @@
     <dependencies>
       <group targetFramework="NETSTANDARD" >
         <dependency id="Microsoft.ML.OnnxRuntimeGenAI.Managed" version="$version$" />
-        <dependency id="Microsoft.ML.OnnxRuntime$ext$" version="1.17.1" />
+        <dependency id="Microsoft.ML.OnnxRuntime$ort_nuget_ext$" version="$ort_version$" />
       </group>
       <group targetFramework="NETCOREAPP" >
         <dependency id="Microsoft.ML.OnnxRuntimeGenAI.Managed" version="$version$" />
-        <dependency id="Microsoft.ML.OnnxRuntime$ext$" version="1.17.1" />
+        <dependency id="Microsoft.ML.OnnxRuntime$ort_nuget_ext$" version="$ort_version$" />
       </group>
       <group targetFramework="NETFRAMEWORK" >
         <dependency id="Microsoft.ML.OnnxRuntimeGenAI.Managed" version="$version$" />
-        <dependency id="Microsoft.ML.OnnxRuntime$ext$" version="1.17.1" />
+        <dependency id="Microsoft.ML.OnnxRuntime$ort_nuget_ext$" version="$ort_version$" />
       </group>
     </dependencies>
   </metadata>
@@ -43,12 +43,12 @@
 <!--     <file src="..\$buildPath$\$configuration$\onnxruntime-genai.dll" target="runtimes\win-arm64\native" /> -->
 
     <!-- Targets -->
-    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.targets" target="build\netstandard2.1\Microsoft.ML.OnnxRuntimeGenAI$ext$.targets" />
-    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.props" target="build\netstandard2.1\Microsoft.ML.OnnxRuntimeGenAI$ext$.props" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.targets" target="build\netstandard2.1\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.targets" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.props" target="build\netstandard2.1\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.props" />
 
     <!-- Includes -->
     <file src="..\src\ort_genai_c.h" target="build\native\include" />
-    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.targets" target="build\native\Microsoft.ML.OnnxRuntimeGenAI$ext$.targets" />
-    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.props" target="build\native\Microsoft.ML.OnnxRuntimeGenAI$ext$.props" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.targets" target="build\native\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.targets" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.props" target="build\native\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.props" />
   </files>
 </package>

--- a/nuget/Microsoft.ML.OnnxRuntimeGenAI.nuspec
+++ b/nuget/Microsoft.ML.OnnxRuntimeGenAI.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <!-- id can be either Microsoft.ML.OnnxRuntimeGenAI or Microsoft.ML.OnnxRuntimeGenAI.Gpu -->
     <!-- depending on the type of build -->
-    <id>Microsoft.ML.OnnxRuntimeGenAI$ext$</id>
+    <id>Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$</id>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
This pull request includes a series of changes aimed at renaming and redefining the GPU parameter as CUDA in various pipeline configuration files. The changes are primarily focused on the parameter names and display names in the `.pipelines/nuget-publishing.yml`, `.pipelines/pypl-publishing.yml`, `.pipelines/stages/nuget-packaging-stage.yml`, and `.pipelines/stages/py-packaging-stage.yml` files. Additionally, the parameter name changes are reflected in the `stages:` and `jobs:` sections of these files. 

Parameter renaming:

* [`.pipelines/nuget-publishing.yml`](diffhunk://#diff-e6ec5ea53c5d408941757974cb3e698481ef8f5bf36870475df104ef6e7b3277L7-R8): Renamed the `enable_win_gpu` and `enable_linux_gpu` parameters to `enable_win_cuda` and `enable_linux_cuda`, respectively. [[1]](diffhunk://#diff-e6ec5ea53c5d408941757974cb3e698481ef8f5bf36870475df104ef6e7b3277L7-R8) [[2]](diffhunk://#diff-e6ec5ea53c5d408941757974cb3e698481ef8f5bf36870475df104ef6e7b3277L17-R18)
* [`.pipelines/pypl-publishing.yml`](diffhunk://#diff-e7c846e17ab5319529d839ddce86308159f05bc27ed172b501c1b996d00d838cL7-R8): Renamed the `enable_win_gpu` and `enable_linux_gpu` parameters to `enable_win_cuda` and `enable_linux_cuda`, respectively. [[1]](diffhunk://#diff-e7c846e17ab5319529d839ddce86308159f05bc27ed172b501c1b996d00d838cL7-R8) [[2]](diffhunk://#diff-e7c846e17ab5319529d839ddce86308159f05bc27ed172b501c1b996d00d838cL17-R18)
* [`.pipelines/stages/nuget-packaging-stage.yml`](diffhunk://#diff-1e491a28b1b87f333551d4804a6ab37ab1edcfdee6968e4b7d92f60f4f285e14L4-R8): Renamed the `enable_win_gpu` and `enable_linux_gpu` parameters to `enable_win_cuda` and `enable_linux_cuda`, respectively.
* [`.pipelines/stages/py-packaging-stage.yml`](diffhunk://#diff-be3b72816cbfd6e63a01189e9f58179f5ec77bd5c916a2541a03e102a9d83e5aL4-R8): Renamed the `enable_win_gpu` and `enable_linux_gpu` parameters to `enable_win_cuda` and `enable_linux_cuda`, respectively.

Reflecting changes in `stages:` and `jobs:`:

* [`.pipelines/nuget-publishing.yml`](diffhunk://#diff-e6ec5ea53c5d408941757974cb3e698481ef8f5bf36870475df104ef6e7b3277L49-R51): Updated the `stages:` section to use the new `enable_win_cuda` and `enable_linux_cuda` parameters.
* [`.pipelines/pypl-publishing.yml`](diffhunk://#diff-e7c846e17ab5319529d839ddce86308159f05bc27ed172b501c1b996d00d838cL48-R50): Updated the `stages:` section to use the new `enable_win_cuda` and `enable_linux_cuda` parameters.
* [`.pipelines/stages/jobs/nuget-win-packaging-job.yml`](diffhunk://#diff-97390677658d875cbd41773aa78037661f27d91cd3d878db42a9073d3764db51L48-R48): Updated the `jobs:` section to use the new `enable_win_cuda` parameter.
* [`.pipelines/stages/nuget-packaging-stage.yml`](diffhunk://#diff-1e491a28b1b87f333551d4804a6ab37ab1edcfdee6968e4b7d92f60f4f285e14L26-R26): Updated the `stages:` section to use the new `enable_win_cuda` and `enable_linux_cuda` parameters. [[1]](diffhunk://#diff-1e491a28b1b87f333551d4804a6ab37ab1edcfdee6968e4b7d92f60f4f285e14L26-R26) [[2]](diffhunk://#diff-1e491a28b1b87f333551d4804a6ab37ab1edcfdee6968e4b7d92f60f4f285e14L40-R40)
* [`.pipelines/stages/py-packaging-stage.yml`](diffhunk://#diff-be3b72816cbfd6e63a01189e9f58179f5ec77bd5c916a2541a03e102a9d83e5aL24-R24): Updated the `stages:` section to use the new `enable_win_cuda` and `enable_linux_cuda` parameters. [[1]](diffhunk://#diff-be3b72816cbfd6e63a01189e9f58179f5ec77bd5c916a2541a03e102a9d83e5aL24-R24) [[2]](diffhunk://#diff-be3b72816cbfd6e63a01189e9f58179f5ec77bd5c916a2541a03e102a9d83e5aL39-R39)