### PR TITLE
Enhance error message when ImportError encountered

### DIFF
--- a/src/python/__init__.py.in
+++ b/src/python/__init__.py.in
@@ -8,7 +8,7 @@ __id__ = "@TARGET_NAME@"
 
 try:
     from onnxruntime_genai.@PACKAGE_DIR_NAME@ import *
-except ImportErrora as e:
+except ImportError as e:
     if __id__ == "onnxruntime-genai-cuda":
         # Try importing onnxruntime_genai. If an ImportError is raised,
         # it could be because the cuda dlls could not be found on windows.

--- a/src/python/__init__.py.in
+++ b/src/python/__init__.py.in
@@ -3,14 +3,18 @@
 
 from onnxruntime_genai import _dll_directory
 
-try:
-    # Try importing onnxruntime_genai. If an ImportError is raised,
-    # it could be because the cuda dlls could not be found on windows.
-    # Try adding the cuda dlls path to the dll search directory
-    # and import onnxruntime_genai again.
-    from onnxruntime_genai.@PACKAGE_DIR_NAME@ import *
-except ImportError:
-    _dll_directory.add_dll_directory()
-    from onnxruntime_genai.@PACKAGE_DIR_NAME@ import *
-
 __version__ = "@VERSION_INFO@"
+__id__ = "@TARGET_NAME@"
+
+try:
+    from onnxruntime_genai.@PACKAGE_DIR_NAME@ import *
+except ImportErrora as e:
+    if __id__ == "onnxruntime-genai-cuda":
+        # Try importing onnxruntime_genai. If an ImportError is raised,
+        # it could be because the cuda dlls could not be found on windows.
+        # Try adding the cuda dlls path to the dll search directory
+        # and import onnxruntime_genai again.
+        _dll_directory.add_dll_directory()
+        from onnxruntime_genai.@PACKAGE_DIR_NAME@ import *
+    else:
+        raise e


### PR DESCRIPTION
Issues like https://github.com/microsoft/onnxruntime-genai/issues/555 indicate that there is a problem importing the module, but the import fails because of <some> DLL issue.

So far we assumed that the issue was a cuda dll not found issue. But this cannot be generally assumed (as in the case of the linked issue).

This PR enhances the error message so we do not always assume that it is a CUDA dll issue.