### PR TITLE
Set PUBLIC_HEADER DESTINATION to include

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -6,7 +6,7 @@ install(TARGETS
   onnxruntime-genai
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib
-  PUBLIC_HEADER
+  PUBLIC_HEADER DESTINATION include
 )
 set(CPACK_PACKAGE_VENDOR "Microsoft")
 set(CPACK_PACKAGE_NAME "onnxruntime-genai")


### PR DESCRIPTION
Unix OS need the explictly set  PUBLIC_HEADER DESTINATION to include inorder to have header files in include folder