### PR TITLE
DML - Preload DirectML.dll to not use OS version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,9 @@ endif()
 
 # Copy the onnxruntime binaries into the build folder so it's found on launch
 file(GLOB onnxruntime_libs "${ORT_LIB_DIR}/${ONNXRUNTIME_FILES}")
+if(USE_DML)
+  list(APPEND onnxruntime_libs "${ORT_LIB_DIR}/DirectML.dll")
+endif()
 foreach(DLL_FILE ${onnxruntime_libs})
   add_custom_command(
     TARGET onnxruntime-genai POST_BUILD

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -13,6 +13,23 @@
 //  Because dml_provider_factory includes windows headers that #define min and max, this next line will prevent this from happening
 #define NOMINMAX
 #include "dml_provider_factory.h"
+
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+
+static std::wstring CurrentModulePath() {
+  wchar_t path[MAX_PATH];
+  GetModuleFileNameW((HINSTANCE)&__ImageBase, path, _countof(path));
+
+  wchar_t absolute_path[MAX_PATH];
+  wchar_t* name;
+  GetFullPathNameW(path, _countof(path), absolute_path, &name);
+
+  auto idx = std::distance(absolute_path, name);
+  auto out_path = std::wstring(absolute_path);
+  out_path.resize(idx);
+
+  return out_path;
+}
 #endif
 
 namespace Generators {
@@ -302,6 +319,9 @@ void Model::CreateSessionOptions() {
       Ort::ThrowOnError(Ort::api->GetExecutionProviderApi("DML", ORT_API_VERSION, reinterpret_cast<const void**>(&p_dml_api)));
       if (!p_dml_api)
         throw std::runtime_error("Unexpected nullptr getting OrtDmlApi");
+      auto directml_dll = CurrentModulePath() + L"DirectML.dll";
+      if (LoadLibraryExW(directml_dll.c_str(), nullptr, 0) == NULL)
+        throw std::runtime_error("DirectML.dll not found");
       p_dml_api->SessionOptionsAppendExecutionProvider_DML(&ort_options, 0);
 #endif
     } else


### PR DESCRIPTION
If we fail to preload, we abort using DirectML as using the OS copy will fail when we try to use it.
Also Copy DirectML.dll to the install folder as part of the other onnxruntime files