### PR TITLE
pin protobuf version

### DIFF
--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -2,7 +2,7 @@ coloredlogs
 flatbuffers
 numpy<2
 packaging
-protobuf
+protobuf==5.27
 sympy
 pytest
 onnx


### PR DESCRIPTION
protobuf's latest version 5.28 causes a crash in ONNX modelproto. pin the protobuf version for now.