### PR TITLE
Separate lines for targetFramework

### DIFF
--- a/nuget/Microsoft.ML.OnnxRuntimeGenAI.Managed.nuspec
+++ b/nuget/Microsoft.ML.OnnxRuntimeGenAI.Managed.nuspec
@@ -13,7 +13,8 @@
     <releaseNotes>Introducing the ONNX Runtime GenAI Library.</releaseNotes>
     <tags>ONNX;ONNX Runtime;ONNX Runtime Gen AI;Machine Learning</tags>
     <dependencies>
-      <group targetFramework="net8.0;netstandard2.0" />
+      <group targetFramework="net8.0" />
+      <group targetFramework="netstandard2.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime-genai/pull/582 added support for netstandard2.0. However, the nuget packaging fails with the error:

```
Unsupported targetFramework value 'net8.0;netstandard2.0'.
```

Addressing that in this PR.