### PR TITLE
Fix packed QKV Add after packed QKV MatMul in model builder

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -591,7 +591,7 @@ class Model:
             self.make_add(name, add_bias_inputs, dtype=self.io_dtype, shape=shape)
 
     def make_packed_add(self, q_add, k_add, v_add, name, root_input, **kwargs):
-        # Combine 3 Adds of shape H into 1 packed Add of shape 3H
+        # Combine 3 Adds of shape N_q, N_kv, and N_kv into 1 packed Add of shape N_q + N_kv + N_kv
         add = np.concatenate([q_add, k_add, v_add], axis=0).flatten()
         self.make_add_bias(add, name, root_input, **kwargs)
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -592,7 +592,7 @@ class Model:
 
     def make_packed_add(self, q_add, k_add, v_add, name, root_input, **kwargs):
         # Combine 3 Adds of shape H into 1 packed Add of shape 3H
-        add = np.stack((q_add, k_add, v_add), axis=0).flatten()
+        add = np.concatenate([q_add, k_add, v_add], axis=0).flatten()
         self.make_add_bias(add, name, root_input, **kwargs)
 
     def make_embedding(self, embedding):


### PR DESCRIPTION
### Description

This PR adds support for packing the bias after a packed QKV MatMul.

### Motivation and Context

This PR is a follow up to [this PR](https://github.com/microsoft/onnxruntime-genai/pull/420).