### PR TITLE
Update linux-gpu-x64-build.yml: change machine pool to A10

### DIFF
--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -21,7 +21,7 @@ jobs:
   linux-cuda-x64-build:
     env :
       PYTHON_EXECUTABLE: "/opt/python/cp38-cp38/bin/python3.8"
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2004-T4" ]
+    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-A10" ]
     steps:
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Change the machine pool to onnxruntime-genai-Ubuntu2204-A10 because we have less T4 machines available.