### PR TITLE
Fix naming transpose nodes

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -528,7 +528,7 @@ class Model:
 
     def make_transpose(self, name, root_input, dtype, shape, perm):
         output = f"{name}/output_0"
-        self.make_node("Transpose", inputs=[root_input], outputs=[output], perm=perm)
+        self.make_node("Transpose", inputs=[root_input], outputs=[output], name=name, perm=perm)
         self.make_value_info(output, dtype, shape=shape)
 
     def make_matmul(self, matmul, name, root_input, **kwargs):


### PR DESCRIPTION
### Description

This PR adds the node name for the `Transpose` nodes.

### Motivation and Context

While adding Phi-3 mini to the model builder, a new checker was added to prevent adding the same node twice in an ONNX model. The new checker found that the `Transpose` nodes were missing their unique names.