### PR TITLE
Destroy the generator at the end of the loop in python examples

### DIFF
--- a/benchmark/python/benchmark_e2e.py
+++ b/benchmark/python/benchmark_e2e.py
@@ -85,6 +85,9 @@ def main(args):
             generator.generate_next_token()
         if args.print_model_output: print(tokenizer.decode(generator.get_sequence(0)))
 
+        # Delete the generator to free the captured graph for the next generator, if graph capture is enabled
+        del generator
+
     tokenize_times = []
     prompt_times = []
     token_gen_times = []
@@ -140,6 +143,9 @@ def main(args):
         wall_clock_end_time = time.time()
         wall_clock_times.append(wall_clock_end_time - wall_clock_start_time)
         if args.print_model_output: print(tokenizer.decode(generator.get_sequence(0)))
+
+        # Delete the generator to free the captured graph for the next generator, if graph capture is enabled
+        del generator
 
     # Calculate tokenization metrics
     avg_tokenization_latency_s = sum(tokenize_times) / len(tokenize_times)

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -72,6 +72,9 @@ def main(args):
         print()
         print()
 
+        # Delete the generator to free the captured graph for the next generator, if graph capture is enabled
+        del generator
+
         if args.timings:
             prompt_time = first_token_timestamp - started_timestamp
             run_time = time.time() - first_token_timestamp

--- a/examples/python/phi3-qa.py
+++ b/examples/python/phi3-qa.py
@@ -69,6 +69,9 @@ def main(args):
         print()
         print()
 
+        # Delete the generator to free the captured graph for the next generator, if graph capture is enabled
+        del generator
+
         if args.timings:
             prompt_time = first_token_timestamp - started_timestamp
             run_time = time.time() - first_token_timestamp


### PR DESCRIPTION
In python, when a variable overwrites an older variable with the same line (as with `generator = og.Generator(model, params)` in the `model-qa.py` loop), the new object is constructed before the old object is destructured. For most objects the order doesn't really matter, but when using graph capture, it does. The reason is that generators hold a reference on the captured graph in order to allow it to be re-used in the future without having to re-capture it, and 2 generators cannot hold a reference on the same graph at the same time since it would result in race conditions.

To work around this issue, we can delete the generator at the end of the loop to make sure the captured graph is freed before the next iteration. Note that this is only a problem in python, as other languages (e.g. C#, C++) will destroy the object as soon as it gets out of scope (even if the C# garbage collector doesn't actually collect the memory at that time, the object is destroyed and the reference on the captured graph is released).

An alternative way to achieve the same thing would be to extract the content of the inner loop into its own function. That way, the generator would automatically be destroyed at the end of the function because Python understand that it cannot possibly be reused.