### PR TITLE
Make manylinux a subfolder of genai during the checkout

### DIFF
--- a/.pipelines/codeql.yaml
+++ b/.pipelines/codeql.yaml
@@ -41,7 +41,7 @@ stages:
     - task: onebranch.pipeline.tsaoptions@1
       displayName: 'OneBranch TSAOptions'
       inputs:
-        tsaConfigFilePath: '$(Build.SourcesDirectory)\.config\tsaoptions.json'
+        tsaConfigFilePath: '$(Pipeline.Workspace)\.config\tsaoptions.json'
         appendSourceBranchName: false
     - task: CredScan@3
       displayName: 🔍 Run CredScan
@@ -49,7 +49,7 @@ stages:
     - task: PoliCheck@2
       inputs:
         targetType: 'F'
-        targetArgument: '$(Build.SourcesDirectory)'
+        targetArgument: '$(Pipeline.Workspace)'
 
     - task: SdtReport@2
       displayName: 📃 Create Security Analysis Report
@@ -65,4 +65,4 @@ stages:
       continueOnError: true
       inputs:
         GdnPublishTsaOnboard: true
-        GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\.config\tsaoptions.json' 
+        GdnPublishTsaConfigFile: '$(Pipeline.Workspace)\.config\tsaoptions.json' 

--- a/.pipelines/codeql.yaml
+++ b/.pipelines/codeql.yaml
@@ -41,7 +41,7 @@ stages:
     - task: onebranch.pipeline.tsaoptions@1
       displayName: 'OneBranch TSAOptions'
       inputs:
-        tsaConfigFilePath: '$(Pipeline.Workspace)\.config\tsaoptions.json'
+        tsaConfigFilePath: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
         appendSourceBranchName: false
     - task: CredScan@3
       displayName: 🔍 Run CredScan
@@ -49,7 +49,7 @@ stages:
     - task: PoliCheck@2
       inputs:
         targetType: 'F'
-        targetArgument: '$(Pipeline.Workspace)'
+        targetArgument: '$(Build.Repository.LocalPath)'
 
     - task: SdtReport@2
       displayName: 📃 Create Security Analysis Report
@@ -65,4 +65,4 @@ stages:
       continueOnError: true
       inputs:
         GdnPublishTsaOnboard: true
-        GdnPublishTsaConfigFile: '$(Pipeline.Workspace)\.config\tsaoptions.json' 
+        GdnPublishTsaConfigFile: '$(Build.Repository.LocalPath)\.config\tsaoptions.json' 

--- a/.pipelines/codeql.yaml
+++ b/.pipelines/codeql.yaml
@@ -41,7 +41,7 @@ stages:
     - task: onebranch.pipeline.tsaoptions@1
       displayName: 'OneBranch TSAOptions'
       inputs:
-        tsaConfigFilePath: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
+        tsaConfigFilePath: '$(Build.SourcesDirectory)\.config\tsaoptions.json'
         appendSourceBranchName: false
     - task: CredScan@3
       displayName: 🔍 Run CredScan
@@ -49,7 +49,7 @@ stages:
     - task: PoliCheck@2
       inputs:
         targetType: 'F'
-        targetArgument: '$(Build.Repository.LocalPath)'
+        targetArgument: '$(Build.SourcesDirectory)'
 
     - task: SdtReport@2
       displayName: 📃 Create Security Analysis Report
@@ -65,4 +65,4 @@ stages:
       continueOnError: true
       inputs:
         GdnPublishTsaOnboard: true
-        GdnPublishTsaConfigFile: '$(Build.Repository.LocalPath)\.config\tsaoptions.json' 
+        GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\.config\tsaoptions.json' 

--- a/.pipelines/codeql.yaml
+++ b/.pipelines/codeql.yaml
@@ -41,7 +41,7 @@ stages:
     - task: onebranch.pipeline.tsaoptions@1
       displayName: 'OneBranch TSAOptions'
       inputs:
-        tsaConfigFilePath: '$(Build.SourcesDirectory)\.config\tsaoptions.json'
+        tsaConfigFilePath: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
         appendSourceBranchName: false
     - task: CredScan@3
       displayName: 🔍 Run CredScan
@@ -49,7 +49,7 @@ stages:
     - task: PoliCheck@2
       inputs:
         targetType: 'F'
-        targetArgument: '$(Build.SourcesDirectory)'
+        targetArgument: '$(Build.Repository.LocalPath)'
 
     - task: SdtReport@2
       displayName: 📃 Create Security Analysis Report
@@ -65,4 +65,4 @@ stages:
       continueOnError: true
       inputs:
         GdnPublishTsaOnboard: true
-        GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\.config\tsaoptions.json' 
+        GdnPublishTsaConfigFile: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'

--- a/.pipelines/stages/jobs/nuget-linux-packaging-job.yml
+++ b/.pipelines/stages/jobs/nuget-linux-packaging-job.yml
@@ -38,7 +38,6 @@ jobs:
   - template: steps/capi-linux-step.yml
     parameters:
       target: 'onnxruntime-genai'
-      genai_src: '$(Build.SourcesDirectory)/onnxruntime-genai'
 
 # TODO: Add a step to build the nuget package
 

--- a/.pipelines/stages/jobs/py-linux-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-linux-packaging-job.yml
@@ -54,7 +54,6 @@ jobs:
   - template: steps/capi-linux-step.yml
     parameters:
       target: 'python'
-      genai_src: '$(Build.SourcesDirectory)/onnxruntime-genai'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: ONNXRuntime python wheel'

--- a/.pipelines/stages/jobs/py-win-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-win-packaging-job.yml
@@ -68,7 +68,7 @@ jobs:
 
   - template: steps/compliant/win-esrp-dll-step.yml
     parameters:
-      FolderPath: '$(Build.SourcesDirectory)\build\release\$(ep)_default\wheel\onnxruntime_genai'
+      FolderPath: '$(Pipeline.Workspace)\build\release\$(ep)_default\wheel\onnxruntime_genai'
       DisplayName: 'ESRP - PYD Sign'
       DoEsrp: true
       Pattern: '*.pyd'
@@ -78,12 +78,12 @@ jobs:
     displayName: 'Build Python Wheel'
 
   - powershell: |
-      Get-ChildItem -Path $(Build.SourcesDirectory) -Recurse
+      Get-ChildItem -Path $(Pipeline.Workspace) -Recurse
 
   - task: CopyFiles@2
     displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
     inputs:
-      SourceFolder: '$(Build.SourcesDirectory)\build\release\$(ep)_default\wheel'
+      SourceFolder: '$(Pipeline.Workspace)\build\release\$(ep)_default\wheel'
       Contents: '*.whl'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 

--- a/.pipelines/stages/jobs/py-win-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-win-packaging-job.yml
@@ -68,7 +68,7 @@ jobs:
 
   - template: steps/compliant/win-esrp-dll-step.yml
     parameters:
-      FolderPath: '$(Pipeline.Workspace)\build\release\$(ep)_default\wheel\onnxruntime_genai'
+      FolderPath: '$(Build.Repository.LocalPath)\build\release\$(ep)_default\wheel\onnxruntime_genai'
       DisplayName: 'ESRP - PYD Sign'
       DoEsrp: true
       Pattern: '*.pyd'
@@ -78,12 +78,12 @@ jobs:
     displayName: 'Build Python Wheel'
 
   - powershell: |
-      Get-ChildItem -Path $(Pipeline.Workspace) -Recurse
+      Get-ChildItem -Path $(Build.Repository.LocalPath) -Recurse
 
   - task: CopyFiles@2
     displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
     inputs:
-      SourceFolder: '$(Pipeline.Workspace)\build\release\$(ep)_default\wheel'
+      SourceFolder: '$(Build.Repository.LocalPath)\build\release\$(ep)_default\wheel'
       Contents: '*.whl'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -10,14 +10,14 @@ steps:
 
 - checkout: manylinux
   clean: true
-  path: manylinux
+  path: onnxruntime-genai/manylinux
   submodules: recursive
 
 - script: |
     set -e -x
     echo "$(Build.SourcesDirectory)"
     echo "$(Build.Repository.LocalPath)"
-    ls $(Build.Repository.LocalPath) -R
+    ls $(Build.SourcesDirectory) -R
   displayName: 'List files from SourceDirectory'
 
 - template: utils/set-nightly-build-option-variable.yml
@@ -38,7 +38,7 @@ steps:
       --context tools/ci_build/github/linux/docker/manylinux \
       --docker-build-args "--build-arg BUILD_UID=$( id -u )" \
       --container-registry onnxruntimebuildcache \
-      --manylinux-src $(Build.Repository.LocalPath)/manylinux \
+      --manylinux-src $(Build.SourcesDirectory)/manylinux \
       --multiple_repos \
       --repository onnxruntime$(ep)build$(arch)
   displayName: 'Get Docker Image'

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -5,7 +5,7 @@ steps:
 
 - checkout: self
   clean: true
-  path: $(Build.SourcesDirectory)/onnxruntime-genai
+  path: $(Build.SourcesDirectory)/g/onnxruntime-genai
   submodules: recursive
 
 - checkout: manylinux

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -5,7 +5,7 @@ steps:
 
 - checkout: self
   clean: true
-  path: $(Build.SourcesDirectory)/g/onnxruntime-genai
+  path: onnxruntime-genai-src
   submodules: recursive
 
 - checkout: manylinux

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -1,35 +1,36 @@
 parameters:
-- name: genai_src
-  type: string
 - name: target
   type: string
 steps:
 
-- checkout: self # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/onnxruntime-genai,
+- checkout: self
   clean: true
-  path: $(Build.SourcesDirectory)
+  path: $(Pipeline.Workspace)
   submodules: recursive
 
-- checkout: manylinux # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/manylinux,
+- checkout: manylinux
   clean: true
-  path: $(Build.SourcesDirectory)/onnxruntime-genai
+  path: $(Pipeline.Workspace)/onnxruntime-genai
   submodules: recursive
 
 - script: |
-    ls $(Build.SourcesDirectory) -R
+    ls $(Pipeline.Workspace) -R
   displayName: 'List files from SourceDirectory'
+  
+- script: |
+    ls $(Pipeline.Workspace) -R
+  displayName: 'List files from SourceDirectory'
+
 - template: utils/set-nightly-build-option-variable.yml
 
 - bash: |
     echo "arch=$(arch)"
     echo "ep=$(ep)"
-    echo "genai_src=${{ parameters.genai_src }}"
   displayName: 'Print Parameters'
 
 - template: utils/download-ort.yml
   parameters:
     archiveType: 'tgz'
-    genai_src: ${{ parameters.genai_src }}
 - bash: |
     set -e -x
     az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
@@ -38,18 +39,18 @@ steps:
       --context tools/ci_build/github/linux/docker/manylinux \
       --docker-build-args "--build-arg BUILD_UID=$( id -u )" \
       --container-registry onnxruntimebuildcache \
-      --manylinux-src $(Build.SourcesDirectory)/manylinux \
+      --manylinux-src $(Pipeline.Workspace)/manylinux \
       --multiple_repos \
       --repository onnxruntime$(ep)build$(arch)
   displayName: 'Get Docker Image'
-  workingDirectory: '${{ parameters.genai_src }}'
+  workingDirectory: '$(Pipeline.Workspace)'
 
 - ${{ if eq(parameters.target, 'onnxruntime-genai') }}:
   - script: |
       set -e -x
       docker run \
       --rm \
-      --volume ${{ parameters.genai_src }}:/ort_genai_src \
+      --volume $(Pipeline.Workspace):/ort_genai_src \
       -w /ort_genai_src/ onnxruntime$(ep)build$(arch) \
       bash -c " \
           /usr/bin/cmake --preset linux_gcc_$(ep)_release \
@@ -57,22 +58,21 @@ steps:
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_release \
             --target onnxruntime-genai"
     displayName: 'Build GenAi'
-    workingDirectory: '${{ parameters.genai_src }}'
+    workingDirectory: '$(Pipeline.Workspace)'
   - task: BinSkim@4
     displayName: 'Run BinSkim'
     inputs:
-      AnalyzeTargetGlob: '$(Build.SourcesDirectory)/onnxruntime-genai/build/**/*genai.so'
+      AnalyzeTargetGlob: '$(Pipeline.Workspace)/onnxruntime-genai/build/**/*genai.so'
     continueOnError: true
   - template: utils/capi-archive.yml
     parameters:
-      genai_src: ${{ parameters.genai_src }}
       archiveType: tar
 - ${{ if eq(parameters.target, 'python') }}:
   - bash: |
       set -e -x
       docker run \
       --rm \
-      --volume ${{ parameters.genai_src }}:/ort_genai_src \
+      --volume $(Pipeline.Workspace):/ort_genai_src \
       -w /ort_genai_src/ onnxruntime$(ep)build$(arch) \
       bash -c " \
           /usr/bin/cmake --preset linux_gcc_$(ep)_release \
@@ -82,12 +82,12 @@ steps:
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_release \
             --target python"
     displayName: 'Build Python $(PyNoDotVer)'
-    workingDirectory: '${{ parameters.genai_src }}'
+    workingDirectory: '$(Pipeline.Workspace)'
   - bash: |
       set -e -x
       docker run \
       --rm \
-      --volume ${{ parameters.genai_src }}:/ort_genai_src \
+      --volume $(Pipeline.Workspace):/ort_genai_src \
       -w /ort_genai_src/ onnxruntime$(ep)build$(arch) \
       bash -c " \
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_release \
@@ -97,15 +97,15 @@ steps:
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_release \
             --target PyPackageBuild"
     displayName: 'PyPackageBuild $(PyNoDotVer)'
-    workingDirectory: '${{ parameters.genai_src }}'
+    workingDirectory: '$(Pipeline.Workspace)'
   - task: CopyFiles@2
     displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
     inputs:
-      SourceFolder: '${{ parameters.genai_src }}/build/gcc_$(ep)/release/wheel'
+      SourceFolder: '$(Pipeline.Workspace)/build/gcc_$(ep)/release/wheel'
       Contents: '*manylinux*.whl'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
 - script: |
-    ls ${{ parameters.genai_src }} -R
+    ls $(Pipeline.Workspace) -R
   displayName: 'List files from SourceDirectory'
 

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -7,12 +7,17 @@ steps:
 
 - checkout: self # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/onnxruntime-genai,
   clean: true
+  path: $(Build.SourcesDirectory)
   submodules: recursive
 
 - checkout: manylinux # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/manylinux,
   clean: true
+  path: $(Build.SourcesDirectory)/onnxruntime-genai
   submodules: recursive
 
+- script: |
+    ls $(Build.SourcesDirectory) -R
+  displayName: 'List files from SourceDirectory'
 - template: utils/set-nightly-build-option-variable.yml
 
 - bash: |

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -5,20 +5,16 @@ steps:
 
 - checkout: self
   clean: true
-  path: $(Pipeline.Workspace)
+  path: $(Build.SourcesDirectory)/onnxruntime-genai
   submodules: recursive
 
 - checkout: manylinux
   clean: true
-  path: $(Pipeline.Workspace)/onnxruntime-genai
+  path: $(Build.Repository.LocalPath)
   submodules: recursive
 
 - script: |
-    ls $(Pipeline.Workspace) -R
-  displayName: 'List files from SourceDirectory'
-  
-- script: |
-    ls $(Pipeline.Workspace) -R
+    ls $(Build.Repository.LocalPath) -R
   displayName: 'List files from SourceDirectory'
 
 - template: utils/set-nightly-build-option-variable.yml
@@ -39,18 +35,18 @@ steps:
       --context tools/ci_build/github/linux/docker/manylinux \
       --docker-build-args "--build-arg BUILD_UID=$( id -u )" \
       --container-registry onnxruntimebuildcache \
-      --manylinux-src $(Pipeline.Workspace)/manylinux \
+      --manylinux-src $(Build.Repository.LocalPath)/manylinux \
       --multiple_repos \
       --repository onnxruntime$(ep)build$(arch)
   displayName: 'Get Docker Image'
-  workingDirectory: '$(Pipeline.Workspace)'
+  workingDirectory: '$(Build.Repository.LocalPath)'
 
 - ${{ if eq(parameters.target, 'onnxruntime-genai') }}:
   - script: |
       set -e -x
       docker run \
       --rm \
-      --volume $(Pipeline.Workspace):/ort_genai_src \
+      --volume $(Build.Repository.LocalPath):/ort_genai_src \
       -w /ort_genai_src/ onnxruntime$(ep)build$(arch) \
       bash -c " \
           /usr/bin/cmake --preset linux_gcc_$(ep)_release \
@@ -58,11 +54,11 @@ steps:
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_release \
             --target onnxruntime-genai"
     displayName: 'Build GenAi'
-    workingDirectory: '$(Pipeline.Workspace)'
+    workingDirectory: '$(Build.Repository.LocalPath)'
   - task: BinSkim@4
     displayName: 'Run BinSkim'
     inputs:
-      AnalyzeTargetGlob: '$(Pipeline.Workspace)/onnxruntime-genai/build/**/*genai.so'
+      AnalyzeTargetGlob: '$(Build.Repository.LocalPath)/onnxruntime-genai/build/**/*genai.so'
     continueOnError: true
   - template: utils/capi-archive.yml
     parameters:
@@ -72,7 +68,7 @@ steps:
       set -e -x
       docker run \
       --rm \
-      --volume $(Pipeline.Workspace):/ort_genai_src \
+      --volume $(Build.Repository.LocalPath):/ort_genai_src \
       -w /ort_genai_src/ onnxruntime$(ep)build$(arch) \
       bash -c " \
           /usr/bin/cmake --preset linux_gcc_$(ep)_release \
@@ -82,12 +78,12 @@ steps:
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_release \
             --target python"
     displayName: 'Build Python $(PyNoDotVer)'
-    workingDirectory: '$(Pipeline.Workspace)'
+    workingDirectory: '$(Build.Repository.LocalPath)'
   - bash: |
       set -e -x
       docker run \
       --rm \
-      --volume $(Pipeline.Workspace):/ort_genai_src \
+      --volume $(Build.Repository.LocalPath):/ort_genai_src \
       -w /ort_genai_src/ onnxruntime$(ep)build$(arch) \
       bash -c " \
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_release \
@@ -97,15 +93,15 @@ steps:
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_release \
             --target PyPackageBuild"
     displayName: 'PyPackageBuild $(PyNoDotVer)'
-    workingDirectory: '$(Pipeline.Workspace)'
+    workingDirectory: '$(Build.Repository.LocalPath)'
   - task: CopyFiles@2
     displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
     inputs:
-      SourceFolder: '$(Pipeline.Workspace)/build/gcc_$(ep)/release/wheel'
+      SourceFolder: '$(Build.Repository.LocalPath)/build/gcc_$(ep)/release/wheel'
       Contents: '*manylinux*.whl'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
 - script: |
-    ls $(Pipeline.Workspace) -R
+    ls $(Build.Repository.LocalPath) -R
   displayName: 'List files from SourceDirectory'
 

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -5,15 +5,18 @@ steps:
 
 - checkout: self
   clean: true
-  path: onnxruntime-genai-src
+  path: onnxruntime-genai
   submodules: recursive
 
 - checkout: manylinux
   clean: true
-  path: $(Build.Repository.LocalPath)/manylinux
+  path: manylinux
   submodules: recursive
 
 - script: |
+    set -e -x
+    echo "$(Build.SourcesDirectory)"
+    echo "$(Build.Repository.LocalPath)"
     ls $(Build.Repository.LocalPath) -R
   displayName: 'List files from SourceDirectory'
 

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -38,7 +38,7 @@ steps:
       --context tools/ci_build/github/linux/docker/manylinux \
       --docker-build-args "--build-arg BUILD_UID=$( id -u )" \
       --container-registry onnxruntimebuildcache \
-      --manylinux-src $(Build.SourcesDirectory)/manylinux \
+      --manylinux-src manylinux \
       --multiple_repos \
       --repository onnxruntime$(ep)build$(arch)
   displayName: 'Get Docker Image'
@@ -61,7 +61,7 @@ steps:
   - task: BinSkim@4
     displayName: 'Run BinSkim'
     inputs:
-      AnalyzeTargetGlob: '$(Build.Repository.LocalPath)/onnxruntime-genai/build/**/*genai.so'
+      AnalyzeTargetGlob: '$(Build.Repository.LocalPath)/build/**/*genai.so'
     continueOnError: true
   - template: utils/capi-archive.yml
     parameters:

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -10,7 +10,7 @@ steps:
 
 - checkout: manylinux
   clean: true
-  path: $(Build.Repository.LocalPath)
+  path: $(Build.Repository.LocalPath)/manylinux
   submodules: recursive
 
 - script: |

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -15,7 +15,7 @@ steps:
 - task: onebranch.pipeline.tsaoptions@1
   displayName: 'OneBranch TSAOptions'
   inputs:
-    tsaConfigFilePath: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
+    tsaConfigFilePath: 'onnxruntime-genai\.config\tsaoptions.json'
     appendSourceBranchName: false
 
 - template: utils/set-nightly-build-option-variable.yml
@@ -34,13 +34,13 @@ steps:
     archiveType: 'zip'
 
 - powershell: |
-    azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v$(cuda_version)" '$(Build.Repository.LocalPath)\cuda_sdk'
+    azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v$(cuda_version)" 'cuda_sdk'
   displayName: 'Download CUDA'
   condition: eq(variables['ep'], 'cuda')
   workingDirectory: '$(Build.Repository.LocalPath)'
 
 - powershell: |
-    cmake --preset windows_$(arch)_$(ep)_release -T cuda='$(Build.Repository.LocalPath)\cuda_sdk\v$(cuda_version)'
+    cmake --preset windows_$(arch)_$(ep)_release -T cuda='cuda_sdk\v$(cuda_version)'
   displayName: 'Configure CMake C API with CUDA'
   condition: eq(variables['ep'], 'cuda')
   workingDirectory: '$(Build.Repository.LocalPath)'

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -15,7 +15,7 @@ steps:
 - task: onebranch.pipeline.tsaoptions@1
   displayName: 'OneBranch TSAOptions'
   inputs:
-    tsaConfigFilePath: '$(Build.SourcesDirectory)\.config\tsaoptions.json'
+    tsaConfigFilePath: '$(Pipeline.Workspace)\.config\tsaoptions.json'
     appendSourceBranchName: false
 
 - template: utils/set-nightly-build-option-variable.yml
@@ -32,30 +32,29 @@ steps:
 - template: utils/download-ort.yml
   parameters:
     archiveType: 'zip'
-    genai_src: '$(Build.SourcesDirectory)'
 
 - powershell: |
-    azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v$(cuda_version)" '$(Build.SourcesDirectory)\cuda_sdk'
+    azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v$(cuda_version)" '$(Pipeline.Workspace)\cuda_sdk'
   displayName: 'Download CUDA'
   condition: eq(variables['ep'], 'cuda')
-  workingDirectory: '$(Build.SourcesDirectory)'
+  workingDirectory: '$(Pipeline.Workspace)'
 
 - powershell: |
-    cmake --preset windows_$(arch)_$(ep)_release -T cuda='$(Build.SourcesDirectory)\cuda_sdk\v$(cuda_version)'
+    cmake --preset windows_$(arch)_$(ep)_release -T cuda='$(Pipeline.Workspace)\cuda_sdk\v$(cuda_version)'
   displayName: 'Configure CMake C API with CUDA'
   condition: eq(variables['ep'], 'cuda')
-  workingDirectory: '$(Build.SourcesDirectory)'
+  workingDirectory: '$(Pipeline.Workspace)'
 
 - powershell: |
     cmake --preset windows_$(arch)_$(ep)_release
   displayName: 'Configure CMake C API without CUDA'
   condition: ne(variables['ep'], 'cuda')
-  workingDirectory: '$(Build.SourcesDirectory)'
+  workingDirectory: '$(Pipeline.Workspace)'
 
 - powershell: |
     cmake --build --preset windows_$(arch)_$(ep)_release --parallel --target ${{ parameters.target }}
   displayName: 'Build C API'
-  workingDirectory: '$(Build.SourcesDirectory)'
+  workingDirectory: '$(Pipeline.Workspace)'
 
 - ${{ if eq(parameters.target, 'onnxruntime-genai') }}:
   - template: compliant/win-esrp-dll-step.yml
@@ -66,17 +65,16 @@ steps:
   - task: BinSkim@4
     displayName: 'Run BinSkim'
     inputs:
-      AnalyzeTargetGlob: '$(Build.SourcesDirectory)\**\*genai.dll'
+      AnalyzeTargetGlob: '$(Pipeline.Workspace)\**\*genai.dll'
     continueOnError: true
 
   - template: utils/capi-archive.yml
     parameters:
-      genai_src: '$(Build.SourcesDirectory)'
       archiveType: zip
 
 - ${{ if eq(parameters.target, 'python') }}:
   - task: BinSkim@4
     displayName: 'Run BinSkim'
     inputs:
-      AnalyzeTargetGlob: '$(Build.SourcesDirectory)\**\*.pyd'
+      AnalyzeTargetGlob: '$(Pipeline.Workspace)\**\*.pyd'
     continueOnError: true

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -16,7 +16,7 @@ steps:
 - task: onebranch.pipeline.tsaoptions@1
   displayName: 'OneBranch TSAOptions'
   inputs:
-    tsaConfigFilePath: 'onnxruntime-genai\.config\tsaoptions.json'
+    tsaConfigFilePath: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
     appendSourceBranchName: false
 
 - template: utils/set-nightly-build-option-variable.yml

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -15,7 +15,7 @@ steps:
 - task: onebranch.pipeline.tsaoptions@1
   displayName: 'OneBranch TSAOptions'
   inputs:
-    tsaConfigFilePath: '$(Pipeline.Workspace)\.config\tsaoptions.json'
+    tsaConfigFilePath: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
     appendSourceBranchName: false
 
 - template: utils/set-nightly-build-option-variable.yml
@@ -34,27 +34,27 @@ steps:
     archiveType: 'zip'
 
 - powershell: |
-    azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v$(cuda_version)" '$(Pipeline.Workspace)\cuda_sdk'
+    azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v$(cuda_version)" '$(Build.Repository.LocalPath)\cuda_sdk'
   displayName: 'Download CUDA'
   condition: eq(variables['ep'], 'cuda')
-  workingDirectory: '$(Pipeline.Workspace)'
+  workingDirectory: '$(Build.Repository.LocalPath)'
 
 - powershell: |
-    cmake --preset windows_$(arch)_$(ep)_release -T cuda='$(Pipeline.Workspace)\cuda_sdk\v$(cuda_version)'
+    cmake --preset windows_$(arch)_$(ep)_release -T cuda='$(Build.Repository.LocalPath)\cuda_sdk\v$(cuda_version)'
   displayName: 'Configure CMake C API with CUDA'
   condition: eq(variables['ep'], 'cuda')
-  workingDirectory: '$(Pipeline.Workspace)'
+  workingDirectory: '$(Build.Repository.LocalPath)'
 
 - powershell: |
     cmake --preset windows_$(arch)_$(ep)_release
   displayName: 'Configure CMake C API without CUDA'
   condition: ne(variables['ep'], 'cuda')
-  workingDirectory: '$(Pipeline.Workspace)'
+  workingDirectory: '$(Build.Repository.LocalPath)'
 
 - powershell: |
     cmake --build --preset windows_$(arch)_$(ep)_release --parallel --target ${{ parameters.target }}
   displayName: 'Build C API'
-  workingDirectory: '$(Pipeline.Workspace)'
+  workingDirectory: '$(Build.Repository.LocalPath)'
 
 - ${{ if eq(parameters.target, 'onnxruntime-genai') }}:
   - template: compliant/win-esrp-dll-step.yml
@@ -65,7 +65,7 @@ steps:
   - task: BinSkim@4
     displayName: 'Run BinSkim'
     inputs:
-      AnalyzeTargetGlob: '$(Pipeline.Workspace)\**\*genai.dll'
+      AnalyzeTargetGlob: '$(Build.Repository.LocalPath)\**\*genai.dll'
     continueOnError: true
 
   - template: utils/capi-archive.yml
@@ -76,5 +76,5 @@ steps:
   - task: BinSkim@4
     displayName: 'Run BinSkim'
     inputs:
-      AnalyzeTargetGlob: '$(Pipeline.Workspace)\**\*.pyd'
+      AnalyzeTargetGlob: '$(Build.Repository.LocalPath)\**\*.pyd'
     continueOnError: true

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -41,7 +41,7 @@ steps:
   workingDirectory: '$(Build.Repository.LocalPath)'
 
 - powershell: |
-    cmake --preset windows_$(arch)_$(ep)_release -T cuda='cuda_sdk\v$(cuda_version)'
+    cmake --preset windows_$(arch)_$(ep)_release -T cuda='$(Build.Repository.LocalPath)\cuda_sdk\v$(cuda_version)'
   displayName: 'Configure CMake C API with CUDA'
   condition: eq(variables['ep'], 'cuda')
   workingDirectory: '$(Build.Repository.LocalPath)'

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -10,6 +10,7 @@ steps:
   condition: or( eq (variables['ep'], ''), eq (variables['arch'], ''))
 
 - checkout: self
+  path: onnxruntime-genai
   clean: true
   submodules: recursive
 - task: onebranch.pipeline.tsaoptions@1

--- a/.pipelines/stages/jobs/steps/compliant-and-cleanup-step.yml
+++ b/.pipelines/stages/jobs/steps/compliant-and-cleanup-step.yml
@@ -10,7 +10,7 @@ steps:
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   inputs:
     GdnPublishTsaOnboard: false
-    GdnPublishTsaConfigFile: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
+    GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.config\tsaoptions.json'
   continueOnError: true
 
 - template: compliant/component-governance-component-detection-step.yml

--- a/.pipelines/stages/jobs/steps/compliant-and-cleanup-step.yml
+++ b/.pipelines/stages/jobs/steps/compliant-and-cleanup-step.yml
@@ -10,7 +10,7 @@ steps:
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   inputs:
     GdnPublishTsaOnboard: false
-    GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.config\tsaoptions.json'
+    GdnPublishTsaConfigFile: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
   continueOnError: true
 
 - template: compliant/component-governance-component-detection-step.yml

--- a/.pipelines/stages/jobs/steps/compliant-and-cleanup-step.yml
+++ b/.pipelines/stages/jobs/steps/compliant-and-cleanup-step.yml
@@ -10,7 +10,7 @@ steps:
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   inputs:
     GdnPublishTsaOnboard: false
-    GdnPublishTsaConfigFile: '$(Pipeline.Workspace)\.config\tsaoptions.json'
+    GdnPublishTsaConfigFile: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
   continueOnError: true
 
 - template: compliant/component-governance-component-detection-step.yml

--- a/.pipelines/stages/jobs/steps/compliant-and-cleanup-step.yml
+++ b/.pipelines/stages/jobs/steps/compliant-and-cleanup-step.yml
@@ -10,7 +10,7 @@ steps:
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   inputs:
     GdnPublishTsaOnboard: false
-    GdnPublishTsaConfigFile: '$(Build.sourcesDirectory)\.config\tsaoptions.json'
+    GdnPublishTsaConfigFile: '$(Pipeline.Workspace)\.config\tsaoptions.json'
   continueOnError: true
 
 - template: compliant/component-governance-component-detection-step.yml

--- a/.pipelines/stages/jobs/steps/compliant/component-governance-component-detection-step.yml
+++ b/.pipelines/stages/jobs/steps/compliant/component-governance-component-detection-step.yml
@@ -19,7 +19,3 @@ steps:
       or(or(and(eq('${{parameters.condition}}', 'ci_only'), and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Scheduled'))),
           and(eq('${{parameters.condition}}', 'always'), always())),
           and(eq('${{parameters.condition}}', 'succeeded'), succeeded()))
-    inputs:
-      # ignore dmlc-core tracker for its CI, which is not used in onnxruntime build
-      # ignore unit tests in emscripten. emscripten unit tests are not used in onnxruntime build
-      ignoreDirectories: '$(Build.Repository.LocalPath)/cmake/external/emsdk/upstream/emscripten/tests'

--- a/.pipelines/stages/jobs/steps/compliant/component-governance-component-detection-step.yml
+++ b/.pipelines/stages/jobs/steps/compliant/component-governance-component-detection-step.yml
@@ -22,4 +22,4 @@ steps:
     inputs:
       # ignore dmlc-core tracker for its CI, which is not used in onnxruntime build
       # ignore unit tests in emscripten. emscripten unit tests are not used in onnxruntime build
-      ignoreDirectories: '$(Build.SourcesDirectory)/cmake/external/emsdk/upstream/emscripten/tests'
+      ignoreDirectories: '$(Pipeline.Workspace)/cmake/external/emsdk/upstream/emscripten/tests'

--- a/.pipelines/stages/jobs/steps/compliant/component-governance-component-detection-step.yml
+++ b/.pipelines/stages/jobs/steps/compliant/component-governance-component-detection-step.yml
@@ -22,4 +22,4 @@ steps:
     inputs:
       # ignore dmlc-core tracker for its CI, which is not used in onnxruntime build
       # ignore unit tests in emscripten. emscripten unit tests are not used in onnxruntime build
-      ignoreDirectories: '$(Pipeline.Workspace)/cmake/external/emsdk/upstream/emscripten/tests'
+      ignoreDirectories: '$(Build.Repository.LocalPath)/cmake/external/emsdk/upstream/emscripten/tests'

--- a/.pipelines/stages/jobs/steps/nuget-win-step.yml
+++ b/.pipelines/stages/jobs/steps/nuget-win-step.yml
@@ -2,17 +2,17 @@ steps:
 - powershell: |
     dotnet build Microsoft.ML.OnnxRuntimeGenAI.csproj -p:Configuration="$(buildConfig)" -p:NativeBuildOutputDir="$(buildDir)\$(buildConfig)"
   displayName: 'Build CSharp'
-  workingDirectory: '$(Pipeline.Workspace)\src\csharp'
+  workingDirectory: '$(Build.Repository.LocalPath)\src\csharp'
 
 - task: BinSkim@4
   displayName: 'Run BinSkim'
   inputs:
-    AnalyzeTargetGlob: '$(Pipeline.Workspace)\src\csharp\**\*.dll'
+    AnalyzeTargetGlob: '$(Build.Repository.LocalPath)\src\csharp\**\*.dll'
   continueOnError: true
 
 - template: compliant/win-esrp-dll-step.yml
   parameters:
-    FolderPath: '$(Pipeline.Workspace)\src\csharp\bin\Release\'
+    FolderPath: '$(Build.Repository.LocalPath)\src\csharp\bin\Release\'
     DisplayName: 'ESRP - Sign C# dlls'
 
 - powershell: |
@@ -26,17 +26,17 @@ steps:
       -Prop version=$VERSION `
       -Prop configuration=$(buildConfig)
   displayName: 'Nuget Packaging'
-  workingDirectory: '$(Pipeline.Workspace)\nuget'
+  workingDirectory: '$(Build.Repository.LocalPath)\nuget'
 
 - powershell: |
-    Get-ChildItem -Path $(Pipeline.Workspace) -Recurse
+    Get-ChildItem -Path $(Build.Repository.LocalPath) -Recurse
   displayName: 'List all files in the repo for'
 
 - powershell: |
-    Get-ChildItem -Path $(Pipeline.Workspace) -Recurse
+    Get-ChildItem -Path $(Build.Repository.LocalPath) -Recurse
 - task: CopyFiles@2
   displayName: 'Copy Nuget to: $(Build.ArtifactStagingDirectory)'
   inputs:
-    SourceFolder: '$(Pipeline.Workspace)\nuget'
+    SourceFolder: '$(Build.Repository.LocalPath)\nuget'
     Contents: '*.nupkg'
     TargetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/.pipelines/stages/jobs/steps/nuget-win-step.yml
+++ b/.pipelines/stages/jobs/steps/nuget-win-step.yml
@@ -2,17 +2,17 @@ steps:
 - powershell: |
     dotnet build Microsoft.ML.OnnxRuntimeGenAI.csproj -p:Configuration="$(buildConfig)" -p:NativeBuildOutputDir="$(buildDir)\$(buildConfig)"
   displayName: 'Build CSharp'
-  workingDirectory: '$(Build.SourcesDirectory)\src\csharp'
+  workingDirectory: '$(Pipeline.Workspace)\src\csharp'
 
 - task: BinSkim@4
   displayName: 'Run BinSkim'
   inputs:
-    AnalyzeTargetGlob: '$(Build.SourcesDirectory)\src\csharp\**\*.dll'
+    AnalyzeTargetGlob: '$(Pipeline.Workspace)\src\csharp\**\*.dll'
   continueOnError: true
 
 - template: compliant/win-esrp-dll-step.yml
   parameters:
-    FolderPath: '$(Build.SourcesDirectory)\src\csharp\bin\Release\'
+    FolderPath: '$(Pipeline.Workspace)\src\csharp\bin\Release\'
     DisplayName: 'ESRP - Sign C# dlls'
 
 - powershell: |
@@ -26,17 +26,17 @@ steps:
       -Prop version=$VERSION `
       -Prop configuration=$(buildConfig)
   displayName: 'Nuget Packaging'
-  workingDirectory: '$(Build.SourcesDirectory)\nuget'
+  workingDirectory: '$(Pipeline.Workspace)\nuget'
 
 - powershell: |
-    Get-ChildItem -Path $(Build.SourcesDirectory) -Recurse
+    Get-ChildItem -Path $(Pipeline.Workspace) -Recurse
   displayName: 'List all files in the repo for'
 
 - powershell: |
-    Get-ChildItem -Path $(Build.SourcesDirectory) -Recurse
+    Get-ChildItem -Path $(Pipeline.Workspace) -Recurse
 - task: CopyFiles@2
   displayName: 'Copy Nuget to: $(Build.ArtifactStagingDirectory)'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\nuget'
+    SourceFolder: '$(Pipeline.Workspace)\nuget'
     Contents: '*.nupkg'
     TargetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/.pipelines/stages/jobs/steps/utils/capi-archive.yml
+++ b/.pipelines/stages/jobs/steps/utils/capi-archive.yml
@@ -1,6 +1,4 @@
 parameters:
-- name: genai_src
-  type: string
 - name: archiveType
   type: string
 steps:
@@ -13,14 +11,14 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy Onnxruntime C API library files to ArtifactStagingDirectory'
   inputs:
-    SourceFolder: '${{ parameters.genai_src }}/ort/lib'
+    SourceFolder: '$(Pipeline.Workspace)/ort/lib'
     TargetFolder: '$(Build.ArtifactStagingDirectory)\$(artifactName)\lib'
 
 - ${{ if eq(parameters.archiveType, 'tar') }}:
   - task: CopyFiles@2
     displayName: 'Copy Onnxruntime C API dll files to ArtifactStagingDirectory'
     inputs:
-      SourceFolder: '${{ parameters.genai_src }}/$(buildDir)'
+      SourceFolder: '$(Pipeline.Workspace)/$(buildDir)'
       Contents: |
         onnxruntime-genai.so
       TargetFolder: '$(Build.ArtifactStagingDirectory)\$(artifactName)\lib'
@@ -28,7 +26,7 @@ steps:
   - task: CopyFiles@2
     displayName: 'Copy Onnxruntime C API dll files to ArtifactStagingDirectory'
     inputs:
-      SourceFolder: '${{ parameters.genai_src }}\$(buildDir)\Release'
+      SourceFolder: '$(Pipeline.Workspace)\$(buildDir)\Release'
       Contents: |
         onnxruntime-genai.dll
         onnxruntime-genai.lib
@@ -38,7 +36,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy GenAi C API header to ArtifactStagingDirectory'
   inputs:
-    SourceFolder: '${{ parameters.genai_src }}/src'
+    SourceFolder: '$(Pipeline.Workspace)/src'
     Contents: |
       ort_genai_c.h
     TargetFolder: '$(Build.ArtifactStagingDirectory)/$(artifactName)/include'
@@ -46,7 +44,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy other files to ArtifactStagingDirectory'
   inputs:
-    SourceFolder: '${{ parameters.genai_src }}'
+    SourceFolder: '$(Pipeline.Workspace)'
     Contents: |
       VERSION_INFO
       LICENSE

--- a/.pipelines/stages/jobs/steps/utils/capi-archive.yml
+++ b/.pipelines/stages/jobs/steps/utils/capi-archive.yml
@@ -11,14 +11,14 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy Onnxruntime C API library files to ArtifactStagingDirectory'
   inputs:
-    SourceFolder: '$(Pipeline.Workspace)/ort/lib'
+    SourceFolder: '$(Build.Repository.LocalPath)/ort/lib'
     TargetFolder: '$(Build.ArtifactStagingDirectory)\$(artifactName)\lib'
 
 - ${{ if eq(parameters.archiveType, 'tar') }}:
   - task: CopyFiles@2
     displayName: 'Copy Onnxruntime C API dll files to ArtifactStagingDirectory'
     inputs:
-      SourceFolder: '$(Pipeline.Workspace)/$(buildDir)'
+      SourceFolder: '$(Build.Repository.LocalPath)/$(buildDir)'
       Contents: |
         onnxruntime-genai.so
       TargetFolder: '$(Build.ArtifactStagingDirectory)\$(artifactName)\lib'
@@ -26,7 +26,7 @@ steps:
   - task: CopyFiles@2
     displayName: 'Copy Onnxruntime C API dll files to ArtifactStagingDirectory'
     inputs:
-      SourceFolder: '$(Pipeline.Workspace)\$(buildDir)\Release'
+      SourceFolder: '$(Build.Repository.LocalPath)\$(buildDir)\Release'
       Contents: |
         onnxruntime-genai.dll
         onnxruntime-genai.lib
@@ -36,7 +36,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy GenAi C API header to ArtifactStagingDirectory'
   inputs:
-    SourceFolder: '$(Pipeline.Workspace)/src'
+    SourceFolder: '$(Build.Repository.LocalPath)/src'
     Contents: |
       ort_genai_c.h
     TargetFolder: '$(Build.ArtifactStagingDirectory)/$(artifactName)/include'
@@ -44,7 +44,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy other files to ArtifactStagingDirectory'
   inputs:
-    SourceFolder: '$(Pipeline.Workspace)'
+    SourceFolder: '$(Build.Repository.LocalPath)'
     Contents: |
       VERSION_INFO
       LICENSE

--- a/.pipelines/stages/jobs/steps/utils/download-ort.yml
+++ b/.pipelines/stages/jobs/steps/utils/download-ort.yml
@@ -1,6 +1,4 @@
 parameters:
-- name: genai_src
-  type: string
 - name: archiveType
   type: string
 steps:
@@ -17,26 +15,26 @@ steps:
     defaultVersionType: 'specificTag'
     version: 'v$(ort_version)'
     itemPattern: '$(ort_filename)*'
-    downloadPath: '${{ parameters.genai_src }}'
+    downloadPath: '$(Pipeline.Workspace)'
   displayName: Download $(ort_filename)
 
 - task: ExtractFiles@1
   inputs:
     archiveFilePatterns: '**/*.${{ parameters.archiveType }}'
-    destinationFolder: '${{ parameters.genai_src }}'
+    destinationFolder: '$(Pipeline.Workspace)'
     cleanDestinationFolder: false
     overwriteExistingFiles: true
   displayName: Unzip OnnxRuntime
 
 - task: CopyFiles@2
   inputs:
-    SourceFolder: '${{ parameters.genai_src }}/$(ort_filename)'
-    TargetFolder: '${{ parameters.genai_src }}/ort'
+    SourceFolder: '$(Pipeline.Workspace)/$(ort_filename)'
+    TargetFolder: '$(Pipeline.Workspace)/ort'
   displayName: Copy OnnxRuntime to ort
 
 - task: DeleteFiles@1
   inputs:
-    SourceFolder: '${{ parameters.genai_src }}/ort/lib'
+    SourceFolder: '$(Pipeline.Workspace)/ort/lib'
     Contents: '*tensorrt*'
     RemoveSourceFolder: false
   displayName: 'Remove tensorrt from lib'

--- a/.pipelines/stages/jobs/steps/utils/download-ort.yml
+++ b/.pipelines/stages/jobs/steps/utils/download-ort.yml
@@ -14,13 +14,13 @@ steps:
     userRepository: 'microsoft/onnxruntime'
     defaultVersionType: 'specificTag'
     version: 'v$(ort_version)'
-    itemPattern: '$(ort_filename)*'
+    itemPattern: '$(ort_filename).${{ parameters.archiveType }}'
     downloadPath: '$(Build.Repository.LocalPath)'
   displayName: Download $(ort_filename)
 
 - task: ExtractFiles@1
   inputs:
-    archiveFilePatterns: '**/*.${{ parameters.archiveType }}'
+    archiveFilePatterns: '$(Build.Repository.LocalPath)/$(ort_filename).${{ parameters.archiveType }}'
     destinationFolder: '$(Build.Repository.LocalPath)'
     cleanDestinationFolder: false
     overwriteExistingFiles: true

--- a/.pipelines/stages/jobs/steps/utils/download-ort.yml
+++ b/.pipelines/stages/jobs/steps/utils/download-ort.yml
@@ -15,26 +15,26 @@ steps:
     defaultVersionType: 'specificTag'
     version: 'v$(ort_version)'
     itemPattern: '$(ort_filename)*'
-    downloadPath: '$(Pipeline.Workspace)'
+    downloadPath: '$(Build.Repository.LocalPath)'
   displayName: Download $(ort_filename)
 
 - task: ExtractFiles@1
   inputs:
     archiveFilePatterns: '**/*.${{ parameters.archiveType }}'
-    destinationFolder: '$(Pipeline.Workspace)'
+    destinationFolder: '$(Build.Repository.LocalPath)'
     cleanDestinationFolder: false
     overwriteExistingFiles: true
   displayName: Unzip OnnxRuntime
 
 - task: CopyFiles@2
   inputs:
-    SourceFolder: '$(Pipeline.Workspace)/$(ort_filename)'
-    TargetFolder: '$(Pipeline.Workspace)/ort'
+    SourceFolder: '$(Build.Repository.LocalPath)/$(ort_filename)'
+    TargetFolder: '$(Build.Repository.LocalPath)/ort'
   displayName: Copy OnnxRuntime to ort
 
 - task: DeleteFiles@1
   inputs:
-    SourceFolder: '$(Pipeline.Workspace)/ort/lib'
+    SourceFolder: '$(Build.Repository.LocalPath)/ort/lib'
     Contents: '*tensorrt*'
     RemoveSourceFolder: false
   displayName: 'Remove tensorrt from lib'


### PR DESCRIPTION
The main purpose of this PR is to use `$(Build.Repository.LocalPath)` to get the abs path of the self repo that CI might need in both cases where single or multiple repos are checked out. Since `$(Build.SourcesDirectory)` become root folder of all repos if check out multiple Repos use default path.