### PR TITLE
Add onnxruntime dependency version to setup.py

### DIFF
--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -119,6 +119,7 @@ steps:
       --rm \
       --volume $(Build.Repository.LocalPath):/ort_genai_src \
       -w /ort_genai_src/ ortgenai$(ep)build$(arch) \
+      -e ONNXRUNTIME_VERSION=$(ONNXRUNTIME_VERSION) \
       bash -c " \
           /usr/bin/cmake --preset linux_gcc_$(ep)_$(build_config) \
             -DENABLE_TESTS=OFF \
@@ -141,6 +142,7 @@ steps:
       --rm \
       --volume $(Build.Repository.LocalPath):/ort_genai_src \
       -w /ort_genai_src/ ortgenai$(ep)build$(arch) \
+      -e ONNXRUNTIME_VERSION=$(ONNXRUNTIME_VERSION) \
       bash -c " \
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_$(build_config) \
             -DENABLE_TESTS=OFF \

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages
 from setuptools.dist import Distribution
 import sys
+import os
 from os import path
 
 if sys.version_info < (3, 0):
@@ -24,18 +25,25 @@ package_name = '@TARGET_NAME@'
 
 def _onnxruntime_dependency() -> str:
     dependency = None
+    ort_version = os.environ.get("ONNXRUNTIME_VERSION", "")
+    is_nightly = True if "dev" in ort_version else False
+
     if package_name == "onnxruntime-genai":
-        dependency = "onnxruntime"
+        dependency = "onnxruntime" if not is_nightly else "ort-nightly"
+
+        import platform
+        if platform.machine() == "ARM64":
+            dependency = "onnxruntime-qnn" if not is_nightly else "ort-nightly-qnn"
     elif package_name == "onnxruntime-genai-cuda":
-        dependency = "onnxruntime-gpu"
+        dependency = "onnxruntime-gpu" if not is_nightly else "ort-nightly-gpu"
     elif package_name == "onnxruntime-genai-directml":
-        dependency = "onnxruntime-directml"
+        dependency = "onnxruntime-directml" if not is_nightly else "ort_nightly-directml"
     elif package_name == "onnxruntime-genai-rocm":
-        dependency = "onnxruntime-rocm"
+        dependency = "onnxruntime-rocm" if not is_nightly else "ort-nightly-rocm"
     else:
         raise ValueError(f'Unable to determine the onnxruntime dependency for {package_name}.')
 
-    return dependency
+    return dependency if not ort_version else dependency + ">=" + ort_version
 
 
 setup(
@@ -48,8 +56,8 @@ setup(
     include_package_data=True,
     package_data={'': ['*.pyd', '*.dll', '*.so*'] + extras},
     install_requires=[
-        'numpy<2',
-        # _onnxruntime_dependency(), # Uncomment this when the onnxruntime stable release contains the ort shared lib
+        'numpy>=1.21.6',
+        _onnxruntime_dependency(),
     ],
     distclass=BinaryDistribution,
     author="Microsoft Corporation",

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -25,14 +25,16 @@ package_name = '@TARGET_NAME@'
 
 def _onnxruntime_dependency() -> str:
     dependency = None
-    ort_version = os.environ.get("ONNXRUNTIME_VERSION", "")
+    # Use dev version as default since CI tests use nightly version for testing
+    ort_version = os.environ.get("ONNXRUNTIME_VERSION", "1.19.0.dev20240805002")
     is_nightly = True if "dev" in ort_version else False
 
     if package_name == "onnxruntime-genai":
         dependency = "onnxruntime" if not is_nightly else "ort-nightly"
 
         import platform
-        if platform.machine() == "ARM64":
+        # win arm64 whls are only available in onnxruntime-qnn
+        if platform.machine() == "ARM64" and sys.platform.startswith("win"):
             dependency = "onnxruntime-qnn" if not is_nightly else "ort-nightly-qnn"
     elif package_name == "onnxruntime-genai-cuda":
         dependency = "onnxruntime-gpu" if not is_nightly else "ort-nightly-gpu"

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -39,7 +39,7 @@ def _onnxruntime_dependency() -> str:
     elif package_name == "onnxruntime-genai-cuda":
         dependency = "onnxruntime-gpu" if not is_nightly else "ort-nightly-gpu"
     elif package_name == "onnxruntime-genai-directml":
-        dependency = "onnxruntime-directml" if not is_nightly else "ort_nightly-directml"
+        dependency = "onnxruntime-directml" if not is_nightly else "ort-nightly-directml"
     elif package_name == "onnxruntime-genai-rocm":
         dependency = "onnxruntime-rocm" if not is_nightly else "ort-nightly-rocm"
     else:


### PR DESCRIPTION
This pull request adds the onnxruntime python package as a dependency of the onnxruntime-genai python package.

When one tries to install onnxruntime-genai, the corresponding onnxruntime python package is auto installed.

Mapping of onnxruntime-genai stable package to onnxruntime packages.

```json
"onnxruntime-genai": "onnxruntime"
"onnxruntime-genai-cuda": "onnxruntime-gpu"
"onnxruntime-genai-directml": "onnxruntime-directml"
"onnxruntime-genai <win arm64>": "onnxruntime-qnn"
```

Mapping of onnxruntime-genai dev (aka nightly) package to onnxruntime packages.

```json
"onnxruntime-genai": "ort-nightly"
"onnxruntime-genai-cuda": "ort-nightly-gpu"
"onnxruntime-genai-directml": "ort-nightly-directml"
"onnxruntime-genai <win arm64>": "ort-nightly-qnn"
```

By default, the nightly dependency version is used. If the `ONNXRUNTIME_VERSION` env variable is set, the default version can be overridden.

This pull request also changes the numpy dependency to be >= 1.21.6 (same as ort)