### PR TITLE
Avoid installing dependencies on CI machine

### DIFF
--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           python3 -m pip install -r test/python/requirements.txt --user
           python3 -m pip install -r test/python/requirements-cpu.txt --user
-          python3 -m pip install build/cpu/wheel/onnxruntime_genai*.whl --user
+          python3 -m pip install build/cpu/wheel/onnxruntime_genai*.whl --user --no-deps
 
       - name: Get HuggingFace Token
         run: |

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           python3 -m pip install -r test/python/requirements.txt --user
           python3 -m pip install -r test/python/requirements-cpu.txt --user
-          python3 -m pip install build/cpu/wheel/onnxruntime_genai*.whl
+          python3 -m pip install build/cpu/wheel/onnxruntime_genai*.whl --no-deps
 
       - name: Get HuggingFace Token
         run: |

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -132,7 +132,7 @@ jobs:
             -w /ort_genai_src onnxruntimecudabuildx64 bash -c " \
               ${{ env.PYTHON_EXECUTABLE }} -m pip install -r test/python/requirements.txt --user && \
               ${{ env.PYTHON_EXECUTABLE }} -m pip install -r test/python/requirements-cuda.txt --user && \
-              ${{ env.PYTHON_EXECUTABLE }} -m pip install /ort_genai_src/build/cuda/wheel/onnxruntime_genai*manylinux*.whl --user && \
+              ${{ env.PYTHON_EXECUTABLE }} -m pip install /ort_genai_src/build/cuda/wheel/onnxruntime_genai*manylinux*.whl --no-deps --user && \
               ${{ env.PYTHON_EXECUTABLE }} test/python/test_onnxruntime_genai.py --cwd test/python --test_models test/test_models --e2e"
 
       # TODO: Enable this by adding dotnet to the docker image

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -68,11 +68,9 @@ jobs:
 
     - name: Install the Python Wheel and Test Dependencies
       run: |
-        python -c "import platform; print(platform.machine()); print(platform.version()); print(platform.platform()); print(platform.system()); print(platform.processor()); print(platform.architecture())"
-        python -c "import sys; print(sys.version)"
         python -m pip install "numpy<2" coloredlogs flatbuffers packaging protobuf sympy pytest
         python -m pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ ort-nightly-qnn
-        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
     - name: Run the Python Tests
       run: |

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         python3 -m pip install -r test\python\requirements.txt --user
         python3 -m pip install -r test\python\requirements-cpu.txt --user
-        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl"))
+        python3 -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
     - name: Get HuggingFace Token
       run: |

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -82,7 +82,7 @@ jobs:
       run: |
         python -m pip install -r test\python\requirements.txt
         python -m pip install -r test\python\requirements-cuda.txt
-        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
     - name: Get HuggingFace Token
       run: |

--- a/.github/workflows/win-directml-x64-build.yml
+++ b/.github/workflows/win-directml-x64-build.yml
@@ -92,7 +92,7 @@ jobs:
       run: |
         python -m pip install -r test\python\requirements.txt
         python -m pip install -r test\python\requirements-directml.txt
-        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl"))
+        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
     - name: Verify Build Artifacts
       if: always()


### PR DESCRIPTION
Package names on nightly feed are `ort-nightly-suffix` and the same package on stable feed is `onnxruntime-suffix`.

Now that #868 makes the default version as the stable version, the CI pipelines started failing as a result of the discrepancy in the names. This PR addresses the problem by avoiding installing the dependency package in the pipeline.