### PR TITLE
Fix python scripts to use options properly

### DIFF
--- a/benchmark/python/benchmark_e2e.py
+++ b/benchmark/python/benchmark_e2e.py
@@ -65,15 +65,17 @@ def main(args):
     # Generate prompt
     prompt = [generate_prompt(model, tokenizer, prompt_length)] * batch_size
     tokens = tokenizer.encode_batch(prompt)
+
+    params = og.GeneratorParams(model)
+    params.input_ids = tokens
+    params.set_search_options({"do_sample":True, "top_k":args.top_k, "top_p":args.top_p, "temperature":temperature, "max_length":max_length, "min_length":max_length})
+
     if args.verbose: print("Running warmup runs...")
     for _ in tqdm(range(args.warmup)):
-        params = og.GeneratorParams(model)
-        params.input_ids = tokens
-        params.set_search_options({"max_length":max_length, "min_length":max_length})
         generator = og.Generator(model, params)
         while not generator.is_done():
             generator.compute_logits()
-            generator.generate_next_token_top_k_top_p(args.top_k, args.top_p, temperature)
+            generator.generate_next_token()
         if args.print_model_output: print(tokenizer.decode(generator.get_sequence(0)))
 
     tokenize_times = []
@@ -84,9 +86,6 @@ def main(args):
     if args.verbose: print(f"Running benchmark for batch size = {batch_size}, prompt length = {prompt_length}")
     for _ in tqdm(range(num_repetitions)):
         # Prepare run
-        params = og.GeneratorParams(model)
-        params.input_ids = tokens
-        params.set_search_options({"max_length":max_length, "min_length":max_length})
         generator = og.Generator(model, params)
 
         # Measure tokenization
@@ -102,7 +101,7 @@ def main(args):
         prompt_times.append(prompt_end_time - prompt_start_time)
 
         sampling_start_time = time.perf_counter()
-        generator.generate_next_token_top_k_top_p(args.top_k, args.top_p, temperature)
+        generator.generate_next_token()
         sampling_end_time = time.perf_counter()
         sampling_times.append(sampling_end_time - sampling_start_time)
 
@@ -115,7 +114,7 @@ def main(args):
             token_gen_end_time = time.perf_counter()
 
             sampling_start_time = time.perf_counter()
-            generator.generate_next_token_top_k_top_p(args.top_k, args.top_p, temperature)
+            generator.generate_next_token()
             sampling_end_time = time.perf_counter()
             
             token_gen_times.append(token_gen_end_time - token_gen_start_time)

--- a/benchmark/python/benchmark_e2e.py
+++ b/benchmark/python/benchmark_e2e.py
@@ -18,12 +18,12 @@ def generate_prompt(model, tokenizer, prompt_length) -> str:
     prompt = "a"
     tokens = tokenizer.encode(prompt)
     params=og.GeneratorParams(model)
-    params.set_search_options({"max_length":prompt_length, "min_length":prompt_length+1})
+    params.set_search_options({"do_sample":True, "top_k":5, "temperature":temperature, "max_length":prompt_length, "min_length":prompt_length+1})
     params.input_ids = tokens
     generator=og.Generator(model, params)
     while not generator.is_done():
         generator.compute_logits()
-        generator.generate_next_token_top_k(5, temperature)
+        generator.generate_next_token()
     return tokenizer.decode(generator.get_sequence(0))
 
 def save_results(results, filename):

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -20,7 +20,7 @@ def main(args):
         input_tokens = tokenizer.encode(text)
 
         params = og.GeneratorParams(model)
-        params.set_search_options({"max_length": args.max_length, "top_p": args.top_p, "top_k": args.top_k, "temperature": args.temperature, "repetition_penalty": args.repetition_penalty})
+        params.set_search_options({"do_sample": True, "max_length": args.max_length, "top_p": args.top_p, "top_k": args.top_k, "temperature": args.temperature, "repetition_penalty": args.repetition_penalty})
         params.input_ids = input_tokens
         generator = og.Generator(model, params)
         if args.verbose: print("Generator created")
@@ -29,7 +29,7 @@ def main(args):
         print(f'\n{text}', end='')
         while not generator.is_done():
             generator.compute_logits()
-            generator.generate_next_token_top_k_top_p(args.top_k, args.top_p, args.temperature)
+            generator.generate_next_token()
             print(tokenizer_stream.decode(generator.get_next_tokens()[0]), end='', flush=True)
         print()
 

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -119,7 +119,7 @@ void Generator::GenerateNextToken_TopK_TopP(int top_k, float top_p, float temper
   if (top_k < 0)
     throw std::runtime_error("top_k must be 0 or greater");
 
-  if (top_p > 0.0f && top_k > 1) {
+  if (top_p > 0.0f && top_p < 1.0f && top_k > 1) {
     search_->SampleTopPAndK(top_p, top_k, temperature);
   } else if (top_k > 1) {
     search_->SampleTopK(top_k, temperature);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -33,6 +33,14 @@ BeamSearch_Cpu::~BeamSearch_Cpu() = default;
 
 void Search_Cpu::SetLogits(RoamingArray<float> logits_unk) {
   next_token_scores_ = logits_unk.GetCPU();
+
+  auto batch_beam_size = params_.BatchBeamSize();
+  assert(next_token_scores_.size() % (batch_beam_size * params_.vocab_size) == 0);  // Should divide evenly
+
+  for (int i = 0; i < batch_beam_size; i++) {
+    std::span<float> const target = next_token_scores_.subspan(i * params_.vocab_size, params_.vocab_size);
+    log_softmax(target);
+  }
 }
 
 RoamingArray<int32_t> GreedySearch_Cpu::GetNextTokens() {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -33,14 +33,6 @@ BeamSearch_Cpu::~BeamSearch_Cpu() = default;
 
 void Search_Cpu::SetLogits(RoamingArray<float> logits_unk) {
   next_token_scores_ = logits_unk.GetCPU();
-
-  auto batch_beam_size = params_.BatchBeamSize();
-  assert(next_token_scores_.size() % (batch_beam_size * params_.vocab_size) == 0);  // Should divide evenly
-
-  for (int i = 0; i < batch_beam_size; i++) {
-    std::span<float> const target = next_token_scores_.subspan(i * params_.vocab_size, params_.vocab_size);
-    log_softmax(target);
-  }
 }
 
 RoamingArray<int32_t> GreedySearch_Cpu::GetNextTokens() {

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -32,14 +32,14 @@ def test_greedy_search(test_data_path, relative_model_path):
     search_params.input_ids = np.array(
         [[0, 0, 0, 52], [0, 0, 195, 731]], dtype=np.int32
     )
-    search_params.set_search_options({"max_length": 10})
+    search_params.set_search_options({"do_sample": False, "max_length": 10})
     input_ids_shape = [2, 4]
     batch_size = input_ids_shape[0]
 
     generator = og.Generator(model, search_params)
     while not generator.is_done():
         generator.compute_logits()
-        generator.generate_next_token_top()
+        generator.generate_next_token()
 
     expected_sequence = np.array(
         [


### PR DESCRIPTION
We were using set_search_options, then for example calling 'get_next_token_topk_topp' which is redundant. We can call 'get_next_token()' and it will use the search options we just set.

Also now bypasses calling TopK_TopP if P is 1.0 when calling generate_next_token
