### PR TITLE
Fix Nuget README file copy step

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -74,7 +74,7 @@ def generate_license(line_list):
     line_list.append('<license type="file">LICENSE</license>')
 
 def generate_readme(line_list):
-    line_list.append('<readme>nuget/PACKAGE.md</readme>')
+    line_list.append('<readme>PACKAGE.md</readme>')
 
 def generate_project_url(line_list, project_url):
     line_list.append("<projectUrl>" + project_url + "</projectUrl>")
@@ -112,7 +112,7 @@ def generate_files(lines, args):
     lines.append('<files>')
 
     lines.append(f'<file src="{args.sources_path}\LICENSE" target="LICENSE" />')
-    lines.append(f'<file src="{args.sources_path}\README.md" target="README.md" />')
+    lines.append(f'<file src="{args.sources_path}\\nuget\PACKAGE.md" target="PACKAGE.md" />')
     lines.append(f'<file src="{args.sources_path}\ThirdPartyNotices.txt" target="ThirdPartyNotices.txt" />')
 
     def add_native_artifact_if_exists(xml_lines, runtime, artifact):


### PR DESCRIPTION
Fix Nuget README file copy step, previously it was copying README.md file, but since the filename has changed it needs to be PACKAGE.md