### PR TITLE
Fix pad token id in config

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -228,7 +228,7 @@ class Model:
                     "num_key_value_heads": self.num_kv_heads,
                 },
                 "eos_token_id": config.eos_token_id,
-                "pad_token_id": config.pad_token_id if hasattr(config, "pad_token_id") and config.pad_token_id is not None else config.eos_token_id,
+                "pad_token_id": config.pad_token_id if hasattr(config, "pad_token_id") and config.pad_token_id is not None else config.eos_token_id[0] if type(config.eos_token_id) == list else config.eos_token_id,
                 "type": self.model_type[ : self.model_type.find("For")].lower(),
                 "vocab_size": self.vocab_size,
             },

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -228,7 +228,7 @@ class Model:
                     "num_key_value_heads": self.num_kv_heads,
                 },
                 "eos_token_id": config.eos_token_id,
-                "pad_token_id": config.pad_token_id if hasattr(config, "pad_token_id") and config.pad_token_id is not None else config.eos_token_id[0] if type(config.eos_token_id) == list else config.eos_token_id,
+                "pad_token_id": config.pad_token_id if hasattr(config, "pad_token_id") and config.pad_token_id is not None else config.eos_token_id[0] if isinstance(config.eos_token_id, list) else config.eos_token_id,
                 "type": self.model_type[ : self.model_type.find("For")].lower(),
                 "vocab_size": self.vocab_size,
             },


### PR DESCRIPTION
### Description

This PR sets `pad_token_id` in `genai_config.json` to a single value when a model does not specify a pad token id but it specifies a list of EOS token ids.

### Motivation and Context

When the pad token id is not specified, `pad_token_id` in `genai_config.json` stores the same value that `eos_token_id` in `genai_config.json` contains. When `eos_token_id` has a list of EOS token ids, then `pad_token_id` also has a list of pad token ids. This causes a parsing issue in ONNX Runtime GenAI because it expects only one pad token id.

This PR also fixes [this issue](https://github.com/microsoft/onnxruntime-genai/issues/384).