### PR TITLE
Add a random_seed search option

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -285,6 +285,8 @@ struct Search_Element : JSON::Element {
       v_.diversity_penalty = static_cast<float>(value);
     } else if (name == "length_penalty") {
       v_.length_penalty = static_cast<float>(value);
+    } else if (name == "random_seed") {
+      v_.random_seed = static_cast<int>(value);
     } else
       throw JSON::unknown_value_error{};
   }

--- a/src/config.h
+++ b/src/config.h
@@ -86,6 +86,7 @@ struct Config {
     float diversity_penalty{};
     float length_penalty{1.0f};        // Exponential penalty to the length that is used with beam-based generation. length_penalty > 0.0 promotes longer sequences, while length_penalty < 0.0 encourages shorter sequences.
     bool past_present_share_buffer{};  // The past/present kv tensors are shared and allocated once to max_length (cuda only)
+    int random_seed{-1};               // -1 = Seed with random device, otherwise use value to seed RNG
   } search;
 };
 

--- a/src/cuda_sampling.cuh
+++ b/src/cuda_sampling.cuh
@@ -1,20 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "smartptrs.h"
+#include <curand_kernel.h>
 
 namespace Generators {
 namespace cuda {
 
 struct SamplingData {
-  SamplingData(int batch_size, int vocab_size, cudaStream_t stream);
-  std::unique_ptr<int, Generators::CudaDeleter> indices_sorted = nullptr;
-  std::unique_ptr<float, Generators::CudaDeleter> scores_sorted = nullptr;
-  std::unique_ptr<float, Generators::CudaDeleter> scores_softmaxed = nullptr;
-  std::unique_ptr<float, Generators::CudaDeleter> prefix_sums = nullptr;
-  std::unique_ptr<float, Generators::CudaDeleter> thresholds = nullptr;
-  std::unique_ptr<int, Generators::CudaDeleter> indices_in = nullptr;
-  std::unique_ptr<int, Generators::CudaDeleter> offsets = nullptr;
-  std::unique_ptr<float, Generators::CudaDeleter> temp_buffer = nullptr;
+  SamplingData(unsigned long long random_seed, int batch_size, int vocab_size, cudaStream_t stream);
+  cuda_unique_ptr<int> indices_sorted;
+  cuda_unique_ptr<float> scores_sorted;
+  cuda_unique_ptr<float> scores_softmaxed;
+  cuda_unique_ptr<float> prefix_sums;
+  cuda_unique_ptr<float> thresholds;
+  cuda_unique_ptr<int> indices_in;
+  cuda_unique_ptr<int> offsets;
+  cuda_unique_ptr<float> temp_buffer;
+  cuda_unique_ptr<curandState> curand_states;
   size_t temp_storage_bytes = 0;
 };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -22,7 +22,7 @@ GreedySearch_Cpu::GreedySearch_Cpu(const GeneratorParams& params)
     std::random_device rd;
     std::array<uint32_t, decltype(gen_)::state_size> data;
     std::generate(std::begin(data), std::end(data), std::ref(rd));
-    std::seed_seq seq{data.begin(), data.end()};
+    std::seed_seq seq(data.begin(), data.end());
     gen_.seed(seq);
   }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -20,7 +20,7 @@ GreedySearch_Cpu::GreedySearch_Cpu(const GeneratorParams& params)
     gen_.seed(params_->search.random_seed);
   else {
     std::random_device rd;
-    std::array<unsigned, decltype(gen_)::state_size> data;
+    std::array<uint32_t, decltype(gen_)::state_size> data;
     std::generate(std::begin(data), std::end(data), std::ref(rd));
     std::seed_seq seq{data.begin(), data.end()};
     gen_.seed(seq);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -15,7 +15,17 @@ Search_Cpu::Search_Cpu(const GeneratorParams& params)
 }
 
 GreedySearch_Cpu::GreedySearch_Cpu(const GeneratorParams& params)
-    : Search_Cpu(params), gen_(rd_()) {
+    : Search_Cpu(params) {
+  if (params_->search.random_seed != -1)
+    gen_.seed(params_->search.random_seed);
+  else {
+    std::random_device rd;
+    std::array<decltype(gen_)::result_type, decltype(gen_)::state_size> data;
+    std::generate(std::begin(data), std::end(data), std::ref(rd));
+    std::seed_seq seq{data.begin(), data.end()};
+    gen_.seed(seq);
+  }
+
   next_tokens_buffer_ = AllocateArray<int32_t>(params.batch_size, &next_tokens_);
   memset(next_tokens_.data(), 0, next_tokens_.size_bytes());
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -20,7 +20,7 @@ GreedySearch_Cpu::GreedySearch_Cpu(const GeneratorParams& params)
     gen_.seed(params_->search.random_seed);
   else {
     std::random_device rd;
-    std::array<decltype(gen_)::result_type, decltype(gen_)::state_size> data;
+    std::array<unsigned, decltype(gen_)::state_size> data;
     std::generate(std::begin(data), std::end(data), std::ref(rd));
     std::seed_seq seq{data.begin(), data.end()};
     gen_.seed(seq);

--- a/src/search.h
+++ b/src/search.h
@@ -83,7 +83,6 @@ struct GreedySearch_Cpu : Search_Cpu {
   std::unique_ptr<bool[]> eos_seen_buffer_;
   int not_done_count_{params_->batch_size};  // When zero, every batch entry is done (starts at batch_size_)
 
-  std::random_device rd_;
   std::mt19937 gen_;
 };
 

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -35,7 +35,7 @@ GreedySearch_Cuda::GreedySearch_Cuda(const GeneratorParams& params)
   cudaMemsetAsync(next_tokens_.data(), 0, next_tokens_.size_bytes(), params_->cuda_stream);
 
   unsigned long long random_seed;
-  if (params_->search.random_seed!=-1)
+  if (params_->search.random_seed != -1)
     random_seed = params_->search.random_seed;
   else
     random_seed = std::random_device{}();

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -33,7 +33,13 @@ GreedySearch_Cuda::GreedySearch_Cuda(const GeneratorParams& params)
     : Search_Cuda{params} {
   next_tokens_buffer_ = CudaMallocArray<int32_t>(params.batch_size, &next_tokens_);
   cudaMemsetAsync(next_tokens_.data(), 0, next_tokens_.size_bytes(), params_->cuda_stream);
-  samplingdata_ = std::make_unique<cuda::SamplingData>(params_->batch_size, params_->vocab_size, params_->cuda_stream);
+
+  unsigned long long random_seed;
+  if (params_->search.random_seed!=-1)
+    random_seed = params_->search.random_seed;
+  else
+    random_seed = std::random_device{}();
+  samplingdata_ = std::make_unique<cuda::SamplingData>(random_seed, params_->batch_size, params_->vocab_size, params_->cuda_stream);
 }
 
 BeamSearch_Cuda::BeamSearch_Cuda(const GeneratorParams& params)


### PR DESCRIPTION
It goes into the search options as `"random_seed":1234` (for example). The default value is -1, which means to use a random seed.

There is an issue with CUDA where the output can eventually differ even if the same seed is used. I did some investigation and the random numbers match, but the tokens chosen will differ eventually in longer outputs.

With CPU the output always matches.
