### PR TITLE
Switch "check_language(CUDA)" to "enable_language(CUDA)"

### DIFF
--- a/cmake/check_cuda.cmake
+++ b/cmake/check_cuda.cmake
@@ -2,7 +2,8 @@
 include(CheckLanguage)
 
 if(USE_CUDA)
-  check_language(CUDA)
+  enable_language(CUDA)
+  message( STATUS "CMAKE_CUDA_COMPILER_VERSION: ${CMAKE_CUDA_COMPILER_VERSION}")
   if(CMAKE_CUDA_COMPILER)
     # Don't let cmake set a default value for CMAKE_CUDA_ARCHITECTURES
     cmake_policy(SET CMP0104 OLD)


### PR DESCRIPTION
Without this change even if we have added "-allow-unsupported-compiler" to CMAKE_CUDA_FLAGS_INIT, the check will still fail. Sorry I don't know why. 
