### PR TITLE
Test fix - ensure random indices don't overlap

### DIFF
--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -123,8 +123,9 @@ void CreateRandomLogits(float* logits, int num_large, int vocab_size, int batch_
     for (int i = 0; i < num_large; i++) {
       float& value = logits[dist_large(engine) + b * vocab_size];
       if (value == 25.0f)
-        i--;  // We hit the same number twice, so do it again
-      value = 25.0f;
+        i--;  // We hit the same number twice, so do it again to ensure num_large values are set to 25.0f
+      else
+        value = 25.0f;
     }
   }
 }

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -110,6 +110,7 @@ TEST(SamplingTests, BatchedSamplingTopPAndKCpu) {
 }
 
 void CreateRandomLogits(float* logits, int num_large, int vocab_size, int batch_size, std::mt19937& engine) {
+  assert(num_large < vocab_size / 2);  // num_large should be much smaller than vocab_size
   std::uniform_real_distribution<float> dist(0.0f, 1.0f);
   for (int b = 0; b < batch_size; b++) {
     for (int v = 0; v < vocab_size; v++) {


### PR DESCRIPTION
CreateRandomLogits might hit the same index twice in the random sampling, this can result in num_large not being hit and resulting in fewer large values in the logits. This will make our unit test fail randomly.

For example, we have a TopK(10) test, and we randomly set 10 score values to be 25 (the rest between 0-1). We test it by setting 10 random values to be 25, and verify the TopK results are all '25'.

But, if a duplicate random index occurs, we'll only have 9 (or fewer) score values as 25, and our Top 10 will include some lower values.
