### PR TITLE
Share downloaded ort with ort-extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ if(MSVC)
   add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
-include(cmake/external/onnxruntime_external_deps.cmake)
 include(cmake/ortlib.cmake)
+include(cmake/external/onnxruntime_external_deps.cmake)
 # All Global variables, including GLOB, for the top level CMakeLists.txt should be defined here
 include(cmake/global_variables.cmake)
 # Checking if CUDA is supported

--- a/cmake/ortlib.cmake
+++ b/cmake/ortlib.cmake
@@ -121,5 +121,9 @@ if(USE_DML)
   set(D3D12_LIB_DIR ${d3d12lib_SOURCE_DIR}/build/native/bin/${DML_BINARY_PLATFORM})
 endif()
 
+# onnxruntime-extensions can use the same onnxruntime headers
+set(ONNXRUNTIME_INCLUDE_DIR ${ORT_HEADER_DIR})
+set(ONNXRUNTIME_LIB_DIR ${ORT_LIB_DIR})
+
 message(STATUS "ORT_HEADER_DIR: ${ORT_HEADER_DIR}")
 message(STATUS "ORT_LIB_DIR: ${ORT_LIB_DIR}")


### PR DESCRIPTION
So far, ort-extensions and ort both download ort to build.

With this pull-request, ort-genai can share the downloaded ort header dir with ort-extensions.