### PR TITLE
Simplify tensor type related code

### DIFF
--- a/src/models/captured_graph_pool.cpp
+++ b/src/models/captured_graph_pool.cpp
@@ -81,11 +81,11 @@ CapturedGraphInfoPtr CapturedGraphPool::ReserveCapturedGraph(const Model& model,
 
     auto output_type = session_info_->GetOutputDataType(config_->model.decoder.outputs.logits);
 
-    if (output_type == Ort::TypeToTensorType<float>::type) {
+    if (output_type == Ort::TypeToTensorType<float>) {
       new_captured_graph->sb_logits32_ = std::make_unique<StaticBuffer>(allocator_device_, max_beam_batch_size);
     }
 
-    if (output_type == Ort::TypeToTensorType<Ort::Float16_t>::type) {
+    if (output_type == Ort::TypeToTensorType<Ort::Float16_t>) {
       new_captured_graph->sb_logits16_ = std::make_unique<StaticBuffer>(allocator_device_, max_beam_batch_size);
     }
 

--- a/src/models/debugging.cpp
+++ b/src/models/debugging.cpp
@@ -7,36 +7,24 @@
 namespace Generators {
 static constexpr size_t c_value_count = 10;  // Dump this many values from the start of a tensor
 
+template <typename... Types>
+const char *TypeToString(ONNXTensorElementDataType type, Ort::TypeList<Types...>) {
+  const char* name = "(please add type to list)";
+  ((type == Ort::TypeToTensorType<Types> ? name=typeid(Types).name(), true : false) || ...);
+  return name; 
+}
+
 const char* TypeToString(ONNXTensorElementDataType type) {
-  switch (type) {
-    case Ort::TypeToTensorType<bool>::type:
-      return "bool";
-    case Ort::TypeToTensorType<int8_t>::type:
-      return "int8";
-    case Ort::TypeToTensorType<uint8_t>::type:
-      return "uint8";
-    case Ort::TypeToTensorType<int16_t>::type:
-      return "int16";
-    case Ort::TypeToTensorType<uint16_t>::type:
-      return "uint16";
-    case Ort::TypeToTensorType<int32_t>::type:
-      return "int32";
-    case Ort::TypeToTensorType<int64_t>::type:
-      return "int64";
-    case Ort::TypeToTensorType<Ort::Float16_t>::type:
-      return "float16";
-    case Ort::TypeToTensorType<float>::type:
-      return "float32";
-    case Ort::TypeToTensorType<double>::type:
-      return "float64";
-    default:
-      assert(false);
-      return "(please add type to list)";
-  }
+  return TypeToString(type, Ort::TensorTypes{});
 }
 
 std::ostream& operator<<(std::ostream& stream, Ort::Float16_t v) {
   stream << Float16ToFloat32(v);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, Ort::BFloat16_t v) {
+  stream << v.value;
   return stream;
 }
 
@@ -66,66 +54,20 @@ template void DumpCudaSpan(std::ostream&, std::span<const float>);
 template void DumpCudaSpan(std::ostream&, std::span<const int32_t>);
 #endif
 
+template <typename... Types>
+bool DumpSpan(std::ostream& stream, ONNXTensorElementDataType type, const void* p_values_raw, size_t count, Ort::TypeList<Types...>) {
+  return ((type == Ort::TypeToTensorType<Types> && (DumpSpan(stream, std::span<const Types>{reinterpret_cast<const Types*>(p_values_raw), count}), true)) || ...);
+}
+
 void DumpValues(std::ostream& stream, ONNXTensorElementDataType type, const void* p_values_raw, size_t count) {
   if (count == 0) {
     return;
   }
 
   stream << SGR::Fg_Green << "Values[ " << SGR::Reset;
+  if (!DumpSpan(stream, type, p_values_raw, count, Ort::TensorTypes{}))
+    stream << SGR::Fg_Red << "Unhandled data type" << SGR::Reset;
 
-  switch (type) {
-    case Ort::TypeToTensorType<bool>::type:
-      DumpSpan(stream, std::span<const bool>(reinterpret_cast<const bool*>(p_values_raw), count));
-      break;
-
-    case Ort::TypeToTensorType<int8_t>::type:
-      DumpSpan(stream, std::span<const int8_t>{reinterpret_cast<const int8_t*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<uint8_t>::type:
-      DumpSpan(stream, std::span<const uint8_t>{reinterpret_cast<const uint8_t*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<int16_t>::type:
-      DumpSpan(stream, std::span<const int16_t>{reinterpret_cast<const int16_t*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<uint16_t>::type:
-      DumpSpan(stream, std::span<const uint16_t>{reinterpret_cast<const uint16_t*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<int32_t>::type:
-      DumpSpan(stream, std::span<const int32_t>{reinterpret_cast<const int32_t*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<uint32_t>::type:
-      DumpSpan(stream, std::span<const uint32_t>{reinterpret_cast<const uint32_t*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<int64_t>::type:
-      DumpSpan(stream, std::span<const int64_t>{reinterpret_cast<const int64_t*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<uint64_t>::type:
-      DumpSpan(stream, std::span<const uint64_t>{reinterpret_cast<const uint64_t*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<Ort::Float16_t>::type:
-      DumpSpan(stream, std::span<const Ort::Float16_t>{reinterpret_cast<const Ort::Float16_t*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<float>::type:
-      DumpSpan(stream, std::span<const float>{reinterpret_cast<const float*>(p_values_raw), count});
-      break;
-
-    case Ort::TypeToTensorType<double>::type:
-      DumpSpan(stream, std::span<const double>{reinterpret_cast<const double*>(p_values_raw), count});
-      break;
-
-    default:
-      stream << SGR::Fg_Red << "Unhandled data type" << SGR::Reset;
-      break;
-  }
   stream << SGR::Fg_Green << "]" << SGR::Reset << std::endl;
 }
 

--- a/src/models/debugging.cpp
+++ b/src/models/debugging.cpp
@@ -8,10 +8,10 @@ namespace Generators {
 static constexpr size_t c_value_count = 10;  // Dump this many values from the start of a tensor
 
 template <typename... Types>
-const char *TypeToString(ONNXTensorElementDataType type, Ort::TypeList<Types...>) {
+const char* TypeToString(ONNXTensorElementDataType type, Ort::TypeList<Types...>) {
   const char* name = "(please add type to list)";
-  ((type == Ort::TypeToTensorType<Types> ? name=typeid(Types).name(), true : false) || ...);
-  return name; 
+  ((type == Ort::TypeToTensorType<Types> ? name = typeid(Types).name(), true : false) || ...);
+  return name;
 }
 
 const char* TypeToString(ONNXTensorElementDataType type) {
@@ -24,7 +24,7 @@ std::ostream& operator<<(std::ostream& stream, Ort::Float16_t v) {
 }
 
 std::ostream& operator<<(std::ostream& stream, Ort::BFloat16_t v) {
-  stream << v.value;
+  stream << "BF16:" << v.value;  // TODO: implement conversion when useful
   return stream;
 }
 

--- a/src/models/input_ids.cpp
+++ b/src/models/input_ids.cpp
@@ -13,14 +13,14 @@ InputIDs::InputIDs(const Model& model, State& state)
   type_ = model_.session_info_->GetInputDataType(name_);
 
   // If 64-bit, convert from 32-bit to 64-bit
-  if (type_ == Ort::TypeToTensorType<int64_t>::type) {
+  if (type_ == Ort::TypeToTensorType<int64_t>) {
     value_ = OrtValue::CreateTensor(model.allocator_cpu_, shape_, type_);
     auto* p_data = value_->GetTensorMutableData<int64_t>();
     for (auto v : state_.params_->input_ids) {
       *p_data++ = v;
     }
   } else {
-    if (type_ != Ort::TypeToTensorType<int32_t>::type)
+    if (type_ != Ort::TypeToTensorType<int32_t>)
       throw std::runtime_error("InputIDs must be int64 or int32");
     value_ = OrtValue::CreateTensor<int32_t>(model.allocator_cpu_.GetInfo(), std::span<int32_t>(const_cast<int32_t*>(state_.params_->input_ids.data()), shape_[0] * shape_[1]), shape_);
   }
@@ -63,7 +63,7 @@ void InputIDs::Update(RoamingArray<int32_t> next_tokens_unk) {
 
 #if USE_DML
       if (model_.device_type_ == DeviceType::DML) {
-        value_int32_ = sb_input_ids_int32_->CreateTensorOnStaticBuffer(shape_, Ort::TypeToTensorType<int32_t>::type);
+        value_int32_ = sb_input_ids_int32_->CreateTensorOnStaticBuffer(shape_, Ort::TypeToTensorType<int32_t>);
       }
 #endif
     }
@@ -72,7 +72,7 @@ void InputIDs::Update(RoamingArray<int32_t> next_tokens_unk) {
   }
 
   // Update input_ids with next tokens, converting from 32-bit to 64-bit
-  if (type_ == Ort::TypeToTensorType<int64_t>::type) {
+  if (type_ == Ort::TypeToTensorType<int64_t>) {
     switch (model_.device_type_) {
 #if USE_CUDA
       case DeviceType::CUDA: {

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -106,7 +106,7 @@ void KV_Cache_Combined::PickPastState(std::span<const int32_t> beam_indices, int
 }
 
 void KV_Cache_Combined::PickPastState(std::span<const int32_t> beam_indices, int index) {
-  if (type_ == Ort::TypeToTensorType<float>::type) {
+  if (type_ == Ort::TypeToTensorType<float>) {
     PickPastState<float>(beam_indices, index);
   } else {
     PickPastState<Ort::Float16_t>(beam_indices, index);
@@ -247,7 +247,7 @@ void KV_Cache::PickPastState(std::span<const int32_t> beam_indices, int index) {
 }
 
 void KV_Cache::PickPastState(std::span<const int32_t> beam_indices, int index) {
-  if (type_ == Ort::TypeToTensorType<float>::type) {
+  if (type_ == Ort::TypeToTensorType<float>) {
     PickPastState<float>(beam_indices, index);
   } else {
     PickPastState<Ort::Float16_t>(beam_indices, index);

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -17,10 +17,10 @@ Logits::Logits(const Model& model, State& state)
   output_raw_ = OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_);
 
   if (state_.GetCapturedGraphInfo()) {
-    if (type_ == Ort::TypeToTensorType<float>::type) {
+    if (type_ == Ort::TypeToTensorType<float>) {
       sb_logits32_ = state_.GetCapturedGraphInfo()->sb_logits32_.get();
     }
-    if (type_ == Ort::TypeToTensorType<Ort::Float16_t>::type) {
+    if (type_ == Ort::TypeToTensorType<Ort::Float16_t>) {
       sb_logits16_ = state_.GetCapturedGraphInfo()->sb_logits16_.get();
     }
   }
@@ -55,14 +55,14 @@ RoamingArray<float> Logits::Get() {
     output_last_tokens_ = OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_);
 
 #if USE_DML
-    if (type_ == Ort::TypeToTensorType<Ort::Float16_t>::type) {
+    if (type_ == Ort::TypeToTensorType<Ort::Float16_t>) {
       logits_of_last_token_fp32_ = OrtValue::CreateTensor(*model_.allocator_device_, shape_, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
     }
 #endif
 
     logits_of_last_token = output_last_tokens_.get();
 
-    size_t element_size = type_ == Ort::TypeToTensorType<float>::type ? 4 : 2;
+    size_t element_size = type_ == Ort::TypeToTensorType<float> ? 4 : 2;
     size_t vocab_index = 0;  // Simpler math to have this index go up by vocab_size for every logit chunk we process
 
     const auto* input_ids = state_.params_->input_ids.data();
@@ -126,7 +126,7 @@ RoamingArray<float> Logits::Get() {
   }
 
   // Convert from float16 to float32 if necessary
-  if (type_ == Ort::TypeToTensorType<Ort::Float16_t>::type) {
+  if (type_ == Ort::TypeToTensorType<Ort::Float16_t>) {
 #if USE_DML
     if (model_.device_type_ == DeviceType::DML) {
       DmlHelpers::DmlCastInputToOutput(
@@ -205,7 +205,7 @@ void Logits::Update() {
     return;
   }
 
-  StaticBuffer* sb_logits = type_ == Ort::TypeToTensorType<Ort::Float16_t>::type ? sb_logits16_ : sb_logits32_;
+  StaticBuffer* sb_logits = type_ == Ort::TypeToTensorType<Ort::Float16_t> ? sb_logits16_ : sb_logits32_;
   output_raw_ = !sb_logits ? OrtValue::CreateTensor(*model_.allocator_device_, shape_, type_)
                            : sb_logits->CreateTensorOnStaticBuffer(shape_, type_);
   state_.outputs_[output_index_] = output_raw_.get();

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -469,7 +469,7 @@ std::shared_ptr<GeneratorParams> CreateGeneratorParams() {
 void ConvertFp16ToFp32(OrtAllocator& allocator, OrtValue& in, std::unique_ptr<OrtValue>& p_out, DeviceType device_type, cudaStream_t stream) {
   auto shape_info = in.GetTensorTypeAndShapeInfo();
   auto shape = shape_info->GetShape();
-  assert(shape_info->GetElementType() == Ort::TypeToTensorType<Ort::Float16_t>::type);
+  assert(shape_info->GetElementType() == Ort::TypeToTensorType<Ort::Float16_t>);
 
   bool allocate_p_out = p_out == nullptr;
   if (p_out) {
@@ -508,7 +508,7 @@ void ConvertFp32ToFp16(OrtAllocator& allocator, OrtValue& in, std::unique_ptr<Or
                        DeviceType device_type, cudaStream_t stream) {
   auto shape_info = in.GetTensorTypeAndShapeInfo();
   auto shape = shape_info->GetShape();
-  assert(shape_info->GetElementType() == Ort::TypeToTensorType<float>::type);
+  assert(shape_info->GetElementType() == Ort::TypeToTensorType<float>);
 
   bool allocate_p_out = p_out == nullptr;
   if (p_out) {

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -57,61 +57,40 @@ struct StringAllocator : OrtAllocator {
   std::string string_;
 };
 
-// This template converts a C++ type into it's ONNXTensorElementDataType
+template <typename... Types>
+struct TypeList {};
+
+using TensorTypes = TypeList<bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float, double, Float16_t, BFloat16_t>;
+
+// Variable templates to convert a C++ type into it's ONNXTensorElementDataType
 template <typename T>
-struct TypeToTensorType;
+constexpr ONNXTensorElementDataType TypeToTensorType = T::Unsupported_Type;  // Force a compile error if hit, please add specialized version if type is valid
 template <>
-struct TypeToTensorType<float> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<bool> = ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
 template <>
-struct TypeToTensorType<Float16_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<int8_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
 template <>
-struct TypeToTensorType<BFloat16_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<uint8_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
 template <>
-struct TypeToTensorType<double> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<int16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
 template <>
-struct TypeToTensorType<int8_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<uint16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
 template <>
-struct TypeToTensorType<int16_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<int32_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
 template <>
-struct TypeToTensorType<int32_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<uint32_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32;
 template <>
-struct TypeToTensorType<int64_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<int64_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
 template <>
-struct TypeToTensorType<uint8_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<uint64_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64;
 template <>
-struct TypeToTensorType<uint16_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<float> = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
 template <>
-struct TypeToTensorType<uint32_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<double> = ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
 template <>
-struct TypeToTensorType<uint64_t> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<Float16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
 template <>
-struct TypeToTensorType<bool> {
-  static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
-};
+constexpr ONNXTensorElementDataType TypeToTensorType<BFloat16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;
 
 inline std::vector<std::string> GetAvailableProviders() {
   int len;
@@ -1168,7 +1147,7 @@ inline void OrtValue::FillSparseTensorBlockSparse(const OrtMemoryInfo& data_mem_
 
 template <typename T>
 inline std::unique_ptr<OrtValue> OrtValue::CreateTensor(const OrtMemoryInfo& info, std::span<T> p_data, std::span<const int64_t> shape) {
-  return CreateTensor(info, p_data.data(), p_data.size_bytes(), shape, Ort::TypeToTensorType<T>::type);
+  return CreateTensor(info, p_data.data(), p_data.size_bytes(), shape, Ort::TypeToTensorType<T>);
 }
 
 inline std::unique_ptr<OrtValue> OrtValue::CreateTensor(const OrtMemoryInfo& info, void* p_data, size_t p_data_byte_count, std::span<const int64_t> shape,
@@ -1180,7 +1159,7 @@ inline std::unique_ptr<OrtValue> OrtValue::CreateTensor(const OrtMemoryInfo& inf
 
 template <typename T>
 inline std::unique_ptr<OrtValue> OrtValue::CreateTensor(OrtAllocator& allocator, std::span<const int64_t> shape) {
-  return CreateTensor(allocator, shape, Ort::TypeToTensorType<T>::type);
+  return CreateTensor(allocator, shape, Ort::TypeToTensorType<T>);
 }
 
 inline std::unique_ptr<OrtValue> OrtValue::CreateTensor(OrtAllocator& allocator, std::span<const int64_t> shape, ONNXTensorElementDataType type) {
@@ -1194,7 +1173,7 @@ inline std::unique_ptr<OrtValue> OrtValue::CreateTensor(OrtAllocator& allocator,
 template <typename T>
 inline std::unique_ptr<OrtValue> OrtValue::CreateSparseTensor(const OrtMemoryInfo& info, T* p_data, const OrtShape& dense_shape,
                                                               const OrtShape& values_shape) {
-  return CreateSparseTensor(info, p_data, dense_shape, values_shape, Ort::TypeToTensorType<T>::type);
+  return CreateSparseTensor(info, p_data, dense_shape, values_shape, Ort::TypeToTensorType<T>);
 }
 
 inline std::unique_ptr<OrtValue> OrtValue::CreateSparseTensor(const OrtMemoryInfo& info, void* p_data, const OrtShape& dense_shape,
@@ -1207,7 +1186,7 @@ inline std::unique_ptr<OrtValue> OrtValue::CreateSparseTensor(const OrtMemoryInf
 
 template <typename T>
 inline std::unique_ptr<OrtValue> OrtValue::CreateSparseTensor(OrtAllocator* allocator, const OrtShape& dense_shape) {
-  return CreateSparseTensor(allocator, dense_shape, Ort::TypeToTensorType<T>::type);
+  return CreateSparseTensor(allocator, dense_shape, Ort::TypeToTensorType<T>);
 }
 
 inline std::unique_ptr<OrtValue> OrtValue::CreateSparseTensor(OrtAllocator* allocator, const OrtShape& dense_shape,

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -64,33 +64,33 @@ using TensorTypes = TypeList<bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, 
 
 // Variable templates to convert a C++ type into it's ONNXTensorElementDataType
 template <typename T>
-constexpr ONNXTensorElementDataType TypeToTensorType = T::Unsupported_Type;  // Force a compile error if hit, please add specialized version if type is valid
+inline constexpr ONNXTensorElementDataType TypeToTensorType = T::Unsupported_Type;  // Force a compile error if hit, please add specialized version if type is valid
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<bool> = ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<bool> = ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<int8_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<int8_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<uint8_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<uint8_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<int16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<int16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<uint16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<uint16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<int32_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<int32_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<uint32_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<uint32_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<int64_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<int64_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<uint64_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<uint64_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<float> = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<float> = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<double> = ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<double> = ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<Float16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<Float16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
 template <>
-constexpr ONNXTensorElementDataType TypeToTensorType<BFloat16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;
+inline constexpr ONNXTensorElementDataType TypeToTensorType<BFloat16_t> = ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;
 
 inline std::vector<std::string> GetAvailableProviders() {
   int len;

--- a/src/models/utils.cpp
+++ b/src/models/utils.cpp
@@ -6,31 +6,31 @@ namespace Generators {
 
 size_t SizeOf(ONNXTensorElementDataType type) {
   switch (type) {
-    case Ort::TypeToTensorType<uint8_t>::type:
+    case Ort::TypeToTensorType<uint8_t>:
       return sizeof(uint8_t);
-    case Ort::TypeToTensorType<int8_t>::type:
+    case Ort::TypeToTensorType<int8_t>:
       return sizeof(int8_t);
-    case Ort::TypeToTensorType<uint16_t>::type:
+    case Ort::TypeToTensorType<uint16_t>:
       return sizeof(uint16_t);
-    case Ort::TypeToTensorType<int16_t>::type:
+    case Ort::TypeToTensorType<int16_t>:
       return sizeof(int16_t);
-    case Ort::TypeToTensorType<uint32_t>::type:
+    case Ort::TypeToTensorType<uint32_t>:
       return sizeof(uint32_t);
-    case Ort::TypeToTensorType<int32_t>::type:
+    case Ort::TypeToTensorType<int32_t>:
       return sizeof(int32_t);
-    case Ort::TypeToTensorType<uint64_t>::type:
+    case Ort::TypeToTensorType<uint64_t>:
       return sizeof(int64_t);
-    case Ort::TypeToTensorType<int64_t>::type:
+    case Ort::TypeToTensorType<int64_t>:
       return sizeof(int64_t);
-    case Ort::TypeToTensorType<bool>::type:
+    case Ort::TypeToTensorType<bool>:
       return sizeof(bool);
-    case Ort::TypeToTensorType<float>::type:
+    case Ort::TypeToTensorType<float>:
       return sizeof(float);
-    case Ort::TypeToTensorType<double>::type:
+    case Ort::TypeToTensorType<double>:
       return sizeof(double);
-    case Ort::TypeToTensorType<Ort::Float16_t>::type:
+    case Ort::TypeToTensorType<Ort::Float16_t>:
       return sizeof(Ort::Float16_t);
-    case Ort::TypeToTensorType<Ort::BFloat16_t>::type:
+    case Ort::TypeToTensorType<Ort::BFloat16_t>:
       return sizeof(Ort::BFloat16_t);
     default:
       throw std::runtime_error("Unsupported ONNXTensorElementDataType in GetTypeSize");

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -46,29 +46,29 @@ pybind11::array_t<T> ToPython(std::span<T> v) {
 ONNXTensorElementDataType ToTensorType(const pybind11::dtype& type) {
   switch (type.num()) {
     case pybind11::detail::npy_api::NPY_BOOL_:
-      return Ort::TypeToTensorType<bool>::type;
+      return Ort::TypeToTensorType<bool>;
     case pybind11::detail::npy_api::NPY_UINT8_:
-      return Ort::TypeToTensorType<uint8_t>::type;
+      return Ort::TypeToTensorType<uint8_t>;
     case pybind11::detail::npy_api::NPY_INT8_:
-      return Ort::TypeToTensorType<int8_t>::type;
+      return Ort::TypeToTensorType<int8_t>;
     case pybind11::detail::npy_api::NPY_UINT16_:
-      return Ort::TypeToTensorType<uint16_t>::type;
+      return Ort::TypeToTensorType<uint16_t>;
     case pybind11::detail::npy_api::NPY_INT16_:
-      return Ort::TypeToTensorType<int16_t>::type;
+      return Ort::TypeToTensorType<int16_t>;
     case pybind11::detail::npy_api::NPY_UINT32_:
-      return Ort::TypeToTensorType<uint32_t>::type;
+      return Ort::TypeToTensorType<uint32_t>;
     case pybind11::detail::npy_api::NPY_INT32_:
-      return Ort::TypeToTensorType<int32_t>::type;
+      return Ort::TypeToTensorType<int32_t>;
     case pybind11::detail::npy_api::NPY_UINT64_:
-      return Ort::TypeToTensorType<uint64_t>::type;
+      return Ort::TypeToTensorType<uint64_t>;
     case pybind11::detail::npy_api::NPY_INT64_:
-      return Ort::TypeToTensorType<int64_t>::type;
+      return Ort::TypeToTensorType<int64_t>;
     case 23 /*NPY_FLOAT16*/:
-      return Ort::TypeToTensorType<Ort::Float16_t>::type;
+      return Ort::TypeToTensorType<Ort::Float16_t>;
     case pybind11::detail::npy_api::NPY_FLOAT_:
-      return Ort::TypeToTensorType<float>::type;
+      return Ort::TypeToTensorType<float>;
     case pybind11::detail::npy_api::NPY_DOUBLE_:
-      return Ort::TypeToTensorType<double>::type;
+      return Ort::TypeToTensorType<double>;
     default:
       throw std::runtime_error("Unsupported numpy type");
   }
@@ -76,64 +76,57 @@ ONNXTensorElementDataType ToTensorType(const pybind11::dtype& type) {
 
 int ToNumpyType(ONNXTensorElementDataType type) {
   switch (type) {
-    case Ort::TypeToTensorType<bool>::type:
+    case Ort::TypeToTensorType<bool>:
       return pybind11::detail::npy_api::NPY_BOOL_;
-    case Ort::TypeToTensorType<int8_t>::type:
+    case Ort::TypeToTensorType<int8_t>:
       return pybind11::detail::npy_api::NPY_INT8_;
-    case Ort::TypeToTensorType<uint8_t>::type:
+    case Ort::TypeToTensorType<uint8_t>:
       return pybind11::detail::npy_api::NPY_UINT8_;
-    case Ort::TypeToTensorType<int16_t>::type:
+    case Ort::TypeToTensorType<int16_t>:
       return pybind11::detail::npy_api::NPY_INT16_;
-    case Ort::TypeToTensorType<uint16_t>::type:
+    case Ort::TypeToTensorType<uint16_t>:
       return pybind11::detail::npy_api::NPY_UINT16_;
-    case Ort::TypeToTensorType<int32_t>::type:
+    case Ort::TypeToTensorType<int32_t>:
       return pybind11::detail::npy_api::NPY_INT32_;
-    case Ort::TypeToTensorType<uint32_t>::type:
+    case Ort::TypeToTensorType<uint32_t>:
       return pybind11::detail::npy_api::NPY_UINT32_;
-    case Ort::TypeToTensorType<int64_t>::type:
+    case Ort::TypeToTensorType<int64_t>:
       return pybind11::detail::npy_api::NPY_INT64_;
-    case Ort::TypeToTensorType<uint64_t>::type:
+    case Ort::TypeToTensorType<uint64_t>:
       return pybind11::detail::npy_api::NPY_UINT64_;
-    case Ort::TypeToTensorType<Ort::Float16_t>::type:
+    case Ort::TypeToTensorType<Ort::Float16_t>:
       return 23 /*NPY_FLOAT16*/;
-    case Ort::TypeToTensorType<float>::type:
+    case Ort::TypeToTensorType<float>:
       return pybind11::detail::npy_api::NPY_FLOAT_;
-    case Ort::TypeToTensorType<double>::type:
+    case Ort::TypeToTensorType<double>:
       return pybind11::detail::npy_api::NPY_DOUBLE_;
     default:
       throw std::runtime_error("Unsupported onnx type");
   }
 }
 
+template <typename... Types>
+const char* TypeToString(ONNXTensorElementDataType type, Ort::TypeList<Types...>) {
+  const char* name = "(please add type to list)";
+  ((type == Ort::TypeToTensorType<Types> ? name = typeid(Types).name(), true : false) || ...);
+  return name;
+}
+
+const char* TypeToString(ONNXTensorElementDataType type) {
+  return TypeToString(type, Ort::TensorTypes{});
+}
+
+template <typename... Types>
+std::string ToFormatDescriptor(ONNXTensorElementDataType type, Ort::TypeList<Types...>) {
+  std::string result;
+  ((type == Ort::TypeToTensorType<Types> ? result = pybind11::format_descriptor<Types>::format(), true : false) || ...);
+  if (result.empty())
+    throw std::runtime_error("Unsupported onnx type");
+  return result;
+}
+
 std::string ToFormatDescriptor(ONNXTensorElementDataType type) {
-  switch (type) {
-    case Ort::TypeToTensorType<bool>::type:
-      return pybind11::format_descriptor<bool>::format();
-    case Ort::TypeToTensorType<int8_t>::type:
-      return pybind11::format_descriptor<int8_t>::format();
-    case Ort::TypeToTensorType<uint8_t>::type:
-      return pybind11::format_descriptor<int8_t>::format();
-    case Ort::TypeToTensorType<int16_t>::type:
-      return pybind11::format_descriptor<int16_t>::format();
-    case Ort::TypeToTensorType<uint16_t>::type:
-      return pybind11::format_descriptor<int16_t>::format();
-    case Ort::TypeToTensorType<int32_t>::type:
-      return pybind11::format_descriptor<int32_t>::format();
-    case Ort::TypeToTensorType<uint32_t>::type:
-      return pybind11::format_descriptor<int32_t>::format();
-    case Ort::TypeToTensorType<int64_t>::type:
-      return pybind11::format_descriptor<int64_t>::format();
-    case Ort::TypeToTensorType<uint64_t>::type:
-      return pybind11::format_descriptor<int64_t>::format();
-    case Ort::TypeToTensorType<Ort::Float16_t>::type:
-      return pybind11::format_descriptor<Ort::Float16_t>::format();
-    case Ort::TypeToTensorType<float>::type:
-      return pybind11::format_descriptor<float>::format();
-    case Ort::TypeToTensorType<double>::type:
-      return pybind11::format_descriptor<double>::format();
-    default:
-      throw std::runtime_error("Unsupported onnx type");
-  }
+  return ToFormatDescriptor(type, Ort::TensorTypes{});
 }
 
 std::unique_ptr<OrtValue> ToOrtValue(pybind11::array& v) {

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -106,17 +106,6 @@ int ToNumpyType(ONNXTensorElementDataType type) {
 }
 
 template <typename... Types>
-const char* TypeToString(ONNXTensorElementDataType type, Ort::TypeList<Types...>) {
-  const char* name = "(please add type to list)";
-  ((type == Ort::TypeToTensorType<Types> ? name = typeid(Types).name(), true : false) || ...);
-  return name;
-}
-
-const char* TypeToString(ONNXTensorElementDataType type) {
-  return TypeToString(type, Ort::TensorTypes{});
-}
-
-template <typename... Types>
 std::string ToFormatDescriptor(ONNXTensorElementDataType type, Ort::TypeList<Types...>) {
   std::string result;
   ((type == Ort::TypeToTensorType<Types> ? result = pybind11::format_descriptor<Types>::format(), true : false) || ...);


### PR DESCRIPTION
Use variadic templates to make the code more generic and simpler.

Switch to using a template variable for TypeToTensorType, which avoids needing ::type all over the code.