### PR TITLE
Fix error message string.

### DIFF
--- a/src/models/prompt_image_processor.cpp
+++ b/src/models/prompt_image_processor.cpp
@@ -76,7 +76,7 @@ std::unique_ptr<OrtValue> ProcessImagePrompt(const Generators::Tokenizer& tokeni
 std::unique_ptr<OrtValue> ProcessPixelValues(ortc::Tensor<float>* pixel_values, ONNXTensorElementDataType expected_type,
                                              Ort::Allocator& allocator) {
   if (!(expected_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT || expected_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16)) {
-    throw std::runtime_error("Expected pixel_values to be of type float or float16. Actual: " + expected_type);
+    throw std::runtime_error("Expected pixel_values to be of type float or float16. Actual: " + std::to_string(expected_type));
   }
   auto pixel_values_value = expected_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
                                 ? OrtValue::CreateTensor<float>(allocator, pixel_values->Shape())


### PR DESCRIPTION
Fixing an issue from an Android build compiler warning. It was adding an integral value to a string literal.