### PR TITLE
fix graph capture API name in python

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ See https://onnxruntime.ai/docs/genai/how-to/install
    input_tokens = tokenizer.encode(prompt)
 
    params = og.GeneratorParams(model)
-   params.try_use_cuda_graph_with_max_batch_size(1)
    params.set_search_options(**search_options)
    params.input_ids = input_tokens
    generator = og.Generator(model, params)

--- a/benchmark/python/benchmark_e2e.py
+++ b/benchmark/python/benchmark_e2e.py
@@ -22,7 +22,7 @@ def generate_prompt(model, tokenizer, prompt_length, use_graph_capture) -> str:
     params.input_ids = tokens
 
     if use_graph_capture:
-        params.try_use_cuda_graph_with_max_batch_size(1)
+        params.try_graph_capture_with_max_batch_size(1)
 
     generator=og.Generator(model, params)
     while not generator.is_done():
@@ -69,7 +69,7 @@ def run_benchmark(args, model, tokenizer, batch_size, prompt_length, generation_
     params.set_search_options(do_sample=True, top_k=args.top_k, top_p=args.top_p, temperature=temperature, max_length=max_length, min_length=max_length)
 
     if args.use_graph_capture:
-        params.try_use_cuda_graph_with_max_batch_size(batch_size)
+        params.try_graph_capture_with_max_batch_size(batch_size)
 
     if args.verbose: print("Running warmup runs...")
     for _ in tqdm(range(args.warmup)):
@@ -105,7 +105,7 @@ def run_benchmark(args, model, tokenizer, batch_size, prompt_length, generation_
         params.set_search_options(max_length=max_length, min_length=max_length)
 
         if args.use_graph_capture:
-            params.try_use_cuda_graph_with_max_batch_size(batch_size)
+            params.try_graph_capture_with_max_batch_size(batch_size)
 
         generator = og.Generator(model, params)
 

--- a/examples/chat_app/interface/hddr_llm_onnx_interface.py
+++ b/examples/chat_app/interface/hddr_llm_onnx_interface.py
@@ -69,7 +69,6 @@ You are a helpful AI assistant.<|eot_id|>"""
         output_tokens = []
 
         params = og.GeneratorParams(self.model)
-        params.try_use_cuda_graph_with_max_batch_size(1)
         params.input_ids = input_ids
 
         search_options = {"max_length" : max_length}

--- a/examples/python/model-generate.py
+++ b/examples/python/model-generate.py
@@ -34,9 +34,9 @@ def main(args):
 
     params.set_search_options(**search_options)
     # Set the batch size for the CUDA graph to the number of prompts if the user didn't specify a batch size
-    params.try_use_cuda_graph_with_max_batch_size(len(prompts))
+    params.try_graph_capture_with_max_batch_size(len(prompts))
     if args.batch_size_for_cuda_graph:
-        params.try_use_cuda_graph_with_max_batch_size(args.batch_size_for_cuda_graph)
+        params.try_graph_capture_with_max_batch_size(args.batch_size_for_cuda_graph)
     params.input_ids = input_tokens
     if args.verbose: print("GeneratorParams created")
 

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -41,7 +41,6 @@ def main(args):
         input_tokens = tokenizer.encode(prompt)
 
         params = og.GeneratorParams(model)
-        params.try_use_cuda_graph_with_max_batch_size(1)
         params.set_search_options(**search_options)
         params.input_ids = input_tokens
         generator = og.Generator(model, params)

--- a/examples/python/phi3-qa.py
+++ b/examples/python/phi3-qa.py
@@ -38,7 +38,6 @@ def main(args):
         input_tokens = tokenizer.encode(prompt)
 
         params = og.GeneratorParams(model)
-        params.try_use_cuda_graph_with_max_batch_size(1)
         params.set_search_options(**search_options)
         params.input_ids = input_tokens
         generator = og.Generator(model, params)

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -36,10 +36,10 @@ GeneratorParams::GeneratorParams(const Model& model)
       device_type{model.device_type_},
       cuda_stream{model.cuda_stream_},
       is_cuda_graph_enabled_{IsCudaGraphEnabled(model.config_->model.decoder.session_options)} {
-        use_cuda_graph = is_cuda_graph_enabled_;
-        if(use_cuda_graph) {
-          max_batch_size = 1; // set it to 1 by default
-        }
+  use_cuda_graph = is_cuda_graph_enabled_;
+  if (use_cuda_graph) {
+    max_batch_size = 1;  // set it to 1 by default
+  }
 }
 
 void GeneratorParams::TryGraphCapture(int max_bs) {

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -36,6 +36,10 @@ GeneratorParams::GeneratorParams(const Model& model)
       device_type{model.device_type_},
       cuda_stream{model.cuda_stream_},
       is_cuda_graph_enabled_{IsCudaGraphEnabled(model.config_->model.decoder.session_options)} {
+        use_cuda_graph = is_cuda_graph_enabled_;
+        if(use_cuda_graph) {
+          max_batch_size = 1; // set it to 1 by default
+        }
 }
 
 void GeneratorParams::TryGraphCapture(int max_bs) {

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -8,6 +8,7 @@
 #include "../json.h"
 #include "../search.h"
 #include "../models/model.h"
+#include "../logging.h"
 
 using namespace pybind11::literals;
 
@@ -268,6 +269,11 @@ struct PyGeneratorParams {
   }
 
   void TryUseCudaGraphWithMaxBatchSize(pybind11::int_ max_batch_size) {
+    Log("warning", "try_use_cuda_graph_with_max_batch_size will be deprecated in release 0.3.0. Please use try_graph_capture_with_max_batch_size instead");
+    params_->TryGraphCapture(max_batch_size.cast<int>());
+  }
+
+  void TryGraphCaptureWithMaxBatchSize(pybind11::int_ max_batch_size) {
     params_->TryGraphCapture(max_batch_size.cast<int>());
   }
 
@@ -368,7 +374,8 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def_readwrite("whisper_input_features", &PyGeneratorParams::py_whisper_input_features_)
       .def("set_model_input", &PyGeneratorParams::SetModelInput)
       .def("set_search_options", &PyGeneratorParams::SetSearchOptions)  // See config.h 'struct Search' for the options
-      .def("try_use_cuda_graph_with_max_batch_size", &PyGeneratorParams::TryUseCudaGraphWithMaxBatchSize);
+      .def("try_use_cuda_graph_with_max_batch_size", &PyGeneratorParams::TryUseCudaGraphWithMaxBatchSize) // will be deprecated
+      .def("try_graph_capture_with_max_batch_size", &PyGeneratorParams::TryGraphCaptureWithMaxBatchSize);
 
   pybind11::class_<TokenizerStream>(m, "TokenizerStream")
       .def("decode", [](TokenizerStream& t, int32_t token) { return t.Decode(token); });

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -373,8 +373,8 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def_readwrite("input_ids", &PyGeneratorParams::py_input_ids_)
       .def_readwrite("whisper_input_features", &PyGeneratorParams::py_whisper_input_features_)
       .def("set_model_input", &PyGeneratorParams::SetModelInput)
-      .def("set_search_options", &PyGeneratorParams::SetSearchOptions)  // See config.h 'struct Search' for the options
-      .def("try_use_cuda_graph_with_max_batch_size", &PyGeneratorParams::TryUseCudaGraphWithMaxBatchSize) // will be deprecated
+      .def("set_search_options", &PyGeneratorParams::SetSearchOptions)                                     // See config.h 'struct Search' for the options
+      .def("try_use_cuda_graph_with_max_batch_size", &PyGeneratorParams::TryUseCudaGraphWithMaxBatchSize)  // will be deprecated
       .def("try_graph_capture_with_max_batch_size", &PyGeneratorParams::TryGraphCaptureWithMaxBatchSize);
 
   pybind11::class_<TokenizerStream>(m, "TokenizerStream")

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -140,7 +140,7 @@ def test_batching(device, phi2_for):
     params.input_ids = tokenizer.encode_batch(prompts)
 
     if device == "dml":
-        params.try_use_cuda_graph_with_max_batch_size(len(prompts))
+        params.try_graph_capture_with_max_batch_size(len(prompts))
 
     output_sequences = model.generate(params)
     print(tokenizer.decode_batch(output_sequences))

--- a/test/python/test_onnxruntime_genai_e2e.py
+++ b/test/python/test_onnxruntime_genai_e2e.py
@@ -47,7 +47,7 @@ def run_model(model_path: str | bytes | os.PathLike):
     sequences = tokenizer.encode_batch(prompts)
     params = og.GeneratorParams(model)
     params.set_search_options(max_length=200)
-    params.try_use_cuda_graph_with_max_batch_size(16)
+    params.try_graph_capture_with_max_batch_size(16)
     params.input_ids = sequences
 
     output_sequences = model.generate(params)


### PR DESCRIPTION
1. fix the API name in python API.
2. enable cuda graph by default and set the max batch size to 1 if it is enabled in config. 

Same functionality as https://github.com/microsoft/onnxruntime-genai/pull/472