### PR TITLE
Add CMAKE_CUDA_FLAGS_INIT

### DIFF
--- a/cmake/presets/CMakeWinConfigPresets.json
+++ b/cmake/presets/CMakeWinConfigPresets.json
@@ -25,7 +25,7 @@
       "cacheVariables": {
         "USE_CUDA": "ON",
         "CMAKE_CUDA_ARCHITECTURES": "60;61;70;75;80;86",
-        "CMAKE_CUDA_FLAGS_INIT": "/DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 -Xcompiler=\" /MP /guard:cf /Qspectre /Ob0 /Od /RTC1\" -allow-unsupported-compiler"
+        "CMAKE_CUDA_FLAGS_INIT": "/DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 -Xcompiler=\" /MP /guard:cf /Qspectre \" -allow-unsupported-compiler"
       }
     },
     {

--- a/cmake/presets/CMakeWinConfigPresets.json
+++ b/cmake/presets/CMakeWinConfigPresets.json
@@ -24,7 +24,8 @@
       "inherits": "windows_cpu_default",
       "cacheVariables": {
         "USE_CUDA": "ON",
-        "CMAKE_CUDA_ARCHITECTURES": "60;61;70;75;80;86"
+        "CMAKE_CUDA_ARCHITECTURES": "60;61;70;75;80;86",
+        "CMAKE_CUDA_FLAGS_INIT": "/DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 -Xcompiler=\" /MP /guard:cf /Qspectre /Ob0 /Od /RTC1\" -allow-unsupported-compiler"
       }
     },
     {


### PR DESCRIPTION
Add CMAKE_CUDA_FLAGS_INIT to the cmake preset files, and append "-allow-unsupported-compiler" there.

We need this change because the latest VC++ compiler isn't compatible with CUDA SDKs we have. 

This PR is similar to https://github.com/microsoft/onnxruntime/pull/21004 