### PR TITLE
Remove unnecessary HF token query

### DIFF
--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -71,12 +71,9 @@ jobs:
           python3 -m pip install -r test/python/requirements-cpu.txt --user
           python3 -m pip install build/cpu/wheel/onnxruntime_genai*.whl --user --no-deps
 
-      - name: Get HuggingFace Token
+      - name: Use Dummy HuggingFace Token
         run: |
-          az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
-          HF_TOKEN=$(az keyvault secret show --vault-name anubissvcsecret --name ANUBIS-HUGGINGFACE-TOKEN --query value)
-          echo "::add-mask::$HF_TOKEN"
-          echo "HF_TOKEN=$HF_TOKEN" >> $GITHUB_ENV
+          echo "HF_TOKEN=12345" >> $GITHUB_ENV
 
       - name: Verify Build Artifacts
         if: always()

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -54,12 +54,9 @@ jobs:
           python3 -m pip install -r test/python/requirements-cpu.txt --user
           python3 -m pip install build/cpu/wheel/onnxruntime_genai*.whl --no-deps
 
-      - name: Get HuggingFace Token
+      - name: Use Dummy HuggingFace Token
         run: |
-          az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
-          HF_TOKEN=$(az keyvault secret show --vault-name anubissvcsecret --name ANUBIS-HUGGINGFACE-TOKEN --query value)
-          echo "::add-mask::$HF_TOKEN"
-          echo "HF_TOKEN=$HF_TOKEN" >> $GITHUB_ENV
+          echo "HF_TOKEN=12345" >> $GITHUB_ENV
 
       - name: Run the python tests
         run: |

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -109,12 +109,9 @@ jobs:
             bash -c " \
               /usr/bin/cmake --build --preset linux_gcc_cuda_release"
 
-      - name: Get HuggingFace Token
+      - name: Use Dummy HuggingFace Token
         run: |
-          az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
-          HF_TOKEN=$(az keyvault secret show --vault-name anubissvcsecret --name ANUBIS-HUGGINGFACE-TOKEN --query value)
-          echo "::add-mask::$HF_TOKEN"
-          echo "HF_TOKEN=$HF_TOKEN" >> $GITHUB_ENV
+          echo "HF_TOKEN=12345" >> $GITHUB_ENV
 
       - name: Install the onnxruntime-genai Python wheel and run python test
         run: |

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -78,12 +78,9 @@ jobs:
         python3 -m pip install -r test\python\requirements-cpu.txt --user
         python3 -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
-    - name: Get HuggingFace Token
+    - name: Use Dummy HuggingFace Token
       run: |
-        az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
-        $HF_TOKEN = (az keyvault secret show --vault-name anubissvcsecret --name ANUBIS-HUGGINGFACE-TOKEN --query value)
-        Write-Output "::add-mask::$HF_TOKEN"
-        Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=$HF_TOKEN"
+        Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=12345"
 
     - name: Run the Python Tests
       run: |

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -84,12 +84,9 @@ jobs:
         python -m pip install -r test\python\requirements-cuda.txt
         python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
-    - name: Get HuggingFace Token
+    - name: Use Dummy HuggingFace Token
       run: |
-        az login --identity --username 63b63039-6328-442f-954b-5a64d124e5b4
-        $HF_TOKEN = (az keyvault secret show --vault-name anubissvcsecret --name ANUBIS-HUGGINGFACE-TOKEN --query value)
-        Write-Output "::add-mask::$HF_TOKEN"
-        Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=$HF_TOKEN"
+        Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=12345"
 
     - name: Run the Python Tests
       run: |


### PR DESCRIPTION
The pipelines do not really need any HF token to run. The pipelines started recently failing due to key vault access issues.

This pull-request removes the need to query the HF token by setting a dummy token.