### PR TITLE
Only log when enabled to avoid unnecessary printing on stdout

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -36,6 +36,8 @@ void SetLogBool(std::string_view name, bool value) {
     g_log.model_output_values = value;
   else if (name == "model_logits")
     g_log.model_logits = value;
+  else if (name == "ort_lib")
+    g_log.ort_lib = value;
   else
     throw JSON::unknown_value_error{};
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -42,6 +42,7 @@ struct LogItems {
   bool model_output_shapes{};  // Before the model runs there are only the output shapes, no values in them. Useful for pre Session::Run debugging
   bool model_output_values{};  // After the model runs the output tensor values can be displayed
   bool model_logits{};         // Same as model_output_values but only for the logits
+  bool ort_lib{};              // Log the onnxruntime library loading and api calls.
 };
 
 extern LogItems g_log;

--- a/src/models/env_utils.cpp
+++ b/src/models/env_utils.cpp
@@ -3,6 +3,8 @@
 
 #include "env_utils.h"
 
+#include <stdexcept>
+
 #if _MSC_VER
 #include <Windows.h>
 #endif
@@ -31,11 +33,25 @@ std::string GetEnvironmentVariable(const char* var_name) {
     return buffer;
   }
 
-  return std::string();
+  return {};
 #else
   const char* val = getenv(var_name);
   return val == nullptr ? "" : std::string(val);
 #endif  // _MSC_VER
+}
+
+void GetEnvironmentVariable(const char* var_name, bool& value) {
+  std::string str_value = GetEnvironmentVariable(var_name);
+  if (str_value == "1" || str_value == "true") {
+    value = true;
+  } else if (str_value == "0" || str_value == "false") {
+    value = false;
+  } else if (!str_value.empty()) {
+    throw std::invalid_argument("Invalid value for environment variable " + std::string(var_name) + ": " + str_value +
+                                ". Expected '1' or 'true' for true, '0' or 'false' for false.");
+  }
+
+  // Otherwise, value will not be modified.
 }
 
 }  // namespace Generators

--- a/src/models/env_utils.cpp
+++ b/src/models/env_utils.cpp
@@ -3,9 +3,13 @@
 
 #include "env_utils.h"
 
+#if _MSC_VER
+#include <Windows.h>
+#endif
+
 namespace Generators {
 
-std::string GetEnvironmentVariable(const char* var) {
+std::string GetEnvironmentVariable(const char* var_name) {
 #if _MSC_VER
   // Why getenv() should be avoided on Windows:
   // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/getenv-wgetenv
@@ -20,7 +24,7 @@ std::string GetEnvironmentVariable(const char* var) {
   // The last argument is the size of the buffer pointed to by the lpBuffer parameter, including the null-terminating character, in characters.
   // If the function succeeds, the return value is the number of characters stored in the buffer pointed to by lpBuffer, not including the terminating null character.
   // Therefore, If the function succeeds, kBufferSize should be larger than char_count.
-  auto char_count = GetEnvironmentVariableA(var_name.c_str(), buffer.data(), kBufferSize);
+  auto char_count = ::GetEnvironmentVariableA(var_name, buffer.data(), kBufferSize);
 
   if (kBufferSize > char_count) {
     buffer.resize(char_count);
@@ -29,7 +33,7 @@ std::string GetEnvironmentVariable(const char* var) {
 
   return std::string();
 #else
-  const char* val = getenv(var);
+  const char* val = getenv(var_name);
   return val == nullptr ? "" : std::string(val);
 #endif  // _MSC_VER
 }

--- a/src/models/env_utils.cpp
+++ b/src/models/env_utils.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "env_utils.h"
+
+namespace Generators {
+
+std::string GetEnvironmentVariable(const char* var) {
+#if _MSC_VER
+  // Why getenv() should be avoided on Windows:
+  // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/getenv-wgetenv
+  // Instead use the Win32 API: GetEnvironmentVariableA()
+
+  // Max limit of an environment variable on Windows including the null-terminating character
+  constexpr DWORD kBufferSize = 32767;
+
+  // Create buffer to hold the result
+  std::string buffer(kBufferSize, '\0');
+
+  // The last argument is the size of the buffer pointed to by the lpBuffer parameter, including the null-terminating character, in characters.
+  // If the function succeeds, the return value is the number of characters stored in the buffer pointed to by lpBuffer, not including the terminating null character.
+  // Therefore, If the function succeeds, kBufferSize should be larger than char_count.
+  auto char_count = GetEnvironmentVariableA(var_name.c_str(), buffer.data(), kBufferSize);
+
+  if (kBufferSize > char_count) {
+    buffer.resize(char_count);
+    return buffer;
+  }
+
+  return std::string();
+#else
+  const char* val = getenv(var);
+  return val == nullptr ? "" : std::string(val);
+#endif  // _MSC_VER
+}
+
+}  // namespace Generators

--- a/src/models/env_utils.h
+++ b/src/models/env_utils.h
@@ -5,6 +5,6 @@
 
 namespace Generators {
 
-std::string GetEnvironmentVariable(const char* var);
+std::string GetEnvironmentVariable(const char* var_name);
 
 }

--- a/src/models/env_utils.h
+++ b/src/models/env_utils.h
@@ -7,4 +7,9 @@ namespace Generators {
 
 std::string GetEnvironmentVariable(const char* var_name);
 
-}
+// This overload is used to get boolean environment variables.
+// If the environment variable is set to "1" or "true" (case-sensitive), value will be set to true.
+// Otherwise, value will not be modified.
+void GetEnvironmentVariable(const char* var_name, bool& value);
+
+}  // namespace Generators

--- a/src/models/env_utils.h
+++ b/src/models/env_utils.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <string>
+
+namespace Generators {
+
+std::string GetEnvironmentVariable(const char* var);
+
+}

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -179,8 +179,9 @@ inline void InitApi() {
     return;
   }
 
-  const std::string ort_lib = Generators::GetEnvironmentVariable("ORTGENAI_LOG_ORT_LIB");
-  if (ort_lib == "1" || ort_lib == "true") {
+  bool ort_lib = false;
+  Generators::GetEnvironmentVariable("ORTGENAI_LOG_ORT_LIB", ort_lib);
+  if (ort_lib) {
     Generators::SetLogBool("enabled", true);
     Generators::SetLogBool("ort_lib", true);
   }

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -178,6 +178,13 @@ inline void InitApi() {
     return;
   }
 
+  char* ort_lib;
+  ort_lib = std::getenv("ORTGENAI_LOG_ORT_LIB");
+  if (ort_lib != nullptr && (std::string(ort_lib) == "1" || std::string(ort_lib) == "true")) {
+    Generators::SetLogBool("enabled", true);
+    Generators::SetLogBool("ort_lib", true);
+  }
+
 #if defined(__linux__)
   // If the GenAI library links against the onnxruntime library, it will have a dependency on a specific
   // version of OrtGetApiBase.

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -93,11 +93,14 @@ p_session_->Run(nullptr, input_names, inputs, std::size(inputs), output_names, o
 #define PATH_MAX (4096)
 #endif
 
-#define LOG_DEBUG(...) Generators::Log("debug", __VA_ARGS__)
-#define LOG_INFO(...) Generators::Log("info", __VA_ARGS__)
-#define LOG_WARN(...) Generators::Log("warning", __VA_ARGS__)
-#define LOG_ERROR(...) Generators::Log("error", __VA_ARGS__)
-#define LOG_FATAL(...) Generators::Log("fatal", __VA_ARGS__)
+#define LOG_WHEN_ENABLED(LOG_FUNC) \
+  if (Generators::g_log.enabled && Generators::g_log.ort_lib) LOG_FUNC
+
+#define LOG_DEBUG(...) LOG_WHEN_ENABLED(Generators::Log("debug", __VA_ARGS__))
+#define LOG_INFO(...) LOG_WHEN_ENABLED(Generators::Log("info", __VA_ARGS__))
+#define LOG_WARN(...) LOG_WHEN_ENABLED(Generators::Log("warning", __VA_ARGS__))
+#define LOG_ERROR(...) LOG_WHEN_ENABLED(Generators::Log("error", __VA_ARGS__))
+#define LOG_FATAL(...) LOG_WHEN_ENABLED(Generators::Log("fatal", __VA_ARGS__))
 
 #endif
 

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -73,6 +73,7 @@ p_session_->Run(nullptr, input_names, inputs, std::size(inputs), output_names, o
 #include "onnxruntime_c_api.h"
 #include "../span.h"
 #include "../logging.h"
+#include "env_utils.h"
 
 #if defined(__ANDROID__)
 #include <android/log.h>
@@ -178,9 +179,8 @@ inline void InitApi() {
     return;
   }
 
-  char* ort_lib;
-  ort_lib = std::getenv("ORTGENAI_LOG_ORT_LIB");
-  if (ort_lib != nullptr && (std::string(ort_lib) == "1" || std::string(ort_lib) == "true")) {
+  const std::string ort_lib = Generators::GetEnvironmentVariable("ORTGENAI_LOG_ORT_LIB");
+  if (ort_lib == "1" || ort_lib == "true") {
     Generators::SetLogBool("enabled", true);
     Generators::SetLogBool("ort_lib", true);
   }


### PR DESCRIPTION
#724 logs when loading the ort lib. The log can create problems if the logging is not enabled (in particular [this line](https://github.com/microsoft/onnxruntime-genai/blob/32378d96cbb7e921e0d986e5e1a56f086c32fe96/src/logging.cpp#L82)) in debug builds. And it also prints to console unnecessary information.

Changing the behavior in this PR.