### PR TITLE
Fix MatMulNBits accuracy level for already-quantized models

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -696,6 +696,7 @@ class Model:
         self.make_node(
             "MatMulNBits", inputs=inputs, outputs=[output], name=name, domain="com.microsoft",
             bits=matmul.bits, block_size=matmul.group_size, K=matmul.in_features, N=matmul.out_features,
+            accuracy_level=self.quant_attrs["int4"]["accuracy_level"],
         )
         self.make_value_info(output, self.io_dtype, shape=['batch_size', 'sequence_length', matmul.out_features])
 
@@ -771,6 +772,7 @@ class Model:
         self.make_node(
             "MatMulNBits", inputs=inputs, outputs=[output], name=name, domain="com.microsoft",
             bits=matmul.bits, block_size=matmul.group_size, K=matmul.in_features, N=matmul.out_features,
+            accuracy_level=self.quant_attrs["int4"]["accuracy_level"],
         )
         self.make_value_info(output, self.io_dtype, shape=['batch_size', 'sequence_length', matmul.out_features])
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -275,7 +275,7 @@ class Model:
         self.quant_attrs = {
             "int4": {
                 "block_size": int(extra_options["int4_block_size"]) if "int4_block_size" in extra_options else 32,
-                "accuracy_level": int(extra_options["int4_accuracy_level"]) if "int4_accuracy_level" in extra_options else None,
+                "accuracy_level": int(extra_options["int4_accuracy_level"]) if "int4_accuracy_level" in extra_options else 0,   # Default is 0 for non-QDQ formats, default is 4 for QDQ formats
             }
         }
         if self.quant_type is not None:

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -695,8 +695,8 @@ class Model:
         output = "logits" if kwargs.get("logits", False) else f"{name}/output_0"
         self.make_node(
             "MatMulNBits", inputs=inputs, outputs=[output], name=name, domain="com.microsoft",
-            bits=matmul.bits, block_size=matmul.group_size, K=matmul.in_features, N=matmul.out_features,
             accuracy_level=self.quant_attrs["int4"]["accuracy_level"],
+            bits=matmul.bits, block_size=matmul.group_size, K=matmul.in_features, N=matmul.out_features,
         )
         self.make_value_info(output, self.io_dtype, shape=['batch_size', 'sequence_length', matmul.out_features])
 
@@ -771,8 +771,8 @@ class Model:
         output = "logits" if kwargs.get("logits", False) else f"{name}/output_0"
         self.make_node(
             "MatMulNBits", inputs=inputs, outputs=[output], name=name, domain="com.microsoft",
-            bits=matmul.bits, block_size=matmul.group_size, K=matmul.in_features, N=matmul.out_features,
             accuracy_level=self.quant_attrs["int4"]["accuracy_level"],
+            bits=matmul.bits, block_size=matmul.group_size, K=matmul.in_features, N=matmul.out_features,
         )
         self.make_value_info(output, self.io_dtype, shape=['batch_size', 'sequence_length', matmul.out_features])
 


### PR DESCRIPTION
### Description

This PR fixes a bug with setting the `accuracy_level` for the `MatMulNBits` op when building ONNX models from already-quantized PyTorch models.

### Motivation and Context

For already-quantized PyTorch models, the model builder creates the `MatMulNBits` op directly instead of invoking ONNX Runtime's 4-bit quantization tool to create the `MatMulNBits` ops. When creating the op, the accuracy level should be specified.