### PR TITLE
Test issue labeler fix

### DIFF
--- a/.github/policies/issueLabeler.yml
+++ b/.github/policies/issueLabeler.yml
@@ -1,4 +1,4 @@
--id:
+id:
 name: Issue Triage
 description: Assign label to issues 
 owner:

--- a/.github/policies/issueLabeler.yml
+++ b/.github/policies/issueLabeler.yml
@@ -1,4 +1,4 @@
-id:
+-id:
 name: Issue Triage
 description: Assign label to issues 
 owner:

--- a/.github/policies/test_issueLabeler.yml
+++ b/.github/policies/test_issueLabeler.yml
@@ -1,0 +1,24 @@
+id:
+name: Issue Triage
+description: Assign label to issues
+owner:
+resource: repository
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - if:
+          - payloadType: Issues
+          - isOpen
+        then:
+          - if:
+              - or:
+                  - titleContains:
+                      pattern: shark
+                  - bodyContains:
+                      pattern: strawberry
+            then:
+              - addLabel:
+                  label: wontfix 
+onFailure:
+onSuccess:


### PR DESCRIPTION
New issue labeler policy validates but is not applying labels to issues as intended.

Creating new policy to test issue labeler that removes RegEx + most other conditions in attempt to identify bug.