### PR TITLE
Add repeat KV to model builder

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -116,7 +116,7 @@ class Model:
             "op_type": "MultiHeadAttention",                                # Attention op to use
             "use_gqa": ep == "cuda" and io_dtype == TensorProto.FLOAT16     # Check if GroupQueryAttention can be used
         }
-        if self.attention_attrs["use_gqa"] or self.num_attn_heads != self.num_kv_heads:
+        if self.attention_attrs["use_gqa"]:
             self.attention_attrs["op_type"] = "GroupQueryAttention"
 
         # Quantization-specific variables (INT4, INT8, etc.)
@@ -166,15 +166,15 @@ class Model:
                 "do_sample": config.do_sample if hasattr(config, "do_sample") else False,
                 "early_stopping": True,
                 "length_penalty": config.length_penalty if hasattr(config, "length_penalty") else 1.0,
-                "max_length": config.max_length if hasattr(config, "max_length") else 20,
+                "max_length": self.context_length,
                 "min_length": 0,
                 "no_repeat_ngram_size": config.no_repeat_ngram_size if hasattr(config, "no_repeat_ngram_size") else 0,
                 "num_beams": config.num_beams if hasattr(config, "num_beams") else 1,
                 "num_return_sequences": config.num_return_sequences if hasattr(config, "num_return_sequences") else 1,
-                "past_present_share_buffer": True if self.attention_attrs["op_type"] == "GroupQueryAttention" else False,
+                "past_present_share_buffer": self.attention_attrs["op_type"] == "GroupQueryAttention",
                 "repetition_penalty": config.repetition_penalty if hasattr(config, "repetition_penalty") else 1.0,
                 "temperature": config.temperature if hasattr(config, "temperature") else 1.0,
-                "top_k": config.top_k if hasattr(config, "top_k") else 50,
+                "top_k": 1,
                 "top_p": config.top_p if hasattr(config, "top_p") else 1.0,
             },
         }
@@ -337,7 +337,7 @@ class Model:
         path = name.split("/")
         onnx_dtype, dims, num = eval(path[-3]), path[-2], eval(path[-1])
         np_dtype = self.to_numpy_dtype[onnx_dtype]
-        value = numpy_helper.from_array(np.array(num if dims == "0D" else [num], dtype=np_dtype), name=name.replace("constants", "numpy_helper"))
+        value = numpy_helper.from_array(np.array(num if dims == "0D" else list(num) if type(num) == tuple else [num], dtype=np_dtype), name=name.replace("constants", "numpy_helper"))
 
         node_name = name.replace("constants", "constant_nodes")
         self.make_node("Constant", inputs=[], outputs=[name], name=node_name, value=value)
@@ -349,10 +349,10 @@ class Model:
         self.make_node("Gather", inputs=inputs, outputs=[output], name=name, axis=axis)
         self.make_value_info(output, TensorProto.INT64, shape=[])
 
-    def make_reshape(self, name, inputs):
+    def make_reshape(self, name, inputs, dtype, shape):
         output = f"{name}/output_0"
         self.make_node("Reshape", inputs=inputs, outputs=[output], name=name)
-        self.make_value_info(output, TensorProto.INT64, shape=None)
+        self.make_value_info(output, dtype, shape=shape)
 
     def make_shape(self, name, root_input, shape):
         output = f"{name}/output_0"
@@ -379,10 +379,10 @@ class Model:
         self.make_node("Concat", inputs=inputs, outputs=[output], name=name, axis=axis)
         self.make_value_info(output, dtype, shape=shape)
 
-    def make_equal(self, name, inputs):
+    def make_equal(self, name, inputs, shape):
         output = f"{name}/output_0"
         self.make_node("Equal", inputs=inputs, outputs=[output], name=name)
-        self.make_value_info(output, TensorProto.BOOL, shape=[4])
+        self.make_value_info(output, TensorProto.BOOL, shape=shape)
 
     def make_where(self, name, inputs, dtype, shape):
         output = f"{name}/output_0"
@@ -437,6 +437,11 @@ class Model:
     def make_mul(self, name, inputs, dtype, shape):
         output = f"{name}/output_0"
         self.make_node("Mul", inputs=inputs, outputs=[output], name=name)
+        self.make_value_info(output, dtype, shape=shape)
+
+    def make_transpose(self, name, root_input, dtype, shape, perm):
+        output = f"{name}/output_0"
+        self.make_node("Transpose", inputs=[root_input], outputs=[output], perm=perm)
         self.make_value_info(output, dtype, shape=shape)
 
     def make_matmul(self, matmul, name, root_input, **kwargs):
@@ -512,7 +517,6 @@ class Model:
         self.layernorm_attrs["root_input"] = layernorm_attrs_value
         self.layernorm_attrs["skip_input"] = layernorm_attrs_value
 
-
     def make_layernorm(self, layer_id, layernorm, skip, simple, location):
         root_input = self.layernorm_attrs["root_input"]
         skip_input = self.layernorm_attrs["skip_input"]
@@ -552,7 +556,7 @@ class Model:
 
         return output_0
 
-    def make_rotary_embedding(self, rotemb, name, root_input, **kwargs):
+    def make_rotary_embedding_caches(self, rotemb):
         cos_cache_name, sin_cache_name = "cos_cache", "sin_cache"
 
         if self.rotemb_attrs["create_rotary_embedding_caches"]:
@@ -576,10 +580,222 @@ class Model:
 
             self.rotemb_attrs["create_rotary_embedding_caches"] = False
 
+        return cos_cache_name, sin_cache_name
+
+    def make_rotary_embedding(self, rotemb, name, root_input, **kwargs):
+        cos_cache_name, sin_cache_name = self.make_rotary_embedding_caches(rotemb)
+
         inputs = [root_input, kwargs.pop("position_ids"), cos_cache_name, sin_cache_name]
         output = f"{name}/output_0"
         self.make_node("RotaryEmbedding", inputs=inputs, outputs=[output], name=name, domain="com.microsoft", interleaved=0, **kwargs)
         self.make_value_info(output, self.io_dtype, shape=['batch_size', 'sequence_length', self.head_size * (self.num_kv_heads if "k_rotary" in name else self.num_attn_heads)])
+
+    # def make_repeat_kv(self, layer_id, root_input, past_kv, present_kv, **kwargs):
+    #     basename = f"/model/layers.{layer_id}/attn/{'k_proj' if past_kv.endswith('key') else 'v_proj'}/repeat_kv"
+        
+    #     reshape_1_name = f"{basename}/Reshape_1"
+    #     reshape_1_inputs = [root_input, f"/model/constants/TensorProto.INT64/1D/0, 0, {self.num_kv_heads}, -1"]
+    #     self.make_reshape(reshape_1_name, reshape_1_inputs, dtype=self.io_dtype, shape=['batch_size', 'sequence_length', self.num_kv_heads, self.head_size])
+    #     transpose_1_name = f"{basename}/Transpose_1"
+    #     transpose_1_input = f"{reshape_1_name}/output_0"
+    #     self.make_transpose(transpose_1_name, transpose_1_input, dtype=self.io_dtype, shape=['batch_size', self.num_kv_heads, 'sequence_length', self.head_size], perm=[0,2,1,3])
+    #     concat_name = f"{basename}/Concat"
+    #     concat_inputs = [past_kv, f"{transpose_1_name}/output_0"]
+    #     self.make_node("Concat", inputs=concat_inputs, outputs=[present_kv], name=concat_name, axis=2)
+
+    #     unsqueeze_name = f"{basename}/Unsqueeze"
+    #     unsqueeze_inputs = [present_kv, "/model/constants/TensorProto.INT64/1D/2"]
+    #     self.make_unsqueeze(unsqueeze_name, unsqueeze_inputs, dtype=self.io_dtype, shape=['batch_size', self.num_kv_heads, 1, 'sequence_length', self.head_size])
+    #     expand_name = f"{basename}/Expand"
+    #     expand_inputs = [f"{unsqueeze_name}/output_0", ???]
+    #     self.make_expand(expand_name, expand_inputs, dtype=self.io_dtype, shape=['batch_size', self.num_kv_heads, self.num_attn_heads // self.num_kv_heads, 'sequence_length', self.head_size])
+    #     reshape_2_name = f"{basename}/Reshape_2"
+    #     reshape_2_inputs = [f"{expand_name}/output_0", f"/model/constants/TensorProto.INT64/1D/0, -1, 0, 0"]
+    #     self.make_reshape(reshape_2_name, reshape_2_inputs, dtype=self.io_dtype, shape=['batch_size', self.num_attn_heads, 'sequence_length', self.head_size])
+    #     transpose_2_name = f"{basename}/Transpose_2"
+    #     transpose_2_input = f"{reshape_2_name}/output_0"
+    #     self.make_transpose(transpose_2_name, transpose_2_input, dtype=self.io_dtype, shape=['batch_size', 'sequence_length', self.num_attn_heads, self.head_size], perm=[0,2,1,3])
+    #     reshape_3_name = f"{basename}/Reshape_3"
+    #     reshape_3_inputs = [f"{transpose_2_name}/output_0", f"/model/constants/TensorProto.INT64/1D/0, 0, -1"]
+    #     self.make_reshape(reshape_2_name, reshape_2_inputs, dtype=self.io_dtype, shape=['batch_size', 'sequence_length', self.num_attn_heads * self.head_size])
+
+    #     input_to_attention = f"{reshape_3_name}/output_0"
+    #     return input_to_attention
+
+    # Note: This function and any corresponding changes to support it are temporary until ORT supports GQA for CPU
+    def make_repeat_kv(self, layer_id, root_input, past_kv, present_kv, **kwargs):
+        # Make subgraph that repeats tensor of shape (batch_size, sequence_length, num_kv_heads, head_size)
+        # to shape (batch_size, sequence_length, num_attn_heads, head_size) in an interleaved pattern
+        # and updates the KV caches
+        #
+        #           root_input
+        #                |
+        #             Reshape
+        #                |
+        #            Transpose
+        #                |
+        #                |   past_kv
+        #                |  /
+        #             Concat
+        #                |  \
+        #                |   present_kv
+        #                |
+        #        +-------+---------+
+        #        |                 |        
+        #        |               Shape
+        #        |                 |
+        #        |     +-----------+-----------+-----------+
+        #        |     |           |           |           |
+        #        |   Gather     Gather      Gather      Gather
+        #        |   (idx=0)    (idx=1)     (idx=2)     (idx=3)
+        #        |     |           |           |           |
+        #        | Unsqueeze   Unsqueeze   Unsqueeze   Unsqueeze
+        #        |     |           |           |           |
+        #        |     +-----------+-----------+-----------+
+        #        |                 |
+        #        |                 +-----------------------+
+        #        |                 |                       |
+        #        |              Concat                   Concat
+        #        |               (5D)                     (4D)
+        #        |                 |                       |
+        #        |              Reshape                    |
+        #        |             /   |   \                   |
+        #        |            /    |    \                  |
+        #        |           /     |     \                /
+        #        |          /      |      \              /
+        #        |         /       |       \            /
+        #        |        /      Shape      \          /
+        #        |       /         |         \        /
+        #        |      |   ConstantOfShape   \      /
+        #        |       \         |       \   \    /
+        #        |        \        |       Mul  |  /
+        #        |         \       |        |  /  /
+        #        |          \      |      Equal  /
+        #        |           \     |       /    /
+        #         \           \    |      /    /
+        #          \           \   |     /    /
+        #           \           \  |    /    /
+        #            \           \ |   /    /
+        #         Unsqueeze       Where    /
+        #             \           /       /
+        #              \         /       /
+        #               \       /       /
+        #                \     /       /
+        #                 Expand      /
+        #                    |       /
+        #                    |      /
+        #                    |     /
+        #                    |    /
+        #                    |   /
+        #                 Reshape
+        #                    |
+        #                Transpose
+        basename = f"/model/layers.{layer_id}/attn/{'k_proj' if past_kv.endswith('key') else 'v_proj'}/repeat_kv"
+
+        # Make the initial subgraph
+        #
+        #                                                       +------> Gather --> Unsqueeze -----+
+        #                                                       |                                  |
+        #                                         past_kv       +------> Gather --> Unsqueeze -----+---> Mul --> Concat (4D)
+        #                                            |          |                                  |
+        # root_input --> Reshape --> Transpose --> Concat --> Shape ---> Gather --> Unsqueeze -----+---> Concat (5D)
+        #                                            |          |                                  |
+        #                                        present_kv     +------> Gather --> Unsqueeze -----+
+        reshape_1_name = f"{basename}/Reshape_1"
+        reshape_1_inputs = [root_input, f"/model/constants/TensorProto.INT64/1D/0, 0, {self.num_kv_heads}, -1"]
+        self.make_reshape(reshape_1_name, reshape_1_inputs, dtype=self.io_dtype, shape=['batch_size', 'sequence_length', self.num_kv_heads, self.head_size])
+        transpose_1_name = f"{basename}/Transpose_1"
+        transpose_1_input = f"{reshape_1_name}/output_0"
+        self.make_transpose(transpose_1_name, transpose_1_input, dtype=self.io_dtype, shape=['batch_size', self.num_kv_heads, 'sequence_length', self.head_size], perm=[0,2,1,3])
+        concat_1_name = f"{basename}/Concat_1"
+        concat_1_inputs = [past_kv, f"{transpose_1_name}/output_0"]
+        self.make_node("Concat", inputs=concat_1_inputs, outputs=[present_kv], name=concat_1_name, axis=2)
+        
+        shape_1_name = f"{basename}/Shape_1"
+        self.make_shape(shape_1_name, present_kv, shape=[4])
+        gather_1_name = f"{basename}/Gather_1"
+        gather_1_inputs = [f"{shape_1_name}/output_0", "/model/constants/TensorProto.INT64/0D/0"]
+        self.make_gather(gather_1_name, gather_1_inputs, axis=0)
+        unsqueeze_1_name = f"{basename}/Unsqueeze_1"
+        unsqueeze_1_inputs = [f"{gather_1_name}/output_0", "/model/constants/TensorProto.INT64/1D/0"]
+        self.make_unsqueeze(unsqueeze_1_name, unsqueeze_1_inputs, dtype=TensorProto.INT64, shape=[1])
+        gather_2_name = f"{basename}/Gather_2"
+        gather_2_inputs = [f"{shape_1_name}/output_0", "/model/constants/TensorProto.INT64/0D/1"]
+        self.make_gather(gather_2_name, gather_2_inputs, axis=0)
+        unsqueeze_2_name = f"{basename}/Unsqueeze_2"
+        unsqueeze_2_inputs = [f"{gather_2_name}/output_0", "/model/constants/TensorProto.INT64/1D/0"]
+        self.make_unsqueeze(unsqueeze_2_name, unsqueeze_2_inputs, dtype=TensorProto.INT64, shape=[1])
+        gather_3_name = f"{basename}/Gather_3"
+        gather_3_inputs = [f"{shape_1_name}/output_0", "/model/constants/TensorProto.INT64/0D/2"]
+        self.make_gather(gather_3_name, gather_3_inputs, axis=0)
+        unsqueeze_3_name = f"{basename}/Unsqueeze_3"
+        unsqueeze_3_inputs = [f"{gather_3_name}/output_0", "/model/constants/TensorProto.INT64/1D/0"]
+        self.make_unsqueeze(unsqueeze_3_name, unsqueeze_3_inputs, dtype=TensorProto.INT64, shape=[1])
+        gather_4_name = f"{basename}/Gather_4"
+        gather_4_inputs = [f"{shape_1_name}/output_0", "/model/constants/TensorProto.INT64/0D/3"]
+        self.make_gather(gather_4_name, gather_4_inputs, axis=0)
+        unsqueeze_4_name = f"{basename}/Unsqueeze_4"
+        unsqueeze_4_inputs = [f"{gather_4_name}/output_0", "/model/constants/TensorProto.INT64/1D/0"]
+        self.make_unsqueeze(unsqueeze_4_name, unsqueeze_4_inputs, dtype=TensorProto.INT64, shape=[1])
+        concat_2_name = f"{basename}/Concat_2"
+        concat_2_inputs = [f"{unsqueeze_1_name}/output_0", f"{unsqueeze_2_name}/output_0", f"/model/constants/TensorProto.INT64/1D/{self.num_attn_heads // self.num_kv_heads}", f"{unsqueeze_3_name}/output_0", f"{unsqueeze_4_name}/output_0"]
+        self.make_concat(concat_2_name, concat_2_inputs, dtype=TensorProto.INT64, shape=[5], axis=0)
+
+        mul_1_name = f"{basename}/Mul_1"
+        mul_1_inputs = [f"{unsqueeze_2_name}/output_0", f"/model/constants/TensorProto.INT64/0D/{self.num_attn_heads // self.num_kv_heads}"]
+        self.make_mul(mul_1_name, mul_1_inputs, dtype=TensorProto.INT64, shape=None)
+        concat_3_name = f"{basename}/Concat_3"
+        concat_3_inputs = [f"{unsqueeze_1_name}/output_0", f"{mul_1_name}/output_0", f"{unsqueeze_3_name}/output_0", f"{unsqueeze_4_name}/output_0"]
+        self.make_concat(concat_3_name, concat_3_inputs, dtype=TensorProto.INT64, shape=[4], axis=0)
+
+        # Make the subgraph that follows the initial subgraph
+        #
+        #                               Mul ---> Equal
+        #                              /              \
+        # Reshape --> Shape --> ConstantOfShape --> Where
+        #    |                                        |
+        #    +----------------------------------------+
+        reshape_2_name = f"{basename}/Reshape_2"
+        reshape_2_inputs = [f"{concat_2_name}/output_0", "/model/constants/TensorProto.INT64/1D/-1"]
+        self.make_reshape(reshape_2_name, reshape_2_inputs, dtype=TensorProto.INT64, shape=None)
+        shape_2_name = f"{basename}/Shape_2"
+        self.make_shape(shape_2_name, f"{reshape_2_name}/output_0", shape=[1])
+        constant_shape_name = f"{basename}/ConstantOfShape"
+        constant_shape_value = numpy_helper.from_array(np.array([1], dtype="int64"))
+        self.make_constant_of_shape(constant_shape_name, f"{shape_2_name}/output_0", value=constant_shape_value, dtype=TensorProto.INT64, shape=[5])
+        mul_2_name = f"{basename}/Mul"
+        mul_2_inputs = [f"{constant_shape_name}/output_0", "/model/constants/TensorProto.INT64/0D/-1"]
+        self.make_mul(mul_2_name, mul_2_inputs, dtype=TensorProto.INT64, shape=[5])
+        equal_name = f"{basename}/Equal"
+        equal_inputs = [f"{reshape_2_name}/output_0", f"{mul_2_name}/output_0"]
+        self.make_equal(equal_name, equal_inputs, shape=[5])
+        where_name = f"{basename}/Where"
+        where_inputs = [f"{equal_name}/output_0", f"{constant_shape_name}/output_0", f"{reshape_2_name}/output_0"]
+        self.make_where(where_name, where_inputs, dtype=TensorProto.INT64, shape=[5])
+
+        # Make the final nodes
+        #
+        # Where (from above)  Concat (from above)
+        #                   \           \
+        # Unsqueeze --> Expand --> Reshape --> Transpose
+        unsqueeze_5_name = f"{basename}/Unsqueeze_5"
+        unsqueeze_5_inputs = [present_kv, "/model/constants/TensorProto.INT64/1D/2"]
+        self.make_unsqueeze(unsqueeze_5_name, unsqueeze_5_inputs, dtype=self.io_dtype, shape=['batch_size', self.num_kv_heads, 1, 'sequence_length', self.head_size])
+        expand_name = f"{basename}/Expand"
+        expand_inputs = [f"{unsqueeze_5_name}/output_0", f"{where_name}/output_0"]
+        self.make_expand(expand_name, expand_inputs, dtype=self.io_dtype, shape=['batch_size', self.num_kv_heads, self.num_attn_heads // self.num_kv_heads, 'sequence_length', self.head_size])
+        reshape_3_name = f"{basename}/Reshape_3"
+        reshape_3_inputs = [f"{expand_name}/output_0", f"{concat_3_name}/output_0"]
+        self.make_reshape(reshape_3_name, reshape_3_inputs, dtype=self.io_dtype, shape=['batch_size', self.num_attn_heads, 'sequence_length', self.head_size])
+        transpose_2_name = f"{basename}/Transpose_2"
+        transpose_2_input = f"{reshape_3_name}/output_0"
+        self.make_transpose(transpose_2_name, transpose_2_input, dtype=self.io_dtype, shape=['batch_size', 'sequence_length', self.num_attn_heads, self.head_size], perm=[0,2,1,3])
+        reshape_4_name = f"{basename}/Reshape_4"
+        reshape_4_inputs = [f"{transpose_2_name}/output_0", f"/model/constants/TensorProto.INT64/1D/0, 0, {self.num_attn_heads * self.head_size}"]
+        self.make_reshape(reshape_4_name, reshape_4_inputs, dtype=self.io_dtype, shape=['batch_size', 'sequence_length', self.num_attn_heads * self.head_size])
+
+        input_to_attention = f"{reshape_4_name}/output_0"
+        return input_to_attention
 
     def make_attention_op(self, name, **kwargs):
         op_type = self.attention_attrs["op_type"]
@@ -648,13 +864,20 @@ class Model:
         #                    |
         #                  O_Add
 
+        q_input_to_attention = ""
+        k_input_to_attention = ""
+        v_input_to_attention = ""
+
         # Make MatMul nodes
         q_matmul_name = f"/model/layers.{layer_id}/attn/q_proj/MatMul"
         self.make_matmul(attention.q_proj.weight.detach().numpy(), q_matmul_name, root_input)
+        q_input_to_attention = f"{q_matmul_name}/output_0"
         k_matmul_name = f"/model/layers.{layer_id}/attn/k_proj/MatMul"
         self.make_matmul(attention.k_proj.weight.detach().numpy(), k_matmul_name, root_input)
+        k_input_to_attention = f"{k_matmul_name}/output_0"
         v_matmul_name = f"/model/layers.{layer_id}/attn/v_proj/MatMul"
         self.make_matmul(attention.v_proj.weight.detach().numpy(), v_matmul_name, root_input)
+        v_input_to_attention = f"{v_matmul_name}/output_0"
 
         # Make Add nodes (if bias exists)
         q_bias_exists = attention.q_proj.bias is not None
@@ -664,27 +887,42 @@ class Model:
         if q_bias_exists:
             q_add_name = f"/model/layers.{layer_id}/attn/q_proj/Add"
             self.make_add_bias(attention.q_proj.bias.detach().numpy(), q_add_name, root_input=f"{q_matmul_name}/output_0")
+            q_input_to_attention = f"{q_add_name}/output_0"
         if k_bias_exists:
             k_add_name = f"/model/layers.{layer_id}/attn/k_proj/Add"
             self.make_add_bias(attention.k_proj.bias.detach().numpy(), k_add_name, root_input=f"{k_matmul_name}/output_0")
+            k_input_to_attention = f"{k_add_name}/output_0"
         if v_bias_exists:
             v_add_name = f"/model/layers.{layer_id}/attn/v_proj/Add"
             self.make_add_bias(attention.v_proj.bias.detach().numpy(), v_add_name, root_input=f"{v_matmul_name}/output_0")
+            v_input_to_attention = f"{v_add_name}/output_0"
 
         # Make RotaryEmbedding nodes
         q_rotary_name = f"/model/layers.{layer_id}/attn/q_rotary/RotaryEmbedding"
         q_rotary_input = f"{q_matmul_name if not q_bias_exists else q_add_name}/output_0"
         self.make_rotary_embedding(attention.rotary_emb, q_rotary_name, q_rotary_input, position_ids=kwargs.get("position_ids", "position_ids"))
+        q_input_to_attention = f"{q_rotary_name}/output_0"
+
         k_rotary_name = f"/model/layers.{layer_id}/attn/k_rotary/RotaryEmbedding"
         k_rotary_input = f"{k_matmul_name if not k_bias_exists else k_add_name}/output_0"
         self.make_rotary_embedding(attention.rotary_emb, k_rotary_name, k_rotary_input, position_ids=kwargs.get("position_ids", "position_ids"))
+        k_input_to_attention = f"{k_rotary_name}/output_0"
+
+        # Make repeat KV nodes (TODO: remove once ORT supports GQA for CPU)
+        past_k = f"past_key_values.{layer_id}.key"
+        past_v = f"past_key_values.{layer_id}.value"
+        present_k = f"present.{layer_id}.key"
+        present_v = f"present.{layer_id}.value"
+        if self.num_attn_heads != self.num_kv_heads and not self.attention_attrs['use_gqa']:
+            k_input_to_attention = self.make_repeat_kv(layer_id, k_input_to_attention, past_k, present_k)
+            v_input_to_attention = self.make_repeat_kv(layer_id, v_input_to_attention, past_v, present_v)
+            past_k, past_v, present_k, present_v = "", "", "", ""
 
         # Make attention node (e.g. MultiHeadAttention, GroupQueryAttention, etc.)
         attn_name = f"/model/layers.{layer_id}/attn/{self.attention_attrs['op_type']}"
         self.make_attention_op(
-            attn_name, q_path=f"{q_rotary_name}/output_0", k_path=f"{k_rotary_name}/output_0", v_path=f"{v_matmul_name if not v_bias_exists else v_add_name}/output_0",
-            past_k=f"past_key_values.{layer_id}.key", past_v=f"past_key_values.{layer_id}.value",
-            present_k=f"present.{layer_id}.key", present_v=f"present.{layer_id}.value", **kwargs,
+            attn_name, q_path=q_input_to_attention, k_path=k_input_to_attention, v_path=v_input_to_attention,
+            past_k=past_k, past_v=past_v, present_k=present_k, present_v=present_v, **kwargs,
         )
 
         # Make MatMul node (output projection weight node)
@@ -938,8 +1176,8 @@ class Model:
 
         # TODO: replace Concat with Expand for performance gains
         concat_name = f"{basename}/Concat"
-        concat_inputs = [f"{end_add_name}/output_0" for _ in range(self.num_kv_heads)]
-        concat_shape = ["batch_size", self.num_kv_heads, "source_sequence_length", "target_sequence_length"]
+        concat_inputs = [f"{end_add_name}/output_0" for _ in range(self.num_attn_heads)]
+        concat_shape = ["batch_size", self.num_attn_heads, "source_sequence_length", "target_sequence_length"]
         self.make_concat(concat_name, concat_inputs, dtype=self.io_dtype, shape=concat_shape, axis=1) # Shape of mask is now (B, N, S, T)
 
         self.mask_attrs["mask_name"] = concat_name
@@ -1027,7 +1265,7 @@ class Model:
         # Merged path
         reshape_name = f"{basename}/Reshape"
         reshape_inputs = [f"{add_2_name}/output_0", f"{concat_3_name}/output_0"]
-        self.make_reshape(reshape_name, reshape_inputs)
+        self.make_reshape(reshape_name, reshape_inputs, dtype=TensorProto.INT64, shape=None)
         less_name = f"{basename}/Less"
         less_inputs = [f"{range_name}/output_0", f"{reshape_name}/output_0"]
         self.make_less(less_name, less_inputs)
@@ -1147,7 +1385,7 @@ class Model:
         self.make_mul(mul_name, mul_inputs, dtype=TensorProto.INT64, shape=["unk"])
         equal_name = f"{basename}/Equal"
         equal_inputs = [f"{concat_name}/output_0", f"{mul_name}/output_0"]
-        self.make_equal(equal_name, equal_inputs)
+        self.make_equal(equal_name, equal_inputs, shape=[4])
         
         where_name = f"{basename}/Where_1"
         where_inputs = [f"{equal_name}/output_0", f"{constant_shape_name}/output_0", f"{concat_name}/output_0"]
@@ -1159,7 +1397,7 @@ class Model:
         self.make_expand(expand_name, expand_inputs, dtype=expand_dtype, shape=expand_shape)
 
         return expand_name
-
+    
 
 class LlamaModel(Model):
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
@@ -1247,7 +1485,7 @@ class MistralModel(LlamaModel):
         self.make_concat(concat_name, concat_inputs, dtype=TensorProto.INT64, shape=[2], axis=0)
         reshape_name = f"{basename}/Reshape"
         reshape_inputs = ["position_ids", f"{concat_name}/output_0"]
-        self.make_reshape(reshape_name, reshape_inputs)
+        self.make_reshape(reshape_name, reshape_inputs, dtype=TensorProto.INT64, shape=None)
 
         return reshape_name
 


### PR DESCRIPTION
### Description

This PR adds `repeat_kv` to the model builder for models where `num_attention_heads != num_key_value_heads`.

### Motivation and Context

By supporting `repeat_kv`, models where `num_attention_heads != num_key_value_heads` can now run on both CPU and GPU.