### PR TITLE
Adding Net Standard 2.0 compatibility

### DIFF
--- a/nuget/Microsoft.ML.OnnxRuntimeGenAI.Managed.nuspec
+++ b/nuget/Microsoft.ML.OnnxRuntimeGenAI.Managed.nuspec
@@ -13,7 +13,7 @@
     <releaseNotes>Introducing the ONNX Runtime GenAI Library.</releaseNotes>
     <tags>ONNX;ONNX Runtime;ONNX Runtime Gen AI;Machine Learning</tags>
     <dependencies>
-      <group targetFramework="netstandard2.1" />
+      <group targetFramework="net8.0;netstandard2.0" />
     </dependencies>
   </metadata>
   <files>
@@ -21,10 +21,13 @@
     <file src="..\README.md" target="README.md" />
     <file src="..\ThirdPartyNotices.txt" target="ThirdPartyNotices.txt" />
 
-    <file src="..\src\csharp\bin\$configuration$\netstandard2.1\Microsoft.ML.OnnxRuntimeGenAI.dll" target="lib\netstandard2.1" />
-    <file src="..\src\csharp\bin\$configuration$\netstandard2.1\Microsoft.ML.OnnxRuntimeGenAI.pdb" target="lib\netstandard2.1" />
+    <file src="..\src\csharp\bin\$configuration$\netstandard2.0\Microsoft.ML.OnnxRuntimeGenAI.dll" target="lib\netstandard2.0" />
+    <file src="..\src\csharp\bin\$configuration$\netstandard2.0\Microsoft.ML.OnnxRuntimeGenAI.pdb" target="lib\netstandard2.0" />
+    <file src="..\src\csharp\bin\$configuration$\net8.0\Microsoft.ML.OnnxRuntimeGenAI.dll" target="lib\net8.0" />
+    <file src="..\src\csharp\bin\$configuration$\net8.0\Microsoft.ML.OnnxRuntimeGenAI.pdb" target="lib\net8.0" />
 
     <!-- Targets -->
-    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.Managed.targets" target="build\netstandard2.1" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.Managed.targets" target="build\netstandard2.0" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.Managed.targets" target="build\net8.0" />
   </files>
 </package>

--- a/nuget/Microsoft.ML.OnnxRuntimeGenAI.nuspec
+++ b/nuget/Microsoft.ML.OnnxRuntimeGenAI.nuspec
@@ -43,8 +43,10 @@
 <!--     <file src="..\$buildPath$\$configuration$\onnxruntime-genai.dll" target="runtimes\win-arm64\native" /> -->
 
     <!-- Targets -->
-    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.targets" target="build\netstandard2.1\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.targets" />
-    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.props" target="build\netstandard2.1\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.props" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.targets" target="build\netstandard2.0\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.targets" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.props" target="build\netstandard2.0\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.props" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.targets" target="build\net8.0\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.targets" />
+    <file src="targets\Microsoft.ML.OnnxRuntimeGenAI.props" target="build\net8.0\Microsoft.ML.OnnxRuntimeGenAI$genai_nuget_ext$.props" />
 
     <!-- Includes -->
     <file src="..\src\ort_genai_c.h" target="build\native\include" />

--- a/src/csharp/Microsoft.ML.OnnxRuntimeGenAI.csproj
+++ b/src/csharp/Microsoft.ML.OnnxRuntimeGenAI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>default</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/csharp/Microsoft.ML.OnnxRuntimeGenAI.csproj
+++ b/src/csharp/Microsoft.ML.OnnxRuntimeGenAI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>default</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -39,6 +39,10 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" Link="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
 </Project>

--- a/test/csharp/Microsoft.ML.OnnxRuntimeGenAI.Tests.csproj
+++ b/test/csharp/Microsoft.ML.OnnxRuntimeGenAI.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU</Platforms>
     <IsTestProject>true</IsTestProject>

--- a/test/csharp/Microsoft.ML.OnnxRuntimeGenAI.Tests.csproj
+++ b/test/csharp/Microsoft.ML.OnnxRuntimeGenAI.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU</Platforms>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
To increase the adoption and support to SDKs like `Semantic Kernel` is very desired to also have support for `netstandard 2.0`.

This is an initial suggestion, the implementations might be improved for best performance.

Resolves #382