### PR TITLE
Extend model type with ChatGLM3

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+//
+// Modifications Copyright(C) 2024 Advanced Micro Devices, Inc. All rights reserved
 #include <algorithm>
 #include <thread>
 
@@ -501,7 +503,7 @@ std::shared_ptr<Model> CreateModel(OrtEnv& ort_env, const char* config_path) {
 
   if (config->model.type == "gpt2")
     return std::make_shared<Gpt_Model>(std::move(config), ort_env);
-  if (config->model.type == "llama" || config->model.type == "gemma" || config->model.type == "gemma2" || config->model.type == "mistral" || config->model.type == "phi" || config->model.type == "phi3" || config->model.type == "phi3small" || config->model.type == "phimoe" || config->model.type == "qwen2" || config->model.type == "nemotron")
+  if (config->model.type == "llama" || config->model.type == "gemma" || config->model.type == "gemma2" || config->model.type == "mistral" || config->model.type == "phi" || config->model.type == "phi3" || config->model.type == "phi3small" || config->model.type == "phimoe" || config->model.type == "qwen2" || config->model.type == "nemotron" || config->model.type == "chatglm")
     return std::make_shared<DecoderOnly_Model>(std::move(config), ort_env);
   if (config->model.type == "whisper")
     return std::make_shared<Whisper_Model>(std::move(config), ort_env);

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -298,9 +298,15 @@ class Model:
             "past_key_names": "past_key_values.%d.key",
             "past_value_names": "past_key_values.%d.value",
         })
+        if self.model_type.find("ChatGLM") != -1:
+            # config.bos_token_id not present in ChatGLM model configs.
+            bos_token_id = 1
+        else:
+            bos_token_id = config.bos_token_id
+
         genai_config = {
             "model": {
-                "bos_token_id": config.bos_token_id,
+                "bos_token_id": bos_token_id,
                 "context_length": self.context_length,
                 "decoder": {
                     "session_options" : {

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -298,15 +298,9 @@ class Model:
             "past_key_names": "past_key_values.%d.key",
             "past_value_names": "past_key_values.%d.value",
         })
-        if self.model_type.find("ChatGLM") != -1:
-            # config.bos_token_id not present in ChatGLM model configs.
-            bos_token_id = 1
-        else:
-            bos_token_id = config.bos_token_id
-
         genai_config = {
             "model": {
-                "bos_token_id": bos_token_id,
+                "bos_token_id": config.bos_token_id if hasattr(config, "bos_token_id") else 1,  # config.bos_token_id not present in ChatGLM model configs.
                 "context_length": self.context_length,
                 "decoder": {
                     "session_options" : {


### PR DESCRIPTION
In addition to #921. Afterwards, what remains is tokenizer support for ChatGLM3.

edit: also added a small fix to populate `bos_token_id` as it is not present in ChatGLM3 source config.