### PR TITLE
Correct do_sample bug in example script

### DIFF
--- a/examples/python/phi3-qa.py
+++ b/examples/python/phi3-qa.py
@@ -14,6 +14,7 @@ def main(args):
     tokenizer_stream = tokenizer.create_stream()
     if args.verbose: print("Tokenizer created")
     if args.verbose: print()
+    args.do_sample = args.do_random_sampling
     search_options = {name:getattr(args, name) for name in ['do_sample', 'max_length', 'min_length', 'top_p', 'top_k', 'temperature', 'repetition_penalty'] if name in args}
     
     # Set the max length to something sensible by default, unless it is specified by the user,


### PR DESCRIPTION
The current Phi-3 example script receives a command-line `do_random_sampling` argument, but the dictionary passed to `set_search_options` looks for `do_sample`, which is the correct parameter name.

This means that the command line argument `-ds / --do-random-sampling` does nothing.

This PR corrects this bug by copying `args.do_random_sampling` into `args.do_sample`.