### PR TITLE
Disable SkipLayerNorm in the model builder for DML

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -618,6 +618,9 @@ class Model:
         root_input = self.layernorm_attrs["root_input"]
         skip_input = self.layernorm_attrs["skip_input"]
 
+        # We don't use SkipLayerNorm or SkipSimplifiedLayerNorm for DML since the Add gets fused with the Matmul
+        skip = skip or self.ep == "dml"
+
         weight = f"model.layers.{layer_id}.{location}_layernorm.weight"
         self.make_external_tensor(layernorm.weight.detach().numpy().astype(self.to_numpy_dtype[self.io_dtype]) + self.layernorm_attrs["add_offset"], weight)
         bias = f"model.layers.{layer_id}.{location}_layernorm.bias"

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -619,7 +619,7 @@ class Model:
         skip_input = self.layernorm_attrs["skip_input"]
 
         # We don't use SkipLayerNorm or SkipSimplifiedLayerNorm for DML since the Add gets fused with the Matmul
-        skip = skip or self.ep == "dml"
+        skip = skip and self.ep != "dml"
 
         weight = f"model.layers.{layer_id}.{location}_layernorm.weight"
         self.make_external_tensor(layernorm.weight.detach().numpy().astype(self.to_numpy_dtype[self.io_dtype]) + self.layernorm_attrs["add_offset"], weight)


### PR DESCRIPTION
The Add is fused into GEMM in DML, so we don't want to fuse it into LayerNorm.