### PR TITLE
Cleanup code and follow best practices

### DIFF
--- a/src/models/embeddings.cpp
+++ b/src/models/embeddings.cpp
@@ -30,16 +30,6 @@ Embeddings::Embeddings(const Model& model, State& state, Embeddings::Mode mode, 
   }
 }
 
-Embeddings::Embeddings(Embeddings&& other, State& state) : model_{other.model_},
-                                                           state_{state},
-                                                           shape_{other.shape_},
-                                                           type_{other.type_},
-                                                           mode_{other.mode_},
-                                                           name_{other.name_},
-                                                           embeddings_{std::move(other.embeddings_)} {
-  Add();
-}
-
 void Embeddings::Add() {
   if (mode_ == Embeddings::Mode::Input) {
     // In case the embeddings are input to a model, they are added
@@ -71,14 +61,14 @@ void Embeddings::UpdateSequenceLength() {
   }
 }
 
-Embeddings& Embeddings::operator=(const Embeddings& other) {
+void Embeddings::ReuseEmbeddingsBuffer(const Embeddings& other) {
   if (mode_ == Embeddings::Mode::Output ||
       other.mode_ == Embeddings::Mode::Input) {
     throw std::runtime_error("Incorrect usage of the embeddings inputs and outputs.");
   }
 
+  // Share the output embeddings OrtValue* from other with the input embedding for this.
   state_.inputs_[index_] = other.state_.outputs_[other.index_];
-  return *this;
 }
 
 }  // namespace Generators

--- a/src/models/embeddings.h
+++ b/src/models/embeddings.h
@@ -12,14 +12,14 @@ struct Embeddings {
   };
 
   Embeddings(const Model& model, State& state, Embeddings::Mode mode, const std::string& name);
-
-  Embeddings(Embeddings&& other, State& state);
+  Embeddings(const Embeddings&) = delete;
+  Embeddings& operator=(const Embeddings&) = delete;
 
   void Add();
 
   void UpdateSequenceLength();
 
-  Embeddings& operator=(const Embeddings& other);
+  void ReuseEmbeddingsBuffer(const Embeddings& other);
 
   OrtValue* Get() { return embeddings_.get(); }
 

--- a/src/models/input_ids.cpp
+++ b/src/models/input_ids.cpp
@@ -39,24 +39,6 @@ InputIDs::InputIDs(const Model& model, State& state)
   }
 }
 
-InputIDs::InputIDs(InputIDs&& other, State& state)
-    : model_{other.model_}, state_{state} {
-  value_ = std::move(other.value_);
-  name_ = other.name_;
-  shape_ = other.shape_;
-  type_ = other.type_;
-
-  sb_input_ids_ = other.sb_input_ids_;
-
-#if USE_DML
-  value_int32_ = std::move(other.value_int32_);
-  sb_input_ids_int32_ = other.sb_input_ids_int32_;
-  input_ids_cast_command_list_state_ = std::move(other.input_ids_cast_command_list_state_);
-#endif
-
-  Add();
-}
-
 void InputIDs::Add() {
   input_index_ = state_.inputs_.size();
 

--- a/src/models/input_ids.h
+++ b/src/models/input_ids.h
@@ -6,8 +6,8 @@ namespace Generators {
 
 struct InputIDs {
   InputIDs(const Model& model, State& state);
-
-  InputIDs(InputIDs&& other, State& state);
+  InputIDs(const InputIDs&) = delete;
+  InputIDs& operator=(const InputIDs&) = delete;
 
   void Add();
   void Update(RoamingArray<int32_t> next_tokens);

--- a/src/models/multi_modal_vision_model.cpp
+++ b/src/models/multi_modal_vision_model.cpp
@@ -255,7 +255,7 @@ RoamingArray<float> MultiModalPipelineState::Run(int current_length, RoamingArra
              params_->hidden_size, params_->device_type, params_->cuda_stream);
     }
 
-    decoder_state_->inputs_embeds_ = embedding_state_->inputs_embeds_;
+    decoder_state_->inputs_embeds_.ReuseEmbeddingsBuffer(embedding_state_->inputs_embeds_);
     auto logits = decoder_state_->Run(current_length, next_tokens, next_indices);
 
     is_prompt_ = false;
@@ -268,7 +268,7 @@ RoamingArray<float> MultiModalPipelineState::Run(int current_length, RoamingArra
   decoder_state_->UpdateInputs(current_length, next_indices);
 
   embedding_state_->Run(current_length, next_tokens, next_indices);
-  decoder_state_->inputs_embeds_ = embedding_state_->inputs_embeds_;
+  decoder_state_->inputs_embeds_.ReuseEmbeddingsBuffer(embedding_state_->inputs_embeds_);
   return decoder_state_->Run(current_length, next_tokens, next_indices);
 }
 

--- a/src/models/multi_modal_vision_model.h
+++ b/src/models/multi_modal_vision_model.h
@@ -14,6 +14,8 @@ namespace Generators {
 
 struct MultiModalVisionModel : Model {
   MultiModalVisionModel(std::unique_ptr<Config> config, OrtEnv& ort_env);
+  MultiModalVisionModel(const MultiModalVisionModel&) = delete;
+  MultiModalVisionModel& operator=(const MultiModalVisionModel&) = delete;
 
   std::unique_ptr<State> CreateState(RoamingArray<int32_t> sequence_lengths,
                                      const GeneratorParams& params) const override;
@@ -25,6 +27,8 @@ struct MultiModalVisionModel : Model {
 
 struct EmbeddingState : State {
   EmbeddingState(const MultiModalVisionModel& model, const GeneratorParams& params, const CapturedGraphInfo* captured_graph_info);
+  EmbeddingState(const EmbeddingState&) = delete;
+  EmbeddingState& operator=(const EmbeddingState&) = delete;
 
   RoamingArray<float> Run(int current_length, RoamingArray<int32_t> next_tokens,
                           RoamingArray<int32_t> next_indices = {}) override;
@@ -45,6 +49,8 @@ struct EmbeddingState : State {
 
 struct VisionState : State {
   VisionState(const MultiModalVisionModel& model, const GeneratorParams& params);
+  VisionState(const VisionState&) = delete;
+  VisionState& operator=(const VisionState&) = delete;
 
   RoamingArray<float> Run(int current_length, RoamingArray<int32_t> next_tokens,
                           RoamingArray<int32_t> next_indices = {}) override;
@@ -61,6 +67,8 @@ struct VisionState : State {
 struct DecoderState : State {
   DecoderState(const MultiModalVisionModel& model, RoamingArray<int32_t> sequence_lengths,
                const GeneratorParams& params, const CapturedGraphInfo* captured_graph_info);
+  DecoderState(const DecoderState&) = delete;
+  DecoderState& operator=(const DecoderState&) = delete;
 
   RoamingArray<float> Run(int current_length, RoamingArray<int32_t> next_tokens,
                           RoamingArray<int32_t> next_indices) override;
@@ -84,6 +92,8 @@ struct DecoderState : State {
 struct MultiModalPipelineState : State {
   MultiModalPipelineState(const MultiModalVisionModel& model, RoamingArray<int32_t> sequence_lengths,
                           const GeneratorParams& params);
+  MultiModalPipelineState(const MultiModalPipelineState&) = delete;
+  MultiModalPipelineState& operator=(const MultiModalPipelineState&) = delete;
 
   RoamingArray<float> Run(int current_length, RoamingArray<int32_t> next_tokens,
                           RoamingArray<int32_t> next_indices) override;

--- a/src/models/static_buffer.h
+++ b/src/models/static_buffer.h
@@ -14,6 +14,8 @@ namespace Generators {
 struct StaticBuffer {
   // Add max_beam_batch_size to the constructor
   StaticBuffer(Ort::Allocator* allocator, size_t max_beam_batch_size);
+  StaticBuffer(const StaticBuffer&) = delete;
+  StaticBuffer& operator=(const StaticBuffer&) = delete;
   ~StaticBuffer();
 
   std::unique_ptr<OrtValue> CreateTensorOnStaticBuffer(std::span<const int64_t> shape,


### PR DESCRIPTION
onnxruntime-genai was using `operator=` that has a different meaning than what it was being used as.

This pull request cleans up the code, deletes copy constructor and assignment operator for some of the classes.