### PR TITLE
[Genny] Add missing build flags on DirectML package

### DIFF
--- a/examples/csharp/Genny/Genny/Genny.csproj
+++ b/examples/csharp/Genny/Genny/Genny.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.4.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.4.0" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' "/>
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.4.0" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.4.0" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' "/>
   </ItemGroup>

--- a/examples/csharp/Genny/Genny/Genny.csproj
+++ b/examples/csharp/Genny/Genny/Genny.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.4.0" />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.4.0" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.4.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.4.0" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' "/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The build flags are missing from the `DirectML:` Nuget packages, this is causing it to supersede the `CUDA` package if selected

Adding back the `Debug_DirectML` and `Release_DirectML` conditional flags

Mentioned in Issue https://github.com/microsoft/onnxruntime-genai/issues/933