### PR TITLE
Disable graph capture for embedding model

### DIFF
--- a/src/models/model.h
+++ b/src/models/model.h
@@ -132,6 +132,7 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model> {
   std::unique_ptr<Config> config_;
   std::unique_ptr<OrtSessionOptions> session_options_;
   std::unique_ptr<OrtSessionOptions> vision_session_options_;
+  std::unique_ptr<OrtSessionOptions> embedding_session_options_;
   std::unique_ptr<OrtRunOptions> run_options_;
 
   cuda_stream_holder cuda_stream_;

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -131,8 +131,6 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model> {
 
   std::unique_ptr<Config> config_;
   std::unique_ptr<OrtSessionOptions> session_options_;
-  std::unique_ptr<OrtSessionOptions> vision_session_options_;
-  std::unique_ptr<OrtSessionOptions> embedding_session_options_;
   std::unique_ptr<OrtRunOptions> run_options_;
 
   cuda_stream_holder cuda_stream_;
@@ -157,10 +155,10 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model> {
   void InitDeviceAllocator(OrtSession& session);
   void CreateSessionOptions();
 
- private:
   void CreateSessionOptionsFromConfig(const Config::SessionOptions& config_session_options,
                                       OrtSessionOptions& session_options,
-                                      bool is_primary_session_options);
+                                      bool is_primary_session_options,
+                                      bool disable_graph_capture);
 
 #if USE_DML
   mutable DmlObjects dml_objects_;

--- a/src/models/multi_modal_vision_model.cpp
+++ b/src/models/multi_modal_vision_model.cpp
@@ -56,7 +56,6 @@ int64_t GetNumImageTokens(const std::vector<GeneratorParams::Input>& extra_input
 
 MultiModalVisionModel::MultiModalVisionModel(std::unique_ptr<Config> config, OrtEnv& ort_env)
     : Model{std::move(config)} {
-
   // The embedding and vision models don't support graph capture because of control flow nodes, so disable graph capture for them
   auto vision_session_options = OrtSessionOptions::Create();
   CreateSessionOptionsFromConfig(config_->model.decoder.session_options, *vision_session_options, true, true);


### PR DESCRIPTION
The new embedding model for the vision pipeline contains `if` nodes, so graph capture is not possible.