### PR TITLE
Add Phi-3 small on CPU in model builder

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -2344,7 +2344,7 @@ class Phi3Small8KModel(Model):
 
         # Make input MatMul and Add nodes
         up_matmul_name = f"/model/layers.{layer_id}/mlp/up_proj/MatMul"
-        self.make_matmul(mlp.up_proj.weight.detach().numpy(), up_matmul_name, root_input)
+        self.make_matmul(mlp.up_proj, up_matmul_name, root_input)
         up_add_name = f"/model/layers.{layer_id}/mlp/up_proj/Add"
         self.make_add_bias(mlp.up_proj.bias.detach().numpy(), up_add_name, f"{up_matmul_name}/output_0")
 
@@ -2390,7 +2390,7 @@ class Phi3Small8KModel(Model):
 
         # Make output MatMul and Add nodes
         down_matmul_name = f"/model/layers.{layer_id}/mlp/down_proj/MatMul"
-        self.make_matmul(mlp.down_proj.weight.detach().numpy(), down_matmul_name, f"{mul_name}/output_0")
+        self.make_matmul(mlp.down_proj, down_matmul_name, f"{mul_name}/output_0")
         down_add_name = f"/model/layers.{layer_id}/mlp/down_proj/Add"
         self.make_add_bias(mlp.down_proj.bias.detach().numpy(), down_add_name, f"{down_matmul_name}/output_0")
 
@@ -2454,12 +2454,8 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
         elif config.architectures[0] == "Phi3ForCausalLM" and config.max_position_embeddings == 131072:
             onnx_model = Phi3Mini128KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Phi3SmallForCausalLM" and config.max_position_embeddings == 8192:
-            print("WARNING: This model only works for CUDA currently because `SparseAttention` is only supported for CUDA in ONNX Runtime. Setting `--execution_provider cuda` by default.")
-            execution_provider = "cuda"
             onnx_model = Phi3Small8KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Phi3SmallForCausalLM" and config.max_position_embeddings == 131072:
-            print("WARNING: This model only works for CUDA currently because `SparseAttention` is only supported for CUDA in ONNX Runtime. Setting `--execution_provider cuda` by default.")
-            execution_provider = "cuda"
             onnx_model = Phi3Small128KModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Phi3VForCausalLM":
             print("WARNING: This is only generating the text component of the model. Setting `--extra_options exclude_embeds=true` by default.")


### PR DESCRIPTION
### Description

This PR adds support for building Phi-3 small ONNX models for CPU in the model builder.

### Motivation and Context

Previously, the `SparseAttention` operator was only supported on CUDA in ONNX Runtime. With the [recent support](https://github.com/microsoft/onnxruntime/pull/21110) for `SparseAttention` on CPU, Phi-3 small ONNX models can now run on CPU. This PR also helps [this issue](https://github.com/microsoft/onnxruntime-genai/issues/519).

To use these changes, both ONNX Runtime and ONNX Runtime GenAI need to be [built from source](https://onnxruntime.ai/docs/genai/howto/build-from-source.html#option-3-build-from-source). Because the official PyTorch repo does not have a `tokenizer.json` file, the `tokenizer.json` file needed for Phi-3 small in ONNX Runtime GenAI can be downloaded from the Hugging Face repos. Please see [here](https://huggingface.co/microsoft/Phi-3-small-8k-instruct-onnx-cuda/blob/main/cuda-int4-rtn-block-32/tokenizer.json) for Phi-3 small 8K and [here](https://huggingface.co/microsoft/Phi-3-small-128k-instruct-onnx-cuda/blob/main/cuda-int4-rtn-block-32/tokenizer.json) for Phi-3 small 128K.