### PR TITLE
Fix ORT version and C# build errors 

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -68,6 +68,7 @@ jobs:
           ORT_NIGHTLY_VERSION=$(curl -s "${{ env.ORT_NIGHTLY_REST_API }}" | jq -r '.value[0].versions[0].normalizedVersion')
           echo "$ORT_NIGHTLY_VERSION"
           echo "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" >> $GITHUB_ENV
+          $ONNXRUNTIME_VERSION = ${{ env.ORT_NIGHTLY_VERSION }}
 
       # have to create a dummy project to use `add package`
       - name: Download OnnxRuntime Nightly

--- a/.github/workflows/linux-cpu-arm64-build.yml
+++ b/.github/workflows/linux-cpu-arm64-build.yml
@@ -36,6 +36,7 @@ jobs:
           $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
           Write-Host "$ORT_NIGHTLY_VERSION"
           "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
+          $ONNXRUNTIME_VERSION = ${{ env.ORT_NIGHTLY_VERSION }}
 
       - name: Download OnnxRuntime Nightly
         run: |

--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -34,6 +34,7 @@ jobs:
           $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
           Write-Host "$ORT_NIGHTLY_VERSION"
           "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
+          $ONNXRUNTIME_VERSION = ${{ env.ORT_NIGHTLY_VERSION }}
 
       - name: Download OnnxRuntime Nightly
         run: |

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -48,6 +48,7 @@ jobs:
           $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
           Write-Host "$ORT_NIGHTLY_VERSION"
           "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
+          $ONNXRUNTIME_VERSION = ${{ env.ORT_NIGHTLY_VERSION }}
 
       - name: Download OnnxRuntime Nightly
         run: |

--- a/.github/workflows/mac-cpu-arm64-build.yml
+++ b/.github/workflows/mac-cpu-arm64-build.yml
@@ -26,6 +26,7 @@ jobs:
           ORT_NIGHTLY_VERSION=$(curl -s "${{ env.ORT_NIGHTLY_REST_API }}" | jq -r '.value[0].versions[0].normalizedVersion')
           echo "$ORT_NIGHTLY_VERSION" 
           echo "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" >> $GITHUB_ENV
+          ONNXRUNTIME_VERSION = ${{ env.ORT_NIGHTLY_VERSION }}
       - name: Download OnnxRuntime Nightly
         run: |
           nuget install ${{ env.ORT_PACKAGE_NAME }} -version ${{ env.ORT_NIGHTLY_VERSION }} -x

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -42,6 +42,7 @@ jobs:
         Write-Host "$ORT_NIGHTLY_VERSION"
         "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
         nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -x -NonInteractive
+        $ONNXRUNTIME_VERSION = ${{ env.ORT_NIGHTLY_VERSION }}
 
     - run: Get-ChildItem  ${{ env.ORT_PACKAGE_NAME }} -Recurse
       continue-on-error: true

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -49,6 +49,7 @@ jobs:
         Write-Host "$ORT_NIGHTLY_VERSION"
         "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
         nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -x -NonInteractive
+        $ONNXRUNTIME_VERSION = ${{ env.ORT_NIGHTLY_VERSION }}
 
     - run: Get-ChildItem  ${{ env.ORT_PACKAGE_NAME }} -Recurse
       continue-on-error: true

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -51,6 +51,7 @@ jobs:
         Write-Host "$ORT_NIGHTLY_VERSION"
         "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
         nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -ExcludeVersion -NonInteractive
+        $ONNXRUNTIME_VERSION = ${{ env.ORT_NIGHTLY_VERSION }}
 
     - run: Get-ChildItem  ${{ env.ORT_PACKAGE_NAME }} -Recurse
       continue-on-error: true

--- a/build.py
+++ b/build.py
@@ -82,9 +82,9 @@ def _parse_args():
 
     parser.add_argument("--skip_tests", action="store_true", help="Skip all tests. Overrides --test.")
     parser.add_argument("--skip_wheel", action="store_true", help="Skip building the Python wheel.")
-    parser.add_argument("--skip_csharp", action="store_true", help="Skip building the C# API.")
 
-    # Default to not building the Java bindings
+    # Default to not building the language bindings
+    parser.add_argument("--build_csharp", action="store_true", help="Build the C# API.")
     parser.add_argument("--build_java", action="store_true", help="Build Java bindings.")
 
     parser.add_argument("--parallel", action="store_true", help="Enable parallel build.")
@@ -263,8 +263,7 @@ def _validate_android_args(args: argparse.Namespace):
             log.info(f"Setting CMake generator to '{args.cmake_generator}' for cross-compiling for Android.")
 
         # no C# on Android so automatically skip
-        if not args.skip_csharp:
-            args.skip_csharp = True
+        args.build_csharp = False
 
 
 def _validate_ios_args(args: argparse.Namespace):
@@ -519,7 +518,7 @@ def build(args: argparse.Namespace, env: dict[str, str]):
 
     util.run(make_command, env=env)
 
-    if not args.skip_csharp:
+    if args.build_csharp:
         dotnet = str(_resolve_executable_path("dotnet"))
 
         # Build the library
@@ -536,7 +535,7 @@ def test(args: argparse.Namespace, env: dict[str, str]):
     ctest_cmd = [str(args.ctest_path), "--build-config", args.config, "--verbose", "--timeout", "10800"]
     util.run(ctest_cmd, cwd=str(args.build_dir))
 
-    if not args.skip_csharp:
+    if args.build_csharp:
         dotnet = str(_resolve_executable_path("dotnet"))
         csharp_test_command = [dotnet, "test"]
         csharp_test_command += _get_csharp_properties(args)

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -25,8 +25,8 @@ package_name = '@TARGET_NAME@'
 
 def _onnxruntime_dependency() -> str:
     dependency = None
-    # Use dev version as default since CI tests use nightly version for testing
-    ort_version = os.environ.get("ONNXRUNTIME_VERSION", "1.19.0.dev20240805002")
+    # Use stable version as default and export nightly version in CI tests for testing
+    ort_version = os.environ.get("ONNXRUNTIME_VERSION", "1.19.0")
     is_nightly = True if "dev" in ort_version else False
 
     if package_name == "onnxruntime-genai":


### PR DESCRIPTION
### Description

This PR fixes two build errors with the main branch regarding the ONNX Runtime version and the C# API.

### Motivation and Context

The version of ONNX Runtime assumed to be installed is a dev version to help with CI testing. However, users who build ONNX Runtime GenAI from source may not be using the dev version and should not have to export `ONNXRUNTIME_VERSION` as an environment variable to specify the version. This variable can be set in the CIs instead.

For building the C# API, this step should be optional to match [how ONNX Runtime builds the C# API optionally](https://github.com/microsoft/onnxruntime/blob/628c0a8f0ee25eda0731310eadaec34c53a5da69/tools/ci_build/build.py#L267).