### PR TITLE
Adds OgaAppendTokenSequence function

### DIFF
--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -103,9 +103,18 @@ struct OgaSequences : OgaAbstract {
     return OgaSequencesGetSequenceData(this, index);
   }
 
+  void Append(const int32_t* tokens, uint32_t token_cnt) {
+    OgaCheckResult(OgaAppendTokenSequence(tokens, token_cnt, this));
+  }
 #if __cplusplus >= 202002L
   std::span<const int32_t> Get(size_t index) const {
     return {SequenceData(index), SequenceCount(index)};
+  }
+  void Append(const std::span<const int32_t>& sequence) {
+    OgaCheckResult(OgaAppendTokenSequence(sequence.data(), sequence.size(), this));
+  }
+  void Append(const std::vector<const int32_t>& sequence) {
+    OgaCheckResult(OgaAppendTokenSequence(sequence.data(), sequence.size(), this));
   }
 #endif
 

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -103,7 +103,7 @@ struct OgaSequences : OgaAbstract {
     return OgaSequencesGetSequenceData(this, index);
   }
 
-  void Append(const int32_t* tokens, uint32_t token_cnt) {
+  void Append(const int32_t* tokens, size_t token_cnt) {
     OgaCheckResult(OgaAppendTokenSequence(tokens, token_cnt, this));
   }
 #if __cplusplus >= 202002L

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -113,7 +113,7 @@ struct OgaSequences : OgaAbstract {
   void Append(const std::span<const int32_t>& sequence) {
     OgaCheckResult(OgaAppendTokenSequence(sequence.data(), sequence.size(), this));
   }
-  void Append(const std::vector<const int32_t>& sequence) {
+  void Append(const std::vector<int32_t>& sequence) {
     OgaCheckResult(OgaAppendTokenSequence(sequence.data(), sequence.size(), this));
   }
 #endif

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -58,12 +58,12 @@ OgaResult* OGA_API_CALL OgaCreateSequences(OgaSequences** out) {
   OGA_CATCH
 }
 
-OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t * token_ptr, int32_t token_cnt, OgaSequences* sequence) {
+OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t * token_ptr, uint32_t token_cnt, OgaSequences* sequence) {
   OGA_TRY
   Generators::TokenSequences* toks = reinterpret_cast<Generators::TokenSequences*>(sequence);
   std::vector<int32_t> tmp(token_cnt);
   for (size_t i = 0; i < token_cnt; i++) {
-    tmp[i] = (token_ptr[i]);
+    tmp[i] = token_ptr[i];
   }
   toks->emplace_back(std::move(tmp));
   return nullptr;

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -58,6 +58,18 @@ OgaResult* OGA_API_CALL OgaCreateSequences(OgaSequences** out) {
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t * token_ptr, int32_t token_cnt, OgaSequences* sequence) {
+  OGA_TRY
+  Generators::TokenSequences* toks = reinterpret_cast<Generators::TokenSequences*>(sequence);
+  std::vector<int32_t> tmp(token_cnt);
+  for (size_t i = 0; i < token_cnt; i++) {
+    tmp[i] = (token_ptr[i]);
+  }
+  toks->emplace_back(std::move(tmp));
+  return nullptr;
+  OGA_CATCH
+}
+
 size_t OGA_API_CALL OgaSequencesCount(const OgaSequences* p) {
   return reinterpret_cast<const Generators::TokenSequences*>(p)->size();
 }

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -58,7 +58,7 @@ OgaResult* OGA_API_CALL OgaCreateSequences(OgaSequences** out) {
   OGA_CATCH
 }
 
-OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t * token_ptr, size_t token_cnt, OgaSequences* sequence) {
+OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t* token_ptr, size_t token_cnt, OgaSequences* sequence) {
   OGA_TRY
   Generators::TokenSequences* toks = reinterpret_cast<Generators::TokenSequences*>(sequence);
   std::vector<int32_t> tmp(token_cnt);

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -58,7 +58,7 @@ OgaResult* OGA_API_CALL OgaCreateSequences(OgaSequences** out) {
   OGA_CATCH
 }
 
-OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t * token_ptr, uint32_t token_cnt, OgaSequences* sequence) {
+OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t * token_ptr, size_t token_cnt, OgaSequences* sequence) {
   OGA_TRY
   Generators::TokenSequences* toks = reinterpret_cast<Generators::TokenSequences*>(sequence);
   std::vector<int32_t> tmp(token_cnt);

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -101,7 +101,7 @@ OGA_EXPORT size_t OGA_API_CALL OgaSequencesCount(const OgaSequences* sequences);
 
 /*
  * \brief Appends token_cnt number of tokens from token_ptr to sequence
- * \param[in] token_ptr constant pointer to int32 tokens 
+ * \param[in] token_ptr constant pointer to int32 tokens
  * \param[in] token_cnt number of tokens to read from token_ptr
  * \param[in] sequences OgaSequences object to append the tokens to
  * \return OgaResult containing the error message when tokens could not been added, else nullptr.

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -100,6 +100,15 @@ OGA_EXPORT void OGA_API_CALL OgaDestroySequences(OgaSequences* sequences);
 OGA_EXPORT size_t OGA_API_CALL OgaSequencesCount(const OgaSequences* sequences);
 
 /*
+ * \brief Appends token_cnt number of tokens from token_ptr to sequence
+ * \param[in] token_ptr constant pointer to int32 tokens 
+ * \param[in] token_cnt number of tokens to read from token_ptr
+ * \param[in] sequences OgaSequences object to append the tokens to
+ * \return OgaResult containing the error message when tokens could not been added, else nullptr.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t* token_ptr, int32_t token_cnt, OgaSequences* sequence);
+
+/*
  * \brief Returns the number of tokens in the sequence at the given index
  * \param[in] sequences
  * \return The number of tokens in the sequence at the given index

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -106,7 +106,7 @@ OGA_EXPORT size_t OGA_API_CALL OgaSequencesCount(const OgaSequences* sequences);
  * \param[in] sequences OgaSequences object to append the tokens to
  * \return OgaResult containing the error message when tokens could not been added, else nullptr.
  */
-OGA_EXPORT OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t* token_ptr, int32_t token_cnt, OgaSequences* sequence);
+OGA_EXPORT OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t* token_ptr, uint32_t token_cnt, OgaSequences* sequence);
 
 /*
  * \brief Returns the number of tokens in the sequence at the given index

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -106,7 +106,7 @@ OGA_EXPORT size_t OGA_API_CALL OgaSequencesCount(const OgaSequences* sequences);
  * \param[in] sequences OgaSequences object to append the tokens to
  * \return OgaResult containing the error message when tokens could not been added, else nullptr.
  */
-OGA_EXPORT OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t* token_ptr, uint32_t token_cnt, OgaSequences* sequence);
+OGA_EXPORT OgaResult* OGA_API_CALL OgaAppendTokenSequence(const int32_t* token_ptr, size_t token_cnt, OgaSequences* sequence);
 
 /*
  * \brief Returns the number of tokens in the sequence at the given index

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -84,27 +84,19 @@ TEST(CAPITests, AppendTokensToSequence) {
   // Basically create a copy
   for (size_t i = 0; i < sequences->Count(); i++) {
     std::span<const int32_t> sequence = sequences->Get(i);
-    appended_sequences->append(sequence.data(), sequence.size());
+    appended_sequences->Append(sequence.data(), sequence.size());
   }
   // All sequences should be copied
-  if (appended_sequences->Count() != sequences->Count()) {
-    throw std::runtime_error("Appending Token sequence failed!");
-  }
+  EXPECT_EQ(appended_sequences->Count() != sequences->Count());
 
   // Compare each token in each sequence
   for (int i = 0; i< sequences->Count(); i++) {
     std::span<const int32_t> sequence = sequences->Get(i);
     std::span<const int32_t> appended_sequence = appended_sequences->Get(i);
-
-    if (sequence.size() != appended_sequence.size()) {
-      throw std::runtime_error("Appended token count mismatch!");
-    }
-
+    EXPECT_EQ(sequence.size(), appended_sequence.size());
     
     for (int j = 0; j < sequence.size(); j++) {
-      if(sequence[j] != appended_sequence[j]) {
-        throw std::runtime_error("Appended token mismatch!");
-      }
+      EXPECT_EQ(sequence[j], appended_sequence[j])
     }
   }
 #endif

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -60,6 +60,56 @@ TEST(CAPITests, TokenizerCAPI) {
 #endif
 }
 
+TEST(CAPITests, AppendTokensToSequence) {
+  #if TEST_PHI2
+  auto model = OgaModel::Create(MODEL_PATH "phi-2");
+  auto tokenizer = OgaTokenizer::Create(*model);
+
+  const char* input_strings[] = {
+      "This is a test.",
+      "Rats are awesome pets!",
+      "The quick brown fox jumps over the lazy dog.",
+  };
+
+  auto sequences = OgaSequences::Create();
+  auto appended_sequences = OgaSequences::Create();
+
+  // Encode all strings
+  {
+    for (auto& string : input_strings)
+      tokenizer->Encode(string, *sequences);
+  }
+
+  // Append token sequence to another sequence
+  // Basically create a copy
+  for (size_t i = 0; i < sequences->Count(); i++) {
+    std::span<const int32_t> sequence = sequences->Get(i);
+    appended_sequences->append(sequence.data(), sequence.size());
+  }
+  // All sequences should be copied
+  if(appended_sequences->Count() != sequences->Count()) {
+    throw std::runtime_error("Appending Token sequence failed!");
+  }
+
+  // Compare each token in each sequence
+  for {int i = 0; i< sequences->Count();i++} {
+    std::span<const int32_t> sequence = sequences->Get(i);
+    std::span<const int32_t> appended_sequence = appended_sequences->Get(i);
+
+    if(sequence.size() != appended_sequence.size()) {
+      throw std::runtime_error("Appended token count mismatch!");
+    }
+
+    
+    for {int j = 0; j < sequence.size();j++} {
+      if(sequence[j] != appended_sequence[j]) {
+        throw std::runtime_error("Appended token mismatch!");
+      }
+    }
+  }
+#endifdc
+}
+
 TEST(CAPITests, EndToEndPhiBatch) {
 #if TEST_PHI2
   auto model = OgaModel::Create(MODEL_PATH "phi-2");

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -87,21 +87,21 @@ TEST(CAPITests, AppendTokensToSequence) {
     appended_sequences->append(sequence.data(), sequence.size());
   }
   // All sequences should be copied
-  if(appended_sequences->Count() != sequences->Count()) {
+  if (appended_sequences->Count() != sequences->Count()) {
     throw std::runtime_error("Appending Token sequence failed!");
   }
 
   // Compare each token in each sequence
-  for {int i = 0; i< sequences->Count();i++} {
+  for (int i = 0; i< sequences->Count(); i++) {
     std::span<const int32_t> sequence = sequences->Get(i);
     std::span<const int32_t> appended_sequence = appended_sequences->Get(i);
 
-    if(sequence.size() != appended_sequence.size()) {
+    if (sequence.size() != appended_sequence.size()) {
       throw std::runtime_error("Appended token count mismatch!");
     }
 
     
-    for {int j = 0; j < sequence.size();j++} {
+    for (int j = 0; j < sequence.size(); j++) {
       if(sequence[j] != appended_sequence[j]) {
         throw std::runtime_error("Appended token mismatch!");
       }

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -107,7 +107,7 @@ TEST(CAPITests, AppendTokensToSequence) {
       }
     }
   }
-#endifdc
+#endif
 }
 
 TEST(CAPITests, EndToEndPhiBatch) {


### PR DESCRIPTION
Adding a function to the C API that allows the developer to add a custom token sequence into a OgaSeqence. 

There is no option currently to add tokens to the OgaSequences because the `std::vector` is hidden from the developer.