### PR TITLE
Check for resource leaks on Shutdown() to help users

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -20,11 +20,11 @@ std::atomic<int> TrackedResource::count_{};
 // Validate process exit conditions, as this is done atexit, we print errors to stderr and throw an exception to stop the process
 void ValidateShutdown() {
   if (GetOrtGlobals()) {
-    std::cerr << "Shutdown must be called before process exit, please check the documentation for the proper API to call to ensure clean shutdown." << std::endl;
+    std::cerr << "OGA Error: Shutdown must be called before process exit, please check the documentation for the proper API to call to ensure clean shutdown." << std::endl;
     std::abort();
   }
   if (TrackedResource::Count()) {
-    std::cerr << "Resources leaked: " + std::to_string(TrackedResource::Count()) + " All Oga resources must be cleaned up before shutdown." << std::endl;
+    std::cerr << "OGA Error: " + std::to_string(TrackedResource::Count()) + " resources leaked. All Oga resources must be cleaned up before shutdown." << std::endl;
     std::abort();
   }
 }

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -27,8 +27,10 @@ void ValidateShutdown() {
     std::cerr << "OGA Error: Shutdown must be called before process exit, please check the documentation for the proper API to call to ensure clean shutdown." << std::endl;
     std::abort();
   }
-  if (LeakTypes::Dump())
+  if (LeakTypes::Dump()) {
+    std::cerr << "    Please see the documentation for the API being used to ensure proper cleanup." << std::endl;
     std::abort();
+  }
 }
 
 static bool _1 = (std::atexit(ValidateShutdown), false);  // Call ValidateShutdown at exit

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -27,10 +27,6 @@ void ValidateShutdown() {
     std::cerr << "OGA Error: Shutdown must be called before process exit, please check the documentation for the proper API to call to ensure clean shutdown." << std::endl;
     std::abort();
   }
-  if (LeakTypes::Dump()) {
-    std::cerr << "    Please see the documentation for the API being used to ensure proper cleanup." << std::endl;
-    std::abort();
-  }
 }
 
 static bool _1 = (std::atexit(ValidateShutdown), false);  // Call ValidateShutdown at exit
@@ -42,7 +38,16 @@ GetOrtGlobals() {
 }
 
 void Shutdown() {
-  GetOrtGlobals().reset();
+  auto& globals = GetOrtGlobals();
+  if (!globals)
+    return;
+
+  if (LeakTypes::Dump()) {
+    std::cerr << "    Please see the documentation for the API being used to ensure proper cleanup." << std::endl;
+    std::abort();
+  }
+
+  globals.reset();  // Delete now because on process exit is too late
 }
 
 OrtEnv& GetOrtEnv() {

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -17,7 +17,7 @@ OrtGlobals::OrtGlobals() : env_{OrtEnv::Create(OrtLoggingLevel::ORT_LOGGING_LEVE
 
 template <typename... Types>
 bool LeakTypeList<Types...>::Dump() {
-  ((LeakChecked<Types>::Count() != 0 ? std::cerr << "OGA Error: " << LeakChecked<Types>::Count() << " instances of " << typeid(Types).name() << " were leaked." << std::endl : void()), ...);
+  ((LeakChecked<Types>::Count() != 0 ? std::cerr << "OGA Error: " << LeakChecked<Types>::Count() << " instances of " << typeid(Types).name() << " were leaked." << std::endl : std::cerr), ...);
   return ((LeakChecked<Types>::Count() != 0) || ...);
 }
 

--- a/src/generators.h
+++ b/src/generators.h
@@ -55,7 +55,17 @@ enum struct DeviceType {
 
 std::string to_string(DeviceType device_type);
 
-struct GeneratorParams : std::enable_shared_from_this<GeneratorParams> {
+struct TrackedResource {
+  TrackedResource() { count_++; }
+  ~TrackedResource() { count_--; }
+
+  static int Count() { return count_; }
+
+ private:
+  static std::atomic<int> count_;
+};
+
+struct GeneratorParams : std::enable_shared_from_this<GeneratorParams>, TrackedResource {
   GeneratorParams() = default;  // This constructor is only used if doing a custom model handler vs built-in
   GeneratorParams(const Model& model);
 
@@ -125,7 +135,7 @@ struct GeneratorParams : std::enable_shared_from_this<GeneratorParams> {
                                    // The model outlives the GeneratorParams
 };
 
-struct Generator {
+struct Generator : TrackedResource {
   Generator(const Model& model, const GeneratorParams& params);
 
   bool IsDone() const;

--- a/src/generators.h
+++ b/src/generators.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <assert.h>
+#include <atomic>
 #include <cmath>
 #include <cstring>
 #include "filesystem.h"
@@ -59,7 +60,7 @@ struct TrackedResource {
   TrackedResource() { ++count_; }
   ~TrackedResource() { --count_; }
 
-  static int Count() { return count_.load(); }
+  static int Count() { return count_; }
 
  private:
   static std::atomic<int> count_;

--- a/src/generators.h
+++ b/src/generators.h
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-
+// Licensed under the MIT License.
 #pragma once
 
-// Licensed under the MIT License.
 #include <algorithm>
 #include <array>
 #include <assert.h>
@@ -32,6 +31,7 @@
 using cudaStream_t = void*;
 #endif
 
+#include "leakcheck.h"
 #include "smartptrs.h"
 #include "models/onnxruntime_api.h"
 #include "models/debugging.h"
@@ -40,13 +40,10 @@ using cudaStream_t = void*;
 #include "tensor.h"
 
 namespace Generators {
-struct GeneratorParams;
-struct Generator;
 struct Model;
 struct State;
 struct Search;
 struct Tokenizer;
-struct TokenizerStream;
 
 // OgaSequences are a vector of int32 vectors
 using TokenSequences = std::vector<std::vector<int32_t>>;
@@ -58,28 +55,6 @@ enum struct DeviceType {
 };
 
 std::string to_string(DeviceType device_type);
-
-template<typename... Types>
-struct LeakTypeList {
-  template<typename T>
-  static constexpr bool is_tracked = (std::is_same_v<T, Types> || ...);
-  static bool Dump();
-};
-
-using LeakTypes = LeakTypeList<GeneratorParams, Generator, Model, Search, Tokenizer, TokenizerStream>;
-
-template<typename T>
-struct LeakChecked {
-  static_assert(LeakTypes::is_tracked<T>, "Please add this type to 'TrackedTypes' above");
-
-  LeakChecked() { ++count_; }
-  ~LeakChecked() { --count_; }
-
-  static int Count() { return count_; }
-
- private:
-  static inline std::atomic<int> count_;
-};
 
 struct GeneratorParams : std::enable_shared_from_this<GeneratorParams>, LeakChecked<GeneratorParams> {
   GeneratorParams() = default;  // This constructor is only used if doing a custom model handler vs built-in

--- a/src/generators.h
+++ b/src/generators.h
@@ -56,10 +56,10 @@ enum struct DeviceType {
 std::string to_string(DeviceType device_type);
 
 struct TrackedResource {
-  TrackedResource() { count_++; }
-  ~TrackedResource() { count_--; }
+  TrackedResource() { ++count_; }
+  ~TrackedResource() { --count_; }
 
-  static int Count() { return count_; }
+  static int Count() { return count_.load(); }
 
  private:
   static std::atomic<int> count_;

--- a/src/leakcheck.h
+++ b/src/leakcheck.h
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// This file will track the number of instances of each type that are created and destroyed. This is useful for
+// debugging memory leaks. To use this, just add the type to the LeakTypeList in this file. Then have that type
+// inherit from LeakChecked<(itself)>.
+//
+// On process exit, ValidateShutdown() will call LeakTypeList::Dump() and print out any types that have leaked.
+
 namespace Generators {
 struct GeneratorParams;
 struct Generator;
@@ -32,4 +38,4 @@ struct LeakChecked {
   static inline std::atomic<int> count_;
 };
 
-} // namespace Generators
+}  // namespace Generators

--- a/src/leakcheck.h
+++ b/src/leakcheck.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Generators {
+struct GeneratorParams;
+struct Generator;
+struct Model;
+struct Search;
+struct Tensor;
+struct Tokenizer;
+struct TokenizerStream;
+
+template <typename... Types>
+struct LeakTypeList {
+  template <typename T>
+  static constexpr bool is_tracked = (std::is_same_v<T, Types> || ...);
+  static bool Dump();
+};
+
+using LeakTypes = LeakTypeList<GeneratorParams, Generator, Model, Search, Tensor, Tokenizer, TokenizerStream>;
+
+template <typename T>
+struct LeakChecked {
+  static_assert(LeakTypes::is_tracked<T>, "Please add this type to 'TrackedTypes' above");
+
+  LeakChecked() { ++count_; }
+  ~LeakChecked() { --count_; }
+
+  static int Count() { return count_; }
+
+ private:
+  static inline std::atomic<int> count_;
+};
+
+} // namespace Generators

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -105,7 +105,7 @@ struct SessionInfo {
   std::unordered_map<std::string, ONNXTensorElementDataType> inputs_, outputs_;
 };
 
-struct Model : std::enable_shared_from_this<Model> {
+struct Model : std::enable_shared_from_this<Model>, TrackedResource {
   Model(std::unique_ptr<Config> config);
   virtual ~Model();
 

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -48,7 +48,7 @@ struct State {
   int current_batch_size_{0};
 };
 
-struct TokenizerStream {
+struct TokenizerStream : LeakChecked<TokenizerStream> {
   TokenizerStream(const Tokenizer& tokenizer);
 
   const std::string& Decode(int32_t token);
@@ -63,7 +63,7 @@ struct TokenizerStream {
 // Sequence length is vector.size()/count
 std::vector<int32_t> PadInputs(std::span<std::span<const int32_t>> sequences, int32_t pad_token_id);
 
-struct Tokenizer : std::enable_shared_from_this<Tokenizer> {
+struct Tokenizer : std::enable_shared_from_this<Tokenizer>, LeakChecked<Tokenizer> {
   Tokenizer(Config& config);
 
   std::unique_ptr<TokenizerStream> CreateStream() const;
@@ -105,7 +105,7 @@ struct SessionInfo {
   std::unordered_map<std::string, ONNXTensorElementDataType> inputs_, outputs_;
 };
 
-struct Model : std::enable_shared_from_this<Model>, TrackedResource {
+struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model> {
   Model(std::unique_ptr<Config> config);
   virtual ~Model();
 

--- a/src/search.h
+++ b/src/search.h
@@ -5,7 +5,7 @@
 
 namespace Generators {
 
-struct Search {
+struct Search : LeakChecked<Search> {
   Search(const GeneratorParams& params) : params_{params.shared_from_this()} {}
   virtual ~Search() = default;
 

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Generators {
 
-struct Tensor : std::enable_shared_from_this<Tensor> {
+struct Tensor : std::enable_shared_from_this<Tensor>, LeakChecked<Tensor> {
   Tensor() = default;
   Tensor(std::unique_ptr<OrtValue> ort_tensor) : ort_tensor_{std::move(ort_tensor)} {}
 

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -170,8 +170,6 @@ TEST(CAPITests, GreedySearchGptFp32CAPI) {
     const auto* expected_output_start = &expected_output[i * max_length];
     EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence_data, sequence_length * sizeof(int32_t)));
   }
-
-  model.release();
 }
 #endif
 

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -170,6 +170,8 @@ TEST(CAPITests, GreedySearchGptFp32CAPI) {
     const auto* expected_output_start = &expected_output[i * max_length];
     EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence_data, sequence_length * sizeof(int32_t)));
   }
+
+  model.release();
 }
 #endif
 


### PR DESCRIPTION
Adds an instance count to the main types users allocate and destroy through our external API.

On calling Shutdown(), if any count is non zero it will say the count and type of what hasn't been cleaned up.
Will also say if Shutdown() hasn't been called.

Also adds a check on process exit that Shutdown() is called. If not, will give an error message and abort the process.

This should help users more easily write correct code. Trivial to extend to more types, just add to the type list and inherit from LeakChecked.

Example output:
```
[----------] Global test environment tear-down
[==========] 31 tests from 4 test suites ran. (45750 ms total)
[  PASSED  ] 31 tests.
Shutting down OnnxRuntime... done
OGA Error: 1 instances of struct Generators::Model were leaked.
    Please see the documentation for the API being used to ensure proper cleanup.
```