### PR TITLE
Attention mask with cuda graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,56 +6,58 @@ This library provides the generative AI loop for ONNX models, including inferenc
 
 Users can call a high level `generate()` method, or run each iteration of the model in a loop.
 
-* Support greedy/beam search and TopP, TopK sampling to generate token sequences
-* Built in logits processing like repetition penalties
-* Easy custom scoring
+- Support greedy/beam search and TopP, TopK sampling to generate token sequences
+- Built in logits processing like repetition penalties
+- Easy custom scoring
 
 See full documentation at [https://onnxruntime.ai/docs/genai].
 
 ## Features
 
-* Supported model architectures:
-  * Gemma
-  * LLaMA
-  * Mistral
-  * Phi-2
-* Supported targets:   
-  * CPU
-  * GPU (CUDA)
-* Supported sampling features
-  * Beam search
-  * Greedy search
-  * Top P/Top K
-* APIs
-  * Python
-  * C#
-  * C/C++  
+- Supported model architectures:
+  - Gemma
+  - LLaMA
+  - Mistral
+  - Phi-2
+- Supported targets:
+  - CPU
+  - GPU (CUDA)
+- Supported sampling features
+  - Beam search
+  - Greedy search
+  - Top P/Top K
+- APIs
+  - Python
+  - C#
+  - C/C++
 
 ## Coming very soon
 
-* Support for DirectML
-* Support for the encoder decoder model architectures, such as whisper, T5 and BART.
+- Support for DirectML
+- Support for the encoder decoder model architectures, such as whisper, T5 and BART.
 
 ## Coming soon
 
-* Support for mobile devices (Android and iOS) with Java and Objective-C bindings
+- Support for mobile devices (Android and iOS) with Java and Objective-C bindings
 
 ## Roadmap
 
-* Stable diffusion pipeline
-* Automatic model download and cache
-* More model architectures
+- Stable diffusion pipeline
+- Automatic model download and cache
+- More model architectures
 
 ## Sample code for phi-2 in Python
 
 [Install](https://onnxruntime.ai/docs/genai/howto/install) the onnxruntime-genai Python package.
 
 1. Build the model
+
 ```shell
-python -m onnxruntime_genai.models.builder -m microsoft/phi-2 -e cpu -p int4 -o ./models/phi2
+python -m onnxruntime_genai.models.builder -m microsoft/phi-2 -e cpu -p int4 -o ./models/phi2 #--extra_options enable_cuda_graph=1
 ```
 
 2. Run inference
+
 ```python
 import os
 import onnxruntime_genai as og
@@ -75,6 +77,7 @@ tokens = tokenizer.encode(prompt)
 
 params = og.GeneratorParams(model)
 params.set_search_options({"max_length":200})
+#params.try_use_cuda_graph_with_max_batch_size(16)
 params.input_ids = tokens
 
 output_tokens = model.generate(params)
@@ -87,9 +90,9 @@ print(text)
 
 ## Model download and export
 
-ONNX models are run from a local folder, via a string supplied to the `Model()` method. 
+ONNX models are run from a local folder, via a string supplied to the `Model()` method.
 
-You can bring your own ONNX model or use the model builder utility, included in this package. 
+You can bring your own ONNX model or use the model builder utility, included in this package.
 
 Install model builder dependencies.
 
@@ -101,28 +104,32 @@ pip install onnx
 pip install onnxruntime
 ```
 
-Export int4 CPU version 
+Export int4 CPU version
+
 ```bash
 huggingface-cli login --token <your HuggingFace token>
 python -m onnxruntime_genai.models.builder -m microsoft/phi-2 -p int4 -e cpu -o <model folder>
 ```
+
 ## Getting the latest nightly Onnxruntime build
-By default, onnxruntime-genai uses the latest stable release of onnxruntime. If you want to use the latest nightly build 
+
+By default, onnxruntime-genai uses the latest stable release of onnxruntime. If you want to use the latest nightly build
 of onnxruntime, you can download the nightly build of onnxruntime from our
 [Azure DevOps Artifacts](https://aiinfra.visualstudio.com/PublicPackages/_artifacts/feed/OnnxRuntime/).
 nuget package can be uncompressed by renaming the extension to `.zip` and extracting the contents.
 The onnxruntime dynamlic libraries and header files are available in the nightly build. You can extract the nuget package
 and copy the dynamic libraries and header files to the `ort/` folder under onnxruntime-genai project root on the same level
-as this `README.md` file. 
+as this `README.md` file.
 
 The library files are located in the `runtime/$OS-$Arch/native` folder and the header files are located in the
 `build/native/include` folder in the nuget package.
 
 The final folder structure should look like this:
+
 ```
 onnxruntime-genai
 │   README.md
-│   ... 
+│   ...
 │   ort/
 │   │   include/
 │   │   │   coreml_provider_factory.h
@@ -135,7 +142,7 @@ onnxruntime-genai
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 
@@ -149,8 +156,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/src/models/kernels.cu
+++ b/src/models/kernels.cu
@@ -1,71 +1,87 @@
-#include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <cuda_runtime.h>
 #include <stdint.h>
 
 namespace Generators {
 namespace cuda {
 
-template <typename T>
-__global__ void UpdatePositionIds(T* positions, int batch_beam_size) {
-  int i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i < batch_beam_size)
-    positions[i]++;
+template <typename T> __global__ void UpdatePositionIds(T *positions, int batch_beam_size) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < batch_beam_size)
+        positions[i]++;
 }
 
-template <typename T>
-void Launch_UpdatePositionIds(T* positions, int batch_beam_size, cudaStream_t stream) {
-  UpdatePositionIds<T><<<(batch_beam_size + 255) / 256, 256, 0, stream>>>(positions, batch_beam_size);
+template <typename T> void Launch_UpdatePositionIds(T *positions, int batch_beam_size, cudaStream_t stream) {
+    UpdatePositionIds<T><<<(batch_beam_size + 255) / 256, 256, 0, stream>>>(positions, batch_beam_size);
 }
 
-template void Launch_UpdatePositionIds(int32_t* positions, int batch_beam_size, cudaStream_t stream);
-template void Launch_UpdatePositionIds(int64_t* positions, int batch_beam_size, cudaStream_t stream);
+template void Launch_UpdatePositionIds(int32_t *positions, int batch_beam_size, cudaStream_t stream);
+template void Launch_UpdatePositionIds(int64_t *positions, int batch_beam_size, cudaStream_t stream);
 
 template <typename T>
-__global__ void UpdateAttentionMask(T* mask_data, const T* old_mask_data, int batch_beam_size, int current_length) {
-  int global_index = blockIdx.x * blockDim.x + threadIdx.x;
-  int i = global_index / current_length;
-  int j = global_index % current_length;
-  if (i < batch_beam_size) {
-    if (j < current_length - 1) {
-      mask_data[i * current_length + j] = old_mask_data[i * (current_length - 1) + j];
-    } else {
-      mask_data[i * current_length + j] = 1;
+__global__ void CopyAndUpdateAttentionMask(T *mask_data, const T *old_mask_data, int batch_beam_size,
+                                           int current_length) {
+    int global_index = blockIdx.x * blockDim.x + threadIdx.x;
+    int i = global_index / current_length;
+    int j = global_index % current_length;
+    if (i < batch_beam_size) {
+        if (j < current_length - 1) {
+            mask_data[i * current_length + j] = old_mask_data[i * (current_length - 1) + j];
+        } else {
+            mask_data[i * current_length + j] = 1;
+        }
     }
-  }
 }
 
 template <typename T>
-void Launch_UpdateAttentionMask(T* mask_data, const T* old_mask_data, int batch_beam_size, int current_length, cudaStream_t stream) {
-  UpdateAttentionMask<T><<<(batch_beam_size * current_length + 255) / 256, 256, 0, stream>>>(mask_data, old_mask_data, batch_beam_size, current_length);
+__global__ void UpdateAttentionMask(T *mask_data, int batch_beam_size, int current_length, int max_length) {
+    int i = blockIdx.x;
+    if (i < batch_beam_size) {
+        mask_data[i * max_length + current_length] = 1;
+    }
 }
 
-template void Launch_UpdateAttentionMask(int32_t* mask_data, const int32_t* old_mask_data, int batch_beam_size, int current_length, cudaStream_t stream);
-template void Launch_UpdateAttentionMask(int64_t* mask_data, const int64_t* old_mask_data, int batch_beam_size, int current_length, cudaStream_t stream);
-
-__global__ void ConvertFp16ToFp32(const half* src, float* dst, int count) {
-  int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (idx < count)
-    dst[idx] = __half2float(src[idx]);
+template <typename T>
+void Launch_UpdateAttentionMask(T *mask_data, const T *old_mask_data, int batch_beam_size, int current_length,
+                                int max_length, bool update_only, cudaStream_t stream) {
+    if (update_only) {
+        UpdateAttentionMask<T>
+            <<<batch_beam_size, 1, 0, stream>>>(mask_data, batch_beam_size, current_length, max_length);
+    } else {
+        CopyAndUpdateAttentionMask<T><<<(batch_beam_size * current_length + 255) / 256, 256, 0, stream>>>(
+            mask_data, old_mask_data, batch_beam_size, current_length);
+    }
 }
 
-void LaunchFp16ToFp32(const uint16_t* fp16, float* fp32, int count, cudaStream_t stream) {
-  int block_size = 256;
-  int num_blocks = (count + block_size - 1) / block_size;
-  ConvertFp16ToFp32<<<num_blocks, block_size, 0, stream>>>(reinterpret_cast<const half*>(fp16), fp32, count);
+template void Launch_UpdateAttentionMask(int32_t *mask_data, const int32_t *old_mask_data, int batch_beam_size,
+                                         int current_length, int max_length, bool update_only, cudaStream_t stream);
+template void Launch_UpdateAttentionMask(int64_t *mask_data, const int64_t *old_mask_data, int batch_beam_size,
+                                         int current_length, int max_length, bool update_only, cudaStream_t stream);
+
+__global__ void ConvertFp16ToFp32(const half *src, float *dst, int count) {
+    int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    if (idx < count)
+        dst[idx] = __half2float(src[idx]);
 }
 
-__global__ void ConvertInt32ToInt64(const int32_t* src, int64_t* dst, int count) {
-  int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (idx < count) {
-    dst[idx] = src[idx];
-  }
+void LaunchFp16ToFp32(const uint16_t *fp16, float *fp32, int count, cudaStream_t stream) {
+    int block_size = 256;
+    int num_blocks = (count + block_size - 1) / block_size;
+    ConvertFp16ToFp32<<<num_blocks, block_size, 0, stream>>>(reinterpret_cast<const half *>(fp16), fp32, count);
 }
 
-void LaunchInt32ToInt64(const int32_t* src, int64_t* dst, int count, cudaStream_t stream) {
-  int block_size = 256;
-  int num_blocks = (count + block_size - 1) / block_size;
-  ConvertInt32ToInt64<<<num_blocks, block_size, 0, stream>>>(src, dst, count);
+__global__ void ConvertInt32ToInt64(const int32_t *src, int64_t *dst, int count) {
+    int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    if (idx < count) {
+        dst[idx] = src[idx];
+    }
 }
 
-}  // namespace cuda
-}  // namespace Generators
+void LaunchInt32ToInt64(const int32_t *src, int64_t *dst, int count, cudaStream_t stream) {
+    int block_size = 256;
+    int num_blocks = (count + block_size - 1) / block_size;
+    ConvertInt32ToInt64<<<num_blocks, block_size, 0, stream>>>(src, dst, count);
+}
+
+} // namespace cuda
+} // namespace Generators

--- a/src/models/kernels.cu
+++ b/src/models/kernels.cu
@@ -26,7 +26,7 @@ __global__ void CopyAndUpdateAttentionMask(T *mask_data, const T *old_mask_data,
     int j = global_index % current_length;
     if (i < batch_beam_size) {
         if (j < current_length - 1) {
-            mask_data[i * max_length + j] = old_mask_data[i * (max_length - 1) + j];
+            mask_data[i * max_length + j] = old_mask_data[i * (current_length - 1) + j];
         } else {
             mask_data[i * max_length + j] = 1;
         }
@@ -48,7 +48,7 @@ void Launch_UpdateAttentionMask(T *mask_data, const T *old_mask_data, int batch_
         UpdateAttentionMask<T>
             <<<batch_beam_size, 1, 0, stream>>>(mask_data, batch_beam_size, current_length, max_length);
     } else {
-        CopyAndUpdateAttentionMask<T><<<(batch_beam_size * current_length + 255) / 256, 256, 0, stream>>>(
+        CopyAndUpdateAttentionMask<T><<<(batch_beam_size * max_length + 255) / 256, 256, 0, stream>>>(
             mask_data, old_mask_data, batch_beam_size, current_length, max_length);
     }
 }

--- a/src/models/kernels.h
+++ b/src/models/kernels.h
@@ -6,7 +6,8 @@ namespace cuda {
 template <typename T>
 void Launch_UpdatePositionIds(T* positions, int batch_beam_size, cudaStream_t stream);
 template <typename T>
-void Launch_UpdateAttentionMask(T* mask_data, const T* old_mask_data, int batch_beam_size, int current_length, cudaStream_t stream);
+void Launch_UpdateAttentionMask(T* mask_data, const T* old_mask_data, int batch_beam_size, int current_length,
+                                int max_length, bool update_only, cudaStream_t stream);
 
 void LaunchFp16ToFp32(const uint16_t* fp16, float* fp32, int count, cudaStream_t stream);
 void LaunchInt32ToInt64(const int32_t* src, int64_t* dst, int count, cudaStream_t stream);

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -160,7 +160,7 @@ void PositionInputs::UpdateAttentionMask(int current_length) {
     }
 #if USE_CUDA
     case DeviceType::CUDA: {
-      int max_seq_len = state_.params_->search.max_length;
+      int max_seq_len = sb_attention_mask_ ? state_.params_->search.max_length : current_length;
       bool update_only = sb_attention_mask_ && !is_first_mask_update_;
       if (type_ == Ort::TypeToTensorType<int32_t>::type) {
         cuda::Launch_UpdateAttentionMask(attention_mask_next_->GetTensorMutableData<int32_t>(),

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -141,9 +141,11 @@ void PositionInputs::UpdatePositionIDs(int current_length) {
 
 void PositionInputs::UpdateAttentionMask(int current_length) {
   // Update attention mask
-  if (sb_attention_mask_ && is_first_mask_update_) {
-    attention_mask_shape_[1] = state_.params_->search.max_length;
-    attention_mask_next_ = sb_attention_mask_->CreateTensorOnStaticBuffer(attention_mask_shape_, type_);
+  if (sb_attention_mask_) {
+    if (is_first_mask_update_) {
+      attention_mask_shape_[1] = state_.params_->search.max_length;
+      attention_mask_next_ = sb_attention_mask_->CreateTensorOnStaticBuffer(attention_mask_shape_, type_);
+    }
   } else {
     assert(attention_mask_shape_[1] == current_length - 1);  // We should always be growing by 1
     attention_mask_shape_[1] = current_length;

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -10,8 +10,6 @@ PositionInputs::PositionInputs(const Model& model, State& state, RoamingArray<in
       state_{state} {
   has_mask_input_ = model_.session_info_->HasInput(model_.config_->model.decoder.inputs.attention_mask);
   has_posid_input_ = model_.session_info_->HasInput(model_.config_->model.decoder.inputs.position_ids);
-  has_seqlens_k_input_ = model_.session_info_->HasInput(model_.config_->model.decoder.inputs.seqlens_k);
-  has_total_sequence_length_input_ = model_.session_info_->HasInput(model_.config_->model.decoder.inputs.total_sequence_length);
 
   type_ = Ort::TypeToTensorType<int32_t>::type;
   if (has_mask_input_) {
@@ -50,20 +48,18 @@ PositionInputs::PositionInputs(const Model& model, State& state, RoamingArray<in
 
   if (model_.device_type_ == DeviceType::CUDA && model_.use_cuda_graph_) {
     size_t max_beam_batch_size = static_cast<size_t>(model_.config_->search.num_beams) * model_.max_batch_size_;
-    sb_position_ids_ = std::make_unique<StaticBuffer>(model_.allocator_device_, max_beam_batch_size);
-    sb_seqlens_k_ = std::make_unique<StaticBuffer>(model_.allocator_device_, max_beam_batch_size);
+    if (has_posid_input_) {
+      sb_position_ids_ = std::make_unique<StaticBuffer>(model_.allocator_device_, max_beam_batch_size);
+    }
+    if (has_mask_input_) {
+      sb_attention_mask_ = std::make_unique<StaticBuffer>(model_.allocator_device_, max_beam_batch_size);
+    }
   }
 }
 
 void PositionInputs::Add() {
   if (has_posid_input_) {
     AddPositionIDs();
-  }
-  if (has_seqlens_k_input_) {
-    AddSeqlensK();
-  }
-  if (has_total_sequence_length_input_) {
-    AddTotalSequenceLength();
   }
   if (has_mask_input_) {
     AddAttentionMask();
@@ -73,12 +69,6 @@ void PositionInputs::Add() {
 void PositionInputs::Update(int current_length) {
   if (has_posid_input_) {
     UpdatePositionIDs(current_length);
-  }
-  if (has_seqlens_k_input_) {
-    UpdateSeqlensK(current_length);
-  }
-  if (has_total_sequence_length_input_) {
-    UpdateTotalSequenceLength(current_length);
   }
   if (has_mask_input_) {
     UpdateAttentionMask(current_length);
@@ -97,31 +87,6 @@ void PositionInputs::AddPositionIDs() {
 
   state_.inputs_.push_back(position_ids_.get());
   state_.input_names_.push_back(model_.config_->model.decoder.inputs.position_ids.c_str());
-}
-
-void PositionInputs::AddSeqlensK() {
-  seqlens_k_input_index_ = state_.inputs_.size();
-
-  senlens_k_shape_ = {static_cast<int64_t>(state_.params_->batch_size) * state_.params_->search.num_beams};
-  seqlens_k_ = OrtValue::CreateTensor(model_.allocator_cpu_, senlens_k_shape_, Ort::TypeToTensorType<int32_t>::type);
-
-  std::copy(initial_sequence_lengths_.begin(),
-            initial_sequence_lengths_.end(),
-            seqlens_k_->GetTensorMutableData<int32_t>());
-
-  state_.inputs_.push_back(seqlens_k_.get());
-  state_.input_names_.push_back(model_.config_->model.decoder.inputs.seqlens_k.c_str());
-}
-
-void PositionInputs::AddTotalSequenceLength() {
-  total_sequence_length_input_index_ = state_.inputs_.size();
-  total_sequence_length_ = OrtValue::CreateTensor(model_.allocator_cpu_,
-                                                  {},
-                                                  Ort::TypeToTensorType<int32_t>::type);
-
-  total_sequence_length_->GetTensorMutableData<int32_t>()[0] = state_.params_->sequence_length;
-  state_.inputs_.push_back(total_sequence_length_.get());
-  state_.input_names_.push_back(model_.config_->model.decoder.inputs.total_sequence_length.c_str());
 }
 
 void PositionInputs::UpdatePositionIDs(int current_length) {
@@ -174,58 +139,56 @@ void PositionInputs::UpdatePositionIDs(int current_length) {
   }
 }
 
-void PositionInputs::UpdateSeqlensK(int current_length) {
-#if USE_CUDA
-  assert(type_ == Ort::TypeToTensorType<int32_t>::type);
-  assert(model_.device_type_ == DeviceType::CUDA);
-
-  if (is_first_seqlen_update_) {
-    if (!sb_seqlens_k_) {
-      seqlens_k_ = OrtValue::CreateTensor(*model_.allocator_device_, senlens_k_shape_, Ort::TypeToTensorType<int32_t>::type);
-    } else {
-      seqlens_k_ = sb_seqlens_k_->CreateTensorOnStaticBuffer(senlens_k_shape_, Ort::TypeToTensorType<int32_t>::type);
-    }
-    state_.inputs_[seqlens_k_input_index_] = seqlens_k_.get();
-    cudaMemcpyAsync(seqlens_k_->GetTensorMutableRawData(), initial_sequence_lengths_.data(), sizeof(int32_t) * initial_sequence_lengths_.size(), cudaMemcpyHostToDevice, model_.cuda_stream_);
-    is_first_seqlen_update_ = false;
-  } else {
-    cuda::Launch_UpdatePositionIds(seqlens_k_->GetTensorMutableData<int32_t>(), static_cast<int>(senlens_k_shape_[0]), model_.cuda_stream_);
-  }
-#endif
-}
-
-void PositionInputs::UpdateTotalSequenceLength(int current_length) {
-  total_sequence_length_->GetTensorMutableData<int32_t>()[0] = current_length;
-}
-
 void PositionInputs::UpdateAttentionMask(int current_length) {
   // Update attention mask
-  assert(attention_mask_shape_[1] == current_length - 1);  // We should always be growing by 1
-  attention_mask_shape_[1] = current_length;
-
-  std::unique_ptr<OrtValue> next_attention_mask = OrtValue::CreateTensor(*model_.allocator_device_, attention_mask_shape_, type_);
+  if (sb_attention_mask_ && is_first_mask_update_) {
+    attention_mask_shape_[1] = state_.params_->search.max_length;
+    attention_mask_next_ = sb_attention_mask_->CreateTensorOnStaticBuffer(attention_mask_shape_, type_);
+  } else {
+    assert(attention_mask_shape_[1] == current_length - 1);  // We should always be growing by 1
+    attention_mask_shape_[1] = current_length;
+    attention_mask_next_ = OrtValue::CreateTensor(model_.allocator_cpu_, attention_mask_shape_, type_);
+  }
 
   switch (model_.device_type_) {
     case DeviceType::CPU: {
       if (type_ == Ort::TypeToTensorType<int32_t>::type)
-        UpdateAttentionMaskImpl(next_attention_mask->GetTensorMutableData<int32_t>(), attention_mask_->GetTensorData<int32_t>(), current_length);
+        UpdateAttentionMaskImpl(attention_mask_next_->GetTensorMutableData<int32_t>(), attention_mask_->GetTensorData<int32_t>(), current_length);
       else
-        UpdateAttentionMaskImpl(next_attention_mask->GetTensorMutableData<int64_t>(), attention_mask_->GetTensorData<int64_t>(), current_length);
+        UpdateAttentionMaskImpl(attention_mask_next_->GetTensorMutableData<int64_t>(), attention_mask_->GetTensorData<int64_t>(), current_length);
       break;
     }
 #if USE_CUDA
-    case DeviceType::CUDA:
-      if (type_ == Ort::TypeToTensorType<int32_t>::type)
-        cuda::Launch_UpdateAttentionMask(next_attention_mask->GetTensorMutableData<int32_t>(), attention_mask_->GetTensorData<int32_t>(), static_cast<int>(attention_mask_shape_[0]), current_length, model_.cuda_stream_);
-      else
-        cuda::Launch_UpdateAttentionMask(next_attention_mask->GetTensorMutableData<int64_t>(), attention_mask_->GetTensorData<int64_t>(), static_cast<int>(attention_mask_shape_[0]), current_length, model_.cuda_stream_);
+    case DeviceType::CUDA: {
+      int max_seq_len = state_.params_->search.max_length;
+      bool update_only = sb_attention_mask_ && !is_first_mask_update_;
+      if (type_ == Ort::TypeToTensorType<int32_t>::type) {
+        cuda::Launch_UpdateAttentionMask(attention_mask_next_->GetTensorMutableData<int32_t>(),
+                                         attention_mask_->GetTensorData<int32_t>(),
+                                         static_cast<int>(attention_mask_shape_[0]),
+                                         current_length,
+                                         max_seq_len,
+                                         update_only,
+                                         model_.cuda_stream_);
+      } else {
+        cuda::Launch_UpdateAttentionMask(attention_mask_next_->GetTensorMutableData<int64_t>(),
+                                         attention_mask_->GetTensorData<int64_t>(),
+                                         static_cast<int>(attention_mask_shape_[0]),
+                                         current_length,
+                                         max_seq_len,
+                                         update_only,
+                                         model_.cuda_stream_);
+      }
       break;
+    }
 #endif
     default:
       throw std::runtime_error("PositionIDs::Update - Unsupported device type");
   }
-  attention_mask_ = std::move(next_attention_mask);
+  attention_mask_ = std::move(attention_mask_next_);
   state_.inputs_[mask_input_index_] = attention_mask_.get();
+
+  is_first_mask_update_ = false;
 }
 
 template <typename T>

--- a/src/models/position_inputs.h
+++ b/src/models/position_inputs.h
@@ -13,13 +13,9 @@ struct PositionInputs {
  private:
   void AddAttentionMask();
   void AddPositionIDs();
-  void AddSeqlensK();
-  void AddTotalSequenceLength();
 
   void UpdatePositionIDs(int current_length);
   void UpdateAttentionMask(int current_length);
-  void UpdateSeqlensK(int current_length);
-  void UpdateTotalSequenceLength(int current_length);
 
   template <typename T>
   void InitializeTensors(std::array<int64_t, 2> shape, cpu_span<int32_t> sequence_lengths);
@@ -34,33 +30,27 @@ struct PositionInputs {
 
   size_t mask_input_index_{~0U};
   size_t posid_input_index_{~0U};
-  size_t seqlens_k_input_index_{~0U};
-  size_t total_sequence_length_input_index_{~0U};
 
   ONNXTensorElementDataType type_;  // Common type for position_ids and attention_mask
 
   bool has_mask_input_{false};
   bool has_posid_input_{false};
-  bool has_seqlens_k_input_{false};
-  bool has_total_sequence_length_input_{false};
 
   std::array<int64_t, 2> position_ids_shape_{};  // {params.batch_size*params.beam_size, params.sequence_length}
   std::unique_ptr<OrtValue> position_ids_;
   std::array<int64_t, 2> attention_mask_shape_{};  // {params.batch_size*params.beam_size, params.sequence_length}
   std::unique_ptr<OrtValue> attention_mask_;
-  std::array<int64_t, 1> senlens_k_shape_{};  // {params.batch_size*params.beam_size}
-  std::unique_ptr<OrtValue> seqlens_k_;
-  std::unique_ptr<OrtValue> total_sequence_length_;  // Scalar
 
-  std::unique_ptr<OrtValue> position_ids_next_;  // Replaces position_ids_ after the first Run() call
+  std::unique_ptr<OrtValue> position_ids_next_;    // Replaces position_ids_ after the first Run() call
+  std::unique_ptr<OrtValue> attention_mask_next_;  // Replaces attention_mask_ after the first Run() call
   std::vector<int32_t> initial_sequence_lengths_;
 
   // Used for decoding runs with cuda graphs.
   std::unique_ptr<StaticBuffer> sb_position_ids_;
-  std::unique_ptr<StaticBuffer> sb_seqlens_k_;
+  std::unique_ptr<StaticBuffer> sb_attention_mask_;
 
   bool is_first_posid_update_{true};
-  bool is_first_seqlen_update_{true};
+  bool is_first_mask_update_{true};
 };
 
 }  // namespace Generators

--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -3,6 +3,7 @@
 This folder contains the model builder for quickly creating optimized and quantized ONNX models within a few minutes that run with ONNX Runtime GenAI.
 
 # Contents
+
 - [Current Support](#current-support)
 - [Usage](#usage)
   - [Full Usage](#full-usage)
@@ -20,6 +21,7 @@ This folder contains the model builder for quickly creating optimized and quanti
 - [Design](#design)
 
 ## Current Support
+
 The tool currently supports the following model architectures.
 
 - Gemma
@@ -32,7 +34,9 @@ It is intended for supporting the latest, popular state-of-the-art models.
 ## Usage
 
 ### Full Usage
+
 For all available options, please use the `-h/--help` flag.
+
 ```
 # From wheel:
 python3 -m onnxruntime_genai.models.builder --help
@@ -42,7 +46,9 @@ python3 builder.py --help
 ```
 
 ### Original PyTorch Model from Hugging Face
+
 This scenario is where your PyTorch model is not downloaded locally (either in the default Hugging Face cache directory or in a local folder on disk).
+
 ```
 # From wheel:
 python3 -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p precision -e execution_provider -c cache_dir_to_save_hf_files
@@ -52,7 +58,9 @@ python3 builder.py -m model_name -o path_to_output_folder -p precision -e execut
 ```
 
 ### Original PyTorch Model from Disk
+
 This scenario is where your PyTorch model is already downloaded locally (either in the default Hugging Face cache directory or in a local folder on disk).
+
 ```
 # From wheel:
 python3 -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p precision -e execution_provider -c cache_dir_where_hf_files_are_saved
@@ -62,7 +70,9 @@ python3 builder.py -m model_name -o path_to_output_folder -p precision -e execut
 ```
 
 ### Customized or Finetuned PyTorch Model
+
 This scenario is where your PyTorch model has been customized or finetuned for one of the currently supported model architectures and your model can be loaded in Hugging Face.
+
 ```
 # From wheel:
 python3 -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o path_to_output_folder -p precision -e execution_provider -c cache_dir_to_store_temp_files
@@ -72,7 +82,9 @@ python3 builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p p
 ```
 
 ### GGUF Model
+
 This scenario is where your float16/float32 GGUF model is already on disk.
+
 ```
 # From wheel:
 python3 -m onnxruntime_genai.models.builder -m model_name -i path_to_gguf_file -o path_to_output_folder -p precision -e execution_provider -c cache_dir_for_hf_files
@@ -82,7 +94,9 @@ python3 builder.py -m model_name -i path_to_gguf_file -o path_to_output_folder -
 ```
 
 ### Extra Options
+
 This scenario is for when you want to have control over some specific settings. The below example shows how you can pass key-value arguments to `--extra_options`.
+
 ```
 # From wheel:
 python3 -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p precision -e execution_provider -c cache_dir_for_hf_files --extra_options filename=decoder.onnx
@@ -90,10 +104,13 @@ python3 -m onnxruntime_genai.models.builder -m model_name -o path_to_output_fold
 # From source:
 python3 builder.py -m model_name -o path_to_output_folder -p precision -e execution_provider -c cache_dir_for_hf_files --extra_options filename=decoder.onnx
 ```
+
 To see all available options through `--extra_options`, please use the `help` commands in the `Full Usage` section above.
 
 #### Config Only
+
 This scenario is for when you already have your optimized and/or quantized ONNX model and you need to create the config files to run with ONNX Runtime GenAI.
+
 ```
 # From wheel:
 python3 -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p precision -e execution_provider -c cache_dir_for_hf_files --extra_options config_only=true
@@ -105,6 +122,7 @@ python3 builder.py -m model_name -o path_to_output_folder -p precision -e execut
 Afterwards, please open the `genai_config.json` file in the output folder and modify the fields as needed for your model. You should store your ONNX model in the output folder as well.
 
 #### Exclude Embedding Layer
+
 This scenario is for when you want to exclude the embedding layer from your ONNX model.
 
 ```
@@ -116,6 +134,7 @@ python3 builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p p
 ```
 
 #### Exclude Language Modeling Head
+
 This scenario is for when you want to exclude the language modeling head from your ONNX model.
 
 ```
@@ -126,7 +145,20 @@ python3 -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o p
 python3 builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p precision -e execution_provider -c cache_dir_to_store_temp_files --extra_options exclude_lm_head=true
 ```
 
+#### Enable Cuda Graph
+
+This scenario is for when you want to enable cuda graph for your ONNX model.
+
+```
+# From wheel:
+python3 -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o path_to_output_folder -p precision -e execution_provider -c cache_dir_to_store_temp_files --extra_options enable_cuda_graph=1
+
+# From source:
+python3 builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p precision -e execution_provider -c cache_dir_to_store_temp_files --extra_options enable_cuda_graph=1
+```
+
 ### Unit Testing Models
+
 This scenario is where your PyTorch model is already downloaded locally (either in the default Hugging Face cache directory or in a local folder on disk). If it is not already downloaded locally, here is an example of how you can download it.
 
 ```
@@ -143,7 +175,9 @@ tokenizer.save_pretrained(cache_dir)
 ```
 
 #### Option 1: Use the model builder directly
+
 This option is the simplest but it will download another copy of the PyTorch model onto disk to accommodate the change in the number of hidden layers.
+
 ```
 # From wheel:
 python3 -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p precision -e execution_provider --extra_options num_hidden_layers=4

--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -15,6 +15,7 @@ This folder contains the model builder for quickly creating optimized and quanti
     - [Config Only](#config-only)
     - [Exclude Embedding Layer](#exclude-embedding-layer)
     - [Exclude Language Modeling Head](#exclude-language-modeling-head)
+    - [Enable Cuda Graph](#enable-cuda-graph)
   - [Unit Testing Models](#unit-testing-models)
     - [Option 1: Use the model builder directly](#option-1-use-the-model-builder-directly)
     - [Option 2: Edit the config.json file](#option-2-edit-the-configjson-file-on-disk-and-then-run-the-model-builder)


### PR DESCRIPTION
To keep attention_mask as model's input when using cuda graph, we assume shared_kv_cache is used and attention_mask is allocated with [max_batch, max_seq_length]

1. revert seqlens_k and total_seq_len in model builder and GenAI tool.
2. allocate attention_mask with fixed size [max_batch, max_seq_length] if using cuda graph
3. add readme