### PR TITLE
Fix example calling errors in readme

### DIFF
--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -41,6 +41,6 @@ The `model-qa` script streams the output text token by token.
 
 To run the python examples...
 ```bash
-python model-generate.py -m {path to model folder} -pr {input prompt in quotes}
+python model-generate.py -m {path to model folder} -pr {input prompt}
 python model-qa.py -m {path to model folder}
 ```

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -41,6 +41,6 @@ The `model-qa` script streams the output text token by token.
 
 To run the python examples...
 ```bash
-python model-generate.py -m {path to model folder} -ep {cpu or cuda} -i {string prompt}
-python model-qa.py -m {path to model folder} -ep {cpu or cuda}
+python model-generate.py -m {path to model folder} -pr {input prompt in quotes}
+python model-qa.py -m {path to model folder}
 ```


### PR DESCRIPTION
There are some deprecated arguments in the official example for model-generate.py and model-qa.py in readme:

1. Argument -ep is no using anymore
2. Argument -i means 'Min number of tokens to generate including the prompt' and not the string prompt