### PR TITLE
Avoid using env allocator by default

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -40,6 +40,8 @@ struct Config {
     std::optional<std::string> log_id;
     std::optional<int> log_severity_level;
     std::optional<std::string> enable_profiling;
+    // TODO(baijumeswani): Sharing env allocators across sessions leads to crashes on windows and iOS.
+    //                     Identify the reason for the crash to enable allocator sharing by default.
     bool use_env_allocators{false};
 
     std::vector<ProviderOptions> provider_options;

--- a/src/config.h
+++ b/src/config.h
@@ -40,7 +40,7 @@ struct Config {
     std::optional<std::string> log_id;
     std::optional<int> log_severity_level;
     std::optional<std::string> enable_profiling;
-    bool use_env_allocators{true};
+    bool use_env_allocators{false};
 
     std::vector<ProviderOptions> provider_options;
   };


### PR DESCRIPTION
Temporary fix for https://github.com/microsoft/onnxruntime-genai/issues/929 and https://github.com/microsoft/onnxruntime/issues/22252

