### PR TITLE
Add Phi-3 models to model builder

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -2318,8 +2318,8 @@ def get_args():
         "-e",
         "--execution_provider",
         required=True,
-        choices=["cpu", "cuda", "dml"],
-        help="Execution provider to target with precision of model (e.g. FP16 CUDA, INT4 CPU)",
+        choices=["cpu", "cuda", "dml", "web"],
+        help="Execution provider to target with precision of model (e.g. FP16 CUDA, INT4 CPU, INT4 WEB)",
     )
 
     parser.add_argument(

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -1589,7 +1589,7 @@ class Model:
         tile_shape = ["batch_size", self.num_attn_heads, "source_sequence_length", "target_sequence_length"]
         self.make_tile(tile_name, tile_inputs, dtype=self.io_dtype, shape=tile_shape) # Shape of mask is now (B, N, S, T)
 
-        self.mask_attrs["mask_name"] = concat_name
+        self.mask_attrs["mask_name"] = tile_name
 
     def make_past_key_subgraph(self, basename):
         shape_name = f"{basename}/Shape"

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -23,6 +23,7 @@ import textwrap
 class Model:
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
         self.context_length = config.max_position_embeddings
+        self.original_context_length = config.original_max_position_embeddings if hasattr(config, "original_max_position_embeddings") else config.max_position_embeddings
         self.window_size = config.sliding_window if hasattr(config, "sliding_window") else -1  # default is -1 in GroupQueryAttention kernel
         self.intermediate_size = config.intermediate_size
         self.hidden_size = config.hidden_size
@@ -122,10 +123,14 @@ class Model:
         }
 
         # Mask-specific variables
+        # TODO: Reconcile differences between `seqlens_k` and `key_total_seq_lens` in the GroupQueryAttention and SparseAttention implementations. Ideally the same subgraph can be shared for both.
         self.mask_attrs = {
             "mask_name": "",            # Name of node that outputs 4D causal attention mask (used as add_qk in MultiHeadAttention)
             "seqlens_k": "",            # Sum of each row in attention mask - 1 (used as input to GroupQueryAttention)
-            "total_seq_len": "",        # Size of total sequence length in attention mask (used as input to GroupQueryAttention)
+            "total_seq_len": "",        # Size of total sequence length in attention mask (used as input to GroupQueryAttention and SparseAttention)
+            "block_row_indices": "",    # Row indices of CSR format of block mask (used as input to SparseAttention)
+            "block_col_indices": "",    # Col indices of CSR format of block mask (used as input to SparseAttention)
+            "key_total_seq_lens": "",   # Sum of each row in attention mask (used as input to SparseAttention)
         }
 
         # Embedding-specific variables
@@ -146,27 +151,60 @@ class Model:
         }
 
         # RotaryEmbedding-specific variables
-        short_factor = config.rope_scaling["short_factor"] if hasattr(config, "rope_scaling") and config.rope_scaling is not None else []
-        long_factor = config.rope_scaling["long_factor"] if hasattr(config, "rope_scaling") and config.rope_scaling is not None else []
+        position_scale = config.rope_position_scale if hasattr(config, "rope_position_scale") else 1
         partial_rotary_factor = config.partial_rotary_factor if hasattr(config, "partial_rotary_factor") else 1.0
-        rope_theta = config.rope_theta if hasattr(config, "rope_theta") else 10000
+        rope_theta = config.rope_theta if hasattr(config, "rope_theta") else config.rope_embedding_base if hasattr(config, "rope_embedding_base") else 10000
         self.rotemb_attrs = {
             "create_rotary_embedding_caches": True,          # Create cos/sin caches for rotary embeddings
+            "cache_length": self.context_length,             # Cache length to use when creating cos/sin caches for rotary embeddings
             "theta": rope_theta,                             # Base value if calculating cos/sin caches from scratch
-            "short_factor": short_factor,                    # Short factor for PhiLongRoPE
-            "long_factor": long_factor,                      # Long factor for PhiLongRoPE
             "partial_rotary_factor": partial_rotary_factor,  # Factor for partial rotary embeddings
             "interleaved": 0,                                # Interleave the rotary embeddings (e.g. [0, 0, 0, 1, 1, 1] to [0, 1, 0, 1, 0, 1], RotaryEmbedding kernel expects a default value of 0)
             "num_heads": 0,                                  # For partial rotary embeddings (RotaryEmbedding kernel expects a default value of 0)
             "rotary_embedding_dim": 0,                       # For partial rotary embeddings (RotaryEmbedding kernel expects a default value of 0)
+            "rescale_factors": 1,                            # Rescale factors when calculating `inv_freq` in rotary embeddings
+            "t_dtype": torch.int64,                          # Torch dtype when calculating `t` in rotary embeddings
+            "position_scale": position_scale,                # Scale value when calculating `t` in rotary embeddings
+            "mscale": 1,                                     # Magnitude scaling factor when scaling `emb.cos()/emb.sin()` in rotary embeddings
+            "mscale_policy": "",                             # Magnitude scaling policy when scaling `emb.cos()/emb.sin()` in rotary embeddings
         }
+        if hasattr(config, "rope_scaling") and config.rope_scaling is not None:
+            # For models with multiple rotary embedding caches
+            self.rotemb_attrs["mscale_policy"] = config.rope_scaling["type"]
+            short_factor = torch.tensor(config.rope_scaling["short_factor"], dtype=torch.float32)
+            long_factor = torch.tensor(config.rope_scaling["long_factor"], dtype=torch.float32)
+
+            short_mscale = config.rope_scaling["short_mscale"] if "short_mscale" in config.rope_scaling else 0
+            long_mscale = config.rope_scaling["long_mscale"] if "long_mscale" in config.rope_scaling else 0
+            short_mscale = short_mscale if short_mscale > 0 else self.make_mscale(self.context_length / self.original_context_length)
+            long_mscale = long_mscale if long_mscale > 0 else self.make_mscale(self.context_length / self.original_context_length)
+
+            self.rotemb_attrs["multi_cache"] = {
+                "short_factor": short_factor,                # Short factor when calculating `inv_freq` in rotary embeddings
+                "long_factor": long_factor,                  # Long factor when calculating `inv_freq` in rotary embeddings
+                "short_mscale": short_mscale,                # Magnitude scaling for short factor when scaling `emb.cos()/emb.sin()` in rotary embeddings
+                "long_mscale": long_mscale,                  # Magnitude scaling for long factor when scaling `emb.cos()/emb.sin()` in rotary embeddings
+            }
 
         # Attention-specific variables (MHA, GQA, GQA + Rot.Emb., etc.)
+        # Block-sparse attention-specific variables
+        sparse_block_size = config.blocksparse_block_size if hasattr(config, "blocksparse_block_size") else 0
+        kernel_block_size = config.blocksparse_triton_kernel_block_size if hasattr(config, "blocksparse_triton_kernel_block_size") else 0
+        local_blocks = config.blocksparse_num_local_blocks if hasattr(config, "blocksparse_num_local_blocks") else 0
+        vert_block_stride = config.blocksparse_vert_stride if hasattr(config, "blocksparse_vert_stride") else 0
+        homo_head = config.blocksparse_homo_head_pattern if hasattr(config, "blocksparse_homo_head_pattern") else False
         self.attention_attrs = {
             "op_type": "MultiHeadAttention",                 # Attention op to use
             "scale": 1 / np.sqrt(self.head_size),            # Scale value after calculating Q x K' in attention
-            "use_rotemb_in_attn": False,                     # Use rotary embeddings within attention op (instead of a separate RotaryEmbedding op)
+            "use_rotemb_in_attn": False,                     # Use rotary embeddings within attention (instead of a separate RotaryEmbedding op)
             "use_packed_matmul": False,                      # Use packed MatMul (instead of 3 separate MatMuls for Q/K/V)
+            "block_sparse": {
+                "sparse_block_size": sparse_block_size,      # Sparse block size for SparseAttention op
+                "kernel_block_size": kernel_block_size,      # Kernel block size for sparse attention
+                "local_blocks": local_blocks,                # Number of local blocks for sparse attention
+                "vert_stride": vert_block_stride,            # Vertical stride to use for sparse attention
+                "homo_head": homo_head,                      # Use homo head pattern for sparse attention
+            }
         }
         valid_gqa_configurations = [
             ("cpu", TensorProto.FLOAT),
@@ -186,11 +224,6 @@ class Model:
                 self.attention_attrs["use_rotemb_in_attn"] = True
                 self.input_names.remove("position_ids")
 
-        if self.ep in {"web"}:
-            # ort-web for now wants to use MHA
-            self.attention_attrs["use_packed_matmul"] = False
-            self.attention_attrs["op_type"] = "MultiHeadAttention"
-
         self.past_present_share_buffer = self.attention_attrs["op_type"] == "GroupQueryAttention"
 
         # MLP-specific variables
@@ -199,6 +232,17 @@ class Model:
             "use_fc": False,            # Use fully-connected style for MLP (FC1/FC2)
             "output_0": "",             # Output 0 for MLP layer
         }
+
+        # LM head-specific variables
+        self.lm_head_attrs = {
+            "scale": 1,                 # Scale value to multiply output of LM head by
+            "mask": None,               # LM head mask for tokens in the vocabulary
+        }
+        if hasattr(config, "dummy_token_indices"):
+            # Create LM head mask for tokens in the vocabulary
+            dummy_tokens_mask = torch.zeros(self.vocab_size).bool()
+            dummy_tokens_mask[config.dummy_token_indices] = True
+            self.lm_head_attrs["mask"] = dummy_tokens_mask
 
         # Quantization-specific variables (INT4, INT8, etc.)
         self.quant_attrs = {
@@ -492,6 +536,16 @@ class Model:
         self.make_node("Greater", inputs=inputs, outputs=[output], name=name)
         self.make_value_info(output, TensorProto.BOOL, shape=shape)
 
+    def make_isinf(self, name, root_input, shape):
+        output = f"{name}/output_0"
+        self.make_node("IsInf", inputs=[root_input], outputs=[output], name=name)
+        self.make_value_info(output, TensorProto.BOOL, shape=shape)
+
+    def make_clip(self, name, inputs, dtype, shape):
+        output = f"{name}/output_0"
+        self.make_node("Clip", inputs=inputs, outputs=[output], name=name)
+        self.make_value_info(output, dtype, shape=shape)
+
     def make_where(self, name, inputs, dtype, shape):
         output = f"{name}/output_0"
         self.make_node("Where", inputs=inputs, outputs=[output], name=name)
@@ -672,27 +726,61 @@ class Model:
 
         return output_0
 
-    def make_rotary_embedding_caches(self, rotemb):
-        cos_cache_name, sin_cache_name = "cos_cache", "sin_cache"
+    def make_mscale_su(self, mscale):
+        if mscale <= 1.0:
+            return 1.0
+        return np.sqrt(1 + np.log(mscale) / np.log(self.original_context_length))
+
+    def make_mscale_yarn(self, mscale):
+        if mscale <= 1.0:
+            return 1.0
+        return 0.1 * np.log(mscale) + 1.0
+
+    def make_mscale(self, mscale):
+        if self.rotemb_attrs["mscale_policy"] == "su":
+            return self.make_mscale_su(mscale)
+        elif self.rotemb_attrs["mscale_policy"] == "yarn":
+            return self.make_mscale_yarn(mscale)
+        else:
+            return float(mscale)
+
+    def make_rotary_embedding_caches_from_scratch(self):
+        dim = int(self.rotemb_attrs["partial_rotary_factor"] * self.head_size)
+        inv_freq = 1.0 / (self.rotemb_attrs["rescale_factors"] * (self.rotemb_attrs["theta"] ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim)))
+
+        position_scale = self.rotemb_attrs["position_scale"] if self.context_length == self.original_context_length else 1
+        t = (torch.arange(self.rotemb_attrs["cache_length"], dtype=self.rotemb_attrs["t_dtype"]) * position_scale).type_as(inv_freq)
+
+        freqs = torch.outer(t, inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos_cache, sin_cache = emb.cos() * self.rotemb_attrs["mscale"], emb.sin() * self.rotemb_attrs["mscale"]
+        return cos_cache, sin_cache
+
+    def make_rotary_embedding_caches(self, rotemb, **kwargs):
+        cos_cache_name = kwargs.get("cos_cache_name", "cos_cache")
+        sin_cache_name = kwargs.get("sin_cache_name", "sin_cache")
 
         if self.rotemb_attrs["create_rotary_embedding_caches"]:
             if not hasattr(rotemb, "cos_cached"):
                 # Create cos/sin caches if not already created
-                dim = int(self.rotemb_attrs["partial_rotary_factor"] * self.head_size)
-                inv_freq = 1.0 / (self.rotemb_attrs["theta"] ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
-                t = torch.arange(self.context_length, dtype=torch.int64).type_as(inv_freq)
-                freqs = torch.outer(t, inv_freq)
-                emb = torch.cat((freqs, freqs), dim=-1)
-                cos_cache, sin_cache = emb.cos(), emb.sin()
+                cos_cache, sin_cache = self.make_rotary_embedding_caches_from_scratch()
             else:
                 cos_cache, sin_cache = rotemb.cos_cached, rotemb.sin_cached
 
             # Reshape cos/sin cache from (M, H) to (M, H/2)
             hidden_dim = cos_cache.shape[-1]
             cos_cache = cos_cache.squeeze()[:, : (hidden_dim // 2)].detach().numpy()
-            self.make_external_tensor(cos_cache.astype(self.to_numpy_dtype[self.io_dtype]), cos_cache_name)
+            cos_cache = cos_cache.astype(self.to_numpy_dtype[self.io_dtype])
             sin_cache = sin_cache.squeeze()[:, : (hidden_dim // 2)].detach().numpy()
-            self.make_external_tensor(sin_cache.astype(self.to_numpy_dtype[self.io_dtype]), sin_cache_name)
+            sin_cache = sin_cache.astype(self.to_numpy_dtype[self.io_dtype])
+
+            if "cos_cache_name" not in kwargs and "sin_cache_name" not in kwargs:
+                # Save cos/sin caches to disk
+                self.make_external_tensor(cos_cache, cos_cache_name)
+                self.make_external_tensor(sin_cache, sin_cache_name)
+            else:
+                # Return cos/sin caches since they will be custom-saved
+                return cos_cache, sin_cache
 
             self.rotemb_attrs["create_rotary_embedding_caches"] = False
 
@@ -706,7 +794,78 @@ class Model:
         self.make_node("RotaryEmbedding", inputs=inputs, outputs=[output], name=name, domain="com.microsoft", interleaved=self.rotemb_attrs["interleaved"], **kwargs)
         self.make_value_info(output, self.io_dtype, shape=['batch_size', 'sequence_length', self.head_size * (self.num_kv_heads if "k_rotary" in name else self.num_attn_heads)])
 
-    # TODO: This function and any corresponding changes to support it are temporary until ORT supports GQA for CPU
+    def make_rotary_embedding_multi_cache(self):
+        # Create dummy rotary embedding class
+        rotemb = type("RotaryEmbedding", (object,), {'content':{}})()
+
+        # Create caches for when sequence_length > self.original_context_length
+        self.rotemb_attrs["rescale_factors"] = self.rotemb_attrs["multi_cache"]["long_factor"]
+        self.rotemb_attrs["cache_length"] = self.context_length
+        self.rotemb_attrs["mscale"] = self.rotemb_attrs["multi_cache"]["long_mscale"]
+        cos_cache_large_name, sin_cache_large_name = "cos_cache_large", "sin_cache_large"
+        cos_cache_large, sin_cache_large = self.make_rotary_embedding_caches(rotemb, cos_cache_name=cos_cache_large_name, sin_cache_name=sin_cache_large_name)
+
+        # Create caches for when sequence_length <= self.original_context_length
+        self.rotemb_attrs["rescale_factors"] = self.rotemb_attrs["multi_cache"]["short_factor"]
+        self.rotemb_attrs["cache_length"] = self.original_context_length
+        self.rotemb_attrs["mscale"] = self.rotemb_attrs["multi_cache"]["short_mscale"]
+        cos_cache_small_name, sin_cache_small_name = "cos_cache_small", "sin_cache_small"
+        cos_cache_small, sin_cache_small = self.make_rotary_embedding_caches(rotemb, cos_cache_name=cos_cache_small_name, sin_cache_name=sin_cache_small_name)
+
+        self.rotemb_attrs["create_rotary_embedding_caches"] = False
+
+        # Make the following subgraph to decide which cos/sin caches to use in the rotary embeddings
+        #
+        # attention_mask --> Shape --> Gather --> Greater --> If --> (cos_cache, sin_cache)
+        #                             (idx=1)
+        #
+
+        basename = "/model/rotemb_caches_subgraph"
+        gather_name = ""
+        if self.attention_attrs["op_type"] == "GroupQueryAttention":
+            gather_name = "/model/attn_mask_reformat/attn_mask_subgraph/Gather"
+        else:
+            gather_name = "/model/attn_mask_reformat/attn_mask_subgraph/Gather_2"
+
+        greater_name = f"{basename}/Greater"
+        greater_inputs = [f"{gather_name}/output_0", f"/model/constants/TensorProto.INT64/0D/{self.original_context_length}"]
+        self.make_greater(greater_name, greater_inputs, shape=[])
+        if_name = f"{basename}/If"
+        if_cos_cache_output, if_sin_cache_output = "cos_cache", "sin_cache"
+        self.make_node(
+            "If", inputs=[f"{greater_name}/output_0"], outputs=[if_cos_cache_output, if_sin_cache_output], name=if_name,
+            then_branch=self.make_graph(
+                name="large_rotemb_caches_graph",
+                inputs=[],
+                outputs=[
+                    helper.make_tensor_value_info(cos_cache_large_name, self.io_dtype, shape=cos_cache_large.shape),
+                    helper.make_tensor_value_info(sin_cache_large_name, self.io_dtype, shape=sin_cache_large.shape),
+                ],
+                initializer=[],
+                value_info=[],
+                nodes=[
+                    helper.make_node("Constant", inputs=[], outputs=[cos_cache_large_name], name="/large/cos_cache/Constant", value=numpy_helper.from_array(cos_cache_large)),
+                    helper.make_node("Constant", inputs=[], outputs=[sin_cache_large_name], name="/large/sin_cache/Constant", value=numpy_helper.from_array(sin_cache_large)),
+                ],
+            ),
+            else_branch=self.make_graph(
+                name="small_rotemb_caches_graph",
+                inputs=[],
+                outputs=[
+                    helper.make_tensor_value_info(cos_cache_small_name, self.io_dtype, shape=cos_cache_small.shape),
+                    helper.make_tensor_value_info(sin_cache_small_name, self.io_dtype, shape=sin_cache_small.shape),
+                ],
+                initializer=[],
+                value_info=[],
+                nodes=[
+                    helper.make_node("Constant", inputs=[], outputs=[cos_cache_small_name], name="/small/cos_cache/Constant", value=numpy_helper.from_array(cos_cache_small)),
+                    helper.make_node("Constant", inputs=[], outputs=[sin_cache_small_name], name="/small/sin_cache/Constant", value=numpy_helper.from_array(sin_cache_small)),
+                ],
+            ),
+        )
+        self.make_value_info(if_cos_cache_output, self.io_dtype, shape=["max_sequence_length", "head_dim / 2"])
+        self.make_value_info(if_sin_cache_output, self.io_dtype, shape=["max_sequence_length", "head_dim / 2"])
+
     def make_repeat_kv(self, layer_id, root_input, past_kv, present_kv, **kwargs):
         # Make subgraph that repeats tensor of shape (batch_size, sequence_length, num_kv_heads, head_size)
         # to shape (batch_size, sequence_length, num_attn_heads, head_size) in an interleaved pattern
@@ -892,6 +1051,8 @@ class Model:
             self.make_multi_head_attention(name, add_qk=f"{self.mask_attrs['mask_name']}/output_0", **kwargs)
         elif op_type == "GroupQueryAttention":
             self.make_group_query_attention(name, seqlens_k=f"{self.mask_attrs['seqlens_k']}/output_0", total_seq_len=f"{self.mask_attrs['total_seq_len']}/output_0", **kwargs)
+        elif op_type == "SparseAttention":
+            self.make_sparse_attention(name, block_row_indices=self.mask_attrs['block_row_indices'], block_col_indices=self.mask_attrs['block_col_indices'], key_total_seq_lens=f"{self.mask_attrs['key_total_seq_lens']}/output_0", total_seq_len=f"{self.mask_attrs['total_seq_len']}/output_0", **kwargs)
         else:
             raise NotImplementedError(f"The {op_type} op is not currently supported.")
 
@@ -924,6 +1085,22 @@ class Model:
             do_rotary=self.attention_attrs["use_rotemb_in_attn"], rotary_interleaved=self.rotemb_attrs["interleaved"],
         )
         self.make_value_info(output, self.io_dtype, shape=['batch_size', 'sequence_length', self.head_size * self.num_attn_heads])
+
+    def make_sparse_attention(self, name, **kwargs):
+        inputs = [
+            kwargs["q_path"], kwargs["k_path"], kwargs["v_path"],
+            kwargs.get("past_k"), kwargs.get("past_v"),
+            kwargs.get("block_row_indices"), kwargs.get("block_col_indices"),
+            kwargs.get("total_seq_len"), kwargs.get("key_total_seq_lens"),
+            kwargs.get("cos_cache", ""), kwargs.get("sin_cache", ""),
+        ]
+        output = f"{name}/output_0"
+        outputs = [output, kwargs.get("present_k", ""), kwargs.get("present_v", "")]
+        self.make_node(
+            "SparseAttention", inputs=inputs, outputs=outputs, name=name, domain="com.microsoft",
+            num_heads=self.num_attn_heads, kv_num_heads=self.num_kv_heads, scale=self.attention_attrs["scale"], sparse_block_size=self.attention_attrs["block_sparse"]["sparse_block_size"],
+            do_rotary=self.attention_attrs["use_rotemb_in_attn"], rotary_interleaved=self.rotemb_attrs["interleaved"],
+        )
 
     def make_attention(self, layer_id, attention, root_input, **kwargs):
         # Make nodes for the Attention subgraph
@@ -1052,6 +1229,32 @@ class Model:
         # Assign output 0 of previous output node as skip input to next SkipLayerNorm
         self.layernorm_attrs["skip_input"] = f"{o_matmul_name if not o_bias_exists else o_add_name}/output_0"
 
+    def make_attention_unpacked(self, layer_id, attention, root_input, **kwargs):
+        q_size = self.num_attn_heads * self.head_size
+        kv_size = self.num_kv_heads * self.head_size
+
+        qkv_proj = 'qkv_proj' if hasattr(attention, 'qkv_proj') else 'query_key_value'
+        qkv_linear = eval(f"attention.{qkv_proj}")
+
+        attention.q_proj = torch.nn.Linear(in_features=q_size, out_features=q_size)
+        attention.q_proj.weight = torch.nn.Parameter(qkv_linear.weight[: q_size, :])
+        attention.q_proj.bias = None if qkv_linear.bias is None else torch.nn.Parameter(qkv_linear.bias[: q_size])
+
+        attention.k_proj = torch.nn.Linear(in_features=q_size, out_features=kv_size)
+        attention.k_proj.weight = torch.nn.Parameter(qkv_linear.weight[q_size : q_size + kv_size, :])
+        attention.k_proj.bias = None if qkv_linear.bias is None else torch.nn.Parameter(qkv_linear.bias[q_size : q_size + kv_size])
+
+        attention.v_proj = torch.nn.Linear(in_features=q_size, out_features=kv_size)
+        attention.v_proj.weight = torch.nn.Parameter(qkv_linear.weight[q_size + kv_size :, :])
+        attention.v_proj.bias = None if qkv_linear.bias is None else torch.nn.Parameter(qkv_linear.bias[q_size + kv_size :])
+
+        # Delete original packed weights and any references to them (e.g. `del qkv_linear` isn't sufficient)
+        del qkv_linear
+        if hasattr(attention, 'qkv_proj'):
+            del attention.qkv_proj
+        else:
+            del attention.query_key_value
+
     def make_mlp(self, layer_id, mlp, root_input):
         if self.mlp_attrs["use_proj"]:
             self.make_mlp_proj(layer_id, mlp, root_input)
@@ -1166,19 +1369,42 @@ class Model:
             output_name = self.make_gelu(layer_id, root_input, activation="FastGelu")
         elif self.activation in {"gelu"}:
             output_name = self.make_gelu(layer_id, root_input, activation="Gelu")
+        elif self.activation in {"gegelu", "geglu"}:
+            output_name = self.make_gelu(layer_id, root_input, activation="QuickGelu")
         else:
             raise NotImplementedError(f"The {self.activation} activation function is not currently supported.")
         return output_name
 
     def make_lm_head(self, lm_head):
         bias_exists = lm_head.bias is not None
+        scale_exists = self.lm_head_attrs["scale"] != 1
+        mask_exists = self.lm_head_attrs["mask"] is not None
+
         matmul_name = "/lm_head/MatMul"
         root_input = self.layernorm_attrs["output_0"]
-        self.make_matmul(lm_head.weight.detach().numpy(), matmul_name, root_input, logits=not bias_exists)
+        self.make_matmul(lm_head.weight.detach().numpy(), matmul_name, root_input, logits=not bias_exists and not scale_exists)
 
         if bias_exists:
             add_name = "/lm_head/Add"
-            self.make_add_bias(lm_head.bias.detach().numpy(), add_name, root_input=f"{matmul_name}/output_0", logits=True)
+            self.make_add_bias(lm_head.bias.detach().numpy(), add_name, root_input=f"{matmul_name}/output_0", logits=not scale_exists)
+
+        if scale_exists:
+            mul_name = "/lm_head/Mul"
+            mul_inputs = [f"{matmul_name if not bias_exists else add_name}/output_0", f"/model/constants/{self.to_str_dtype[self.io_dtype]}/0D/{self.lm_head_attrs['scale']}"]
+            mul_output = "logits" if not mask_exists else f"{mul_name}/output_0"
+            self.make_node('Mul', inputs=mul_inputs, outputs=[mul_output], name=mul_name)
+            self.make_value_info(mul_output, self.io_dtype, shape=['batch_size', 'sequence_length', self.vocab_size])
+
+        if mask_exists:
+            # Save logits mask as initializer
+            logits_mask_name = "logits_mask"
+            self.make_external_tensor(self.lm_head_attrs["mask"].detach().numpy(), logits_mask_name)
+
+            where_name = "/lm_head/Where"
+            where_inputs = [logits_mask_name, f"/model/constants/{self.to_str_dtype[self.io_dtype]}/0D/{np.finfo(self.to_numpy_dtype[self.io_dtype]).min}", f"{mul_name}/output_0"]
+            where_output = "logits"
+            self.make_node('Where', inputs=where_inputs, outputs=[where_output], name=where_name)
+            self.make_value_info(where_output, self.io_dtype, shape=['batch_size', 'sequence_length', self.vocab_size])
 
     def make_layer(self, layer_id, layer):
         # Each LLM decoder layer is typically defined as:
@@ -1279,6 +1505,9 @@ class Model:
             #         4D causal attention mask
             self.make_attention_mask_reformatting_for_mha()
 
+        if self.attention_attrs["block_sparse"]["sparse_block_size"] != 0:
+            self.make_attention_mask_reformatting_for_sparse_attn()
+
     def make_attention_mask_reformatting_for_mha(self):
         # Make nodes for the attention mask subgraphs that reformat the
         # 2D attention mask (B, S) to 4D causal attention mask (B, N, S, T)
@@ -1358,9 +1587,9 @@ class Model:
         tile_name = f"{basename}/Tile"
         tile_inputs = [f"{end_add_name}/output_0", f"/model/constants/TensorProto.INT64/1D/1, {self.num_attn_heads}, 1, 1"]
         tile_shape = ["batch_size", self.num_attn_heads, "source_sequence_length", "target_sequence_length"]
-        self.make_tile(tile_name, tile_inputs, dtype=self.io_dtype, shape=tile_shape)
+        self.make_tile(tile_name, tile_inputs, dtype=self.io_dtype, shape=tile_shape) # Shape of mask is now (B, N, S, T)
 
-        self.mask_attrs["mask_name"] = tile_name
+        self.mask_attrs["mask_name"] = concat_name
 
     def make_past_key_subgraph(self, basename):
         shape_name = f"{basename}/Shape"
@@ -1618,6 +1847,43 @@ class Model:
         self.mask_attrs["seqlens_k"] = cast_1_name
         self.mask_attrs["total_seq_len"] = cast_2_name
 
+    def make_attention_mask_reformatting_for_sparse_attn(self):
+        # Make nodes for the attention mask subgraph that calculates 
+        # attributes about the 2D attention mask to use in SparseAttention
+        #
+        #                attention_mask
+        #               /              \
+        #          ReduceSum          Shape
+        #              |                |
+        #        Cast to int32        Gather
+        #              |                |
+        #      key_total_seq_lens  Cast to int32
+        #            (1D)               |
+        #                          total_seq_len
+        #                             (int)
+
+        basename = "/model/attn_mask_reformat"
+        attn_mask_basename = f"{basename}/attn_mask_subgraph"
+
+        # Left path
+        reduce_sum_name = f"{attn_mask_basename}/ReduceSum"
+        reduce_sum_inputs = ["attention_mask", "/model/constants/TensorProto.INT64/1D/1"]
+        self.make_reduce_sum(reduce_sum_name, reduce_sum_inputs, dtype=TensorProto.INT64, shape=["batch_size", 1])
+        cast_1_name = f"{attn_mask_basename}/ReduceSum/Cast"
+        self.make_cast(cast_1_name, f"{reduce_sum_name}/output_0", dtype=TensorProto.INT32, shape=["batch_size", 1])
+
+        # Right path
+        shape_name = f"{attn_mask_basename}/Shape"
+        self.make_shape(shape_name, "attention_mask", shape=[2])
+        gather_name = f"{attn_mask_basename}/Gather"
+        gather_inputs = [f"{shape_name}/output_0", "/model/constants/TensorProto.INT64/0D/1"]
+        self.make_gather(gather_name, gather_inputs, axis=0)
+        cast_2_name = f"{attn_mask_basename}/Gather/Cast"
+        self.make_cast(cast_2_name, f"{gather_name}/output_0", dtype=TensorProto.INT32, shape=None)
+
+        self.mask_attrs["key_total_seq_lens"] = cast_1_name
+        self.mask_attrs["total_seq_len"] = cast_2_name
+
     def make_position_ids_reformatting(self):
         # Make nodes for the position ids reformatting subgraph
         #
@@ -1637,7 +1903,7 @@ class Model:
 
         basename = "/model/pos_ids_reformat"
         shape_name = f"{basename}/Shape"
-        self.make_shape(shape_name, "input_ids", shape=[2])
+        self.make_shape(shape_name, root_input="input_ids" if not self.exclude_embeds else "inputs_embeds", shape=[2] if not self.exclude_embeds else [3])
         gather_name = f"{basename}/Gather"
         gather_inputs = [f"{shape_name}/output_0", "/model/constants/TensorProto.INT64/0D/1"]
         self.make_gather(gather_name, gather_inputs, axis=0)
@@ -1712,22 +1978,7 @@ class Phi3Mini4KModel(MistralModel):
         super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
 
     def make_attention(self, layer_id, attention, root_input, **kwargs):
-        q_size = self.num_attn_heads * self.head_size
-        kv_size = self.num_kv_heads * self.head_size
-
-        attention.q_proj = torch.nn.Linear(in_features=q_size, out_features=q_size)
-        attention.q_proj.weight = torch.nn.Parameter(attention.qkv_proj.weight[: q_size, :])
-        attention.q_proj.bias = None if attention.qkv_proj.bias is None else torch.nn.Parameter(attention.qkv_proj.bias[: q_size])
-
-        attention.k_proj = torch.nn.Linear(in_features=q_size, out_features=kv_size)
-        attention.k_proj.weight = torch.nn.Parameter(attention.qkv_proj.weight[q_size : q_size + kv_size, :])
-        attention.k_proj.bias = None if attention.qkv_proj.bias is None else torch.nn.Parameter(attention.qkv_proj.bias[q_size : q_size + kv_size])
-
-        attention.v_proj = torch.nn.Linear(in_features=q_size, out_features=kv_size)
-        attention.v_proj.weight = torch.nn.Parameter(attention.qkv_proj.weight[q_size + kv_size :, :])
-        attention.v_proj.bias = None if attention.qkv_proj.bias is None else torch.nn.Parameter(attention.qkv_proj.bias[q_size + kv_size :])
-
-        del attention.qkv_proj
+        super().make_attention_unpacked(layer_id, attention, root_input, **kwargs)
         super().make_attention(layer_id, attention, root_input, **kwargs)
 
     def make_mlp_proj(self, layer_id, mlp, root_input):
@@ -1744,113 +1995,217 @@ class Phi3Mini4KModel(MistralModel):
 class Phi3Mini128KModel(Phi3Mini4KModel):
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
         super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
-        self.original_max_position_embeddings = config.original_max_position_embeddings
-        self.mscale = self.context_length / self.original_max_position_embeddings
-        self.magnitude_scaling_policy = "su"
-        self.make_rotary_embedding_caches_subgraph()
+        self.make_rotary_embedding_multi_cache()
 
-    def calculate_mscale_su(self):
-        if self.mscale <= 1.0:
-            return 1.0
-        return np.sqrt(1 + np.log(self.mscale) / np.log(self.original_max_position_embeddings))
 
-    def calculate_mscale_yarn(self):
-        if self.mscale <= 1.0:
-            return 1.0
-        return 0.1 * np.log(self.mscale) + 1.0
+class Phi3Small8KModel(Model):
+    def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
+        super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
+        self.layernorm_attrs["simple"] = False
+        self.embed_attrs["scale"] = config.mup_embedding_multiplier
+        self.rotemb_attrs["t_dtype"] = torch.float32
+        self.lm_head_attrs["scale"] = 1 / config.mup_width_multiplier
 
-    def calculate_mscale(self):
-        if self.magnitude_scaling_policy == "su":
-            return self.calculate_mscale_su()
-        elif self.magnitude_scaling_policy == "yarn":
-            return self.calculate_mscale_yarn()
+        self.calculate_block_mask()
+        self.dense_attention_every_n_layers = config.dense_attention_every_n_layers
+        if config.mup_use_scaling:
+            self.attention_attrs["scale"] = config.mup_attn_multiplier / self.head_size
+
+        self.clamp_limit = config.gegelu_limit
+
+    def calculate_cdiv(self, a, b):
+        return -(a // -b)
+
+    def calculate_block_mask(self):
+        # Initialize parameters for calculating block dense mask
+        n_heads = self.num_attn_heads
+        q_len = self.context_length
+        N_CTX = self.context_length
+        BLOCK = self.attention_attrs["block_sparse"]["sparse_block_size"]
+        local_blocks = self.attention_attrs["block_sparse"]["local_blocks"]
+        vert_stride = self.attention_attrs["block_sparse"]["vert_stride"]
+        homo_head = self.attention_attrs["block_sparse"]["homo_head"]
+
+        N_BLOCK = self.calculate_cdiv(N_CTX, BLOCK)
+        if homo_head:
+            q_pos = torch.arange(N_BLOCK)[:, None]
+            k_pos = torch.arange(N_BLOCK)[None]
+            mask_vert_strided = (torch.arange(N_BLOCK) + 1) % vert_stride == 0
+            block_mask_dense = ((q_pos >= k_pos) & ((q_pos - k_pos < local_blocks) | mask_vert_strided))
+            N_BLOCK_Q = self.calculate_cdiv(q_len, BLOCK)
+            block_mask_dense_output = block_mask_dense[-N_BLOCK_Q:].contiguous().to_sparse_csr()
+
+            crows = block_mask_dense_output.crow_indices()
+            cols = block_mask_dense_output.col_indices()
+
+            crows = crows[None].expand(n_heads, crows.shape[0])
+            cols = cols[None].expand(n_heads, cols.shape[0])
         else:
-            return float(self.mscale)
+            q_pos = torch.arange(N_BLOCK)[None, :, None]
+            k_pos = torch.arange(N_BLOCK)[None, None]
+            head_sliding_step = max(1, int(vert_stride / n_heads))  # if vert_stride <= n_heads, rotating the heads
+            mask_vert_strided = [(torch.arange(N_BLOCK) + h * head_sliding_step + 1) % vert_stride == 0 for h in range(n_heads)]
+            mask_vert_strided = torch.vstack(mask_vert_strided).unsqueeze(1)
+            block_mask_dense = ((q_pos >= k_pos) & ((q_pos - k_pos < local_blocks) | mask_vert_strided))
+            N_BLOCK_Q = self.calculate_cdiv(q_len, BLOCK)
+            block_mask_dense_output = block_mask_dense[:, -N_BLOCK_Q:]
 
-    def calculate_rotary_embedding_caches(self, t, rescale_factors):
-        # Create cos/sin caches for both cases
-        dim = int(self.rotemb_attrs["partial_rotary_factor"] * self.head_size)
-        inv_freq = 1.0 / (rescale_factors * (self.rotemb_attrs["theta"] ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim)))
-        freqs = torch.outer(t, inv_freq)
-        mscale = self.calculate_mscale()
-        emb = torch.cat((freqs, freqs), dim=-1)
-        cos_cache, sin_cache = emb.cos() * mscale, emb.sin() * mscale
+            # Dense to crow_col
+            pad = -1
+            dim = block_mask_dense_output.dim()
+            assert dim in (2, 3)
+            if dim == 2:
+                block_mask_dense_output = block_mask_dense_output[None]
+            block_mask_dense_output = [xi.to_sparse_csr() for xi in block_mask_dense_output]
+            crows = torch.vstack([xi.crow_indices() for xi in block_mask_dense_output])
+            cols = [xi.col_indices() for xi in block_mask_dense_output]
+            max_cols = max(len(xi) for xi in cols)
+            cols = [torch.cat([xi, pad + xi.new_zeros(max_cols - xi.shape[0])]) for xi in cols]
+            cols = torch.vstack(cols)
+            if dim == 2:
+                crows = crows[0]
+                cols = cols[0]
 
-        # Reshape cos/sin cache from (M, H) to (M, H/2)
-        hidden_dim = cos_cache.shape[-1]
-        cos_cache = cos_cache.squeeze()[:, : (hidden_dim // 2)].detach().numpy()
-        cos_cache = cos_cache.astype(self.to_numpy_dtype[self.io_dtype])
-        sin_cache = sin_cache.squeeze()[:, : (hidden_dim // 2)].detach().numpy()
-        sin_cache = sin_cache.astype(self.to_numpy_dtype[self.io_dtype])
+        # Create tensors for row indices and col indices
+        crows_name = "block_row_indices"
+        self.make_external_tensor(crows.detach().numpy().astype(np.int32), crows_name)
+        self.mask_attrs["block_row_indices"] = crows_name
+        
+        cols_name = "block_col_indices"
+        self.make_external_tensor(cols.detach().numpy().astype(np.int32), cols_name)
+        self.mask_attrs["block_col_indices"] = cols_name
 
-        return cos_cache, sin_cache
+    def make_attention(self, layer_id, attention, root_input, **kwargs):
+        dense_attention_op = self.attention_attrs["op_type"]
+        sparse_attention_op = "SparseAttention"
 
-    def make_rotary_embedding_caches_subgraph(self):
-        # Create caches for when sequence_length > self.original_max_position_embeddings
-        t = torch.arange(self.context_length, dtype=torch.float32)
-        rescale_factors = torch.tensor(self.rotemb_attrs["long_factor"], dtype=torch.float32)
-        cos_cache_large_name, sin_cache_large_name = "cos_cache_large", "sin_cache_large"
-        cos_cache_large, sin_cache_large = self.calculate_rotary_embedding_caches(t, rescale_factors)
+        # Use dense attention every n layers and use sparse attention otherwise
+        if (self.layer_id + 1) % self.dense_attention_every_n_layers != 0:
+            # Use sparse attention
+            self.attention_attrs["op_type"] = sparse_attention_op
 
-        # Create caches for when sequence_length <= self.original_max_position_embeddings
-        t = torch.arange(self.original_max_position_embeddings, dtype=torch.float32)
-        rescale_factors = torch.tensor(self.rotemb_attrs["short_factor"], dtype=torch.float32)
-        cos_cache_small_name, sin_cache_small_name = "cos_cache_small", "sin_cache_small"
-        cos_cache_small, sin_cache_small = self.calculate_rotary_embedding_caches(t, rescale_factors)
+        q_size = self.num_attn_heads * self.head_size
+        kv_size = self.num_kv_heads * self.head_size
 
-        self.rotemb_attrs["create_rotary_embedding_caches"] = False
+        qkv_weight = attention.query_key_value.weight.T.view(self.hidden_size, self.num_kv_heads, (self.num_attn_heads // self.num_kv_heads) + 2, self.head_size)
+        qkv_bias = attention.query_key_value.bias.view(self.num_kv_heads, (self.num_attn_heads // self.num_kv_heads) + 2, self.head_size)
 
-        # Make the following subgraph to decide which cos/sin caches to use in the rotary embeddings
+        attention.q_proj = torch.nn.Linear(in_features=q_size, out_features=q_size)
+        attention.q_proj.weight = torch.nn.Parameter(qkv_weight[:, :, :-2].reshape(q_size, q_size).T)
+        attention.q_proj.bias = None if attention.query_key_value.bias is None else torch.nn.Parameter(qkv_bias[:, :-2].flatten())
+
+        attention.k_proj = torch.nn.Linear(in_features=q_size, out_features=kv_size)
+        attention.k_proj.weight = torch.nn.Parameter(qkv_weight[:, :, [-2]].reshape(q_size, kv_size).T)
+        attention.k_proj.bias = None if attention.query_key_value.bias is None else torch.nn.Parameter(qkv_bias[:, [-2]].flatten())
+
+        attention.v_proj = torch.nn.Linear(in_features=q_size, out_features=kv_size)
+        attention.v_proj.weight = torch.nn.Parameter(qkv_weight[:, :, [-1]].reshape(q_size, kv_size).T)
+        attention.v_proj.bias = None if attention.query_key_value.bias is None else torch.nn.Parameter(qkv_bias[:, [-1]].flatten())
+
+        del qkv_weight
+        del qkv_bias
+        del attention.query_key_value
+
+        super().make_attention(layer_id, attention, root_input, **kwargs)
+        self.attention_attrs["op_type"] = dense_attention_op
+
+    def make_mlp_proj(self, layer_id, mlp, root_input):
+        # Make nodes for the MLP subgraph
         #
-        # attention_mask --> Shape --> Gather --> Greater --> If --> (cos_cache, sin_cache)
-        #                             (idx=1)
-        #
+        #           root_input
+        #               |
+        #          UpProjMatMul
+        #               |
+        #           UpProjAdd
+        #          /          \
+        #         /            \
+        #        /              \
+        #      Slice             Slice
+        #    (even idx)        (odd idx)
+        #    /   |   \         /   |   \
+        #  Cast  |    |      Cast  |    |
+        #   |    |    |       |    |    |
+        # IsInf  |   Clip   IsInf  |   Clip
+        #   |    |    |       |    |    |
+        #    \   |   /         \   |   /
+        #     \  |  /           \  |  /
+        #      Where             Where
+        #        |                 |
+        #    QuickGelu            Add
+        #        |                 |
+        #        +--------+--------+
+        #                 |
+        #                Mul
+        #                 |
+        #           DownProjMatMul
+        #                 |
+        #            DownProjAdd
+        
+        # Make input MatMul and Add nodes
+        up_matmul_name = f"/model/layers.{layer_id}/mlp/up_proj/MatMul"
+        self.make_matmul(mlp.up_proj.weight.detach().numpy(), up_matmul_name, root_input)
+        up_add_name = f"/model/layers.{layer_id}/mlp/up_proj/Add"
+        self.make_add_bias(mlp.up_proj.bias.detach().numpy(), up_add_name, f"{up_matmul_name}/output_0")
 
-        basename = "/model/rotemb_caches_subgraph"
-        gather_name = ""
-        if self.attention_attrs["op_type"] == "GroupQueryAttention":
-            gather_name = "/model/attn_mask_reformat/attn_mask_subgraph/Gather"
-        else:
-            gather_name = "/model/attn_mask_reformat/attn_mask_subgraph/Gather_2"
+        # Left path
+        slice_1_name = f"/model/layers.{layer_id}/mlp/gelu/Slice"
+        slice_1_inputs = [f"{up_add_name}/output_0", "/model/constants/TensorProto.INT64/1D/0", f"/model/constants/TensorProto.INT64/1D/{np.iinfo(np.int64).max}", "/model/constants/TensorProto.INT64/1D/-1", "/model/constants/TensorProto.INT64/1D/2"]
+        self.make_slice(slice_1_name, slice_1_inputs, dtype=self.io_dtype, shape=["batch_size", "sequence_length", self.intermediate_size])
+        cast_1_name = f"/model/layers.{layer_id}/mlp/gelu/Cast"
+        self.make_cast(cast_1_name, f"{slice_1_name}/output_0", dtype=TensorProto.FLOAT, shape=["batch_size", "sequence_length", self.intermediate_size])
+        isinf_1_name = f"/model/layers.{layer_id}/mlp/gelu/IsInf"
+        self.make_isinf(isinf_1_name, f"{cast_1_name}/output_0", shape=["batch_size", "sequence_length", self.intermediate_size])
+        clip_1_name = f"/model/layers.{layer_id}/mlp/gelu/Clip"
+        clip_1_inputs = [f"{slice_1_name}/output_0", "", f"/model/constants/{self.to_str_dtype[self.io_dtype]}/0D/{self.clamp_limit}"]
+        self.make_clip(clip_1_name, clip_1_inputs, self.io_dtype, shape=["batch_size", "sequence_length", self.intermediate_size])
+        where_1_name = f"/model/layers.{layer_id}/mlp/gelu/Where"
+        where_1_inputs = [f"{isinf_1_name}/output_0", f"{slice_1_name}/output_0", f"{clip_1_name}/output_0"]
+        self.make_where(where_1_name, where_1_inputs, dtype=self.io_dtype, shape=["batch_size", "sequence_length", self.intermediate_size])
+        # Make activation
+        act_fn_name = self.make_activation(layer_id, root_input=f"{where_1_name}/output_0")
 
-        greater_name = f"{basename}/Greater"
-        greater_inputs = [f"{gather_name}/output_0", f"/model/constants/TensorProto.INT64/0D/{self.original_max_position_embeddings}"]
-        self.make_greater(greater_name, greater_inputs, shape=[])
-        if_name = f"{basename}/If"
-        if_cos_cache_output, if_sin_cache_output = "cos_cache", "sin_cache"
-        self.make_node(
-            "If", inputs=[f"{greater_name}/output_0"], outputs=[if_cos_cache_output, if_sin_cache_output], name=if_name,
-            then_branch=self.make_graph(
-                name="large_rotemb_caches_graph",
-                inputs=[],
-                outputs=[
-                    helper.make_tensor_value_info(cos_cache_large_name, self.io_dtype, shape=cos_cache_large.shape),
-                    helper.make_tensor_value_info(sin_cache_large_name, self.io_dtype, shape=sin_cache_large.shape),
-                ],
-                initializer=[],
-                value_info=[],
-                nodes=[
-                    helper.make_node("Constant", inputs=[], outputs=[cos_cache_large_name], name="/large/cos_cache/Constant", value=numpy_helper.from_array(cos_cache_large)),
-                    helper.make_node("Constant", inputs=[], outputs=[sin_cache_large_name], name="/large/sin_cache/Constant", value=numpy_helper.from_array(sin_cache_large)),
-                ],
-            ),
-            else_branch=self.make_graph(
-                name="small_rotemb_caches_graph",
-                inputs=[],
-                outputs=[
-                    helper.make_tensor_value_info(cos_cache_small_name, self.io_dtype, shape=cos_cache_small.shape),
-                    helper.make_tensor_value_info(sin_cache_small_name, self.io_dtype, shape=sin_cache_small.shape),
-                ],
-                initializer=[],
-                value_info=[],
-                nodes=[
-                    helper.make_node("Constant", inputs=[], outputs=[cos_cache_small_name], name="/small/cos_cache/Constant", value=numpy_helper.from_array(cos_cache_small)),
-                    helper.make_node("Constant", inputs=[], outputs=[sin_cache_small_name], name="/small/sin_cache/Constant", value=numpy_helper.from_array(sin_cache_small)),
-                ],
-            ),
-        )
-        self.make_value_info(if_cos_cache_output, self.io_dtype, shape=["max_sequence_length", "head_dim / 2"])
-        self.make_value_info(if_sin_cache_output, self.io_dtype, shape=["max_sequence_length", "head_dim / 2"])
+        # Right path
+        slice_2_name = f"/model/layers.{layer_id}/mlp/linear/Slice"
+        slice_2_inputs = [f"{up_add_name}/output_0", "/model/constants/TensorProto.INT64/1D/1", f"/model/constants/TensorProto.INT64/1D/{np.iinfo(np.int64).max}", "/model/constants/TensorProto.INT64/1D/-1", "/model/constants/TensorProto.INT64/1D/2"]
+        self.make_slice(slice_2_name, slice_2_inputs, dtype=self.io_dtype, shape=["batch_size", "sequence_length", self.intermediate_size])
+        cast_2_name = f"/model/layers.{layer_id}/mlp/linear/Cast"
+        self.make_cast(cast_2_name, f"{slice_2_name}/output_0", dtype=TensorProto.FLOAT, shape=["batch_size", "sequence_length", self.intermediate_size])
+        isinf_2_name = f"/model/layers.{layer_id}/mlp/linear/IsInf"
+        self.make_isinf(isinf_2_name, f"{cast_2_name}/output_0", shape=["batch_size", "sequence_length", self.intermediate_size])
+        clip_2_name = f"/model/layers.{layer_id}/mlp/linear/Clip"
+        clip_2_inputs = [f"{slice_2_name}/output_0", f"/model/constants/{self.to_str_dtype[self.io_dtype]}/0D/-{self.clamp_limit}", f"/model/constants/{self.to_str_dtype[self.io_dtype]}/0D/{self.clamp_limit}"]
+        self.make_clip(clip_2_name, clip_2_inputs, self.io_dtype, shape=["batch_size", "sequence_length", self.intermediate_size])
+        where_2_name = f"/model/layers.{layer_id}/mlp/linear/Where"
+        where_2_inputs = [f"{isinf_2_name}/output_0", f"{slice_2_name}/output_0", f"{clip_2_name}/output_0"]
+        self.make_where(where_2_name, where_2_inputs, dtype=self.io_dtype, shape=["batch_size", "sequence_length", self.intermediate_size])
+        add_name = f"/model/layers.{layer_id}/mlp/linear/Add"
+        add_inputs = [f"{where_2_name}/output_0", f"/model/constants/{self.to_str_dtype[self.io_dtype]}/0D/1"]
+        self.make_add(add_name, add_inputs, dtype=self.io_dtype, shape=["batch_size", "sequence_length", self.intermediate_size])
+
+        # Make Mul node after activation
+        mul_name = f"/model/layers.{layer_id}/mlp/Mul"
+        mul_inputs = [f"{act_fn_name}/output_0", f"{add_name}/output_0"]
+        self.make_mul(mul_name, mul_inputs, dtype=self.io_dtype, shape=["batch_size", "sequence_length", self.intermediate_size])
+
+        # Make output MatMul and Add nodes
+        down_matmul_name = f"/model/layers.{layer_id}/mlp/down_proj/MatMul"
+        self.make_matmul(mlp.down_proj.weight.detach().numpy(), down_matmul_name, f"{mul_name}/output_0")
+        down_add_name = f"/model/layers.{layer_id}/mlp/down_proj/Add"
+        self.make_add_bias(mlp.down_proj.bias.detach().numpy(), down_add_name, f"{down_matmul_name}/output_0")
+
+        # Assign output 0 of previous MatMul as skip input to next SkipLayerNorm
+        self.layernorm_attrs["skip_input"] = f"{down_add_name}/output_0"
+
+
+class Phi3Small128KModel(Phi3Small8KModel):
+    def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
+        super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
+        self.make_rotary_embedding_multi_cache()
+
+
+class Phi3VModel(Phi3Mini128KModel):
+    def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
+        super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
 
 
 def parse_extra_options(kv_items):
@@ -1879,7 +2234,7 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
     config = AutoConfig.from_pretrained(hf_name, use_auth_token=True, trust_remote_code=True, **extra_kwargs)
 
     # Set input/output precision of ONNX model
-    io_dtype = TensorProto.FLOAT if precision in {"int8", "fp32"} or (precision == "int4" and execution_provider in ["cpu"]) else TensorProto.FLOAT16
+    io_dtype = TensorProto.FLOAT if precision in {"int8", "fp32"} or (precision == "int4" and execution_provider == "cpu") else TensorProto.FLOAT16
 
     if "config_only" not in extra_options:
         # List architecture options in alphabetical order
@@ -1895,6 +2250,14 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
             onnx_model = Phi3Mini4KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Phi3ForCausalLM" and config.max_position_embeddings == 131072:
             onnx_model = Phi3Mini128KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
+        elif config.architectures[0] == "Phi3SmallForCausalLM" and config.max_position_embeddings == 8192:
+            onnx_model = Phi3Small8KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
+        elif config.architectures[0] == "Phi3SmallForCausalLM" and config.max_position_embeddings == 131072:
+            onnx_model = Phi3Small128KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
+        elif config.architectures[0] == "Phi3VForCausalLM":
+            print("WARNING: This is only generating the text component of the model. Setting `--extra_options exclude_embeds=true` by default.")
+            extra_options["exclude_embeds"] = True
+            onnx_model = Phi3VModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         else:
             raise NotImplementedError(f"The {hf_name} model is not currently supported.")
 
@@ -1955,8 +2318,8 @@ def get_args():
         "-e",
         "--execution_provider",
         required=True,
-        choices=["cpu", "cuda", "dml", "web"],
-        help="Execution provider to target with precision of model (e.g. FP16 CUDA, INT4 CPU, INT4 WEB)",
+        choices=["cpu", "cuda", "dml"],
+        help="Execution provider to target with precision of model (e.g. FP16 CUDA, INT4 CPU)",
     )
 
     parser.add_argument(

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -2251,8 +2251,12 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
         elif config.architectures[0] == "Phi3ForCausalLM" and config.max_position_embeddings == 131072:
             onnx_model = Phi3Mini128KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Phi3SmallForCausalLM" and config.max_position_embeddings == 8192:
+            print("WARNING: This model only works for CUDA currently because `SparseAttention` is only supported for CUDA in ONNX Runtime. Setting `--execution_provider cuda` by default.")
+            execution_provider = "cuda"
             onnx_model = Phi3Small8KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Phi3SmallForCausalLM" and config.max_position_embeddings == 131072:
+            print("WARNING: This model only works for CUDA currently because `SparseAttention` is only supported for CUDA in ONNX Runtime. Setting `--execution_provider cuda` by default.")
+            execution_provider = "cuda"
             onnx_model = Phi3Small128KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Phi3VForCausalLM":
             print("WARNING: This is only generating the text component of the model. Setting `--extra_options exclude_embeds=true` by default.")


### PR DESCRIPTION
### Description

This PR adds [Microsoft's Phi-3](https://azure.microsoft.com/en-us/blog/new-models-added-to-the-phi-3-family-available-on-microsoft-azure/) models to the model builder. Warnings have been added for Phi-3 small and Phi-3 vision regarding their current limitations.

### Motivation and Context

"Phi-3 models are the most capable and cost-effective small language models (SLMs) available, outperforming models of the same size and next size up across a variety of language, reasoning, coding, and math benchmarks." --Microsoft