### PR TITLE
Moving ORT-Genai DLL into lib folder

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -5,6 +5,7 @@ set_target_properties(
 install(TARGETS
   onnxruntime-genai
   LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib
   PUBLIC_HEADER
 )
 set(CPACK_PACKAGE_VENDOR "Microsoft")


### PR DESCRIPTION
Moving ORT-Genai Windows dll into lib folder