### PR TITLE
Add quantized PyTorch to ONNX example

### DIFF
--- a/examples/python/awq-quantized-model.md
+++ b/examples/python/awq-quantized-model.md
@@ -68,7 +68,7 @@ $ curl https://raw.githubusercontent.com/microsoft/onnxruntime-genai/main/exampl
 $ python awq-quantized-model.py --model_path /path/to/folder/containing/your/pytorch/model/ --quant_path /path/to/new/folder/to/save/quantized/pytorch/model/in/ --output_path /path/to/new/folder/to/save/quantized/and/optimized/onnx/model/in/
 
 # Example:
-# $ python awq-quantized-model.py --model_path ./phi3-mini-4k-instruct/ --quant_path ./phi3-mini-4k-instruct-awq/ --output_path /phi3-mini-4k-instruct-awq-onnx/
+# $ python awq-quantized-model.py --model_path ./phi3-mini-4k-instruct/ --quant_path ./phi3-mini-4k-instruct-awq/ --output_path ./phi3-mini-4k-instruct-awq-onnx/
 ```
 
 Once the ONNX model has been created and the script has loaded the model, it will ask you for input in a loop, streaming the output as it is produced the model. For example:

--- a/examples/python/awq-quantized-model.md
+++ b/examples/python/awq-quantized-model.md
@@ -1,0 +1,80 @@
+# Create AWQ-quantized and optimized ONNX models from PyTorch models with AutoAWQ + ONNX Runtime generate() API
+
+## Steps
+1. [Download your PyTorch model](#1-download-your-pytorch-model)
+2. [Install AutoAWQ](#2-install-autoawq)
+3. [Install the generate() API](#3-install-the-generate-api)
+4. [Run example script](#4-run-example-script)
+
+## Introduction
+
+Activation-aware Weight Quantization (AWQ) works by identifying the top 1% most salient weights that are most important for maintaining accuracy and quantizing the remaining 99% of weights. This leads to less accuracy loss from quantization compared to many other quantization techniques. For more on AWQ, see [here](https://arxiv.org/abs/2306.00978).
+
+This tutorial downloads the Phi-3 mini short context PyTorch model, applies AWQ quantization, generates the corresponding optimized & quantized ONNX model, and runs the ONNX model with ONNX Runtime's generate() API. If you would like to use another model, please change the model name in the instructions below.
+
+## 1. Download your PyTorch model
+
+You can use Hugging Face's `from_pretrained` and `save_pretrained` methods to download and save the base PyTorch model.
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import os
+
+# Change these as needed
+model_name = "microsoft/Phi-3-mini-4k-instruct"
+cache_dir = os.path.join(".", "cache_dir")
+output_dir = os.path.join(".", "phi3-mini-4k-instruct")
+
+tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
+model = AutoModelForCausalLM.from_pretrained(model_name, cache_dir=cache_dir)
+
+tokenizer.save_pretrained(output_dir)
+model.save_pretrained(output_dir)
+```
+
+Alternatively, you can use your own PyTorch model that can be loaded with Hugging Face's APIs.
+
+## 2. Install AutoAWQ
+
+```bash
+$ git clone https://github.com/casper-hansen/AutoAWQ
+$ cd AutoAWQ
+$ pip install -e .
+```
+
+Note: You can try to install AutoAWQ directly with `pip install autoawq`. However, AutoAWQ will try to auto-detect the CUDA version installed on your machine. If the CUDA version it detects is incorrect, the `.whl` file that `pip` will choose will be incorrect. This will cause an error during runtime when trying to quantize. Thus, it is recommended to install AutoAWQ from source to get the right `.whl` file.
+
+## 3. Install the generate() API
+
+Currently, this feature is brand new and requires building the generate() API [from source](https://onnxruntime.ai/docs/genai/howto/build-from-source.html).
+
+<!-- Uncomment below once new RC is built and published -->
+<!-- ```bash
+$ pip install numpy
+$ pip install --pre onnxruntime-genai-cuda --index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-genai/pypi/simple/
+```
+
+You should now see `onnxruntime-genai-cuda` in your `pip list`. -->
+
+## 4. Run example script
+
+Run your PyTorch model with [awq-quantized-model.py](https://github.com/microsoft/onnxruntime-genai/blob/main/examples/python/awq-quantized-model.py).
+
+```bash
+# Get example script
+$ curl https://raw.githubusercontent.com/microsoft/onnxruntime-genai/main/examples/python/awq-quantized-model.py -o awq-quantized-model.py
+
+# Run example script
+$ python awq-quantized-model.py --model_path /path/to/folder/containing/your/pytorch/model/ --quant_path /path/to/new/folder/to/save/quantized/pytorch/model/in/ --output_path /path/to/new/folder/to/save/quantized/and/optimized/onnx/model/in/
+
+# Example:
+# $ python awq-quantized-model.py --model_path ./phi3-mini-4k-instruct/ --quant_path ./phi3-mini-4k-instruct-awq/ --output_path /phi3-mini-4k-instruct-awq-onnx/
+```
+
+Once the ONNX model has been created and the script has loaded the model, it will ask you for input in a loop, streaming the output as it is produced the model. For example:
+
+```bash
+Input: What color is the sky?
+
+Output:  The color of the sky can appear blue during a clear day due to Rayleigh scattering, which scatters shorter wavelengths of light (blue) more than longer wavelengths (red). However, the sky can also appear in various colors at sunrise and sunset, such as orange, pink, or purple, due to the scattering of light by the atmosphere when the sun is low on the horizon. Additionally, the sky can appear black at night when there is no sunlight.
+```

--- a/examples/python/awq-quantized-model.py
+++ b/examples/python/awq-quantized-model.py
@@ -1,0 +1,120 @@
+import argparse
+import os
+
+from awq import AutoAWQForCausalLM
+from transformers import AutoTokenizer
+from onnxruntime_genai.models.builder import create_model
+import onnxruntime_genai as og
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-m",
+        "--model_path",
+        required=True,
+        help="Folder to load PyTorch model and associated files from",
+    )
+
+    parser.add_argument(
+        "-q",
+        "--quant_path",
+        required=True,
+        help="Folder to saved AWQ-quantized PyTorch model and associated files in",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output_path",
+        required=True,
+        help="Folder to save AWQ-quantized ONNX model and associated files in",
+    )
+
+    args = parser.parse_args()
+    return args
+
+def quantize_model(args):
+    quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 4, "version": "GEMM" }
+
+    # Load model
+    model = AutoAWQForCausalLM.from_pretrained(
+        args.model_path, **{"low_cpu_mem_usage": True, "use_cache": False}
+    )
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path, trust_remote_code=True)
+
+    # Quantize model
+    model.quantize(tokenizer, quant_config=quant_config)
+
+    # Save quantized model
+    model.save_quantized(args.quant_path)
+    tokenizer.save_pretrained(args.quant_path)
+
+    print(f'Model is quantized and saved at "{args.quant_path}"')
+
+def run_model(args):
+    model = og.Model(args.output_path)
+    tokenizer = og.Tokenizer(model)
+    tokenizer_stream = tokenizer.create_stream()
+
+    # Override any default search options in `genai_config.json`
+    search_options = {
+        'min_length': 1,
+        'max_length': 2048,
+    }
+
+    # Chat template for Phi-3 (replace with the chat template for your model)
+    chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
+    while True:
+        text = input("Input: ")
+        if not text:
+            print("Error, input cannot be empty")
+            continue
+        prompt = f'{chat_template.format(input=text)}'
+
+        input_tokens = tokenizer.encode(prompt)
+
+        params = og.GeneratorParams(model)
+        params.set_search_options(**search_options)
+        params.input_ids = input_tokens
+
+        generator = og.Generator(model, params)
+
+        print()
+        print("Output: ", end='', flush=True)
+
+        try:
+            while not generator.is_done():
+                generator.compute_logits()
+                generator.generate_next_token()
+
+                new_token = generator.get_next_tokens()[0]
+                print(tokenizer_stream.decode(new_token), end='', flush=True)
+        except KeyboardInterrupt:
+            print("  --control+c pressed, aborting generation--")
+        print()
+        print()
+
+        # Delete the generator to free the captured graph for the next generator, if graph capture is enabled
+        del generator
+
+def main():
+    args = parse_args()
+
+    # Quantize PyTorch model
+    quantize_model(args)
+
+    # Create ONNX model
+    model_name = None
+    input_folder = args.quant_path
+    output_folder = args.output_path
+    precision = "int4"
+    execution_provider = "cuda"
+    cache_dir = os.path.join(".", "cache_dir")
+
+    create_model(model_name, input_folder, output_folder, precision, execution_provider, cache_dir)
+
+    # Run ONNX model
+    run_model(args)
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/awq-quantized-model.py
+++ b/examples/python/awq-quantized-model.py
@@ -20,7 +20,7 @@ def parse_args():
         "-q",
         "--quant_path",
         required=True,
-        help="Folder to saved AWQ-quantized PyTorch model and associated files in",
+        help="Folder to save AWQ-quantized PyTorch model and associated files in",
     )
 
     parser.add_argument(

--- a/examples/python/phi-3-tutorial.md
+++ b/examples/python/phi-3-tutorial.md
@@ -4,7 +4,7 @@
 1. [Setup](#setup)
 2. [Choose your platform](#choose-your-platform)
 3. [Run with DirectML](#run-with-directml)
-4. [Run with NVDIA CUDA](#run-with-nvidia-cuda)
+4. [Run with NVIDIA CUDA](#run-with-nvidia-cuda)
 5. [Run on CPU](#run-on-cpu)
 
 ## Introduction

--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -83,7 +83,7 @@ python3 -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o p
 python3 builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p precision -e execution_provider -c cache_dir_to_store_temp_files
 ```
 
-### Quantized PyTorch model
+### Quantized PyTorch Model
 
 This scenario is where your PyTorch model is one of the currently supported model architectures, has already been quantized to INT4 precision, and your model can be loaded in the Hugging Face style via [AutoGPTQ](https://github.com/AutoGPTQ/AutoGPTQ) or [AutoAWQ](https://github.com/casper-hansen/AutoAWQ).
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -58,9 +58,9 @@ class Model:
             "cuda": {
                 "enable_cuda_graph": enable_cuda_graph,        # "1" if the the model is able to enable cuda graph, "0" otherwise
             },
-            "rocm":{
+            "rocm": {
                 "tunable_op_enable": "1",
-                "tunable_op_tuning_enable": "1"
+                "tunable_op_tuning_enable": "1",
             },
             "dml": {},
             "web": {},
@@ -1539,12 +1539,18 @@ class Model:
         # Load weights of original model
         if input_path.endswith(".gguf"):
             # Load GGUF model
-            from gguf_model import GGUFModel
+            try:
+                from gguf_model import GGUFModel
+            except:
+                from onnxruntime_genai.models.gguf_model import GGUFModel
             model = GGUFModel.from_pretrained(self.model_type, input_path, self.head_size, self.hidden_size, self.intermediate_size, self.num_attn_heads, self.num_kv_heads, self.vocab_size)
             self.layernorm_attrs["add_offset"] = 0  # add offset already done for GGUF models
         elif self.quant_type is not None:
             # Load quantized PyTorch model
-            from quantized_model import QuantModel
+            try:
+                from quantized_model import QuantModel
+            except:
+                from onnxruntime_genai.models.quantized_model import QuantModel
             q_size = self.num_attn_heads * self.head_size
             kv_size = self.num_kv_heads * self.head_size
             model = QuantModel.from_pretrained(self.quant_type, input_path, self.quant_attrs["bits"], self.quant_attrs["group_size"], self.quant_attrs["use_g_idx"], q_size, kv_size, self.intermediate_size)


### PR DESCRIPTION
### Description

This PR adds an end-to-end example for quantizing a PyTorch model with [AutoAWQ](https://github.com/casper-hansen/AutoAWQ), creating the corresponding optimized and quantized ONNX model, and running the ONNX model with ONNX Runtime GenAI.

### Motivation and Context

This PR shows an end-to-end example for [the quantized PyTorch support in the model builder](https://github.com/microsoft/onnxruntime-genai/pull/600).