### PR TITLE
Add LLaMA 3.1 to model builder

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -201,7 +201,6 @@ class Model:
                     "low_freq_factor": low_freq_factor,
                     "high_freq_factor": high_freq_factor,
                 }
-                print(self.rotemb_attrs["rescale_inv_freq"])
 
         # Attention-specific variables (MHA, GQA, GQA + Rot.Emb., etc.)
         # Block-sparse attention-specific variables

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -197,9 +197,9 @@ class Model:
                 low_freq_factor = config.rope_scaling["low_freq_factor"] if "low_freq_factor" in config.rope_scaling else 0
                 high_freq_factor = config.rope_scaling["high_freq_factor"] if "high_freq_factor" in config.rope_scaling else 0
                 self.rotemb_attrs["rescale_inv_freq"] = {
-                    "factor": factor,
-                    "low_freq_factor": low_freq_factor,
-                    "high_freq_factor": high_freq_factor,
+                    "factor": factor,                            # Scale factor when calculating `new_freq` in rotary embeddings
+                    "low_freq_factor": low_freq_factor,          # Low freq factor when calculating `low_freq_wavelen` in rotary embeddings
+                    "high_freq_factor": high_freq_factor,        # High freq factor when calculating `high_freq_wavelen` in rotary embeddings
                 }
 
         # Attention-specific variables (MHA, GQA, GQA + Rot.Emb., etc.)


### PR DESCRIPTION
### Description

This PR adds [Meta's LLaMA 3.1](https://ai.meta.com/blog/meta-llama-3-1/) to the model builder. Here is an example command to get the ONNX model.

```bash
$ git clone https://github.com/microsoft/onnxruntime-genai
$ cd onnxruntime-genai/src/python/py/models
$ python3 builder.py -m meta-llama/Meta-Llama-3.1-8B-Instruct -o ./llama3.1_8b_instruct_fp16/ -p fp16 -e cuda -c ./cache/
```

### Motivation and Context

LLaMA 3.1 is the next generation of the LLaMA models. This PR also helps [this issue](https://github.com/microsoft/onnxruntime-genai/issues/721).