### PR TITLE
Use C language linkage in all JNI function implementations.

### DIFF
--- a/src/java/UpdatingJavaBindings.md
+++ b/src/java/UpdatingJavaBindings.md
@@ -75,6 +75,10 @@ A header file for each class with the JNI function signatures will be generated 
 To create/update the .cpp file that implements the JNI function (which will be located in src/main/native), 
 cut-and-paste the relevant parts of the header into the .cpp file.
 
+If creating the .cpp file, add a `#include` for the corresponding generated header file.
+While not strictly necessary, doing so allows us to not have to explicitly specify the correct language linkage
+(`extern "C"`) for the JNI functions as the linkage is inherited from the earlier declarations in the header.
+
 Update the first 2 parameters of each new function to be meaningful by adding the parameter names
     Generated:  `JNIEnv*, jobject`
     Meaningful: `JNIEnv* env, jobject thiz`

--- a/src/java/src/main/native/ai_onnxruntime_genai_Generator.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Generator.cpp
@@ -2,15 +2,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_Generator.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
-#include <iostream>
-
 using namespace Helpers;
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_Generator_createGenerator(JNIEnv* env, jobject thiz, jlong model_handle,
                                                     jlong generator_params_handle) {
   const OgaModel* model = reinterpret_cast<const OgaModel*>(model_handle);
@@ -23,27 +22,27 @@ Java_ai_onnxruntime_genai_Generator_createGenerator(JNIEnv* env, jobject thiz, j
   return reinterpret_cast<jlong>(generator);
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Generator_destroyGenerator(JNIEnv* env, jobject thiz, jlong native_handle) {
   OgaDestroyGenerator(reinterpret_cast<OgaGenerator*>(native_handle));
 }
 
-extern "C" JNIEXPORT jboolean JNICALL
+JNIEXPORT jboolean JNICALL
 Java_ai_onnxruntime_genai_Generator_isDone(JNIEnv* env, jobject thiz, jlong native_handle) {
   return OgaGenerator_IsDone(reinterpret_cast<OgaGenerator*>(native_handle));
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Generator_computeLogitsNative(JNIEnv* env, jobject thiz, jlong native_handle) {
   ThrowIfError(env, OgaGenerator_ComputeLogits(reinterpret_cast<OgaGenerator*>(native_handle)));
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Generator_generateNextTokenNative(JNIEnv* env, jobject thiz, jlong native_handle) {
   ThrowIfError(env, OgaGenerator_GenerateNextToken(reinterpret_cast<OgaGenerator*>(native_handle)));
 }
 
-extern "C" JNIEXPORT jintArray JNICALL
+JNIEXPORT jintArray JNICALL
 Java_ai_onnxruntime_genai_Generator_getSequenceNative(JNIEnv* env, jobject thiz, jlong generator, jlong index) {
   const OgaGenerator* oga_generator = reinterpret_cast<const OgaGenerator*>(generator);
 
@@ -65,7 +64,7 @@ Java_ai_onnxruntime_genai_Generator_getSequenceNative(JNIEnv* env, jobject thiz,
   return java_int_array;
 }
 
-extern "C" JNIEXPORT jint JNICALL
+JNIEXPORT jint JNICALL
 Java_ai_onnxruntime_genai_Generator_getSequenceLastToken(JNIEnv* env, jobject thiz, jlong generator, jlong index) {
   const OgaGenerator* oga_generator = reinterpret_cast<const OgaGenerator*>(generator);
 

--- a/src/java/src/main/native/ai_onnxruntime_genai_GeneratorParams.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_GeneratorParams.cpp
@@ -2,13 +2,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_GeneratorParams.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
 using namespace Helpers;
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_GeneratorParams_createGeneratorParams(JNIEnv* env, jobject thiz, jlong model_handle) {
   const OgaModel* model = reinterpret_cast<const OgaModel*>(model_handle);
   OgaGeneratorParams* generator_params = nullptr;
@@ -19,13 +20,13 @@ Java_ai_onnxruntime_genai_GeneratorParams_createGeneratorParams(JNIEnv* env, job
   return reinterpret_cast<jlong>(generator_params);
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_GeneratorParams_destroyGeneratorParams(JNIEnv* env, jobject thiz, jlong native_handle) {
   OgaGeneratorParams* generator_params = reinterpret_cast<OgaGeneratorParams*>(native_handle);
   OgaDestroyGeneratorParams(generator_params);
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_GeneratorParams_setSearchOptionNumber(JNIEnv* env, jobject thiz, jlong native_handle,
                                                                 jstring option_name, jdouble value) {
   OgaGeneratorParams* generator_params = reinterpret_cast<OgaGeneratorParams*>(native_handle);
@@ -34,7 +35,7 @@ Java_ai_onnxruntime_genai_GeneratorParams_setSearchOptionNumber(JNIEnv* env, job
   ThrowIfError(env, OgaGeneratorParamsSetSearchNumber(generator_params, name, value));
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_GeneratorParams_setSearchOptionBool(JNIEnv* env, jobject thiz, jlong native_handle,
                                                               jstring option_name, jboolean value) {
   OgaGeneratorParams* generator_params = reinterpret_cast<OgaGeneratorParams*>(native_handle);
@@ -43,7 +44,7 @@ Java_ai_onnxruntime_genai_GeneratorParams_setSearchOptionBool(JNIEnv* env, jobje
   ThrowIfError(env, OgaGeneratorParamsSetSearchBool(generator_params, name, value));
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_GeneratorParams_setInputSequences(JNIEnv* env, jobject thiz, jlong native_handle,
                                                             jlong sequences_handle) {
   OgaGeneratorParams* generator_params = reinterpret_cast<OgaGeneratorParams*>(native_handle);
@@ -52,7 +53,7 @@ Java_ai_onnxruntime_genai_GeneratorParams_setInputSequences(JNIEnv* env, jobject
   ThrowIfError(env, OgaGeneratorParamsSetInputSequences(generator_params, sequences));
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_GeneratorParams_setInputIDs(JNIEnv* env, jobject thiz, jlong native_handle,
                                                       jobject token_ids, jint sequence_length, jint batch_size) {
   OgaGeneratorParams* generator_params = reinterpret_cast<OgaGeneratorParams*>(native_handle);
@@ -63,7 +64,7 @@ Java_ai_onnxruntime_genai_GeneratorParams_setInputIDs(JNIEnv* env, jobject thiz,
   ThrowIfError(env, OgaGeneratorParamsSetInputIDs(generator_params, tokens, num_tokens, sequence_length, batch_size));
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_GeneratorParams_setModelInput(JNIEnv* env, jobject thiz, jlong native_handle,
                                                         jstring input_name, jlong tensor) {
   OgaGeneratorParams* generator_params = reinterpret_cast<OgaGeneratorParams*>(native_handle);
@@ -73,7 +74,7 @@ Java_ai_onnxruntime_genai_GeneratorParams_setModelInput(JNIEnv* env, jobject thi
   ThrowIfError(env, OgaGeneratorParamsSetModelInput(generator_params, name, input_tensor));
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_GeneratorParams_setInputs(JNIEnv* env, jobject thiz, jlong native_handle,
                                                     jlong namedTensors) {
   OgaGeneratorParams* generator_params = reinterpret_cast<OgaGeneratorParams*>(native_handle);

--- a/src/java/src/main/native/ai_onnxruntime_genai_Images.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Images.cpp
@@ -2,7 +2,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_Images.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
@@ -13,8 +14,8 @@ using namespace Helpers;
  * Method:    loadImages
  * Signature: (J)V
  */
-JNIEXPORT
-jlong JNICALL Java_ai_onnxruntime_genai_Images_loadImages(JNIEnv* env, jobject thiz, jstring image_path) {
+JNIEXPORT jlong JNICALL
+Java_ai_onnxruntime_genai_Images_loadImages(JNIEnv* env, jobject thiz, jstring image_path) {
   CString path(env, image_path);
 
   OgaImages* images = nullptr;
@@ -30,7 +31,7 @@ jlong JNICALL Java_ai_onnxruntime_genai_Images_loadImages(JNIEnv* env, jobject t
  * Method:    destroyImages
  * Signature: (J)V
  */
-JNIEXPORT
-void JNICALL Java_ai_onnxruntime_genai_Images_destroyImages(JNIEnv* env, jobject thiz, jlong native_handle) {
+JNIEXPORT void JNICALL
+Java_ai_onnxruntime_genai_Images_destroyImages(JNIEnv* env, jobject thiz, jlong native_handle) {
   OgaDestroyImages(reinterpret_cast<OgaImages*>(native_handle));
 }

--- a/src/java/src/main/native/ai_onnxruntime_genai_Model.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Model.cpp
@@ -2,13 +2,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_Model.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
 using namespace Helpers;
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_Model_createModel(JNIEnv* env, jobject thiz, jstring model_path) {
   CString path{env, model_path};
 
@@ -20,13 +21,13 @@ Java_ai_onnxruntime_genai_Model_createModel(JNIEnv* env, jobject thiz, jstring m
   return reinterpret_cast<jlong>(model);
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Model_destroyModel(JNIEnv* env, jobject thiz, jlong model_handle) {
   OgaModel* model = reinterpret_cast<OgaModel*>(model_handle);
   OgaDestroyModel(model);
 }
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_Model_generate(JNIEnv* env, jobject thiz, jlong model_handle,
                                          jlong generator_params_handle) {
   const OgaModel* model = reinterpret_cast<const OgaModel*>(model_handle);

--- a/src/java/src/main/native/ai_onnxruntime_genai_MultiModalProcessor.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_MultiModalProcessor.cpp
@@ -2,13 +2,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_MultiModalProcessor.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
 using namespace Helpers;
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_MultiModalProcessor_createMultiModalProcessor(JNIEnv* env, jobject thiz, jlong model_handle) {
   const OgaModel* model = reinterpret_cast<const OgaModel*>(model_handle);
   OgaMultiModalProcessor* processor = nullptr;
@@ -20,13 +21,13 @@ Java_ai_onnxruntime_genai_MultiModalProcessor_createMultiModalProcessor(JNIEnv* 
   return reinterpret_cast<jlong>(processor);
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_MultiModalProcessor_destroyMultiModalProcessor(JNIEnv* env, jobject thiz, jlong processor_handle) {
   OgaMultiModalProcessor* processor = reinterpret_cast<OgaMultiModalProcessor*>(processor_handle);
   OgaDestroyMultiModalProcessor(processor);
 }
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_MultiModalProcessor_processorProcessImages(JNIEnv* env, jobject thiz, jlong processor_handle,
                                                                      jstring prompt, jlong images_handle) {
   const OgaMultiModalProcessor* processor = reinterpret_cast<const OgaMultiModalProcessor*>(processor_handle);
@@ -42,7 +43,7 @@ Java_ai_onnxruntime_genai_MultiModalProcessor_processorProcessImages(JNIEnv* env
   return reinterpret_cast<jlong>(named_tensors);
 }
 
-extern "C" JNIEXPORT jstring JNICALL
+JNIEXPORT jstring JNICALL
 Java_ai_onnxruntime_genai_MultiModalProcessor_processorDecode(JNIEnv* env, jobject thiz, jlong processor_handle,
                                                               jintArray sequence) {
   const OgaMultiModalProcessor* processor = reinterpret_cast<const OgaMultiModalProcessor*>(processor_handle);
@@ -64,7 +65,7 @@ Java_ai_onnxruntime_genai_MultiModalProcessor_processorDecode(JNIEnv* env, jobje
   return result;
 }
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_MultiModalProcessor_createTokenizerStreamFromProcessor(JNIEnv* env, jobject thiz, jlong processor_handle) {
   const OgaMultiModalProcessor* processor = reinterpret_cast<const OgaMultiModalProcessor*>(processor_handle);
   OgaTokenizerStream* tokenizer_stream = nullptr;

--- a/src/java/src/main/native/ai_onnxruntime_genai_NamedTensors.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_NamedTensors.cpp
@@ -2,7 +2,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_NamedTensors.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
@@ -13,7 +14,7 @@ using namespace Helpers;
  * Method:    destroyNamedTensors
  * Signature: (J)V
  */
-JNIEXPORT
-void JNICALL Java_ai_onnxruntime_genai_NamedTensors_destroyNamedTensors(JNIEnv* env, jobject thiz, jlong native_handle) {
+JNIEXPORT void JNICALL
+Java_ai_onnxruntime_genai_NamedTensors_destroyNamedTensors(JNIEnv* env, jobject thiz, jlong native_handle) {
   OgaDestroyNamedTensors(reinterpret_cast<OgaNamedTensors*>(native_handle));
 }

--- a/src/java/src/main/native/ai_onnxruntime_genai_Sequences.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Sequences.cpp
@@ -2,26 +2,27 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_Sequences.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
 using namespace Helpers;
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Sequences_destroySequences(JNIEnv* env, jobject thiz, jlong sequences_handle) {
   OgaSequences* sequences = reinterpret_cast<OgaSequences*>(sequences_handle);
   OgaDestroySequences(sequences);
 }
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_Sequences_getSequencesCount(JNIEnv* env, jobject thiz, jlong sequences_handle) {
   const OgaSequences* sequences = reinterpret_cast<const OgaSequences*>(sequences_handle);
   size_t num_sequences = OgaSequencesCount(sequences);
   return static_cast<jlong>(num_sequences);
 }
 
-extern "C" JNIEXPORT jintArray JNICALL
+JNIEXPORT jintArray JNICALL
 Java_ai_onnxruntime_genai_Sequences_getSequenceNative(JNIEnv* env, jobject thiz, jlong sequences_handle,
                                                       jlong sequence_index) {
   const OgaSequences* sequences = reinterpret_cast<const OgaSequences*>(sequences_handle);

--- a/src/java/src/main/native/ai_onnxruntime_genai_Tensor.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Tensor.cpp
@@ -2,24 +2,21 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_Tensor.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
 using namespace Helpers;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /*
  * Class:     ai_onnxruntime_genai_Tensor
  * Method:    createTensor
  * Signature: (Ljava/nio/ByteBuffer;[JI)J
  */
-JNIEXPORT
-jlong JNICALL Java_ai_onnxruntime_genai_Tensor_createTensor(JNIEnv* env, jobject thiz, jobject tensor_data,
-                                                            jlongArray shape_dims_in, jint element_type_in) {
+JNIEXPORT jlong JNICALL
+Java_ai_onnxruntime_genai_Tensor_createTensor(JNIEnv* env, jobject thiz, jobject tensor_data,
+                                              jlongArray shape_dims_in, jint element_type_in) {
   void* data = env->GetDirectBufferAddress(tensor_data);
   const int64_t* shape_dims = env->GetLongArrayElements(shape_dims_in, /*isCopy*/ 0);
   size_t shape_dims_count = env->GetArrayLength(shape_dims_in);
@@ -38,11 +35,7 @@ jlong JNICALL Java_ai_onnxruntime_genai_Tensor_createTensor(JNIEnv* env, jobject
  * Method:    destroyTensor
  * Signature: (J)V
  */
-JNIEXPORT
-void JNICALL Java_ai_onnxruntime_genai_Tensor_destroyTensor(JNIEnv* env, jobject thiz, jlong native_handle) {
+JNIEXPORT void JNICALL
+Java_ai_onnxruntime_genai_Tensor_destroyTensor(JNIEnv* env, jobject thiz, jlong native_handle) {
   OgaDestroyTensor(reinterpret_cast<OgaTensor*>(native_handle));
 }
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/java/src/main/native/ai_onnxruntime_genai_Tokenizer.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Tokenizer.cpp
@@ -2,13 +2,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_Tokenizer.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
 using namespace Helpers;
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_Tokenizer_createTokenizer(JNIEnv* env, jobject thiz, jlong model_handle) {
   const OgaModel* model = reinterpret_cast<const OgaModel*>(model_handle);
   OgaTokenizer* tokenizer = nullptr;
@@ -20,13 +21,13 @@ Java_ai_onnxruntime_genai_Tokenizer_createTokenizer(JNIEnv* env, jobject thiz, j
   return reinterpret_cast<jlong>(tokenizer);
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Tokenizer_destroyTokenizer(JNIEnv* env, jobject thiz, jlong tokenizer_handle) {
   OgaTokenizer* tokenizer = reinterpret_cast<OgaTokenizer*>(tokenizer_handle);
   OgaDestroyTokenizer(tokenizer);
 }
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_Tokenizer_tokenizerEncode(JNIEnv* env, jobject thiz, jlong tokenizer_handle,
                                                     jobjectArray strings) {
   const OgaTokenizer* tokenizer = reinterpret_cast<const OgaTokenizer*>(tokenizer_handle);
@@ -49,7 +50,7 @@ Java_ai_onnxruntime_genai_Tokenizer_tokenizerEncode(JNIEnv* env, jobject thiz, j
   return reinterpret_cast<jlong>(sequences);
 }
 
-extern "C" JNIEXPORT jstring JNICALL
+JNIEXPORT jstring JNICALL
 Java_ai_onnxruntime_genai_Tokenizer_tokenizerDecode(JNIEnv* env, jobject thiz, jlong tokenizer_handle,
                                                     jintArray sequence) {
   const OgaTokenizer* tokenizer = reinterpret_cast<const OgaTokenizer*>(tokenizer_handle);
@@ -71,7 +72,7 @@ Java_ai_onnxruntime_genai_Tokenizer_tokenizerDecode(JNIEnv* env, jobject thiz, j
   return result;
 }
 
-extern "C" JNIEXPORT jlong JNICALL
+JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_Tokenizer_createTokenizerStream(JNIEnv* env, jobject thiz, jlong tokenizer_handle) {
   const OgaTokenizer* tokenizer = reinterpret_cast<const OgaTokenizer*>(tokenizer_handle);
   OgaTokenizerStream* tokenizer_stream = nullptr;

--- a/src/java/src/main/native/ai_onnxruntime_genai_TokenizerStream.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_TokenizerStream.cpp
@@ -2,15 +2,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include <jni.h>
+#include "ai_onnxruntime_genai_TokenizerStream.h"
+
 #include "ort_genai_c.h"
 #include "utils.h"
 
-#include <iostream>
-
 using namespace Helpers;
 
-extern "C" JNIEXPORT jstring JNICALL
+JNIEXPORT jstring JNICALL
 Java_ai_onnxruntime_genai_TokenizerStream_tokenizerStreamDecode(JNIEnv* env, jobject thiz,
                                                                 jlong tokenizer_stream_handle, jint token) {
   OgaTokenizerStream* tokenizer_stream = reinterpret_cast<OgaTokenizerStream*>(tokenizer_stream_handle);
@@ -27,7 +26,7 @@ Java_ai_onnxruntime_genai_TokenizerStream_tokenizerStreamDecode(JNIEnv* env, job
   return result;
 }
 
-extern "C" JNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_TokenizerStream_destroyTokenizerStream(JNIEnv* env, jobject thiz,
                                                                  jlong tokenizer_stream_handle) {
   OgaTokenizerStream* tokenizer_stream = reinterpret_cast<OgaTokenizerStream*>(tokenizer_stream_handle);


### PR DESCRIPTION
# Description
- Use C language linkage in all JNI function implementations. It was missing from a few, like `Java_ai_onnxruntime_genai_Images_loadImages`. We could explicitly add `extern "C"` to those definitions as well, but I went with including the header that contains the JNI function declarations instead as it is less duplication.
- Updates for formatting consistency.

# Motivation/Context
Encountered error in Android app:
`java.lang.UnsatisfiedLinkError: No implementation found for long ai.onnxruntime.genai.Images.loadImages(java.lang.String) (tried Java_ai_onnxruntime_genai_Images_loadImages and Java_ai_onnxruntime_genai_Images_loadImages__Ljava_lang_String_2) - is the library loaded, e.g. System.loadLibrary?`