### PR TITLE
Fix python packaging pipeline

### DIFF
--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -122,8 +122,9 @@ steps:
       docker run \
       --rm \
       --volume $(Build.Repository.LocalPath):/ort_genai_src \
-      -w /ort_genai_src/ ortgenai$(ep)build$(arch) \
+      -w /ort_genai_src/ \
       -e ONNXRUNTIME_VERSION=$(ONNXRUNTIME_VERSION) \
+      ortgenai$(ep)build$(arch) \
       bash -c " \
           /usr/bin/cmake --preset linux_gcc_$(ep)_$(build_config) \
             -DENABLE_TESTS=OFF \
@@ -145,8 +146,9 @@ steps:
       docker run \
       --rm \
       --volume $(Build.Repository.LocalPath):/ort_genai_src \
-      -w /ort_genai_src/ ortgenai$(ep)build$(arch) \
+      -w /ort_genai_src/ \
       -e ONNXRUNTIME_VERSION=$(ONNXRUNTIME_VERSION) \
+      ortgenai$(ep)build$(arch) \
       bash -c " \
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_$(build_config) \
             -DENABLE_TESTS=OFF \


### PR DESCRIPTION
The packaging pipeline fails because the docker run command has the image before the env option.

This PR fixes that.