### PR TITLE
Add fields to debug issueLabeler.yml

### DIFF
--- a/.github/policies/issueLabeler.yml
+++ b/.github/policies/issueLabeler.yml
@@ -1,6 +1,9 @@
+id:
 name: Issue Triage
 description: Assign label to issues 
+owner:
 resource: repository
+where:
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:
@@ -79,3 +82,5 @@ configuration:
             then:
               - addLabel:
                   label: model:transformer
+onFailure:
+onSuccess:


### PR DESCRIPTION
Other examples of GitOps Resource Management policy implementation (e.g., https://github.com/microsoft/winget-pkgs/pull/109069/files) include additional blank fields. Checking to see whether adding these fields will address the fact that policy is not currently applying any labels.