### PR TITLE
Fix Linux CUDA NuGet package validation

### DIFF
--- a/.pipelines/stages/jobs/nuget-validation-job.yml
+++ b/.pipelines/stages/jobs/nuget-validation-job.yml
@@ -189,7 +189,7 @@ jobs:
             bash -c " \
                 export ORTGENAI_LOG_ORT_LIB=1 && \
                 cd /ort_genai_src/examples/csharp/HelloPhi && \
-                chmod +x ./bin/Release_Cuda/net6.0/linux-x64/HelloPhi
+                chmod +x ./bin/Release_Cuda/net6.0/linux-x64/HelloPhi && \
                 ./bin/Release_Cuda/net6.0/linux-x64/HelloPhi -m ./models/phi-3"
 
         displayName: 'Run Example With Artifact'

--- a/.pipelines/stages/jobs/nuget-validation-job.yml
+++ b/.pipelines/stages/jobs/nuget-validation-job.yml
@@ -188,7 +188,6 @@ jobs:
             -w /ort_genai_src/ $(cuda_docker_image) \
             bash -c " \
                 export ORTGENAI_LOG_ORT_LIB=1 && \
-                dotnet --info && \
                 cd /ort_genai_src/examples/csharp/HelloPhi && \
                 chmod +x ./bin/Release/net6.0/linux-x64/HelloPhi.dll
                 ./bin/Release/net6.0/linux-x64/HelloPhi.dll -m ./models/phi-3"

--- a/.pipelines/stages/jobs/nuget-validation-job.yml
+++ b/.pipelines/stages/jobs/nuget-validation-job.yml
@@ -189,8 +189,8 @@ jobs:
             bash -c " \
                 export ORTGENAI_LOG_ORT_LIB=1 && \
                 cd /ort_genai_src/examples/csharp/HelloPhi && \
-                chmod +x ./bin/Release/net6.0/linux-x64/HelloPhi.dll
-                ./bin/Release/net6.0/linux-x64/HelloPhi.dll -m ./models/phi-3"
+                chmod +x ./bin/Release_Cuda/net6.0/linux-x64/HelloPhi.dll
+                ./bin/Release_Cuda/net6.0/linux-x64/HelloPhi.dll -m ./models/phi-3"
 
         displayName: 'Run Example With Artifact'
         workingDirectory: '$(Build.Repository.LocalPath)'

--- a/.pipelines/stages/jobs/nuget-validation-job.yml
+++ b/.pipelines/stages/jobs/nuget-validation-job.yml
@@ -190,7 +190,8 @@ jobs:
                 export ORTGENAI_LOG_ORT_LIB=1 && \
                 dotnet --info && \
                 cd /ort_genai_src/examples/csharp/HelloPhi && \
-                dotnet run -r $(os)-$(arch) --configuration $(csproj_configuration) --no-build --verbosity normal -- -m ./models/phi-3"
+                chmod +x ./bin/Release/net6.0/linux-x64/HelloPhi.dll
+                ./bin/Release/net6.0/linux-x64/HelloPhi.dll -m ./models/phi-3"
 
         displayName: 'Run Example With Artifact'
         workingDirectory: '$(Build.Repository.LocalPath)'

--- a/.pipelines/stages/jobs/nuget-validation-job.yml
+++ b/.pipelines/stages/jobs/nuget-validation-job.yml
@@ -189,8 +189,8 @@ jobs:
             bash -c " \
                 export ORTGENAI_LOG_ORT_LIB=1 && \
                 cd /ort_genai_src/examples/csharp/HelloPhi && \
-                chmod +x ./bin/Release_Cuda/net6.0/linux-x64/HelloPhi.dll
-                ./bin/Release_Cuda/net6.0/linux-x64/HelloPhi.dll -m ./models/phi-3"
+                chmod +x ./bin/Release_Cuda/net6.0/linux-x64/HelloPhi
+                ./bin/Release_Cuda/net6.0/linux-x64/HelloPhi -m ./models/phi-3"
 
         displayName: 'Run Example With Artifact'
         workingDirectory: '$(Build.Repository.LocalPath)'


### PR DESCRIPTION
Specifying `rid` make the artifact self-contained, which means it can run without dotnet environment.