### PR TITLE
Add C++ benchmark program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ if(USE_CUDA AND CMAKE_CUDA_COMPILER AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_compile_definitions(_DEBUG=1)
 endif()
 
+if(MSVC)
+  add_compile_options(/Zc:__cplusplus)  # set updated value for __cplusplus macro instead of 199711L
+endif()
+
 message(STATUS "Adding source files")
 
 file(GLOB generator_srcs CONFIGURE_DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,8 @@ if(USE_CUDA AND CMAKE_CUDA_COMPILER AND CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 if(MSVC)
-  add_compile_options(/Zc:__cplusplus)  # set updated value for __cplusplus macro instead of 199711L
+  # set updated value for __cplusplus macro instead of 199711L
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus>)
 endif()
 
 message(STATUS "Adding source files")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,8 @@ else()
   set(ONNXRUNTIME_EXTENSIONS_LIB "tfmtok_c.so")
 endif()
 
+file(GLOB onnxruntime_libs "${ORT_LIB_DIR}/${ONNXRUNTIME_FILES}")
+
 if(NO_TOKENIZEROOT)
   add_compile_definitions(NO_TOKENIZER=1)
   message("----------------Tokenizer Disabled------------------")
@@ -148,6 +150,11 @@ if(ENABLE_PYTHON)
   message("------------------Enabling Python Wheel------------------")
 endif()
 
+if(ENABLE_MODEL_BENCHMARK)
+  add_subdirectory("${CMAKE_SOURCE_DIR}/benchmark/c")
+  message("------------------Enabling model benchmark------------------")
+endif()
+
 if(NOT EXISTS "${ORT_LIB_DIR}/${ONNXRUNTIME_LIB}")
   message(FATAL_ERROR "Expected the ONNX Runtime library to be found at ${ORT_LIB_DIR}/${ONNXRUNTIME_LIB}. Actual: Not found.")
 endif()
@@ -158,7 +165,6 @@ if(USE_CUDA AND NOT EXISTS "${ORT_LIB_DIR}/${ONNXRUNTIME_PROVIDERS_CUDA_LIB}")
   message(FATAL_ERROR "Expected the ONNX Runtime providers cuda library to be found at ${ORT_LIB_DIR}/${ONNXRUNTIME_PROVIDERS_CUDA_LIB}. Actual: Not found.")
 endif()
 
-file(GLOB onnxruntime_libs "${ORT_LIB_DIR}/${ONNXRUNTIME_FILES}")
 target_link_directories(onnxruntime-genai PRIVATE ${ORT_LIB_DIR})
 target_link_libraries(onnxruntime-genai PRIVATE ${ONNXRUNTIME_LIB})
 
@@ -182,7 +188,6 @@ if(MSVC)
 endif()
 
 # Copy the onnxruntime binaries into the build folder so it's found on launch
-file(GLOB onnxruntime_libs "${ORT_LIB_DIR}/${ONNXRUNTIME_FILES}")
 foreach(DLL_FILE ${onnxruntime_libs})
   add_custom_command(
     TARGET onnxruntime-genai POST_BUILD

--- a/benchmark/c/CMakeLists.txt
+++ b/benchmark/c/CMakeLists.txt
@@ -1,8 +1,13 @@
-add_executable(model_benchmark
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set(model_benchmark_srcs
   ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/options.h
   ${CMAKE_CURRENT_SOURCE_DIR}/options.cpp
 )
+
+add_executable(model_benchmark ${model_benchmark_srcs})
 
 target_include_directories(model_benchmark PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16,3 +21,5 @@ target_link_directories(model_benchmark PRIVATE ${ORT_LIB_DIR})
 add_custom_command(TARGET model_benchmark POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${onnxruntime_libs} $<TARGET_FILE_DIR:model_benchmark>
 )
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${model_benchmark_srcs})

--- a/benchmark/c/CMakeLists.txt
+++ b/benchmark/c/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(model_benchmark
+  ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+)
+
+target_include_directories(model_benchmark PRIVATE
+  ${CMAKE_SOURCE_DIR}/src  # directory containing the ort_genai headers
+)
+
+target_link_libraries(model_benchmark PRIVATE onnxruntime-genai-static ${ONNXRUNTIME_LIB})
+
+target_link_directories(model_benchmark PRIVATE ${ORT_LIB_DIR})
+
+add_custom_command(TARGET model_benchmark POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${onnxruntime_libs} $<TARGET_FILE_DIR:model_benchmark>
+)

--- a/benchmark/c/CMakeLists.txt
+++ b/benchmark/c/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_executable(model_benchmark
   ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/options.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/options.cpp
 )
 
 target_include_directories(model_benchmark PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src  # directory containing the ort_genai headers
 )
 

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -1,33 +1,187 @@
+#include <algorithm>
+#include <chrono>
 #include <iostream>
+#include <numeric>
+#include <vector>
 
 #include "ort_genai.h"
 
-constexpr const char* kModelPath = "C:/Users/edch/models/phi3-3.8b-int4-cpu";
+#include "options.h"
 
-int main() {
-  auto model = OgaModel::Create(kModelPath);
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using Duration = Clock::duration;
+using DurationFp = std::chrono::duration<float, Duration::period>;
+
+using MicrosecondsFp = std::chrono::duration<float, std::chrono::microseconds::period>;
+
+class Timing {
+ public:
+  Timing(const Timing&) = delete;
+  Timing& operator=(const Timing&) = delete;
+
+  Timing(std::vector<Duration>& measurements)
+      : measurements_{measurements}, start_{Clock::now()} {
+  }
+
+  ~Timing() {
+    const auto measurement = Clock::now() - start_;
+    measurements_.push_back(measurement);
+  }
+
+ private:
+  std::vector<Duration>& measurements_;
+  const Clock::time_point start_;
+};
+
+struct Statistics {
+  DurationFp average{};
+  DurationFp p50{};
+  DurationFp p90{};
+  DurationFp p99{};
+  size_t n{};
+};
+
+Statistics ComputeStats(const std::vector<Duration>& measurements) {
+  Statistics stats{};
+  if (measurements.empty()) {
+    return stats;
+  }
+
+  stats.n = measurements.size();
+
+  const auto sum = std::accumulate(measurements.begin(), measurements.end(), Duration{0});
+  stats.average = DurationFp{sum} / stats.n;
+
+  std::vector<Duration> sorted = measurements;
+  std::sort(sorted.begin(), sorted.end());
+
+  stats.p50 = sorted[stats.n * 0.5];
+  stats.p90 = sorted[stats.n * 0.9];
+  stats.p99 = sorted[stats.n * 0.99];
+
+  return stats;
+}
+
+}  // namespace
+
+void RunBenchmark(const benchmark::Options& opts) {
+  auto model = OgaModel::Create(opts.model_path.c_str());
 
   auto tokenizer = OgaTokenizer::Create(*model);
 
-  auto sequences = OgaSequences::Create();
-
   const char* prompt = "My perfect Sunday is ";
-  tokenizer->Encode(prompt, *sequences);
+  auto prompt_sequences = OgaSequences::Create();
 
-  auto params = OgaGeneratorParams::Create(*model);
-  params->SetSearchOption("max_length", 200);
-  params->SetInputSequences(*sequences);
+  tokenizer->Encode(prompt, *prompt_sequences);
 
-  auto generator = OgaGenerator::Create(*model, *params);
-  while(!generator->IsDone()) {
-    generator->ComputeLogits();
-    generator->GenerateNextToken();
+  const size_t num_prompt_tokens = prompt_sequences->Get(0).size();
+  const size_t num_tokens = num_prompt_tokens + opts.num_tokens_to_generate;
+
+  auto make_generator_params = [&] {
+    auto params = OgaGeneratorParams::Create(*model);
+    params->SetSearchOption("max_length", num_tokens);
+    params->SetSearchOption("min_length", num_tokens);
+    params->SetInputSequences(*prompt_sequences);
+    return params;
+  };
+
+  // warmup
+  for (size_t i = 0; i < opts.num_warmup_iterations; ++i) {
+    auto params = make_generator_params();
+
+    auto generator = OgaGenerator::Create(*model, *params);
+    while (!generator->IsDone()) {
+      generator->ComputeLogits();
+      generator->GenerateNextToken();
+    }
   }
 
-  auto output_sequence = generator->GetSequence(0);
-  auto out_string = tokenizer->Decode(output_sequence);
+  std::vector<Duration> e2e_gen_times, prompt_processing_times, token_gen_times, sampling_times;
+  // note: be sure to reserve enough to avoid vector reallocations in the measured code
+  e2e_gen_times.reserve(opts.num_iterations);
+  prompt_processing_times.reserve(opts.num_iterations);
+  token_gen_times.reserve(opts.num_iterations * (opts.num_tokens_to_generate - 1));
+  sampling_times.reserve(opts.num_iterations * opts.num_tokens_to_generate);
 
-  std::cout << "output: " << out_string << "\n";
+  for (size_t i = 0; i < opts.num_iterations; ++i) {
+    auto params = make_generator_params();
 
-  return 0;
+    auto generator = OgaGenerator::Create(*model, *params);
+
+    {
+      Timing e2e_gen_timing{e2e_gen_times};
+
+      {
+        Timing prompt_processing_timing{prompt_processing_times};
+        generator->ComputeLogits();
+      }
+
+      {
+        Timing sampling_timing{sampling_times};
+        generator->GenerateNextToken();
+      }
+
+      while (!generator->IsDone()) {
+        {
+          Timing token_gen_timing{token_gen_times};
+          generator->ComputeLogits();
+        }
+
+        {
+          Timing sampling_timing{sampling_times};
+          generator->GenerateNextToken();
+        }
+      }
+    }
+
+    // auto output_sequence = generator->GetSequence(0);
+    // auto out_string = tokenizer->Decode(output_sequence);
+  }
+
+  {
+    const auto e2e_gen_stats = ComputeStats(e2e_gen_times);
+    const auto prompt_processing_stats = ComputeStats(prompt_processing_times);
+    const auto token_gen_stats = ComputeStats(token_gen_times);
+    const auto sampling_stats = ComputeStats(sampling_times);
+
+    auto write_per_token_stats = [](const std::string& label,
+                                    const Statistics& stats,
+                                    const size_t tokens_per_measurement) {
+      const auto avg_us = MicrosecondsFp{stats.average};
+      std::cout << label << ":\n"
+                << "\tavg latency (us): " << avg_us.count() / tokens_per_measurement
+                << ",\tavg throughput (tps): " << 1.0e6f / avg_us.count() * tokens_per_measurement
+                << ",\tp50 latency (us): " << MicrosecondsFp{stats.p50}.count() / tokens_per_measurement
+                << ",\tn: " << stats.n << " * " << tokens_per_measurement
+                << "\n";
+    };
+
+    auto write_stats = [](const std::string& label,
+                          const Statistics& stats) {
+      const auto avg_us = MicrosecondsFp{stats.average};
+      std::cout << label << ":\n"
+                << "\tavg latency (us): " << avg_us.count()
+                << ",\tp50 latency (us): " << MicrosecondsFp{stats.p50}.count()
+                << ",\tn: " << stats.n
+                << "\n";
+    };
+
+    write_per_token_stats("prompt processing per token", prompt_processing_stats, num_prompt_tokens);
+    write_per_token_stats("token generation", token_gen_stats, 1);
+    write_per_token_stats("token sampling", sampling_stats, 1);
+    write_stats("e2e generation", e2e_gen_stats);
+  }
+}
+
+int main(int argc, const char** argv) {
+  try {
+    const auto opts = benchmark::ParseOptionsFromCommandLine(argc, argv);
+    RunBenchmark(opts);
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "Exception: " << e.what() << "\n";
+    return 1;
+  }
 }

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -1,7 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #include <algorithm>
 #include <chrono>
 #include <iostream>
 #include <numeric>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "ort_genai.h"
@@ -11,10 +16,9 @@
 namespace {
 
 using Clock = std::chrono::steady_clock;
+
 using Duration = Clock::duration;
 using DurationFp = std::chrono::duration<float, Duration::period>;
-
-using MicrosecondsFp = std::chrono::duration<float, std::chrono::microseconds::period>;
 
 class Timing {
  public:
@@ -37,6 +41,7 @@ class Timing {
 
 struct Statistics {
   DurationFp average{};
+  DurationFp stddev{};
   DurationFp p50{};
   DurationFp p90{};
   DurationFp p99{};
@@ -61,20 +66,61 @@ Statistics ComputeStats(const std::vector<Duration>& measurements) {
   stats.p90 = sorted[stats.n * 0.9];
   stats.p99 = sorted[stats.n * 0.99];
 
+  if (stats.n > 1) {
+    const float variance =
+        std::transform_reduce(
+            measurements.begin(), measurements.end(),
+            0.0f,
+            std::plus<>{},
+            [mean = stats.average.count()](const Duration& m) {
+              const float distance_from_mean = m.count() - mean;
+              return distance_from_mean * distance_from_mean;
+            }) /
+        (stats.n - 1);
+
+    const float stddev = std::sqrtf(variance);
+    stats.stddev = DurationFp{stddev};
+  }
+
   return stats;
 }
 
-}  // namespace
+std::string GeneratePrompt(size_t num_prompt_tokens, const OgaModel& model, const OgaTokenizer& tokenizer) {
+  const char* const base_prompt = "A";
+  auto base_prompt_sequences = OgaSequences::Create();
+
+  tokenizer.Encode(base_prompt, *base_prompt_sequences);
+
+  auto params = OgaGeneratorParams::Create(model);
+  params->SetSearchOption("max_length", num_prompt_tokens);
+  params->SetSearchOption("min_length", num_prompt_tokens);
+  params->SetInputSequences(*base_prompt_sequences);
+
+  auto output_sequences = model.Generate(*params);
+  return std::string{tokenizer.Decode(output_sequences->Get(0))};
+}
 
 void RunBenchmark(const benchmark::Options& opts) {
-  auto model = OgaModel::Create(opts.model_path.c_str());
+  if (opts.verbose) {
+    std::cout << "Batch size: " << opts.batch_size
+              << ", prompt tokens: " << opts.num_prompt_tokens
+              << ", tokens to generate: " << opts.num_tokens_to_generate
+              << "\n";
+  }
 
+  auto model = OgaModel::Create(opts.model_path.c_str());
   auto tokenizer = OgaTokenizer::Create(*model);
 
-  const char* prompt = "My perfect Sunday is ";
+  const std::string prompt = GeneratePrompt(opts.num_prompt_tokens, *model, *tokenizer);
   auto prompt_sequences = OgaSequences::Create();
 
-  tokenizer->Encode(prompt, *prompt_sequences);
+  if (opts.batch_size < 1) {
+    throw std::runtime_error("Batch size must be at least 1.");
+  }
+
+  for (size_t i = 0; i < opts.batch_size; ++i) {
+    tokenizer->Encode(prompt.c_str(), *prompt_sequences);
+  }
 
   const size_t num_prompt_tokens = prompt_sequences->Get(0).size();
   const size_t num_tokens = num_prompt_tokens + opts.num_tokens_to_generate;
@@ -88,13 +134,16 @@ void RunBenchmark(const benchmark::Options& opts) {
   };
 
   // warmup
+  if (opts.verbose) std::cout << "Running warmup iterations (" << opts.num_warmup_iterations << ")...\n";
   for (size_t i = 0; i < opts.num_warmup_iterations; ++i) {
     auto params = make_generator_params();
+    auto output_sequences = model->Generate(*params);
 
-    auto generator = OgaGenerator::Create(*model, *params);
-    while (!generator->IsDone()) {
-      generator->ComputeLogits();
-      generator->GenerateNextToken();
+    if (opts.verbose && i == 0) {
+      // show prompt and output on first iteration
+      std::cout << "Prompt:\n\t" << prompt << "\n";
+      auto output = tokenizer->Decode(output_sequences->Get(0));
+      std::cout << "Output:\n\t" << output << "\n";
     }
   }
 
@@ -105,9 +154,9 @@ void RunBenchmark(const benchmark::Options& opts) {
   token_gen_times.reserve(opts.num_iterations * (opts.num_tokens_to_generate - 1));
   sampling_times.reserve(opts.num_iterations * opts.num_tokens_to_generate);
 
+  if (opts.verbose) std::cout << "Running iterations (" << opts.num_iterations << ")...\n";
   for (size_t i = 0; i < opts.num_iterations; ++i) {
     auto params = make_generator_params();
-
     auto generator = OgaGenerator::Create(*model, *params);
 
     {
@@ -135,9 +184,6 @@ void RunBenchmark(const benchmark::Options& opts) {
         }
       }
     }
-
-    // auto output_sequence = generator->GetSequence(0);
-    // auto out_string = tokenizer->Decode(output_sequence);
   }
 
   {
@@ -149,33 +195,38 @@ void RunBenchmark(const benchmark::Options& opts) {
     auto write_per_token_stats = [](const std::string& label,
                                     const Statistics& stats,
                                     const size_t tokens_per_measurement) {
+      using MicrosecondsFp = std::chrono::duration<float, std::chrono::microseconds::period>;
       const auto avg_us = MicrosecondsFp{stats.average};
-      std::cout << label << ":\n"
-                << "\tavg latency (us): " << avg_us.count() / tokens_per_measurement
-                << ",\tavg throughput (tps): " << 1.0e6f / avg_us.count() * tokens_per_measurement
-                << ",\tp50 latency (us): " << MicrosecondsFp{stats.p50}.count() / tokens_per_measurement
-                << ",\tn: " << stats.n << " * " << tokens_per_measurement
+      std::cout << label << ":"
+                << "\n\tavg (us):       " << avg_us.count()
+                << "\n\tavg (tokens/s): " << 1.0e6f / avg_us.count() * tokens_per_measurement
+                << "\n\tp50 (us):       " << MicrosecondsFp{stats.p50}.count()
+                << "\n\tstddev (us):    " << MicrosecondsFp{stats.stddev}.count()
+                << "\n\tn:              " << stats.n << " * " << tokens_per_measurement << " token(s)"
                 << "\n";
     };
 
-    auto write_stats = [](const std::string& label,
-                          const Statistics& stats) {
-      const auto avg_us = MicrosecondsFp{stats.average};
-      std::cout << label << ":\n"
-                << "\tavg latency (us): " << avg_us.count()
-                << ",\tp50 latency (us): " << MicrosecondsFp{stats.p50}.count()
-                << ",\tn: " << stats.n
+    auto write_e2e_stats = [](const std::string& label,
+                              const Statistics& stats) {
+      using MillisecondsFp = std::chrono::duration<float, std::chrono::milliseconds::period>;
+      std::cout << label << ":"
+                << "\n\tavg (ms):       " << MillisecondsFp{stats.average}.count()
+                << "\n\tp50 (ms):       " << MillisecondsFp{stats.p50}.count()
+                << "\n\tstddev (ms):    " << MillisecondsFp{stats.stddev}.count()
+                << "\n\tn:              " << stats.n
                 << "\n";
     };
 
-    write_per_token_stats("prompt processing per token", prompt_processing_stats, num_prompt_tokens);
-    write_per_token_stats("token generation", token_gen_stats, 1);
-    write_per_token_stats("token sampling", sampling_stats, 1);
-    write_stats("e2e generation", e2e_gen_stats);
+    write_per_token_stats("Prompt processing", prompt_processing_stats, opts.batch_size * num_prompt_tokens);
+    write_per_token_stats("Token generation", token_gen_stats, opts.batch_size);
+    write_per_token_stats("Token sampling", sampling_stats, opts.batch_size);
+    write_e2e_stats("E2E generation", e2e_gen_stats);
   }
 }
 
-int main(int argc, const char** argv) {
+}  // namespace
+
+int main(int argc, char** argv) {
   try {
     const auto opts = benchmark::ParseOptionsFromCommandLine(argc, argv);
     RunBenchmark(opts);

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -129,13 +129,6 @@ std::string GeneratePrompt(size_t num_prompt_tokens, const OgaModel& model, cons
 }
 
 void RunBenchmark(const benchmark::Options& opts) {
-  if (opts.verbose) {
-    std::cout << "Batch size: " << opts.batch_size
-              << ", prompt tokens: " << opts.num_prompt_tokens
-              << ", tokens to generate: " << opts.num_tokens_to_generate
-              << "\n";
-  }
-
   auto model = OgaModel::Create(opts.model_path.c_str());
   auto tokenizer = OgaTokenizer::Create(*model);
 
@@ -217,15 +210,21 @@ void RunBenchmark(const benchmark::Options& opts) {
   }
 
   {
+    std::cout << "Batch size: " << opts.batch_size
+              << ", prompt tokens: " << num_prompt_tokens
+              << ", tokens to generate: " << opts.num_tokens_to_generate
+              << "\n";
+
     const auto e2e_gen_stats = ComputeStats(e2e_gen_times);
     const auto prompt_processing_stats = ComputeStats(prompt_processing_times);
     const auto token_gen_stats = ComputeStats(token_gen_times);
     const auto sampling_stats = ComputeStats(sampling_times);
 
-    WritePerTokenStats("Prompt processing", prompt_processing_stats, opts.batch_size * num_prompt_tokens);
+    WritePerTokenStats("Prompt processing (time to first token)",
+                       prompt_processing_stats, opts.batch_size * num_prompt_tokens);
     WritePerTokenStats("Token generation", token_gen_stats, opts.batch_size);
     WritePerTokenStats("Token sampling", sampling_stats, opts.batch_size);
-    WriteE2EStats("E2E generation", e2e_gen_stats);
+    WriteE2EStats("E2E generation (entire generation loop)", e2e_gen_stats);
   }
 }
 

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -123,7 +123,9 @@ std::string GeneratePrompt(size_t num_prompt_tokens, const OgaModel& model, cons
   params->SetInputSequences(*base_prompt_sequences);
 
   auto output_sequences = model.Generate(*params);
-  return std::string{tokenizer.Decode(output_sequences->Get(0))};
+  const auto output_sequence_length = output_sequences->SequenceCount(0);
+  const auto* output_sequence_data = output_sequences->SequenceData(0);
+  return std::string{tokenizer.Decode(output_sequence_data, output_sequence_length)};
 }
 
 void RunBenchmark(const benchmark::Options& opts) {
@@ -148,7 +150,7 @@ void RunBenchmark(const benchmark::Options& opts) {
     tokenizer->Encode(prompt.c_str(), *prompt_sequences);
   }
 
-  const size_t num_prompt_tokens = prompt_sequences->Get(0).size();
+  const size_t num_prompt_tokens = prompt_sequences->SequenceCount(0);
   const size_t num_tokens = num_prompt_tokens + opts.num_tokens_to_generate;
 
   auto make_generator_params = [&] {
@@ -169,7 +171,9 @@ void RunBenchmark(const benchmark::Options& opts) {
     if (opts.verbose && i == 0) {
       // show prompt and output on first iteration
       std::cout << "Prompt:\n\t" << prompt << "\n";
-      auto output = tokenizer->Decode(output_sequences->Get(0));
+      const auto output_sequence_length = output_sequences->SequenceCount(0);
+      const auto* output_sequence_data = output_sequences->SequenceData(0);
+      const auto output = tokenizer->Decode(output_sequence_data, output_sequence_length);
       std::cout << "Output:\n\t" << output << "\n";
     }
   }

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -70,13 +70,12 @@ Statistics ComputeStats(const std::vector<Duration>& measurements) {
 
   if (stats.n > 1) {
     const float variance =
-        std::transform_reduce(
+        std::accumulate(
             measurements.begin(), measurements.end(),
             0.0f,
-            std::plus<>{},
-            [mean = stats.average.count()](const Duration& m) {
+            [mean = stats.average.count()](float accumulator, const Duration& m) -> float {
               const float distance_from_mean = m.count() - mean;
-              return distance_from_mean * distance_from_mean;
+              return accumulator + distance_from_mean * distance_from_mean;
             }) /
         (stats.n - 1);
 

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+
+#include "ort_genai.h"
+
+constexpr const char* kModelPath = "C:/Users/edch/models/phi3-3.8b-int4-cpu";
+
+int main() {
+  auto model = OgaModel::Create(kModelPath);
+
+  auto tokenizer = OgaTokenizer::Create(*model);
+
+  auto sequences = OgaSequences::Create();
+
+  const char* prompt = "My perfect Sunday is ";
+  tokenizer->Encode(prompt, *sequences);
+
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 200);
+  params->SetInputSequences(*sequences);
+
+  auto generator = OgaGenerator::Create(*model, *params);
+  while(!generator->IsDone()) {
+    generator->ComputeLogits();
+    generator->GenerateNextToken();
+  }
+
+  auto output_sequence = generator->GetSequence(0);
+  auto out_string = tokenizer->Decode(output_sequence);
+
+  std::cout << "output: " << out_string << "\n";
+
+  return 0;
+}

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -80,7 +80,7 @@ Statistics ComputeStats(const std::vector<Duration>& measurements) {
             }) /
         (stats.n - 1);
 
-    const float stddev = std::sqrtf(variance);
+    const float stddev = std::sqrt(variance);
     stats.stddev = DurationFp{stddev};
   }
 

--- a/benchmark/c/options.cpp
+++ b/benchmark/c/options.cpp
@@ -1,0 +1,84 @@
+#include "options.h"
+
+#include <cstdlib>
+#include <charconv>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+
+namespace benchmark {
+
+namespace {
+
+[[noreturn]] void PrintHelpAndExit(const char* program_name, int exit_code) {
+  Options defaults{};
+  std::ostringstream s;
+
+  s << "Usage: " << program_name << " -i <model path> <other options>\n"
+    << "  Options:\n"
+    << "    -i <path>     - Path to the ONNX model directory to benchmark, compatible with onnxruntime-genai.\n"
+    << "    -g <number>   - Number of tokens to generate. Default: " << defaults.num_tokens_to_generate << "\n"
+    << "    -r <number>   - Number of times to repeat the benchmark. Default: " << defaults.num_iterations << "\n"
+    << "    -w <number>   - Number of warmup runs before benchmarking. Default: " << defaults.num_warmup_iterations << "\n"
+    << "    -h            - Show this help message and exit.\n";
+
+  std::cerr << s.str();
+  std::exit(exit_code);
+}
+
+template <typename T>
+T ParseNumber(std::string_view s) {
+  T n;
+  const auto *s_begin = s.data(), *s_end = s.data() + s.size();
+  const auto [ptr, ec] = std::from_chars(s_begin, s_end, n);
+  if (ec != std::errc{} || ptr != s_end) {
+    throw std::runtime_error("Failed to parse option value.");
+  }
+  return n;
+}
+
+}  // namespace
+
+Options ParseOptionsFromCommandLine(int argc, const char** argv) {
+  const char* const program_name = argc > 0 ? argv[0] : "model_benchmark";
+  try {
+    Options opts{};
+
+    auto next_arg = [argc, argv](int& idx) {
+      if (idx + 1 >= argc) {
+        throw std::runtime_error("Option value not provided.");
+      }
+      return std::string_view{argv[++idx]};
+    };
+
+    for (int i = 1; i < argc; ++i) {
+      std::string_view arg{argv[i]};
+
+      if (arg == "-i") {
+        opts.model_path = next_arg(i);
+      } else if (arg == "-g") {
+        opts.num_tokens_to_generate = ParseNumber<size_t>(next_arg(i));
+      } else if (arg == "-r") {
+        opts.num_iterations = ParseNumber<size_t>(next_arg(i));
+      } else if (arg == "-w") {
+        opts.num_warmup_iterations = ParseNumber<size_t>(next_arg(i));
+      } else if (arg == "-h") {
+        PrintHelpAndExit(program_name, 0);
+      } else {
+        throw std::runtime_error("Unknown option.");
+      }
+    }
+
+    if (opts.model_path.empty()) {
+      throw std::runtime_error("ONNX model directory path must be provided.");
+    }
+
+    return opts;
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    PrintHelpAndExit(program_name, 1);
+  }
+}
+
+}  // namespace benchmark

--- a/benchmark/c/options.cpp
+++ b/benchmark/c/options.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #include "options.h"
 
 #include <cstdlib>
@@ -5,7 +8,9 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <string_view>
+#include <system_error>
 
 namespace benchmark {
 
@@ -17,11 +22,22 @@ namespace {
 
   s << "Usage: " << program_name << " -i <model path> <other options>\n"
     << "  Options:\n"
-    << "    -i <path>     - Path to the ONNX model directory to benchmark, compatible with onnxruntime-genai.\n"
-    << "    -g <number>   - Number of tokens to generate. Default: " << defaults.num_tokens_to_generate << "\n"
-    << "    -r <number>   - Number of times to repeat the benchmark. Default: " << defaults.num_iterations << "\n"
-    << "    -w <number>   - Number of warmup runs before benchmarking. Default: " << defaults.num_warmup_iterations << "\n"
-    << "    -h            - Show this help message and exit.\n";
+    << "    -i,--input_folder <path>\n"
+    << "      Path to the ONNX model directory to benchmark, compatible with onnxruntime-genai.\n "
+    << "    -b,--batch_size <number>\n"
+    << "      Number of sequences to generate in parallel.\n"
+    << "    -l,--prompt_length <number>\n"
+    << "      Number of tokens in the prompt. Default: " << defaults.num_prompt_tokens << "\n"
+    << "    -g,--generation_length <number>\n"
+    << "      Number of tokens to generate. Default: " << defaults.num_tokens_to_generate << "\n"
+    << "    -r,--repetitions <number>\n"
+    << "      Number of times to repeat the benchmark. Default: " << defaults.num_iterations << "\n"
+    << "    -w,--warmup <number>\n"
+    << "      Number of warmup runs before benchmarking. Default: " << defaults.num_warmup_iterations << "\n"
+    << "    -v,--verbose\n"
+    << "      Show more informational output."
+    << "    -h,--help\n"
+    << "      Show this help message and exit.\n";
 
   std::cerr << s.str();
   std::exit(exit_code);
@@ -33,14 +49,20 @@ T ParseNumber(std::string_view s) {
   const auto *s_begin = s.data(), *s_end = s.data() + s.size();
   const auto [ptr, ec] = std::from_chars(s_begin, s_end, n);
   if (ec != std::errc{} || ptr != s_end) {
-    throw std::runtime_error("Failed to parse option value.");
+    throw std::runtime_error(std::string{"Failed to parse option value as number: "}.append(s));
   }
   return n;
 }
 
+void VerifyOptions(const Options& opts) {
+  if (opts.model_path.empty()) {
+    throw std::runtime_error("ONNX model directory path must be provided.");
+  }
+}
+
 }  // namespace
 
-Options ParseOptionsFromCommandLine(int argc, const char** argv) {
+Options ParseOptionsFromCommandLine(int argc, const char* const* argv) {
   const char* const program_name = argc > 0 ? argv[0] : "model_benchmark";
   try {
     Options opts{};
@@ -55,24 +77,28 @@ Options ParseOptionsFromCommandLine(int argc, const char** argv) {
     for (int i = 1; i < argc; ++i) {
       std::string_view arg{argv[i]};
 
-      if (arg == "-i") {
+      if (arg == "-i" || arg == "--input_folder") {
         opts.model_path = next_arg(i);
-      } else if (arg == "-g") {
+      } else if (arg == "-b" || arg == "--batch_size") {
+        opts.batch_size = ParseNumber<size_t>(next_arg(i));
+      } else if (arg == "-l" || arg == "--prompt_length") {
+        opts.num_prompt_tokens = ParseNumber<size_t>(next_arg(i));
+      } else if (arg == "-g" || arg == "--generation_length") {
         opts.num_tokens_to_generate = ParseNumber<size_t>(next_arg(i));
-      } else if (arg == "-r") {
+      } else if (arg == "-r" || arg == "--repetitions") {
         opts.num_iterations = ParseNumber<size_t>(next_arg(i));
-      } else if (arg == "-w") {
+      } else if (arg == "-w" || arg == "--warmup") {
         opts.num_warmup_iterations = ParseNumber<size_t>(next_arg(i));
-      } else if (arg == "-h") {
+      } else if (arg == "-v" || arg == "--verbose") {
+        opts.verbose = true;
+      } else if (arg == "-h" || arg == "--help") {
         PrintHelpAndExit(program_name, 0);
       } else {
-        throw std::runtime_error("Unknown option.");
+        throw std::runtime_error(std::string{"Unknown option: "}.append(arg));
       }
     }
 
-    if (opts.model_path.empty()) {
-      throw std::runtime_error("ONNX model directory path must be provided.");
-    }
+    VerifyOptions(opts);
 
     return opts;
   } catch (const std::exception& e) {

--- a/benchmark/c/options.cpp
+++ b/benchmark/c/options.cpp
@@ -25,7 +25,7 @@ namespace {
     << "    -i,--input_folder <path>\n"
     << "      Path to the ONNX model directory to benchmark, compatible with onnxruntime-genai.\n "
     << "    -b,--batch_size <number>\n"
-    << "      Number of sequences to generate in parallel.\n"
+    << "      Number of sequences to generate in parallel. Default: " << defaults.batch_size << "\n"
     << "    -l,--prompt_length <number>\n"
     << "      Number of tokens in the prompt. Default: " << defaults.num_prompt_tokens << "\n"
     << "    -g,--generation_length <number>\n"
@@ -35,7 +35,7 @@ namespace {
     << "    -w,--warmup <number>\n"
     << "      Number of warmup runs before benchmarking. Default: " << defaults.num_warmup_iterations << "\n"
     << "    -v,--verbose\n"
-    << "      Show more informational output."
+    << "      Show more informational output.\n"
     << "    -h,--help\n"
     << "      Show this help message and exit.\n";
 

--- a/benchmark/c/options.h
+++ b/benchmark/c/options.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace benchmark {
+
+struct Options {
+  std::string model_path{};
+  size_t num_tokens_to_generate{128};
+  size_t num_iterations{5};
+  size_t num_warmup_iterations{1};
+};
+
+Options ParseOptionsFromCommandLine(int argc, const char** argv);
+
+}  // namespace benchmark

--- a/benchmark/c/options.h
+++ b/benchmark/c/options.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <string>
@@ -6,11 +9,14 @@ namespace benchmark {
 
 struct Options {
   std::string model_path{};
+  size_t num_prompt_tokens{16};
   size_t num_tokens_to_generate{128};
+  size_t batch_size{1};
   size_t num_iterations{5};
   size_t num_warmup_iterations{1};
+  bool verbose{false};
 };
 
-Options ParseOptionsFromCommandLine(int argc, const char** argv);
+Options ParseOptionsFromCommandLine(int argc, const char* const* argv);
 
 }  // namespace benchmark

--- a/build.py
+++ b/build.py
@@ -95,7 +95,6 @@ def validate_cuda_home(cuda_home: str | bytes | os.PathLike | None):
 
 def build(
     skip_wheel: bool = False,
-    skip_python: bool = False,
     use_cuda: bool | None = None,
     use_dml: bool | None = None,
     cuda_home: str | bytes | os.PathLike | None = None,
@@ -126,13 +125,13 @@ def build(
 
     if is_windows():
         if not cmake_generator:
-            command += ["-G", "Visual Studio 17 2022", "-A", "x64"]  # this doesn't work for ARM64 Windows
+            command += ["-G", "Visual Studio 17 2022", "-A", "x64"]
         if cuda_home:
             toolset = "host=x64" + ",cuda=" + cuda_home
             command += ["-T", toolset]
     command += [f"-DCMAKE_BUILD_TYPE={config}"]
 
-    build_wheel = "OFF" if (skip_python or skip_wheel) else "ON"
+    build_wheel = "OFF" if skip_wheel else "ON"
     build_dir = os.path.abspath(build_dir) if build_dir else os.path.join(os.getcwd(), "build")
 
     command += [
@@ -145,7 +144,6 @@ def build(
         "-DUSE_CUDA=ON" if cuda_home else "-DUSE_CUDA=OFF",
         "-DUSE_DML=ON" if use_dml else "-DUSE_DML=OFF",
         f"-DBUILD_WHEEL={build_wheel}",
-        "-DENABLE_PYTHON=" + ("OFF" if skip_python else "ON"),
     ]
 
     if ort_home:
@@ -218,7 +216,6 @@ if __name__ == "__main__":
         "Read from CUDA_HOME or CUDA_PATH environment variable if not specified. Not read if --use_cuda is not specified.",
     )
     parser.add_argument("--skip_wheel", action="store_true", help="Skip building the Python wheel.")
-    parser.add_argument("--skip_python", action="store_true", help="Skip building the Python API.")
     parser.add_argument("--ort_home", default=None, help="Root directory of onnxruntime.")
     parser.add_argument("--skip_csharp", action="store_true", help="Skip building the C# API.")
     parser.add_argument("--build_dir", default=None, help="Path to output directory.")
@@ -236,7 +233,6 @@ if __name__ == "__main__":
     update_submodules()
     build(
         skip_wheel=args.skip_wheel,
-        skip_python=args.skip_python,
         use_cuda=args.use_cuda,
         use_dml=args.use_dml,
         cuda_home=args.cuda_home,

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -6,5 +6,6 @@ option(NO_TOKENIZER "Don't include the Tokenizer" OFF)
 option(ENABLE_PYTHON "Build the Python API." ON)
 option(ENABLE_TESTS "Enable tests" ON)
 option(TEST_PHI2 "Enable tests for Phi2" OFF)
+option(ENABLE_MODEL_BENCHMARK "Build model benchmark program" ON)
 
 cmake_dependent_option(BUILD_WHEEL "Build the python wheel" ON "ENABLE_PYTHON" OFF)

--- a/src/csharp/Generator.cs
+++ b/src/csharp/Generator.cs
@@ -32,8 +32,8 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         public ReadOnlySpan<int> GetSequence(ulong index)
         {
-            ulong sequenceLength = NativeMethods.OgaGenerator_GetSequenceLength(_generatorHandle, (UIntPtr)index).ToUInt64();
-            IntPtr sequencePtr = NativeMethods.OgaGenerator_GetSequence(_generatorHandle, (UIntPtr)index);
+            ulong sequenceLength = NativeMethods.OgaGenerator_GetSequenceCount(_generatorHandle, (UIntPtr)index).ToUInt64();
+            IntPtr sequencePtr = NativeMethods.OgaGenerator_GetSequenceData(_generatorHandle, (UIntPtr)index);
             unsafe
             {
                 return new ReadOnlySpan<int>(sequencePtr.ToPointer(), (int)sequenceLength);

--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -82,15 +82,15 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         // This function returns the length of the sequence at the given index.
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
-        public static extern UIntPtr /* size_t */ OgaGenerator_GetSequenceLength(IntPtr /* const OgaGenerator* */ generator,
-                                                                                 UIntPtr /* size_t */ index);
+        public static extern UIntPtr /* size_t */ OgaGenerator_GetSequenceCount(IntPtr /* const OgaGenerator* */ generator,
+                                                                                UIntPtr /* size_t */ index);
 
         // This function returns the sequence data at the given index. The returned pointer is owned by the
         // OgaGenerator object and will be freed when the OgaGenerator object is destroyed. It is expected
         // that the caller copies the data returned by this function after calling this function.
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
-        public static extern IntPtr /* const in32_t* */ OgaGenerator_GetSequence(IntPtr /* const OgaGenerator* */ generator,
-                                                                                 UIntPtr /* size_t */ index);
+        public static extern IntPtr /* const in32_t* */ OgaGenerator_GetSequenceData(IntPtr /* const OgaGenerator* */ generator,
+                                                                                     UIntPtr /* size_t */ index);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaCreateSequences(out IntPtr /* OgaSequences** */ sequences);

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -1,5 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include <span>
+#include <stdexcept>
+
 #include "ort_genai_c.h"
 
 // GenAI C++ API

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -63,7 +63,7 @@ struct OgaModel : OgaAbstract {
     return std::unique_ptr<OgaModel>(p);
   }
 
-  std::unique_ptr<OgaSequences> Generate(const OgaGeneratorParams& params) {
+  std::unique_ptr<OgaSequences> Generate(const OgaGeneratorParams& params) const {
     OgaSequences* p;
     OgaCheckResult(OgaGenerate(this, &params, &p));
     return std::unique_ptr<OgaSequences>(p);
@@ -147,6 +147,8 @@ struct OgaGeneratorParams : OgaAbstract {
     return std::unique_ptr<OgaGeneratorParams>(p);
   }
 
+  // Set a search option value.
+  // This template only allows numeric or boolean values.
   template <typename T>
   std::enable_if_t<std::is_arithmetic_v<T>, void>
   SetSearchOption(const char* name, T value) {

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <memory>
-#include <span>
+#include "span.h"  // TODO Use the std span header if we can assume C++20.
 #include <stdexcept>
 #include <type_traits>
 

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <span>
 #include <stdexcept>
+#include <type_traits>
 
 #include "ort_genai_c.h"
 
@@ -146,16 +147,15 @@ struct OgaGeneratorParams : OgaAbstract {
     return std::unique_ptr<OgaGeneratorParams>(p);
   }
 
-  void SetSearchOption(const char* name, int value) {
-    OgaCheckResult(OgaGeneratorParamsSetSearchNumber(this, name, value));
-  }
-
-  void SetSearchOption(const char* name, double value) {
-    OgaCheckResult(OgaGeneratorParamsSetSearchNumber(this, name, value));
-  }
-
-  void SetSearchOption(const char* name, bool value) {
-    OgaCheckResult(OgaGeneratorParamsSetSearchBool(this, name, value));
+  template <typename T>
+  std::enable_if_t<std::is_arithmetic_v<T>, void>
+  SetSearchOption(const char* name, T value) {
+    if constexpr (std::is_same_v<T, bool>) {
+      OgaCheckResult(OgaGeneratorParamsSetSearchBool(this, name, value));
+    } else {
+      OgaCheckResult(OgaGeneratorParamsSetSearchNumber(this, name,
+                                                       static_cast<double>(value)));
+    }
   }
 
   void SetInputIDs(const int32_t* input_ids, size_t input_ids_count, size_t sequence_length, size_t batch_size) {

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -205,17 +205,17 @@ struct OgaGenerator : OgaAbstract {
     OgaCheckResult(OgaGenerator_GenerateNextToken(this));
   }
 
-  size_t GetSequenceLength(size_t index) const {
-    return OgaGenerator_GetSequenceLength(this, index);
+  size_t GetSequenceCount(size_t index) const {
+    return OgaGenerator_GetSequenceCount(this, index);
   }
 
   const int32_t* GetSequenceData(size_t index) const {
-    return OgaGenerator_GetSequence(this, index);
+    return OgaGenerator_GetSequenceData(this, index);
   }
 
 #if __cplusplus >= 202002L
   std::span<const int32_t> GetSequence(size_t index) const {
-    return {GetSequenceData(index), GetSequenceLength(index)};
+    return {GetSequenceData(index), GetSequenceCount(index)};
   }
 #endif
 

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -5,7 +5,6 @@
 
 #include <memory>
 #include <stdexcept>
-#include <type_traits>
 
 #if __cplusplus >= 202002L
 #include <span>
@@ -168,17 +167,12 @@ struct OgaGeneratorParams : OgaAbstract {
     return std::unique_ptr<OgaGeneratorParams>(p);
   }
 
-  // Set a search option value.
-  // This template only allows numeric or boolean values.
-  template <typename T>
-  std::enable_if_t<std::is_arithmetic_v<T>, void>
-  SetSearchOption(const char* name, T value) {
-    if constexpr (std::is_same_v<T, bool>) {
-      OgaCheckResult(OgaGeneratorParamsSetSearchBool(this, name, value));
-    } else {
-      OgaCheckResult(OgaGeneratorParamsSetSearchNumber(this, name,
-                                                       static_cast<double>(value)));
-    }
+  void SetSearchOption(const char* name, double value) {
+    OgaCheckResult(OgaGeneratorParamsSetSearchNumber(this, name, value));
+  }
+
+  void SetSearchOptionBool(const char* name, bool value) {
+    OgaCheckResult(OgaGeneratorParamsSetSearchBool(this, name, value));
   }
 
   void SetInputIDs(const int32_t* input_ids, size_t input_ids_count, size_t sequence_length, size_t batch_size) {

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -157,12 +157,12 @@ OgaResult* OGA_API_CALL OgaGenerator_GenerateNextToken(OgaGenerator* generator) 
   OGA_CATCH
 }
 
-size_t OGA_API_CALL OgaGenerator_GetSequenceLength(const OgaGenerator* oga_generator, size_t index) {
+size_t OGA_API_CALL OgaGenerator_GetSequenceCount(const OgaGenerator* oga_generator, size_t index) {
   auto& generator = *reinterpret_cast<const Generators::Generator*>(oga_generator);
   return generator.GetSequence(static_cast<int>(index)).GetCPU().size();
 }
 
-const int32_t* OGA_API_CALL OgaGenerator_GetSequence(const OgaGenerator* oga_generator, size_t index) {
+const int32_t* OGA_API_CALL OgaGenerator_GetSequenceData(const OgaGenerator* oga_generator, size_t index) {
   auto& generator = *reinterpret_cast<const Generators::Generator*>(oga_generator);
   return generator.GetSequence(static_cast<int>(index)).GetCPU().data();
 }

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -182,17 +182,17 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_GenerateNextToken(OgaGenerator* 
  * \param[in] generator The generator to get the count of the tokens for the sequence at the given index.
  * \return The number tokens in the sequence at the given index.
  */
-OGA_EXPORT size_t OGA_API_CALL OgaGenerator_GetSequenceLength(const OgaGenerator* generator, size_t index);
+OGA_EXPORT size_t OGA_API_CALL OgaGenerator_GetSequenceCount(const OgaGenerator* generator, size_t index);
 
 /*
  * \brief Returns a pointer to the sequence data at the given index. The number of tokens in the sequence
- *        is given by OgaGenerator_GetSequenceLength
+ *        is given by OgaGenerator_GetSequenceCount
  * \param[in] generator The generator to get the sequence data for the sequence at the given index.
  * \return The pointer to the sequence data at the given index. The sequence data is owned by the OgaGenerator
  *         and will be freed when the OgaGenerator is destroyed. The caller must copy the data if it needs to
  *         be used after the OgaGenerator is destroyed.
  */
-OGA_EXPORT const int32_t* OGA_API_CALL OgaGenerator_GetSequence(const OgaGenerator* generator, size_t index);
+OGA_EXPORT const int32_t* OGA_API_CALL OgaGenerator_GetSequenceData(const OgaGenerator* generator, size_t index);
 
 OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateTokenizer(const OgaModel* model, OgaTokenizer** out);
 OGA_EXPORT void OGA_API_CALL OgaDestroyTokenizer(OgaTokenizer*);

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+#pragma once
+
 #include <stdint.h>
 #include <cstddef>
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -44,7 +44,6 @@ if(BUILD_WHEEL)
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/py/" DESTINATION ${WHEEL_TARGET_NAME}/)
   file(COPY "${CMAKE_SOURCE_DIR}/ThirdPartyNotices.txt" DESTINATION ${WHEEL_TARGET_NAME}/)
 
-  file(GLOB onnxruntime_libs "${ORT_LIB_DIR}/${ONNXRUNTIME_FILES}")
   add_custom_command(TARGET python POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
     ${onnxruntime_libs} $<TARGET_FILE:python>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,7 +49,6 @@ else()
   target_include_directories(unit_tests PRIVATE ${TOKENIZER_ROOT})
   target_link_libraries(unit_tests PRIVATE tokenizer)
 endif()
-file(GLOB onnxruntime_libs "${ORT_LIB_DIR}/${ONNXRUNTIME_FILES}")
 set(TEST_MODEL_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test_models/")
 set(TEST_MODEL_DES_DIR "$<TARGET_FILE_DIR:unit_tests>/test_models/")
 add_custom_command(TARGET unit_tests POST_BUILD

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -120,7 +120,7 @@ TEST(CAPITests, GreedySearchGptFp32CAPI) {
 
   // Verify outputs match expected outputs
   for (int i = 0; i < batch_size; i++) {
-    const auto sequence_length = generator->GetSequenceLength(i);
+    const auto sequence_length = generator->GetSequenceCount(i);
     const auto* sequence_data = generator->GetSequenceData(i);
 
     ASSERT_LE(sequence_length, max_length);

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -205,7 +205,7 @@ struct Phi2Test {
 TEST(CAPITests, TopKCAPI) {
   Phi2Test test;
 
-  test.params_->SetSearchOption("do_sample", true);
+  test.params_->SetSearchOptionBool("do_sample", true);
   test.params_->SetSearchOption("top_k", 50);
   test.params_->SetSearchOption("temperature", 0.6f);
 
@@ -215,7 +215,7 @@ TEST(CAPITests, TopKCAPI) {
 TEST(CAPITests, TopPCAPI) {
   Phi2Test test;
 
-  test.params_->SetSearchOption("do_sample", true);
+  test.params_->SetSearchOptionBool("do_sample", true);
   test.params_->SetSearchOption("top_p", 0.6f);
   test.params_->SetSearchOption("temperature", 0.6f);
 
@@ -225,7 +225,7 @@ TEST(CAPITests, TopPCAPI) {
 TEST(CAPITests, TopKTopPCAPI) {
   Phi2Test test;
 
-  test.params_->SetSearchOption("do_sample", true);
+  test.params_->SetSearchOptionBool("do_sample", true);
   test.params_->SetSearchOption("top_k", 50);
   test.params_->SetSearchOption("top_p", 0.6f);
   test.params_->SetSearchOption("temperature", 0.6f);

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -120,10 +120,13 @@ TEST(CAPITests, GreedySearchGptFp32CAPI) {
 
   // Verify outputs match expected outputs
   for (int i = 0; i < batch_size; i++) {
-    auto sequence = generator->GetSequence(i);
+    const auto sequence_length = generator->GetSequenceLength(i);
+    const auto* sequence_data = generator->GetSequenceData(i);
 
-    auto* expected_output_start = &expected_output[i * max_length];
-    EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence.data(), max_length * sizeof(int32_t)));
+    ASSERT_LE(sequence_length, max_length);
+
+    const auto* expected_output_start = &expected_output[i * max_length];
+    EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence_data, sequence_length * sizeof(int32_t)));
   }
 
   // Test high level API
@@ -131,10 +134,13 @@ TEST(CAPITests, GreedySearchGptFp32CAPI) {
 
   // Verify outputs match expected outputs
   for (int i = 0; i < batch_size; i++) {
-    auto sequence = sequences->Get(i);
+    const auto sequence_length = sequences->SequenceCount(i);
+    const auto* sequence_data = sequences->SequenceData(i);
 
-    auto* expected_output_start = &expected_output[i * max_length];
-    EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence.data(), max_length * sizeof(int32_t)));
+    ASSERT_LE(sequence_length, max_length);
+
+    const auto* expected_output_start = &expected_output[i * max_length];
+    EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence_data, sequence_length * sizeof(int32_t)));
   }
 }
 


### PR DESCRIPTION
Add a C++ model benchmark program. It is modeled after the existing Python benchmark script (benchmark/python/benchmark_e2e.py).

The motivation for a C++ version is to be able to run without Python. This is useful for Android.