### PR TITLE
Add missing windows build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ This step requires `cmake` to be installed.
       build.bat --config RelWithDebInfo --build_shared_lib --skip_tests --parallel [--use_cuda]
       copy include\onnxruntime\core\session\onnxruntime_c_api.h $ORT_HOME\include
       copy build\Windows\RelWithDebInfo\RelWithDebInfo\*.dll $ORT_HOME\lib
+      copy build\Windows\RelWithDebInfo\RelWithDebInfo\onnxruntime.lib $ORT_HOME\lib
       ```
 
       On Linux


### PR DESCRIPTION
Added copy step for `onnxruntime.lib` which seems to be required for building on windows

Resolves Error:
`LINK : fatal error LNK1104: cannot open file 'onnxruntime.lib' [D:\Repositories\onnxruntime-genai\build\src\python\pyth
on.vcxproj]`
