### PR TITLE
Logging unit tests & C++ API fixes

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -37,8 +37,6 @@ void SetLogBool(std::string_view name, bool value) {
     g_log.model_logits = value;
   else
     throw JSON::unknown_value_error{};
-
-  Log("warning", "Setting a value");
 }
 
 void SetLogString(std::string_view name, std::string_view value) {

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,8 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 #pragma once
-
+/*
+ * General purpose logging for GenAI
+ *
+ * The two functions to access the log are at the top, SetLogBool and SetLogString.
+ * These functions modify the variables in the global LogItems structure.
+ *
+ * For example, to enable logging, just SetLogBool("enabled", true)
+ * To dump model run call input tensors, SetLogBool("model_input_values", true)
+ *
+ * NOTE: The names in LogItems must match the strings in the APIs and the strings displayed for log entries.
+ *       This makes it easy to know what option is displaying which data, and to easily know how to turn options off.
+ *
+ * Logging to a file is special: SetLogString("filename", "path") as "filename" is not a string in LogItems
+ *
+ * COLOR: The functions use ANSI SGR terminal codes for color, the 'struct SGR' below makes it easy to add common
+ *        options during log options. Just look in the code for examples of how to use it. Note that the colors
+ *        may differ in intensity/saturation on different platforms.
+ *
+ *        "warning" messages will appear in yellow, there is a special case in the Log(...) function for this
+ *        There is no red for errors, as errors are exceptions.
+ */
 namespace Generators {
 
 void SetLogBool(std::string_view name, bool value);

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -58,16 +58,6 @@ inline void OgaCheckResult(OgaResult* result) {
   }
 }
 
-struct OgaLog {
-  void SetBool(const char* name, bool value) {
-    OgaCheckResult(OgaSetLogBool(name, value));
-  }
-
-  void SetString(const char* name, const char* value) {
-    OgaCheckResult(OgaSetLogString(name, value));
-  }
-};
-
 struct OgaModel : OgaAbstract {
   static std::unique_ptr<OgaModel> Create(const char* config_path) {
     OgaModel* p;
@@ -286,6 +276,14 @@ struct OgaHandle {
 
 // Global Oga functions
 namespace Oga {
+
+void SetLogBool(const char* name, bool value) {
+  OgaCheckResult(OgaSetLogBool(name, value));
+}
+
+void SetLogString(const char* name, const char* value) {
+  OgaCheckResult(OgaSetLogString(name, value));
+}
 
 void SetCurrentGpuDeviceId(int device_id) {
   OgaCheckResult(OgaSetCurrentGpuDeviceId(device_id));

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -46,7 +46,8 @@ OgaResult* OGA_API_CALL OgaSetLogBool(const char* name, bool value) {
 
 OgaResult* OGA_API_CALL OgaSetLogString(const char* name, const char* value) {
   OGA_TRY
-  Generators::SetLogString(name, value);
+  // Turn nullptr into an empty std::string (nullptr directly will crash the std::string constructor)
+  Generators::SetLogString(name, value ? value : std::string{});
   return nullptr;
   OGA_CATCH
 }

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -109,6 +109,13 @@ TEST(CAPITests, Tensor_And_AddExtraInput) {
   params->SetModelInput("test_input", *tensor);
 }
 
+TEST(CAPITests, Logging) {
+  // Trivial test to ensure the API builds properly
+  Oga::SetLogBool("enabled", true);
+  Oga::SetLogString("filename", nullptr); // If we had a filename set, this would stop logging to the file and go back to the console
+  Oga::SetLogBool("enabled", false);
+}
+
 // DML doesn't support GPT attention
 #if !USE_DML
 TEST(CAPITests, GreedySearchGptFp32CAPI) {

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -146,6 +146,6 @@ def test_batching(device, phi2_for):
     print(tokenizer.decode_batch(output_sequences))
 
 def test_logging():
-    og.set_log_options(enabled: True, model_input_values: True, model_output_shapes: True)
-    og.set_log_options(model_input_values: False, model_output_shapes: False)
-    og.set_log_options(enabled: False)
+    og.set_log_options(enabled=True, model_input_values=True, model_output_shapes=True)
+    og.set_log_options(model_input_values=False, model_output_shapes=False)
+    og.set_log_options(enabled=False)

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -144,3 +144,8 @@ def test_batching(device, phi2_for):
 
     output_sequences = model.generate(params)
     print(tokenizer.decode_batch(output_sequences))
+
+def test_logging():
+    og.set_log_options(enabled: True, model_input_values: True, model_output_shapes: True)
+    og.set_log_options(model_input_values: False, model_output_shapes: False)
+    og.set_log_options(enabled: False)


### PR DESCRIPTION
C++ API mistakenly had the functions in a struct vs a namespace

Added C++ & Python logging unit tests.

Added documentation to logging.h