### PR TITLE
Fix Beam Search for CPU and CUDA... Also include it in our API

### DIFF
--- a/src/beam_search_scorer.cpp
+++ b/src/beam_search_scorer.cpp
@@ -16,7 +16,7 @@ void BeamHypotheses::Init(float length_penalty, std::span<HypothesisScore> beams
   done_ = false;
 }
 
-void BeamHypotheses::Add(std::span<const int32_t> hypothesis, float sum_logprobs) {
+void BeamHypotheses::Add(cpu_span<int32_t> hypothesis, float sum_logprobs) {
   auto length = hypothesis.size();
   float const score = sum_logprobs / std::pow(static_cast<float>(length), length_penalty_);
 
@@ -43,27 +43,27 @@ bool BeamHypotheses::CanImprove(float best_sum_logprobs, int current_length) con
   return beams_.back().score < current_score;
 }
 
-void BeamHypotheses::Output(
-    size_t top_k,
-    size_t max_length,
-    std::span<int32_t> sequences,             // buffer filled with pad token ID, shape (num_return_sequences, max_length)
-    std::span<float> sequences_scores) const  // buffer of shape (num_return_sequences) or empty
-{
-  // Copy the top_k beams into the sequences
-  assert(top_k <= beams_used_);
-  for (int index = 0; index < top_k; index++) {
-    auto& item = beams_[index];
-    std::span<int32_t> const target = sequences.subspan(index * max_length, max_length);
+// void BeamHypotheses::Output(
+//     size_t top_k,
+//     size_t max_length,
+//     std::span<int32_t> sequences,             // buffer filled with pad token ID, shape (num_return_sequences, max_length)
+//     std::span<float> sequences_scores) const  // buffer of shape (num_return_sequences) or empty
+// {
+//   // Copy the top_k beams into the sequences
+//   assert(top_k <= beams_used_);
+//   for (int index = 0; index < top_k; index++) {
+//     auto& item = beams_[index];
+//     std::span<int32_t> const target = sequences.subspan(index * max_length, max_length);
 
-    // Note that word_ids might be less than max_length.
-    // Since the sequences has been filled with pad token ID, so padding is not needed here.
-    copy(item.hypothesis, target);
+//     // Note that word_ids might be less than max_length.
+//     // Since the sequences has been filled with pad token ID, so padding is not needed here.
+//     copy(item.hypothesis, target);
 
-    if (!sequences_scores.empty()) {
-      sequences_scores[index] = item.score;
-    }
-  }
-}
+//     if (!sequences_scores.empty()) {
+//       sequences_scores[index] = item.score;
+//     }
+//   }
+// }
 
 BeamSearchScorer::BeamSearchScorer(const GeneratorParams& parameters)
     : batch_size_{parameters.batch_size},
@@ -146,8 +146,9 @@ void BeamSearchScorer::Process(Sequences& sequences,
         }
 
         // Clone the sequence and append to buffer.
-        std::span<const int32_t> const src = sequences.GetSequence(batch_beam_idx);
-        auto clone = hypothesis_buffer_.subspan(static_cast<size_t>(hypothesis_buffer_used_), sequence_length);
+        cpu_span<const int32_t> const src{sequences.GetSequence(batch_beam_idx)};
+        auto clone_span = hypothesis_buffer_.subspan(static_cast<size_t>(hypothesis_buffer_used_), sequence_length);
+        cpu_span<int32_t> clone{clone_span.data(), sequence_length};
 
         copy(src, clone);
         hypothesis_buffer_used_ += sequence_length;
@@ -169,11 +170,13 @@ void BeamSearchScorer::Process(Sequences& sequences,
     assert(beam_idx == num_beams_);
     assert(static_cast<size_t>(hypothesis_buffer_used_) <= hypothesis_buffer_.size());
 
+    // TODO(aciddelgado): I don't understand
     //  Check if we are done so that we can save a pad step if all(done)
     if (static_cast<size_t>(beam_hyp.beams_used_) < num_beams_) {
       continue;
     }
 
+    // TODO(aciddelgado): What is early stopping?
     if (!early_stopping_) {
       std::span<const float> const topk_scores = next_scores.subspan(batch * num_beams_, top_k);
       const auto best_sum_logprobs = std::max_element(topk_scores.begin(), topk_scores.end());
@@ -182,15 +185,15 @@ void BeamSearchScorer::Process(Sequences& sequences,
       }
     }
 
+    // TODO(aciddelgado): when not_done_count_ hits 0, the generator is done returns true.
     beam_hyp.done_ = true;
     not_done_count_--;
   }
 }
 
+// TODO(aciddelgado): Wasteful output buffer. Create GetBeamOutput() to return views into the sequences. Is the open hypothesis finalization necessary?
 void BeamSearchScorer::Finalize(Sequences& sequences,
-                                size_t num_return_sequences,
-                                cpu_span<int32_t> output,
-                                cpu_span<float> sequence_scores) {
+                                size_t num_return_sequences) {
   // output is Word IDs of each sequence, with shape (batch_size * num_return_sequences, max_sequence_length).
   // sequence_scores is the optional Score of each sequence, with shape (batch_size * num_return_sequences).
 
@@ -208,23 +211,25 @@ void BeamSearchScorer::Finalize(Sequences& sequences,
       beam_hyp.Add(final_tokens, final_score);
     }
   }
+  
+  // TODO(aciddelgado): pillage the below
 
-  // Fill output sequences with pad token ID so that we do not need append it later.
-  std::fill_n(output.data(), output.size(), pad_token_id_);
+  // // Fill output sequences with pad token ID so that we do not need append it later.
+  // std::fill_n(output.data(), output.size(), pad_token_id_);
 
-  // Select the best hypotheses according to number of sequences to return.
-  for (size_t batch_index = 0; batch_index < batch_size_; batch_index++) {
-    BeamHypotheses& beam_hyp = beam_hyps_[batch_index];
+  // // Select the best hypotheses according to number of sequences to return.
+  // for (size_t batch_index = 0; batch_index < batch_size_; batch_index++) {
+  //   BeamHypotheses& beam_hyp = beam_hyps_[batch_index];
 
-    auto batch_output = output.subspan(batch_index * num_return_sequences * max_length_,
-                                       num_return_sequences * max_length_);
-    std::span<float> sequence_scores_buffer;
-    if (!sequence_scores.empty()) {
-      sequence_scores_buffer = sequence_scores.subspan(batch_index * num_return_sequences, num_return_sequences);
-    }
+  //   auto batch_output = output.subspan(batch_index * num_return_sequences * max_length_,
+  //                                      num_return_sequences * max_length_);
+  //   std::span<float> sequence_scores_buffer;
+  //   if (!sequence_scores.empty()) {
+  //     sequence_scores_buffer = sequence_scores.subspan(batch_index * num_return_sequences, num_return_sequences);
+  //   }
 
-    beam_hyp.Output(num_return_sequences, max_length_, batch_output, sequence_scores_buffer);
-  }
+  //   beam_hyp.Output(num_return_sequences, max_length_, batch_output, sequence_scores_buffer);
+  // }
 }
 
 }  // namespace Generators

--- a/src/beam_search_scorer.cpp
+++ b/src/beam_search_scorer.cpp
@@ -88,7 +88,7 @@ void BeamSearchScorer::Process(Sequences& sequences,
   // It contains word ID of whole sequence generated so far.
   // It is different from subgraph input_ids, which only need one word when past state is not empty.
 
-  const int sequence_length = sequences.GetSequenceLength();
+  size_t sequence_length = static_cast<size_t>(sequences.GetSequenceLength());
 
   assert(next_scores.size() == next_tokens.size());
   assert(next_scores.size() == next_indices.size());

--- a/src/beam_search_scorer.cpp
+++ b/src/beam_search_scorer.cpp
@@ -129,7 +129,7 @@ void BeamSearchScorer::Process(Sequences& sequences,
         cpu_span<int32_t> clone{clone_span.data(), sequence_length};
 
         copy(src, clone);
-        hypothesis_buffer_used_ += sequence_length;
+        hypothesis_buffer_used_ += static_cast<int>(sequence_length);
         beam_hyp.Add(clone, next_score);
       } else {
         // Add next predicted token since it is not eos_token.
@@ -156,7 +156,7 @@ void BeamSearchScorer::Process(Sequences& sequences,
     if (!early_stopping_) {
       std::span<const float> const topk_scores = next_scores.subspan(batch * num_beams_, top_k);
       const auto best_sum_logprobs = std::max_element(topk_scores.begin(), topk_scores.end());
-      if (beam_hyp.CanImprove(*best_sum_logprobs, sequence_length)) {
+      if (beam_hyp.CanImprove(*best_sum_logprobs, static_cast<int>(sequence_length))) {
         continue;
       }
     }

--- a/src/beam_search_scorer.h
+++ b/src/beam_search_scorer.h
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "sequences.h"
-#include <iostream>
 #pragma once
 // The implementation is based on huggingface transformers generation_beam_search.py
 namespace Generators {

--- a/src/beam_search_scorer.h
+++ b/src/beam_search_scorer.h
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "sequences.h"
+#include <iostream>
 #pragma once
 // The implementation is based on huggingface transformers generation_beam_search.py
 namespace Generators {

--- a/src/beam_search_scorer.h
+++ b/src/beam_search_scorer.h
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#include <iostream>
 #include "sequences.h"
 #pragma once
 // The implementation is based on huggingface transformers generation_beam_search.py
 namespace Generators {
 
-// TODO(aciddelgado): I don't like the naming here... a score should not hold a hypothesis
 struct HypothesisScore {
   cpu_span<int32_t> hypothesis;
   float score;
@@ -22,16 +20,9 @@ struct BeamHypotheses {
   // Return true if this beats the worst score in the hypothesis
   bool CanImprove(float best_sum_logprobs, int current_length) const;
 
-  RoamingArray<int32_t> GetHypothesis(size_t index) const {
-    return beams_[index].hypothesis;
-  }
+  RoamingArray<int32_t> GetHypothesis(size_t index) const { return beams_[index].hypothesis; }
 
-  // Output results
-  // TODO(aciddelgado): remove this needless copy function
-  void Output(size_t top_k,                              // number of sequences to return
-              size_t max_length,                         // max sequence length
-              std::span<int32_t> sequences,              // buffer with pad token, shape (num_return_sequences, max_length)
-              std::span<float> sequences_scores) const;  // buffer for sequence scores, with shape (num_return_sequences)
+  // TODO(aciddelgado): Methods to get all hypotheses and scores
 
   std::span<HypothesisScore> beams_;  // Beam width sized array of hypotheses, sorted by highest scoring
   int beams_used_;                    // Number of elements used in beams_
@@ -50,9 +41,7 @@ struct BeamSearchScorer {
   void Finalize(Sequences& sequences,
                 size_t num_return_sequences);
 
-  bool IsDone() const {
-    return not_done_count_ == 0; 
-  }
+  bool IsDone() const { return not_done_count_ == 0; }
 
   cpu_span<float> GetNextScores() { return next_beam_scores_; }
   cpu_span<int32_t> GetNextTokens() { return next_beam_tokens_; }

--- a/src/beam_search_scorer_cuda.cpp
+++ b/src/beam_search_scorer_cuda.cpp
@@ -88,7 +88,6 @@ RoamingArray<int32_t> BeamSearchScorer_Cuda::GetBeamHypothesis(size_t batch_id, 
   cuda_host_unique_ptr<float> hypothesis_score = CudaMallocHostArray<float>(1);
   cuda::LaunchBeamSearchScorer_GetHypothesisPtr(batch_id, beam_id, beam_hyps_, hypothesis_ptr.get(), hypothesis_length.get(), hypothesis_score.get(), stream_);
   CudaCheck() == cudaStreamSynchronize(stream_);
-  // std::cout << "hypothesis length: " << *hypothesis_length.get() << std::endl;
   std::span<int32_t> hypothesis_span(*hypothesis_ptr.get(), *hypothesis_length.get());
   return gpu_span<int32_t>{hypothesis_span.data(), hypothesis_span.size()};
 }

--- a/src/beam_search_scorer_cuda.cpp
+++ b/src/beam_search_scorer_cuda.cpp
@@ -72,8 +72,6 @@ void BeamSearchScorer_Cuda::Process(Sequences_Cuda& sequences,
 
 bool BeamSearchScorer_Cuda::IsDoneLater() const {
   cudaEventSynchronize(event_process_complete_);
-  // auto temp_state_gpu_ = CudaMallocHostArray<cuda::BeamScorerState>(1);
-  // cudaMemcpyAsync(temp_state_gpu_.get(), state_gpu_.get(), sizeof(cuda::BeamScorerState), ::cudaMemcpyDeviceToHost, stream_);
   return state_cpu_->not_done_count_ == 0;
 }
 

--- a/src/beam_search_scorer_cuda.cpp
+++ b/src/beam_search_scorer_cuda.cpp
@@ -73,8 +73,8 @@ void BeamSearchScorer_Cuda::Process(Sequences_Cuda& sequences,
 
 bool BeamSearchScorer_Cuda::IsDoneLater() const {
   cudaEventSynchronize(event_process_complete_);
-  auto temp_state_gpu_ = CudaMallocHostArray<cuda::BeamScorerState>(1);
-  cudaMemcpyAsync(temp_state_gpu_.get(), state_gpu_.get(), sizeof(cuda::BeamScorerState), ::cudaMemcpyDeviceToHost, stream_);
+  // auto temp_state_gpu_ = CudaMallocHostArray<cuda::BeamScorerState>(1);
+  // cudaMemcpyAsync(temp_state_gpu_.get(), state_gpu_.get(), sizeof(cuda::BeamScorerState), ::cudaMemcpyDeviceToHost, stream_);
   return state_cpu_->not_done_count_ == 0;
 }
 
@@ -89,6 +89,7 @@ RoamingArray<int32_t> BeamSearchScorer_Cuda::GetBeamHypothesis(size_t batch_id, 
   cuda_host_unique_ptr<float> hypothesis_score = CudaMallocHostArray<float>(1);
   cuda::LaunchBeamSearchScorer_GetHypothesisPtr(batch_id, beam_id, beam_hyps_, hypothesis_ptr.get(), hypothesis_length.get(), hypothesis_score.get(), stream_);
   CudaCheck() == cudaStreamSynchronize(stream_);
+  // std::cout << "hypothesis length: " << *hypothesis_length.get() << std::endl;
   std::span<int32_t> hypothesis_span(*hypothesis_ptr.get(), *hypothesis_length.get());
   return gpu_span<int32_t>{hypothesis_span.data(), hypothesis_span.size()};
 }

--- a/src/beam_search_scorer_cuda.cpp
+++ b/src/beam_search_scorer_cuda.cpp
@@ -3,6 +3,7 @@
 #include "search_cuda.h"
 #include "beam_search_scorer_cuda.cuh"
 #include "beam_search_scorer_cuda.h"
+#include <iostream>
 
 namespace Generators {
 
@@ -72,10 +73,8 @@ void BeamSearchScorer_Cuda::Process(Sequences_Cuda& sequences,
 
 bool BeamSearchScorer_Cuda::IsDoneLater() const {
   cudaEventSynchronize(event_process_complete_);
-  // std::cout << "cpu not done: " << state_cpu_->not_done_count_ << std::endl;
   auto temp_state_gpu_ = CudaMallocHostArray<cuda::BeamScorerState>(1);
   cudaMemcpyAsync(temp_state_gpu_.get(), state_gpu_.get(), sizeof(cuda::BeamScorerState), ::cudaMemcpyDeviceToHost, stream_);
-  // std::cout << "gpu not done: " << temp_state_gpu_->not_done_count_ << std::endl;
   return state_cpu_->not_done_count_ == 0;
 }
 
@@ -89,6 +88,7 @@ RoamingArray<int32_t> BeamSearchScorer_Cuda::GetBeamHypothesis(size_t batch_id, 
   cuda_host_unique_ptr<int> hypothesis_length = CudaMallocHostArray<int>(1);
   cuda_host_unique_ptr<float> hypothesis_score = CudaMallocHostArray<float>(1);
   cuda::LaunchBeamSearchScorer_GetHypothesisPtr(batch_id, beam_id, beam_hyps_, hypothesis_ptr.get(), hypothesis_length.get(), hypothesis_score.get(), stream_);
+  CudaCheck() == cudaStreamSynchronize(stream_);
   std::span<int32_t> hypothesis_span(*hypothesis_ptr.get(), *hypothesis_length.get());
   return gpu_span<int32_t>{hypothesis_span.data(), hypothesis_span.size()};
 }

--- a/src/beam_search_scorer_cuda.cpp
+++ b/src/beam_search_scorer_cuda.cpp
@@ -3,7 +3,6 @@
 #include "search_cuda.h"
 #include "beam_search_scorer_cuda.cuh"
 #include "beam_search_scorer_cuda.h"
-#include <iostream>
 
 namespace Generators {
 

--- a/src/beam_search_scorer_cuda.cu
+++ b/src/beam_search_scorer_cuda.cu
@@ -108,7 +108,7 @@ __global__ void BeamSearchScorer_Process(BeamScorerState& state_cpu,
           continue;
         }
 
-        // Clone the sequence and append to buffer.
+        // Clone the sequence and append to buffer. // TODO(aciddelgado): why???
         const int32_t* src = sequences_buffer + batch_beam_idx * state.max_length_;
         auto clone = hypothesis_buffer_ + atomicAdd(&state.hypothesis_buffer_used_, sequence_length);
 
@@ -214,8 +214,7 @@ void LaunchBeamSearchScorer_AppendNextTokenToSequences(BeamScorerState& state_cp
     block_size.x = batch_beam_size;
     block_size.y = sequence_length;
   } else {
-    if (sequence_length <= max_threads)  // Sequence length fits into thread block, but batch_beam_size does not, so chunk it
-    {
+    if (sequence_length <= max_threads) {  // Sequence length fits into thread block, but batch_beam_size does not, so chunk it
       block_size.x = max_threads / sequence_length;
       block_size.y = sequence_length;
 

--- a/src/beam_search_scorer_cuda.cu
+++ b/src/beam_search_scorer_cuda.cu
@@ -156,7 +156,7 @@ __global__ void BeamSearchScorer_Process(BeamScorerState& state_cpu,
     if (beam_hyp.beams_used_ == state.num_beams_) {
       if (state.early_stopping_ || !beam_hyp.CanImprove(*std::max_element(next_scores + batch_start, next_scores + batch_start + top_k), sequence_length)) {
         beam_hyp.done_ = true;
-        if (atomicAdd(&state.not_done_count_, -1) == 0)
+        if (atomicAdd(&state.not_done_count_, -1) == 1)
           state_cpu.not_done_count_ = 0;  // Update the CPU side
       }
     }

--- a/src/beam_search_scorer_cuda.cu
+++ b/src/beam_search_scorer_cuda.cu
@@ -108,7 +108,7 @@ __global__ void BeamSearchScorer_Process(BeamScorerState& state_cpu,
           continue;
         }
 
-        // Clone the sequence and append to buffer. // TODO(aciddelgado): why???
+        // Clone the sequence and append to buffer. // TODO(aciddelgado): why do we need to clone the sequence here?
         const int32_t* src = sequences_buffer + batch_beam_idx * state.max_length_;
         auto clone = hypothesis_buffer_ + atomicAdd(&state.hypothesis_buffer_used_, sequence_length);
 

--- a/src/beam_search_scorer_cuda.cu
+++ b/src/beam_search_scorer_cuda.cu
@@ -71,29 +71,29 @@ __device__ bool BeamHypotheses::CanImprove(float best_sum_logprobs, int current_
   return beams_[beams_count_ - 1].score < current_score;
 }
 
-__device__ void BeamHypotheses::Output(
-    int top_k,
-    int max_length,
-    int pad_token_id,
-    int32_t* sequences,       // buffer of shape (num_return_sequences, max_length)
-    float* sequences_scores)  // buffer of shape (num_return_sequences) or empty
-{
-  // Copy the top_k beams into the sequences
-  for (int index = 0; index < top_k; index++) {
-    auto& item = beams_[index];
-    int32_t* target = sequences + index * max_length;
+// __device__ void BeamHypotheses::Output(
+//     int top_k,
+//     int max_length,
+//     int pad_token_id,
+//     int32_t* sequences,       // buffer of shape (num_return_sequences, max_length)
+//     float* sequences_scores)  // buffer of shape (num_return_sequences) or empty
+// {
+//   // Copy the top_k beams into the sequences
+//   for (int index = 0; index < top_k; index++) {
+//     auto& item = beams_[index];
+//     int32_t* target = sequences + index * max_length;
 
-    // Note that word_ids might be less than max_length.
-    for (int i = 0; i < item.hypothesis_length; i++)
-      target[i] = item.hypothesis[i];
-    // Pad remaining values with pad token id
-    for (int i = item.hypothesis_length; i < max_length; i++)
-      target[i] = pad_token_id;
+//     // Note that word_ids might be less than max_length.
+//     for (int i = 0; i < item.hypothesis_length; i++)
+//       target[i] = item.hypothesis[i];
+//     // Pad remaining values with pad token id
+//     for (int i = item.hypothesis_length; i < max_length; i++)
+//       target[i] = pad_token_id;
 
-    if (sequences_scores)
-      sequences_scores[index] = item.score;
-  }
-}
+//     if (sequences_scores)
+//       sequences_scores[index] = item.score;
+//   }
+// }
 
 __global__ void BeamSearchScorer_Process(BeamScorerState& state_cpu,
                                          BeamScorerState& state,
@@ -269,9 +269,7 @@ __global__ void BeamSearchScorer_Finalize(BeamScorerState& state,
                                           const int32_t* sequences_buffer,
                                           int sequence_length,
                                           BeamHypotheses* beam_hyps_,
-                                          const float* final_beam_scores,
-                                          int32_t* output,
-                                          float* sequence_scores) {
+                                          const float* final_beam_scores) {
   int batch_index = blockIdx.x * blockDim.x + threadIdx.x;
   if (batch_index >= state.batch_size_)
     return;
@@ -287,17 +285,17 @@ __global__ void BeamSearchScorer_Finalize(BeamScorerState& state,
     }
   }
 
-  int num_return_sequences = 1;
+  // int num_return_sequences = 1;
 
-  // Select the best hypotheses according to number of sequences to return.
-  auto batch_output = output + batch_index * num_return_sequences * state.max_length_;
+  // // Select the best hypotheses according to number of sequences to return.
+  // auto batch_output = output + batch_index * num_return_sequences * state.max_length_;
 
-  beam_hyp.Output(
-      num_return_sequences,
-      state.max_length_,
-      state.pad_token_id_,
-      batch_output,
-      sequence_scores ? sequence_scores + batch_index * num_return_sequences : nullptr);
+  // beam_hyp.Output(
+  //     num_return_sequences,
+  //     state.max_length_,
+  //     state.pad_token_id_,
+  //     batch_output,
+  //     sequence_scores ? sequence_scores + batch_index * num_return_sequences : nullptr);
 }
 
 void LaunchBeamSearchScorer_Finalize(int batch_size,
@@ -306,16 +304,41 @@ void LaunchBeamSearchScorer_Finalize(int batch_size,
                                      int sequence_length,
                                      std::span<BeamHypotheses> beam_hyps,
                                      std::span<const float> final_beam_scores,
-                                     std::span<int32_t> output,
-                                     std::span<float> sequence_scores,
                                      cudaStream_t stream) {
   BeamSearchScorer_Finalize<<<1, batch_size, 0, stream>>>(state,
                                                           sequences.data(),
                                                           sequence_length,
                                                           beam_hyps.data(),
-                                                          final_beam_scores.data(),
-                                                          output.data(),
-                                                          sequence_scores.data());
+                                                          final_beam_scores.data());
+}
+
+__global__ void BeamSearchScorer_GetHypothesisPtr(size_t batch_id,
+                                                  size_t beam_id,
+                                                  BeamHypotheses* beam_hyps_data,
+                                                  int32_t** hypothesis_ptr,
+                                                  int* hypothesis_length,
+                                                  float* hypothesis_score) {
+  auto& beam_hyp = beam_hyps_data[batch_id];
+  // beam_hyp.Output(1, 1, 0, hypothesis, hypothesis_score);
+  auto& item = beam_hyp.beams_[beam_id];
+  hypothesis_ptr[0] = const_cast<int32_t*>(item.hypothesis);
+  hypothesis_length[0] = item.hypothesis_length;
+  hypothesis_score[0] = item.score;
+}
+
+void LaunchBeamSearchScorer_GetHypothesisPtr(size_t batch_id,
+                                             size_t beam_id,
+                                             gpu_span<BeamHypotheses> beam_hyps,
+                                             int32_t** hypothesis_ptr,
+                                             int* hypothesis_length,
+                                             float* hypothesis_score,
+                                             cudaStream_t stream) {
+  BeamSearchScorer_GetHypothesisPtr<<<1, 1, 0, stream>>>(batch_id,
+                                                         beam_id,
+                                                         beam_hyps.data(),
+                                                         hypothesis_ptr,
+                                                         hypothesis_length,
+                                                         hypothesis_score);
 }
 
 __global__ void InitScoresKernel(float* beam_scores,

--- a/src/beam_search_scorer_cuda.cuh
+++ b/src/beam_search_scorer_cuda.cuh
@@ -21,18 +21,6 @@ struct BeamHypotheses {
 
   // Return true if this beats the worst score in the hypothesis
   __device__ bool CanImprove(float best_sum_logprobs, int current_length) const;
-
-  // RoamingArray<int32_t> GetHypothesis(size_t batch_id, size_t beam_id) const {
-  //   // auto beam_span = std::span<int32_t>(beams_[index].hypothesis, beams_[index].hypothesis_length);
-  //   return gpu_span<int32_t>{const_cast<int32_t*>(beams_[index].hypothesis), beams_[index].hypothesis_length};
-  // }
-
-  // Output results
-  // __device__ void Output(int top_k,                 // number of sequences to return
-  //                        int max_length,            // max sequence length
-  //                        int pad_token_id,          // pad token
-  //                        int32_t* sequences,        // buffer with pad token, shape (num_return_sequences, max_length)
-  //                        float* sequences_scores);  // buffer for sequence scores, with shape (num_return_sequences)
 };
 
 struct BeamScorerState {

--- a/src/beam_search_scorer_cuda.h
+++ b/src/beam_search_scorer_cuda.h
@@ -23,7 +23,6 @@ struct BeamSearchScorer_Cuda {
   }
   gpu_span<int32_t> GetNextIndicesGPU() { return next_beam_indices_; }
   RoamingArray<int32_t> GetBeamHypothesis(size_t batch_id, size_t beam_id) const;
-  // LEFT OFF WITH ABOVE... RETHINK SO THAT WE CAN JUST GET THE HYPOTHESIS SEQUENCE OF TOKENS WITHOUT INDEXING INTO GPU MEMORY VIA CPU STUPID BS
 
  private:
   mutable cuda_event_holder event_process_complete_;

--- a/src/beam_search_scorer_cuda.h
+++ b/src/beam_search_scorer_cuda.h
@@ -9,9 +9,7 @@ struct BeamSearchScorer_Cuda {
                std::span<const int32_t> next_indices);
 
   void Finalize(Sequences_Cuda& sequences,
-                size_t num_return_sequences,
-                std::span<int32_t> output_sequences,
-                std::span<float> output_sequence_scores);
+                size_t num_return_sequences);
 
   bool IsDone() const { return false; }  // For CUDA we speculatively run the next step while we wait for the GPU to report status. We use 'IsDoneLater()' for this
   bool IsDoneLater() const;

--- a/src/beam_search_scorer_cuda.h
+++ b/src/beam_search_scorer_cuda.h
@@ -22,6 +22,8 @@ struct BeamSearchScorer_Cuda {
     return next_beam_indices_cpu_;
   }
   gpu_span<int32_t> GetNextIndicesGPU() { return next_beam_indices_; }
+  RoamingArray<int32_t> GetBeamHypothesis(size_t batch_id, size_t beam_id) const;
+  // LEFT OFF WITH ABOVE... RETHINK SO THAT WE CAN JUST GET THE HYPOTHESIS SEQUENCE OF TOKENS WITHOUT INDEXING INTO GPU MEMORY VIA CPU STUPID BS
 
  private:
   mutable cuda_event_holder event_process_complete_;

--- a/src/cuda_sampling.cu
+++ b/src/cuda_sampling.cu
@@ -299,7 +299,7 @@ __global__ void SoftmaxBlockForward(outscalar_t* output, scalar_t* input, int cl
 
 template <bool is_log_softmax>
 void DispatchBlockwiseSoftmaxForward(cudaStream_t* stream, float* output, const float* input, int softmax_elements,
-                                          int input_stride, int output_stride, int batch_count, float temperature=1.0) {
+                                          int input_stride, int output_stride, int batch_count, float temperature) {
   dim3 grid(batch_count);
   constexpr int ILP = sizeof(float4) / sizeof(float);
   dim3 block = SoftmaxGetBlockSize(ILP, softmax_elements);
@@ -313,6 +313,7 @@ void DispatchBlockwiseSoftmaxForward(cudaStream_t* stream, float* output, const 
                                                            softmax_elements, input_stride, output_stride, temperature);
   }
 }
+template void DispatchBlockwiseSoftmaxForward<true>(cudaStream_t*, float*, const float*, int, int, int, int, float);
 
 // Populate Kernels and Launchers
 

--- a/src/cuda_sampling.cuh
+++ b/src/cuda_sampling.cuh
@@ -23,5 +23,8 @@ struct SamplingData {
 void LaunchPopulateIndices(int* indices, int size, int batch_size, cudaStream_t stream);
 void GetSample(SamplingData* data, cudaStream_t stream, int32_t* d_next_token, float* d_scores, int vocab_size, int batch_size, int k, float p, float temperature);
 
+template <bool is_log_softmax>
+void DispatchBlockwiseSoftmaxForward(cudaStream_t* stream, float* output, const float* input, int softmax_elements, int input_stride, int output_stride, int batch_count, float temperature=1.0);
+
 }  // namespace cuda
 }  // namespace Generators

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -207,7 +207,7 @@ TokenSequences Generate(const Model& model, const GeneratorParams& params) {
 
   TokenSequences result;
 
-  auto& search = generator->search_;
+  // auto& search = generator->search_;
   // TODO(aciddelgado): Awful mess. Refactor.
   // if (params.search.num_beams > 1) {
   //   // Beam search case
@@ -227,6 +227,7 @@ TokenSequences Generate(const Model& model, const GeneratorParams& params) {
   // Sampling case
   for (int i = 0; i < params.batch_size * params.search.num_return_sequences; i++) {
     auto sequence = generator->search_->GetSequence(i);
+    std::cout << "Here" << std::endl;
     auto sequence_cpu = sequence.GetCPU();
 
     auto& v = result.emplace_back();

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <iostream>
 #include "generators.h"
 #include "sequences.h"
 #include "models/model.h"
@@ -200,40 +199,17 @@ TokenSequences Generate(const Model& model, const GeneratorParams& params) {
 
   while (!generator->IsDone()) {
     generator->ComputeLogits();
-    // CudaCheck() == cudaStreamSynchronize(params.cuda_stream);
     generator->GenerateNextToken();
-    // CudaCheck() == cudaStreamSynchronize(params.cuda_stream);
   }
 
   TokenSequences result;
-
-  // auto& search = generator->search_;
-  // TODO(aciddelgado): Awful mess. Refactor.
-  // if (params.search.num_beams > 1) {
-  //   // Beam search case
-  //   std::vector<int32_t> output_buffer = std::vector<int32_t>(params.batch_size * params.search.num_return_sequences * search->GetSequenceLength());
-  //   auto output_span = cpu_span<int32_t>(output_buffer.data(), output_buffer.size());
-  //   RoamingArray<int32_t> output{output_span};
-  //   auto score_span = cpu_span<float>{}; // empty so no scores outputted
-  //   RoamingArray<float> scores{score_span};
-  //   search->Finalize(params.search.num_return_sequences, output, scores);
-  //   for (int i = 0; i < params.batch_size * params.search.num_return_sequences; i++) {
-  //     auto sequence = output_span.subspan(i * search->GetSequenceLength(), search->GetSequenceLength());
-
-  //     auto& v = result.emplace_back();
-  //     v.assign(sequence.begin(), sequence.end());
-  //   }
-  // } else {
-  // Sampling case
   for (int i = 0; i < params.batch_size * params.search.num_return_sequences; i++) {
     auto sequence = generator->search_->GetSequence(i);
-    std::cout << "Here" << std::endl;
     auto sequence_cpu = sequence.GetCPU();
 
     auto& v = result.emplace_back();
     v.assign(sequence_cpu.begin(), sequence_cpu.end());
   }
-  // }
   return result;
 }
 

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <iostream>
 #include "generators.h"
 #include "sequences.h"
 #include "models/model.h"
@@ -199,18 +200,39 @@ TokenSequences Generate(const Model& model, const GeneratorParams& params) {
 
   while (!generator->IsDone()) {
     generator->ComputeLogits();
+    // CudaCheck() == cudaStreamSynchronize(params.cuda_stream);
     generator->GenerateNextToken();
+    // CudaCheck() == cudaStreamSynchronize(params.cuda_stream);
   }
 
   TokenSequences result;
 
-  for (int i = 0; i < params.batch_size; i++) {
+  auto& search = generator->search_;
+  // TODO(aciddelgado): Awful mess. Refactor.
+  // if (params.search.num_beams > 1) {
+  //   // Beam search case
+  //   std::vector<int32_t> output_buffer = std::vector<int32_t>(params.batch_size * params.search.num_return_sequences * search->GetSequenceLength());
+  //   auto output_span = cpu_span<int32_t>(output_buffer.data(), output_buffer.size());
+  //   RoamingArray<int32_t> output{output_span};
+  //   auto score_span = cpu_span<float>{}; // empty so no scores outputted
+  //   RoamingArray<float> scores{score_span};
+  //   search->Finalize(params.search.num_return_sequences, output, scores);
+  //   for (int i = 0; i < params.batch_size * params.search.num_return_sequences; i++) {
+  //     auto sequence = output_span.subspan(i * search->GetSequenceLength(), search->GetSequenceLength());
+
+  //     auto& v = result.emplace_back();
+  //     v.assign(sequence.begin(), sequence.end());
+  //   }
+  // } else {
+  // Sampling case
+  for (int i = 0; i < params.batch_size * params.search.num_return_sequences; i++) {
     auto sequence = generator->search_->GetSequence(i);
     auto sequence_cpu = sequence.GetCPU();
 
     auto& v = result.emplace_back();
     v.assign(sequence_cpu.begin(), sequence_cpu.end());
   }
+  // }
   return result;
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -288,7 +288,6 @@ void BeamSearch_Cpu::Finalize(size_t num_return_sequences) {
 RoamingArray<int32_t> BeamSearch_Cpu::GetSequence(size_t index) {
   size_t batch_id = index / params_->search.num_return_sequences;
   size_t beam_id = index % params_->search.num_return_sequences;
-  std::cout << "batch_id: " << batch_id << ", beam_id: " << beam_id << std::endl;
   BeamHypotheses beam_hyp = beam_scorer_->GetBeamHypotheses(batch_id);
   return beam_hyp.GetHypothesis(beam_id);
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -7,6 +7,19 @@
 
 namespace Generators {
 
+void SoftMax(std::span<float> scores, float temperature) {
+  float const max_score = *std::max_element(scores.begin(), scores.end());
+
+  // Subtract max score and scale by temperature
+  std::transform(scores.begin(), scores.end(), scores.begin(), [max_score, temperature](float score) { return std::exp((score - max_score) / temperature); });
+
+  // Compute sum of exponentials
+  float const exp_sum = std::accumulate(scores.begin(), scores.end(), 0.0f);
+
+  // Divide each score by the sum of exponentials
+  std::transform(scores.begin(), scores.end(), scores.begin(), [exp_sum](float score) { return score / exp_sum; });
+}
+
 Search_Cpu::Search_Cpu(const GeneratorParams& params)
     : Search{params},
       sequences_{params.input_ids, params.batch_size, params.search.num_beams, params_->search.max_length} {
@@ -62,6 +75,12 @@ int Search_Cpu::GetSequenceLength() const {
 }
 
 void BeamSearch_Cpu::SelectTop() {
+  // TODO(aciddelgado): Normalize the next_token_scores_ here I think
+  for (int i = 0; i < params_->batch_size; i++) {
+    std::span<float> const scores = next_token_scores_.subspan(i * params_->vocab_size, params_->vocab_size);
+    SoftMax(scores, 1.0); // TODO(aciddelgado): should this be log softmax?
+  }
+
   auto beam_scores = beam_scorer_->GetNextScores();
   // Add beam score to next token scores. Corresponding python code is like:
   //    next_token_scores = next_token_scores + beam_scores[:, None].expand_as(next_token_scores)
@@ -86,14 +105,15 @@ void BeamSearch_Cpu::SelectTop() {
     bool operator<(const ScoreIndex& s) const { return score < s.score; }
   };
 
-  auto scores = std::make_unique<float[]>(top_k * params_->batch_size);
-  auto indices = std::make_unique<int32_t[]>(top_k * params_->batch_size);
-  auto tokens = std::make_unique<int32_t[]>(top_k * params_->batch_size);
+  auto scores = std::make_unique<float[]>(top_k * params_->batch_size); // Score of top_k tokens
+  auto indices = std::make_unique<int32_t[]>(top_k * params_->batch_size); // beam index of top_k tokens
+  auto tokens = std::make_unique<int32_t[]>(top_k * params_->batch_size); // token id of top_k tokens
 
   auto next_scores = std::span<float>(scores.get(), top_k * params_->batch_size);
   auto next_indices = std::span<int32_t>(indices.get(), top_k * params_->batch_size);
   auto next_tokens = std::span<int32_t>(tokens.get(), top_k * params_->batch_size);
 
+  // TODO(aciddelgado): This is TopK with priority queue. Can it be optimized with a partial sort? Likely.
   for (size_t batch_index = 0; batch_index < static_cast<size_t>(params_->batch_size); batch_index++) {
     std::priority_queue<ScoreIndex, std::vector<ScoreIndex>> queue;
     auto token_scores_sub = next_token_scores_.subspan(batch_index * params_->search.num_beams * params_->vocab_size, static_cast<size_t>(params_->search.num_beams) * params_->vocab_size);
@@ -123,6 +143,11 @@ void BeamSearch_Cpu::SelectTop() {
   next_tokens_ = beam_scorer_->GetNextTokens();
 
   AppendNextTokensToSequences();
+
+  // if (beam_scorer_->IsDone()) {
+  //   done_ = true;
+  //   beam_scorer_->Finalize(sequences_, params_->search.num_return_sequences, params_->output_ids, params_->sequence_scores);
+  // }
 }
 
 void GreedySearch_Cpu::SelectTop() {
@@ -138,19 +163,6 @@ void GreedySearch_Cpu::SelectTop() {
   }
 
   AppendNextTokensToSequences();
-}
-
-void SoftMax(std::span<float> scores, float temperature) {
-  float const max_score = *std::max_element(scores.begin(), scores.end());
-
-  // Subtract max score and scale by temperature
-  std::transform(scores.begin(), scores.end(), scores.begin(), [max_score, temperature](float score) { return std::exp((score - max_score) / temperature); });
-
-  // Compute sum of exponentials
-  float const exp_sum = std::accumulate(scores.begin(), scores.end(), 0.0f);
-
-  // Divide each score by the sum of exponentials
-  std::transform(scores.begin(), scores.end(), scores.begin(), [exp_sum](float score) { return score / exp_sum; });
 }
 
 void GreedySearch_Cpu::SampleTopK(int k, float temperature) {
@@ -268,8 +280,22 @@ void BeamSearch_Cpu::AppendNextTokensToSequences() {
   }
 }
 
-void BeamSearch_Cpu::Finalize(size_t num_return_sequences, RoamingArray<int32_t> output, RoamingArray<float> sequence_scores) {
-  beam_scorer_->Finalize(sequences_, num_return_sequences, output, sequence_scores);
+void BeamSearch_Cpu::Finalize(size_t num_return_sequences) {
+  beam_scorer_->Finalize(sequences_, num_return_sequences);
+  finalized_ = true;
+}
+
+RoamingArray<int32_t> BeamSearch_Cpu::GetSequence(size_t index) {
+  size_t batch_id = index / params_->search.num_return_sequences;
+  size_t beam_id = index % params_->search.num_return_sequences;
+  std::cout << "batch_id: " << batch_id << ", beam_id: " << beam_id << std::endl;
+  BeamHypotheses beam_hyp = beam_scorer_->GetBeamHypotheses(batch_id);
+  return beam_hyp.GetHypothesis(beam_id);
+}
+
+RoamingArray<int32_t> BeamSearch_Cpu::GetSequence(size_t batch_id, size_t beam_id) {
+  BeamHypotheses beam_hyp = beam_scorer_->GetBeamHypotheses(batch_id);
+  return beam_hyp.GetHypothesis(beam_id);
 }
 
 std::span<float> Search_Cpu::GetScores(int batch_beam_index) const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -4,6 +4,7 @@
 #include "beam_search_scorer.h"
 #include <queue>
 #include <algorithm>
+#include <iostream>
 
 namespace Generators {
 
@@ -147,22 +148,9 @@ void BeamSearch_Cpu::SelectTop() {
   }
 
 #if 0
-  // Print next_tokens, next_indices, next_scores
-  std::cout << "next_tokens: ";
-  for (int i = 0; i < top_k * params_->batch_size; i++) {
-    std::cout << next_tokens[i] << " ";
-  }
-  std::cout << std::endl;
-  std::cout << "next_indices: ";
-  for (int i = 0; i < top_k * params_->batch_size; i++) {
-    std::cout << next_indices[i] << " ";
-  }
-  std::cout << std::endl;
-  std::cout << "next_scores: ";
-  for (int i = 0; i < top_k * params_->batch_size; i++) {
-    std::cout << next_scores[i] << " ";
-  }
-  std::cout << std::endl;
+  DumpSpan(std::cout, next_tokens);
+  DumpSpan(std::cout, next_indices_);
+  DumpSpan(std::cout, next_scores_);
 #endif
 
   beam_scorer_->Process(sequences_, next_scores, next_tokens, next_indices);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -291,7 +291,7 @@ void GreedySearch_Cpu::AppendNextTokensToSequences() {
   }
 }
 
-bool BeamSearch_Cpu::IsDone() const { 
+bool BeamSearch_Cpu::IsDone() const {
   if (beam_scorer_->IsDone()) {
     return true;
   } else if (sequences_.GetSequenceLength() == params_->search.max_length) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -91,7 +91,7 @@ void BeamSearch_Cpu::SelectTop() {
   // Normalize next token scores
   for (int i = 0; i < params_->BatchBeamSize(); i++) {
     std::span<float> const scores = next_token_scores_.subspan(i * params_->vocab_size, params_->vocab_size);
-    LogSoftMax(scores, 1.0); // Should this be log softmax?
+    LogSoftMax(scores, 1.0);  // Should this be log softmax?
   }
 
   auto beam_scores = beam_scorer_->GetNextScores();
@@ -118,9 +118,9 @@ void BeamSearch_Cpu::SelectTop() {
     bool operator<(const ScoreIndex& s) const { return score < s.score; }
   };
 
-  auto scores = std::make_unique<float[]>(top_k * params_->batch_size); // Score of top_k tokens
-  auto indices = std::make_unique<int32_t[]>(top_k * params_->batch_size); // beam index of top_k tokens
-  auto tokens = std::make_unique<int32_t[]>(top_k * params_->batch_size); // token id of top_k tokens
+  auto scores = std::make_unique<float[]>(top_k * params_->batch_size);     // Score of top_k tokens
+  auto indices = std::make_unique<int32_t[]>(top_k * params_->batch_size);  // beam index of top_k tokens
+  auto tokens = std::make_unique<int32_t[]>(top_k * params_->batch_size);   // token id of top_k tokens
 
   auto next_scores = std::span<float>(scores.get(), top_k * params_->batch_size);
   auto next_indices = std::span<int32_t>(indices.get(), top_k * params_->batch_size);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -90,7 +90,7 @@ int Search_Cpu::GetSequenceLength() const {
 void BeamSearch_Cpu::SelectTop() {
   // Normalize next token scores
   for (int i = 0; i < params_->BatchBeamSize(); i++) {
-    std::span<float> const scores = next_token_scores_.subspan(i * params_->vocab_size, params_->vocab_size);
+    std::span<float> const scores = next_token_scores_.subspan(static_cast<size_t>(i) * static_cast<size_t>(params_->vocab_size), params_->vocab_size);
     LogSoftMax(scores, 1.0);  // Should this be log softmax?
   }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -4,7 +4,6 @@
 #include "beam_search_scorer.h"
 #include <queue>
 #include <algorithm>
-#include <iostream>
 
 namespace Generators {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -291,6 +291,17 @@ void GreedySearch_Cpu::AppendNextTokensToSequences() {
   }
 }
 
+bool BeamSearch_Cpu::IsDone() const { 
+  if (beam_scorer_->IsDone()) {
+    return true;
+  } else if (sequences_.GetSequenceLength() == params_->search.max_length) {
+    if (g_log.enabled && g_log.hit_max_length)
+      Log("hit_max_length", "beam cuda hit");
+    return true;
+  }
+  return false;
+}
+
 void BeamSearch_Cpu::AppendNextTokensToSequences() {
   sequences_.AppendNextTokenToSequences(beam_scorer_->GetNextIndicesCPU(), beam_scorer_->GetNextTokens());
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -65,7 +65,7 @@ void BeamSearch_Cpu::SelectTop() {
   // Normalize next token scores
   for (int i = 0; i < params_->BatchBeamSize(); i++) {
     std::span<float> const scores = next_token_scores_.subspan(static_cast<size_t>(i) * static_cast<size_t>(params_->vocab_size), params_->vocab_size);
-    LogSoftMax(scores, 1.0); 
+    LogSoftMax(scores, 1.0);
   }
 
   auto beam_scores = beam_scorer_->GetNextScores();

--- a/src/search.h
+++ b/src/search.h
@@ -102,7 +102,7 @@ struct BeamSearch_Cpu : Search_Cpu {
   void Finalize(size_t num_return_sequences);
 
   bool finalized_{};  // To avoid calling Finalize multiple times
-  
+
   std::unique_ptr<BeamSearchScorer> beam_scorer_;
 };
 

--- a/src/search.h
+++ b/src/search.h
@@ -93,7 +93,7 @@ struct BeamSearch_Cpu : Search_Cpu {
   RoamingArray<int32_t> GetSequence(size_t index) override;
   RoamingArray<int32_t> GetSequence(size_t batch_id, size_t beam_id);
 
-  bool IsDone() const { return beam_scorer_->IsDone(); }
+  bool IsDone() const;
 
   void SelectTop() override;
 

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -6,6 +6,7 @@
 #include "beam_search_topk.h"
 #include <queue>
 #include <random>
+#include <iostream>
 
 namespace Generators {
 
@@ -217,6 +218,8 @@ bool BeamSearch_Cuda::IsDone() const {
     return true;
 
   if (sequences_.GetSequenceLength() == params_->search.max_length) {
+    // TODO(aciddelgado): LEFT OFF figuring out the floating point exception when we hit max length
+    std::cout << "this is a thing" << std::endl;
     if (g_log.enabled && g_log.hit_max_length)
       Log("hit_max_length", "beam cuda hit");
     return true;

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -6,7 +6,6 @@
 #include "beam_search_topk.h"
 #include <queue>
 #include <random>
-#include <iostream>
 
 namespace Generators {
 
@@ -217,8 +216,8 @@ void BeamSearch_Cuda::Finalize(size_t num_return_sequences) {
 
 RoamingArray<int32_t> BeamSearch_Cuda::GetSequence(size_t index) {
   Finalize(params_->search.num_return_sequences);
-  size_t batch_id = index / params_->search.num_return_sequences;
-  size_t beam_id = index % params_->search.num_return_sequences;
+  const size_t batch_id = index / params_->search.num_return_sequences;
+  const size_t beam_id = index % params_->search.num_return_sequences;
   return beam_scorer_->GetBeamHypothesis(batch_id, beam_id);
 }
 

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -6,6 +6,7 @@
 #include "beam_search_topk.h"
 #include <queue>
 #include <random>
+#include <iostream>
 
 namespace Generators {
 
@@ -51,6 +52,7 @@ BeamSearch_Cuda::BeamSearch_Cuda(const GeneratorParams& params)
   topk_next_tokens_ = CudaMallocArray<int32_t>(2 * batch_beam_size);
   topk_next_indices_ = CudaMallocArray<int32_t>(2 * batch_beam_size);
   topk_next_scores_ = CudaMallocArray<float>(2 * batch_beam_size);
+  softmax_buffer_ = CudaMallocArray<float>(batch_beam_size * params_->vocab_size);
 
   constexpr size_t max_parts_of_vocab = 128;
   size_t topk_buffer_size = batch_beam_size * (max_parts_of_vocab + 1) * params_->search.num_beams * 2 * 2;
@@ -83,29 +85,85 @@ int Search_Cuda::GetSequenceLength() const {
 }
 
 void BeamSearch_Cuda::SelectTop() {
+  cuda::DispatchBlockwiseSoftmaxForward<true>(const_cast<cudaStream_t*>(&params_->cuda_stream), softmax_buffer_.get(), next_token_scores_.data(), params_->vocab_size, 
+                                        params_->vocab_size, params_->vocab_size, params_->BatchBeamSize());
+
+  CudaCheck() == cudaStreamSynchronize(params_->cuda_stream);
+  // // print softmax buffer
+  // auto softmax_buffer_ptr_ = CudaMallocHostArray<float>(params_->BatchBeamSize() * params_->vocab_size);
+  // cudaMemcpyAsync(softmax_buffer_ptr_.get(), softmax_buffer_.get(), params_->BatchBeamSize() * params_->vocab_size * sizeof(float), cudaMemcpyDeviceToHost, params_->cuda_stream);
+  // cudaStreamSynchronize(params_->cuda_stream);
+  // std::span<float> softmax_buffer{softmax_buffer_ptr_.get(), params_->BatchBeamSize() * params_->vocab_size};
+  // std::cout << "softmax_buffer: ";
+  // for (int i = 0; i < params_->batch_size * params_->vocab_size; i++) {
+  //   if (softmax_buffer[i] < 0.0f) {
+  //     std::cout << i << ": " << softmax_buffer[i] << ", ";
+  //   }
+  // }
+  // std::cout << std::endl;
+
+  // // print next token scores
+  // auto next_token_scores_ptr_ = CudaMallocHostArray<float>(params_->BatchBeamSize() * params_->vocab_size);
+  // cudaMemcpyAsync(next_token_scores_ptr_.get(), next_token_scores_.data(), params_->BatchBeamSize() * params_->vocab_size * sizeof(float), cudaMemcpyDeviceToHost, params_->cuda_stream);
+  // cudaStreamSynchronize(params_->cuda_stream);
+  // std::span<float> next_token_scores{next_token_scores_ptr_.get(), params_->BatchBeamSize() * params_->vocab_size};
+  // std::cout << "next_token_scores pre: ";
+  // for (int i = 0; i < params_->BatchBeamSize() * params_->vocab_size; i++) {
+  //   if (next_token_scores[i] < 0.0f) {
+  //     std::cout << next_token_scores[i] << " ";
+  //   }
+  // }
+  // std::cout << std::endl;
+
   auto beam_scores = beam_scorer_->GetNextScores();
 
   // Add beam score to next token scores. Corresponding python code is like:
   //    next_token_scores = next_token_scores + beam_scores[:, None].expand_as(next_token_scores)
-  cuda::LaunchAddProbsKernel(next_token_scores_.data(), beam_scores.data(),
+  cuda::LaunchAddProbsKernel(softmax_buffer_.get(), beam_scores.data(),
                              params_->batch_size, params_->search.num_beams, params_->vocab_size, params_->cuda_stream);
+  
+  CudaCheck() == cudaStreamSynchronize(params_->cuda_stream);
+
+  // cudaMemcpyAsync(softmax_buffer_ptr_.get(), softmax_buffer_.get(), params_->BatchBeamSize() * params_->vocab_size * sizeof(float), cudaMemcpyDeviceToHost, params_->cuda_stream);
+  // cudaStreamSynchronize(params_->cuda_stream);
+  // std::span<float> softmax_buffer{softmax_buffer_ptr_.get(), params_->BatchBeamSize() * params_->vocab_size};
+  // std::cout << "softmax_buffer: ";
+  // for (int i = 0; i < params_->BatchBeamSize() * params_->vocab_size; i++) {
+  //   if (softmax_buffer[i] > 0.0f) {
+  //     std::cout << softmax_buffer[i] << " ";
+  //   }
+  // }
+  // std::cout << std::endl;
+
+  // TODO(aciddelgado): normalize again here??
+
+  // // print next token scores
+  // cudaMemcpyAsync(next_token_scores_ptr_.get(), next_token_scores_.data(), params_->BatchBeamSize() * params_->vocab_size * sizeof(float), cudaMemcpyDeviceToHost, params_->cuda_stream);
+  // cudaStreamSynchronize(params_->cuda_stream);
+  // std::cout << "next_token_scores post: ";
+  // for (int i = 0; i < params_->BatchBeamSize() * params_->vocab_size; i++) {
+  //   if (next_token_scores[i] < 0.0f) {
+  //     std::cout << next_token_scores[i] << " ";
+  //   }
+  // }
+  // std::cout << std::endl;
 
   // TODO: Write output scores?
 
   if (params_->search.num_beams <= 32) {
     constexpr size_t max_parts_of_vocab = 128;
-    size_t candidate_count = params_->BatchBeamSize() * 2 * params_->search.num_beams;
+    size_t candidate_count = params_->BatchBeamSize() * 2 * params_->search.num_beams; // TODO(aciddelgado): is this right
     float* topk_tmp_buffer = topk_buffer_.get();
     float* topk_scores_1st_stage = topk_tmp_buffer;
     int32_t* topk_tokens_1st_stage = reinterpret_cast<int32_t*>(topk_scores_1st_stage + candidate_count * max_parts_of_vocab);
     float* topk_scores_2nd_stage = reinterpret_cast<float*>(topk_tokens_1st_stage + candidate_count * max_parts_of_vocab);
     int32_t* topk_tokens_2nd_stage = reinterpret_cast<int32_t*>(topk_scores_2nd_stage + candidate_count);
 
-    cuda::BeamSearchTopK(next_token_scores_.data(),
+    cuda::BeamSearchTopK(softmax_buffer_.get(),
                          params_->batch_size,
                          params_->search.num_beams,
                          params_->vocab_size,
-                         2 * params_->search.num_beams,
+                         2 * params_->search.num_beams, // TODO(aciddelgado): why 2 * num_beams?
                          topk_scores_1st_stage,
                          topk_tokens_1st_stage,
                          topk_scores_2nd_stage,
@@ -120,9 +178,36 @@ void BeamSearch_Cuda::SelectTop() {
   CudaCheck() == cudaStreamSynchronize(params_->cuda_stream);
 
   size_t size = params_->BatchBeamSize() * 2;
-  std::span<float> next_scores{topk_next_scores_.get(), size};
-  std::span<int32_t> next_tokens{topk_next_tokens_.get(), size};
+  std::span<float> next_scores{topk_next_scores_.get(), size}; // TODO(aciddelgado): why is scores negative?
+  std::span<int32_t> next_tokens{topk_next_tokens_.get(), size}; // TODO(aciddelgado): difference between tokens and indices?
   std::span<int32_t> next_indices{topk_next_indices_.get(), size};
+
+  // auto next_indices_cpu_ptr_ = CudaMallocHostArray<int32_t>(size);
+  // std::span<int32_t> next_indices_cpu{next_indices_cpu_ptr_.get(), size};
+  // cudaMemcpyAsync(next_indices_cpu.data(), next_indices.data(), size * sizeof(int32_t), cudaMemcpyDeviceToHost, params_->cuda_stream);
+  // cudaStreamSynchronize(params_->cuda_stream);
+  // std::cout << "next_indices_cpu: ";
+  // for (int i = 0; i < size; i++)
+  //   std::cout << next_indices_cpu[i] << " ";
+  // std::cout << std::endl;
+
+  // auto next_tokens_cpu_ptr_ = CudaMallocHostArray<int32_t>(size);
+  // std::span<int32_t> next_tokens_cpu{next_tokens_cpu_ptr_.get(), size};
+  // cudaMemcpyAsync(next_tokens_cpu.data(), next_tokens.data(), size * sizeof(int32_t), cudaMemcpyDeviceToHost, params_->cuda_stream);
+  // cudaStreamSynchronize(params_->cuda_stream);
+  // std::cout << "next_tokens_cpu: ";
+  // for (int i = 0; i < size; i++)
+  //   std::cout << next_tokens_cpu[i] << " ";
+  // std::cout << std::endl;
+
+  // auto next_scores_cpu_ptr_ = CudaMallocHostArray<float>(size);
+  // std::span<float> next_scores_cpu{next_scores_cpu_ptr_.get(), size};
+  // cudaMemcpyAsync(next_scores_cpu.data(), next_scores.data(), size * sizeof(float), cudaMemcpyDeviceToHost, params_->cuda_stream);
+  // cudaStreamSynchronize(params_->cuda_stream);
+  // std::cout << "next_scores_cpu: ";
+  // for (int i = 0; i < size; i++)
+  //   std::cout << next_scores_cpu[i] << " ";
+  // std::cout << std::endl;
 
 #if 0
   DumpCudaMemory("Next Scores", next_scores);
@@ -185,8 +270,9 @@ void GreedySearch_Cuda::AppendNextTokensToSequences() {
 
 bool BeamSearch_Cuda::IsDone() const {
   beam_scorer_->IsDone();
-  if (beam_scorer_->IsDoneLater())
+  if (beam_scorer_->IsDoneLater()) {
     return true;
+  }
 
   if (sequences_.GetSequenceLength() == params_->search.max_length) {
     if (g_log.enabled && g_log.hit_max_length)
@@ -200,8 +286,8 @@ void BeamSearch_Cuda::AppendNextTokensToSequences() {
   sequences_.AfterDeviceAppendedNextToken();
 }
 
-void BeamSearch_Cuda::Finalize(size_t num_return_sequences, RoamingArray<int32_t> output, RoamingArray<float> sequence_scores) {
-  beam_scorer_->Finalize(sequences_, num_return_sequences, output.GetGPU(), sequence_scores.GetGPU());
+void BeamSearch_Cuda::Finalize(size_t num_return_sequences) {
+  beam_scorer_->Finalize(sequences_, num_return_sequences);
 }
 
 #if 0

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -213,13 +213,10 @@ void GreedySearch_Cuda::AppendNextTokensToSequences() {
 }
 
 bool BeamSearch_Cuda::IsDone() const {
-  beam_scorer_->IsDone();
   if (beam_scorer_->IsDoneLater())
     return true;
 
   if (sequences_.GetSequenceLength() == params_->search.max_length) {
-    // TODO(aciddelgado): LEFT OFF figuring out the floating point exception when we hit max length
-    std::cout << "this is a thing" << std::endl;
     if (g_log.enabled && g_log.hit_max_length)
       Log("hit_max_length", "beam cuda hit");
     return true;
@@ -239,14 +236,14 @@ void BeamSearch_Cuda::Finalize(size_t num_return_sequences) {
 }
 
 RoamingArray<int32_t> BeamSearch_Cuda::GetSequence(size_t index) {
-  // Finalize(params_->search.num_return_sequences);
+  Finalize(params_->search.num_return_sequences);
   size_t batch_id = index / params_->search.num_return_sequences;
   size_t beam_id = index % params_->search.num_return_sequences;
   return beam_scorer_->GetBeamHypothesis(batch_id, beam_id);
 }
 
 RoamingArray<int32_t> BeamSearch_Cuda::GetSequence(size_t batch_id, size_t beam_id) {
-  // Finalize(params_->search.num_return_sequences);
+  Finalize(params_->search.num_return_sequences);
   return beam_scorer_->GetBeamHypothesis(batch_id, beam_id);
 }
 

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -6,6 +6,7 @@
 #include "beam_search_topk.h"
 #include <queue>
 #include <random>
+#include <iostream>
 
 namespace Generators {
 
@@ -132,30 +133,9 @@ void BeamSearch_Cuda::SelectTop() {
   std::span<int32_t> next_indices{topk_next_indices_.get(), size};
 
 #if 0
-  // Copy next_tokens, next_indices, next_scores to CPU
-  auto next_tokens_cpu = CudaMallocHostArray<int32_t>(size);
-  auto next_indices_cpu = CudaMallocHostArray<int32_t>(size);
-  auto next_scores_cpu = CudaMallocHostArray<float>(size);
-  cudaMemcpyAsync(next_tokens_cpu.get(), next_tokens.data(), size * sizeof(int32_t), cudaMemcpyDeviceToHost, params_->cuda_stream);
-  cudaMemcpyAsync(next_indices_cpu.get(), next_indices.data(), size * sizeof(int32_t), cudaMemcpyDeviceToHost, params_->cuda_stream);
-  cudaMemcpyAsync(next_scores_cpu.get(), next_scores.data(), size * sizeof(float), cudaMemcpyDeviceToHost, params_->cuda_stream);
-  CudaCheck() == cudaStreamSynchronize(params_->cuda_stream);
-  // Print next_tokens_cpu, next_indices_cpu, next_scores_cpu
-  std::span<int32_t> next_tokens_cpu_span{next_tokens_cpu.get(), size};
-  std::span<int32_t> next_indices_cpu_span{next_indices_cpu.get(), size};
-  std::span<float> next_scores_cpu_span{next_scores_cpu.get(), size};
-  std::cout << "next_tokens_cpu: ";
-  for (int i = 0; i < size; i++)
-    std::cout << next_tokens_cpu_span[i] << " ";
-  std::cout << std::endl;
-  std::cout << "next_indices_cpu: ";
-  for (int i = 0; i < size; i++)
-    std::cout << next_indices_cpu_span[i] << " ";
-  std::cout << std::endl;
-  std::cout << "next_scores_cpu: ";
-  for (int i = 0; i < size; i++)
-    std::cout << next_scores_cpu_span[i] << " ";
-  std::cout << std::endl;
+  DumpCudaSpan(std::cout, next_scores);
+  DumpCudaSpan(std::cout, next_tokens);
+  DumpCudaSpan(std::cout, next_indices);
 #endif
 
   beam_scorer_->Process(sequences_, next_scores, next_tokens, next_indices);

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -6,7 +6,6 @@
 #include "beam_search_topk.h"
 #include <queue>
 #include <random>
-#include <iostream>
 
 namespace Generators {
 
@@ -102,7 +101,7 @@ void BeamSearch_Cuda::SelectTop() {
 
   if (params_->search.num_beams <= 32) {
     constexpr size_t max_parts_of_vocab = 128;
-    size_t candidate_count = params_->BatchBeamSize() * 2 * params_->search.num_beams;  // TODO: Why is this the candidate count... why 2?
+    size_t candidate_count = params_->BatchBeamSize() * 2 * params_->search.num_beams;
     float* topk_tmp_buffer = topk_buffer_.get();
     float* topk_scores_1st_stage = topk_tmp_buffer;
     int32_t* topk_tokens_1st_stage = reinterpret_cast<int32_t*>(topk_scores_1st_stage + candidate_count * max_parts_of_vocab);
@@ -162,6 +161,7 @@ void BeamSearch_Cuda::SelectTop() {
   beam_scorer_->Process(sequences_, next_scores, next_tokens, next_indices);
   next_tokens_ = beam_scorer_->GetNextTokens();
 
+  // TODO(aciddelgado): do we need to keep track of sequences both here and in beam hypotheses?
   AppendNextTokensToSequences();
 }
 

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -84,8 +84,8 @@ int Search_Cuda::GetSequenceLength() const {
 }
 
 void BeamSearch_Cuda::SelectTop() {
-  cuda::DispatchBlockwiseSoftmaxForward<true>(const_cast<cudaStream_t*>(&params_->cuda_stream), softmax_buffer_.get(), next_token_scores_.data(), params_->vocab_size, 
-                                        params_->vocab_size, params_->vocab_size, params_->BatchBeamSize());
+  cuda::DispatchBlockwiseSoftmaxForward<true>(const_cast<cudaStream_t*>(&params_->cuda_stream), softmax_buffer_.get(), next_token_scores_.data(), params_->vocab_size,
+                                              params_->vocab_size, params_->vocab_size, params_->BatchBeamSize());
 
   // Copy next_token_scores to CPU
   auto next_token_scores_cpu = CudaMallocHostArray<float>(params_->BatchBeamSize() * params_->vocab_size);
@@ -98,10 +98,10 @@ void BeamSearch_Cuda::SelectTop() {
   //    next_token_scores = next_token_scores + beam_scores[:, None].expand_as(next_token_scores)
   cuda::LaunchAddProbsKernel(softmax_buffer_.get(), beam_scores.data(),
                              params_->batch_size, params_->search.num_beams, params_->vocab_size, params_->cuda_stream);
-  
+
   if (params_->search.num_beams <= 32) {
     constexpr size_t max_parts_of_vocab = 128;
-    size_t candidate_count = params_->BatchBeamSize() * 2 * params_->search.num_beams; // TODO: Why is this the candidate count... why 2?
+    size_t candidate_count = params_->BatchBeamSize() * 2 * params_->search.num_beams;  // TODO: Why is this the candidate count... why 2?
     float* topk_tmp_buffer = topk_buffer_.get();
     float* topk_scores_1st_stage = topk_tmp_buffer;
     int32_t* topk_tokens_1st_stage = reinterpret_cast<int32_t*>(topk_scores_1st_stage + candidate_count * max_parts_of_vocab);
@@ -213,7 +213,7 @@ void GreedySearch_Cuda::AppendNextTokensToSequences() {
 
 bool BeamSearch_Cuda::IsDone() const {
   beam_scorer_->IsDone();
-  if (beam_scorer_->IsDoneLater()) 
+  if (beam_scorer_->IsDoneLater())
     return true;
 
   if (sequences_.GetSequenceLength() == params_->search.max_length) {

--- a/src/search_cuda.cpp
+++ b/src/search_cuda.cpp
@@ -290,6 +290,16 @@ void BeamSearch_Cuda::Finalize(size_t num_return_sequences) {
   beam_scorer_->Finalize(sequences_, num_return_sequences);
 }
 
+RoamingArray<int32_t> BeamSearch_Cuda::GetSequence(size_t index) {
+  size_t batch_id = index / params_->search.num_return_sequences;
+  size_t beam_id = index % params_->search.num_return_sequences;
+  return beam_scorer_->GetBeamHypothesis(batch_id, beam_id);
+}
+
+RoamingArray<int32_t> BeamSearch_Cuda::GetSequence(size_t batch_id, size_t beam_id) {
+  return beam_scorer_->GetBeamHypothesis(batch_id, beam_id);
+}
+
 #if 0
 // Not needed, for greedy can just grab the output sequence directly?
 void GreedySearch::Finalize(size_t num_return_sequences, std::span<int32_t> output, std::span<float> sequence_scores) {

--- a/src/search_cuda.h
+++ b/src/search_cuda.h
@@ -69,17 +69,19 @@ struct BeamSearch_Cuda : Search_Cuda {
   RoamingArray<int32_t> GetNextTokens() override;
   RoamingArray<int32_t> GetNextIndices() override;
   // In Beam Search there are batch_size * num_beams sequences. Index is batch_id * num_beams + beam_id... Easier to use the other version.
-  RoamingArray<int32_t> GetSequence(size_t index) override; // TODO(aciddelgado): implement this
+  RoamingArray<int32_t> GetSequence(size_t index) override;
   RoamingArray<int32_t> GetSequence(size_t batch_id, size_t beam_id);
 
   void SelectTop() override;
-  void Finalize(size_t num_return_sequences) override; // TODO(aciddelgado): remove from interface
 
   bool IsDone() const;
 
  private:
   void AppendNextTokensToSequences();
+  void Finalize(size_t num_return_sequences);
 
+  bool finalized_{};  // To avoid calling Finalize multiple times
+  
   std::unique_ptr<BeamSearchScorer_Cuda> beam_scorer_;
 
   cuda_unique_ptr<int32_t> topk_next_tokens_;

--- a/src/search_cuda.h
+++ b/src/search_cuda.h
@@ -81,7 +81,7 @@ struct BeamSearch_Cuda : Search_Cuda {
   void Finalize(size_t num_return_sequences);
 
   bool finalized_{};  // To avoid calling Finalize multiple times
-  
+
   std::unique_ptr<BeamSearchScorer_Cuda> beam_scorer_;
 
   cuda_unique_ptr<int32_t> topk_next_tokens_;

--- a/src/search_cuda.h
+++ b/src/search_cuda.h
@@ -68,9 +68,10 @@ struct BeamSearch_Cuda : Search_Cuda {
 
   RoamingArray<int32_t> GetNextTokens() override;
   RoamingArray<int32_t> GetNextIndices() override;
+  RoamingArray<int32_t> GetSequence(size_t index) override; // TODO(aciddelgado): implement this
 
   void SelectTop() override;
-  void Finalize(size_t num_return_sequences, RoamingArray<int32_t> output, RoamingArray<float> sequence_scores) override;
+  void Finalize(size_t num_return_sequences) override; // TODO(aciddelgado): remove from interface
 
   bool IsDone() const;
 
@@ -82,6 +83,7 @@ struct BeamSearch_Cuda : Search_Cuda {
   cuda_unique_ptr<int32_t> topk_next_tokens_;
   cuda_unique_ptr<int32_t> topk_next_indices_;
   cuda_unique_ptr<float> topk_next_scores_;
+  cuda_unique_ptr<float> softmax_buffer_;
 
   // temp buffer for topk computation, including:
   // 1st stage needs:

--- a/src/search_cuda.h
+++ b/src/search_cuda.h
@@ -68,7 +68,9 @@ struct BeamSearch_Cuda : Search_Cuda {
 
   RoamingArray<int32_t> GetNextTokens() override;
   RoamingArray<int32_t> GetNextIndices() override;
+  // In Beam Search there are batch_size * num_beams sequences. Index is batch_id * num_beams + beam_id... Easier to use the other version.
   RoamingArray<int32_t> GetSequence(size_t index) override; // TODO(aciddelgado): implement this
+  RoamingArray<int32_t> GetSequence(size_t batch_id, size_t beam_id);
 
   void SelectTop() override;
   void Finalize(size_t num_return_sequences) override; // TODO(aciddelgado): remove from interface

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -31,6 +31,12 @@ void copy(std::span<const T> source, std::span<T> dest) {
 }
 
 template <typename T>
+void copy(cpu_span<const T> source, cpu_span<T> dest) {
+  assert(source.size() == dest.size());
+  std::copy(source.begin(), source.end(), dest.begin());
+}
+
+template <typename T>
 std::unique_ptr<T[]> AllocateArray(size_t count, std::span<T>* p_span = nullptr) {
   T* p = new T[count];
   if (p_span)

--- a/src/softmax.h
+++ b/src/softmax.h
@@ -2,7 +2,30 @@
 
 namespace Generators {
 
-void softmax(std::span<float> values);
-void log_softmax(std::span<float> values);
+void SoftMax(std::span<float> scores, float temperature) {
+  float const max_score = *std::max_element(scores.begin(), scores.end());
+
+  // Subtract max score and scale by temperature
+  std::transform(scores.begin(), scores.end(), scores.begin(), [max_score, temperature](float score) { return std::exp((score - max_score) / temperature); });
+
+  // Compute sum of exponentials
+  float const exp_sum = std::accumulate(scores.begin(), scores.end(), 0.0f);
+
+  // Divide each score by the sum of exponentials
+  std::transform(scores.begin(), scores.end(), scores.begin(), [exp_sum](float score) { return score / exp_sum; });
+}
+
+void LogSoftMax(std::span<float> scores, float temperature) {
+  float const max_score = *std::max_element(scores.begin(), scores.end());
+
+  // Subtract max score and scale by temperature
+  std::transform(scores.begin(), scores.end(), scores.begin(), [max_score, temperature](float score) { return (score - max_score) / temperature; });
+
+  // Compute sum of exponentials
+  float const exp_sum = std::accumulate(scores.begin(), scores.end(), 0.0f, [](float a, float b) { return a + std::exp(b); });
+
+  // Subtract log of sum of exponentials from each score
+  std::transform(scores.begin(), scores.end(), scores.begin(), [exp_sum](float score) { return score - std::log(exp_sum); });
+}
 
 }  // namespace Generators

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -56,56 +56,46 @@ TEST(ModelTests, GreedySearchGptFp32) {
   }
 }
 
-// TEST(ModelTests, BeamSearchGptFp32) {
-//   std::vector<int64_t> input_ids_shape{3, 12};
-//   std::vector<int32_t> input_ids{
-//       0, 0, 0, 0, 0, 52, 195, 731, 321, 301, 734, 620,
-//       41, 554, 74, 622, 206, 222, 75, 223, 221, 198, 224, 572,
-//       0, 0, 0, 52, 328, 219, 328, 206, 288, 227, 896, 328};
+TEST(ModelTests, BeamSearchGptFp32) {
+  std::vector<int64_t> input_ids_shape{3, 12};
+  std::vector<int32_t> input_ids{
+      0, 0, 0, 0, 0, 52, 195, 731, 321, 301, 734, 620,
+      41, 554, 74, 622, 206, 222, 75, 223, 221, 198, 224, 572,
+      0, 0, 0, 52, 328, 219, 328, 206, 288, 227, 896, 328};
 
-//   std::vector<int32_t> expected_output{
-//       0, 0, 0, 0, 0, 52, 195, 731, 321, 301, 734, 620, 131, 131, 131, 181, 638, 638, 638, 638,
-//       41, 554, 74, 622, 206, 222, 75, 223, 221, 198, 224, 572, 292, 292, 292, 292, 292, 292, 292, 292,
-//       0, 0, 0, 52, 328, 219, 328, 206, 288, 227, 896, 328, 328, 669, 669, 669, 669, 669, 669, 669};
+  std::vector<int32_t> expected_output{
+      0, 0, 0, 0, 0, 52, 195, 731, 321, 301, 734, 620, 131, 131, 131, 181, 638, 638, 638, 638,
+      41, 554, 74, 622, 206, 222, 75, 223, 221, 198, 224, 572, 292, 292, 292, 292, 292, 292, 292, 292,
+      0, 0, 0, 52, 328, 219, 328, 206, 288, 227, 896, 328, 328, 669, 669, 669, 669, 669, 669, 669};
 
-//   // The ONNX model is generated like the following:
-//   // python convert_generation.py --model_type gpt2 -m hf-internal-testing/tiny-random-gpt2
-//   //        --output tiny_gpt2_beamsearch_fp16.onnx --use_gpu --max_length 20
-//   // (with separate_gpt2_decoder_for_init_run set to False as it is now set to True by default)
+  // The ONNX model is generated like the following:
+  // python convert_generation.py --model_type gpt2 -m hf-internal-testing/tiny-random-gpt2
+  //        --output tiny_gpt2_beamsearch_fp16.onnx --use_gpu --max_length 20
+  // (with separate_gpt2_decoder_for_init_run set to False as it is now set to True by default)
 
-//   auto model = Generators::CreateModel(Generators::GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto model = Generators::CreateModel(Generators::GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
 
-//   auto params = Generators::CreateGeneratorParams(*model);
-//   params->batch_size = static_cast<int>(input_ids_shape[0]);
-//   params->sequence_length = static_cast<int>(input_ids_shape[1]);
-//   params->input_ids = input_ids;
-//   params->search.max_length = 20;
-//   params->search.length_penalty = 1.0f;
-//   params->search.num_beams = 4;
+  auto params = Generators::CreateGeneratorParams(*model);
+  params->batch_size = static_cast<int>(input_ids_shape[0]);
+  params->sequence_length = static_cast<int>(input_ids_shape[1]);
+  params->input_ids = input_ids;
+  params->search.max_length = 20;
+  params->search.length_penalty = 1.0f;
+  params->search.num_beams = 4;
 
-//   Generators::BeamSearch_Cpu search{*params};
-//   auto state = model->CreateState(search.sequence_lengths_, *params);
+  auto generator = Generators::CreateGenerator(*model, *params);
+  auto result = Generators::Generate(*model, *params);
 
-//   while (!search.IsDone()) {
-//     search.SetLogits(state->Run(search.GetSequenceLength(), search.GetNextTokens(), search.GetNextIndices()));
+  // std::cout << "Expected output: " << tokenizer->Decode(expected_output) << "\r\n";
+  // std::cout << "Actual output: " << tokenizer->Decode(result[0]) << "\r\n";
 
-//     // Scoring
-//     search.ApplyMinLength(1);
-//     search.ApplyRepetitionPenalty(1.0f);
-
-//     search.SelectTop();
-//   }
-
-//   std::vector<int32_t> output_sequence(static_cast<size_t>(search.params_->batch_size) * search.params_->search.max_length);
-//   search.Finalize(1, Generators::cpu_span<int32_t>{output_sequence}, {});
-
-//   // Verify outputs match expected outputs
-//   for (size_t i = 0; i < static_cast<size_t>(search.params_->batch_size); i++) {
-//     auto sequence = std::span<int32_t>(output_sequence.data() + search.params_->search.max_length * i, search.params_->search.max_length);
-//     auto* expected_output_start = &expected_output[i * search.params_->search.max_length];
-//     EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence.data(), params->search.max_length * sizeof(int32_t)));
-//   }
-// }
+  // Verify outputs match expected outputs
+  for (int i = 0; i < params->batch_size; i++) {
+    auto sequence = std::span<int32_t>(result[i].data(), params->search.max_length);
+    auto* expected_output_start = &expected_output[i * params->search.max_length];
+    EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence.data(), params->search.max_length * sizeof(int32_t)));
+  }
+}
 #endif
 
 #if USE_CUDA
@@ -147,59 +137,50 @@ TEST(ModelTests, GreedySearchGptCuda) {
     Test_GreedySearch_Gpt_Cuda(model_path.first, model_path.second);
 }
 
-// void Test_BeamSearch_Gpt_Cuda(const char* model_path, const char* model_label) {
-//   std::vector<int64_t> input_ids_shape{3, 12};
-//   std::vector<int32_t> input_ids{
-//       0, 0, 0, 0, 0, 52, 195, 731, 321, 301, 734, 620,
-//       41, 554, 74, 622, 206, 222, 75, 223, 221, 198, 224, 572,
-//       0, 0, 0, 52, 328, 219, 328, 206, 288, 227, 896, 328};
+void Test_BeamSearch_Gpt_Cuda(const char* model_path, const char* model_label) {
+  std::vector<int64_t> input_ids_shape{3, 12};
+  std::vector<int32_t> input_ids{
+      0, 0, 0, 0, 0, 52, 195, 731, 321, 301, 734, 620,
+      41, 554, 74, 622, 206, 222, 75, 223, 221, 198, 224, 572,
+      0, 0, 0, 52, 328, 219, 328, 206, 288, 227, 896, 328};
 
-//   std::vector<int32_t> expected_output{
-//       0, 0, 0, 0, 0, 52, 195, 731, 321, 301, 734, 620, 131, 131, 131, 181, 638, 638, 638, 638,
-//       41, 554, 74, 622, 206, 222, 75, 223, 221, 198, 224, 572, 292, 292, 292, 292, 292, 292, 292, 292,
-//       0, 0, 0, 52, 328, 219, 328, 206, 288, 227, 896, 328, 328, 669, 669, 669, 669, 669, 669, 669};
+  std::vector<int32_t> expected_output{
+      0, 0, 0, 0, 0, 52, 195, 731, 321, 301, 734, 620, 131, 131, 131, 181, 638, 638, 638, 638,
+      41, 554, 74, 622, 206, 222, 75, 223, 221, 198, 224, 572, 292, 292, 292, 292, 292, 292, 292, 292,
+      0, 0, 0, 52, 328, 219, 328, 206, 288, 227, 896, 328, 328, 669, 669, 669, 669, 669, 669, 669};
 
-//   // The ONNX model is generated like the following:
-//   // python convert_generation.py --model_type gpt2 -m hf-internal-testing/tiny-random-gpt2
-//   //        --output tiny_gpt2_beamsearch_fp16.onnx --use_gpu --max_length 20
-//   // (with separate_gpt2_decoder_for_init_run set to False as it is now set to True by default)
-//   auto model = Generators::CreateModel(Generators::GetOrtEnv(), model_path);
+  // The ONNX model is generated like the following:
+  // python convert_generation.py --model_type gpt2 -m hf-internal-testing/tiny-random-gpt2
+  //        --output tiny_gpt2_beamsearch_fp16.onnx --use_gpu --max_length 20
+  // (with separate_gpt2_decoder_for_init_run set to False as it is now set to True by default)
+  auto model = Generators::CreateModel(Generators::GetOrtEnv(), model_path);
 
-//   auto params = Generators::CreateGeneratorParams(*model);
-//   params->batch_size = static_cast<int>(input_ids_shape[0]);
-//   params->sequence_length = static_cast<int>(input_ids_shape[1]);
-//   params->input_ids = input_ids;
-//   params->search.max_length = 20;
-//   params->search.num_beams = 4;
-//   params->search.length_penalty = 1.0f;
+  auto params = Generators::CreateGeneratorParams(*model);
+  params->batch_size = static_cast<int>(input_ids_shape[0]);
+  params->sequence_length = static_cast<int>(input_ids_shape[1]);
+  params->input_ids = input_ids;
+  params->search.max_length = 20;
+  params->search.num_beams = 4;
+  params->search.length_penalty = 1.0f;
 
-//   auto generator = Generators::CreateGenerator(*model, *params);
+  auto generator = Generators::CreateGenerator(*model, *params);
+  auto result = Generators::Generate(*model, *params);
 
-//   while (!generator->IsDone()) {
-//     generator->ComputeLogits();
-//     generator->GenerateNextToken();
-//   }
+  // std::cout << "Expected output: " << tokenizer->Decode(expected_output) << "\r\n";
+  // std::cout << "Actual output: " << tokenizer->Decode(result[0]) << "\r\n";
 
-//   size_t sequence_length = params->batch_size * params->search.max_length;
-//   auto output_sequence_cuda = Generators::CudaMallocArray<int32_t>(sequence_length);
-//   auto output_sequence_cpu = std::make_unique<int32_t[]>(sequence_length);
+  // Verify outputs match expected outputs
+  for (int i = 0; i < params->batch_size; i++) {
+    auto sequence = std::span<int32_t>(result[i].data(), params->search.max_length);
+    auto* expected_output_start = &expected_output[i * params->search.max_length];
+    EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence.data(), params->search.max_length * sizeof(int32_t)));
+  }
+}
 
-//   generator->search_->Finalize(1, Generators::gpu_span<int32_t>(output_sequence_cuda.get(), sequence_length), {});
-//   cudaMemcpyAsync(output_sequence_cpu.get(), output_sequence_cuda.get(), sequence_length * sizeof(int32_t), cudaMemcpyDeviceToHost, params->cuda_stream);
-//   cudaStreamSynchronize(params->cuda_stream);
-
-//   // Verify outputs match expected outputs
-//   for (int i = 0; i < params->batch_size; i++) {
-//     auto sequence = std::span<int32_t>(output_sequence_cpu.get() + params->search.max_length * i, params->search.max_length);
-//     auto* expected_output_start = &expected_output[i * params->search.max_length];
-//     EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence.data(), params->search.max_length * sizeof(int32_t)));
-//   }
-// }
-
-// TEST(ModelTests, BeamSearchGptCuda) {
-//   for (auto model_path : c_tiny_gpt2_model_paths)
-//     Test_BeamSearch_Gpt_Cuda(model_path.first, model_path.second);
-// }
+TEST(ModelTests, BeamSearchGptCuda) {
+  for (auto model_path : c_tiny_gpt2_model_paths)
+    Test_BeamSearch_Gpt_Cuda(model_path.first, model_path.second);
+}
 
 TEST(ModelTests, TestApiCuda) {
 #if TEST_PHI2

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -164,8 +164,6 @@ void Test_BeamSearch_Gpt_Cuda(const char* model_path, const char* model_label) {
   auto generator = Generators::CreateGenerator(*model, *params);
   auto result = Generators::Generate(*model, *params);
 
-  // std::cout << "Expected output: " << tokenizer->Decode(expected_output) << "\r\n";
-  // std::cout << "Actual output: " << tokenizer->Decode(result[0]) << "\r\n";
 
   // Verify outputs match expected outputs
   for (int i = 0; i < params->batch_size; i++) {

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -92,7 +92,7 @@ TEST(ModelTests, BeamSearchGptFp32) {
   // Verify outputs match expected outputs
   for (int i = 0; i < params->batch_size; i++) {
     auto sequence = std::span<int32_t>(result[i].data(), params->search.max_length);
-    auto* expected_output_start = &expected_output[i * params->search.max_length];
+    auto* expected_output_start = &expected_output[static_cast<size_t>(i) * params->search.max_length];
     EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence.data(), params->search.max_length * sizeof(int32_t)));
   }
 }
@@ -172,7 +172,7 @@ void Test_BeamSearch_Gpt_Cuda(const char* model_path, const char* model_label) {
   // Verify outputs match expected outputs
   for (int i = 0; i < params->batch_size; i++) {
     auto sequence = std::span<int32_t>(result[i].data(), params->search.max_length);
-    auto* expected_output_start = &expected_output[i * params->search.max_length];
+    auto* expected_output_start = &expected_output[static_cast<size_t>(i) * params->search.max_length];
     EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence.data(), params->search.max_length * sizeof(int32_t)));
   }
 }

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -86,8 +86,6 @@ TEST(ModelTests, BeamSearchGptFp32) {
   auto generator = Generators::CreateGenerator(*model, *params);
   auto result = Generators::Generate(*model, *params);
 
-  // std::cout << "Expected output: " << tokenizer->Decode(expected_output) << "\r\n";
-  // std::cout << "Actual output: " << tokenizer->Decode(result[0]) << "\r\n";
 
   // Verify outputs match expected outputs
   for (int i = 0; i < params->batch_size; i++) {


### PR DESCRIPTION
### Summary
Beam Search was hanging and not outputting correct results. Furthermore, it did not fit into our API design. This PR addresses the correctness and API problems with Beam search. We plan to improve both CPU and CUDA performance and memory efficiency in the near future.

### Issues Addressed
Here is a quick summary of the issues addressed by this PR... these apply to both CPU and CUDA implementations:
- No log-softmax normalization was performed before adding beam scores. This caused faulty outputs which did not match the ORT implementation.
- The `is_done` flag was not set or checked properly in the case of EOS token or `max_sequence_length`. This caused hanging, infinite looping, and memory buffer overflow. This sometimes gave the impression of bad performance, while in reality it was a correctness issue.
- `Finalize` was not called automatically. If a user didn't call it manually this could cause a floating point exception or other fault.
- There was no easy way to get output from Beam Search. `Finalize` was clunky and unintuitive as it didn't fit with our API.
- Our testing file was not up to date with our latest APIs.


### API Changes
Given the issues with `Finalize`, this PR introduces an update to the way Beam Search fits into our API. The user no longer has to manually call `Finalize` in order to access the Beam Search results. These are returned automatically by the `Generate()` function and can be accessed using batch beam indexing.