### PR TITLE
Fix onnxruntime-genai-cuda installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install [--pre] numpy onnxruntime-genai-directml
 ### CUDA GPU
 
 ```bash
-pip install numpy onnxruntime-genai-cuda --pre --index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-genai/pypi/simple/
+pip install numpy onnxruntime-genai-cuda --pre --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-genai/pypi/simple/
 ```
 
 


### PR DESCRIPTION
Without `--extra-index-url`, it runs into an error because of not finding NumPy on the MSFT index:

```
pip install numpy onnxruntime-genai-cuda --pre --index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-genai/pypi/simple/ Looking in indexes: https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-genai/pypi/simple/ ERROR: Could not find a version that satisfies the requirement numpy (from versions: none) ERROR: No matching distribution found for numpy
```