### PR TITLE
Update test_issueLabeler.yml to test out RegEx

### DIFF
--- a/.github/policies/test_issueLabeler.yml
+++ b/.github/policies/test_issueLabeler.yml
@@ -7,18 +7,15 @@ where:
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:
-      - if:
+      - description: Add ep:CUDA label to new issues
+        if:
           - payloadType: Issues
           - isOpen
+          - titleContains:
+              pattern: /\bcuda\b/i
+              isRegex: True
         then:
-          - if:
-              - or:
-                  - titleContains:
-                      pattern: shark
-                  - bodyContains:
-                      pattern: strawberry
-            then:
-              - addLabel:
-                  label: wontfix 
+          - addLabel:
+              label: ep:CUDA 
 onFailure:
 onSuccess:


### PR DESCRIPTION
Testing new GitOps Resource Management Policy to see whether it can successfully apply the ep:CUDA label to any open issue w/ cuda in the title