### PR TITLE
Remove label after #endif

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -77,7 +77,7 @@ void SGRExample(std::ostream& stream) {
 }
 
 bool RunExample = (SGRExample(std::cerr), false);
-#endif SGR_EXAMPLE
+#endif
 
 std::ostream& Log(std::string_view label, std::string_view string) {
   assert(g_log.enabled);


### PR DESCRIPTION
Accidentally typed it and it happened to work. It shouldn't be there.