### PR TITLE
Disable memory arena for DML to reduce memory fragmentation

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -381,6 +381,7 @@ void Model::CreateSessionOptions() {
       }
 
       ort_options.AddConfigEntry("ep.dml.enable_graph_capture", "1");
+      ort_options.AddConfigEntry("ep.dml.disable_memory_arena", "1");
       p_dml_api_->SessionOptionsAppendExecutionProvider_DML1(&ort_options, dml_device_.Get(), dml_objects_.command_queue.Get());
       is_intel_device_ = DmlHelpers::IsIntelDevice(dml_objects_.d3d12_device.Get());
 


### PR DESCRIPTION
Memory arenas are not really useful in ort-genai because we know the sizes of all inputs/outputs upfront and keep reusing the same resources between iterations. This should reduce the memory usage of phi-3-v by quite a bit.