### PR TITLE
Make Microsoft.ML.OnnxRuntimeGenAI.Tokenizer a Microsoft.ML.Tokenizers.Tokenizer

### DIFF
--- a/src/csharp/Adapters.cs
+++ b/src/csharp/Adapters.cs
@@ -31,8 +31,10 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         /// <param name="adapterName">adapter name</param>
         public void LoadAdapter(string adapterPath, string adapterName)
         {
-            Result.VerifySuccess(NativeMethods.OgaLoadAdapter(handle,
-                StringUtils.ToUtf8(adapterPath), StringUtils.ToUtf8(adapterName)));
+            Result.VerifySuccess(NativeMethods.OgaLoadAdapter(
+                handle,
+                StringUtils.ToNullTerminatedUtf8(adapterPath), 
+                StringUtils.ToNullTerminatedUtf8(adapterName)));
         }
 
         /// <summary>
@@ -42,7 +44,9 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         /// <param name="adapterName"></param>
         public void UnloadAdapter(string adapterName)
         {
-            Result.VerifySuccess(NativeMethods.OgaUnloadAdapter(handle, StringUtils.ToUtf8(adapterName)));
+            Result.VerifySuccess(NativeMethods.OgaUnloadAdapter(
+                handle, 
+                StringUtils.ToNullTerminatedUtf8(adapterName)));
         }
 
         internal IntPtr Handle { get { return handle; } }

--- a/src/csharp/Audios.cs
+++ b/src/csharp/Audios.cs
@@ -23,7 +23,9 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             Result.VerifySuccess(NativeMethods.OgaCreateStringArray(out IntPtr stringArray));
             foreach (string audioPath in audioPaths)
             {
-                Result.VerifySuccess(NativeMethods.OgaStringArrayAddString(stringArray, StringUtils.ToUtf8(audioPath)));
+                Result.VerifySuccess(NativeMethods.OgaStringArrayAddString(
+                    stringArray,
+                    StringUtils.ToNullTerminatedUtf8(audioPath)));
             }
             Result.VerifySuccess(NativeMethods.OgaLoadAudios(stringArray, out IntPtr audiosHandle));
             NativeMethods.OgaDestroyStringArray(stringArray);

--- a/src/csharp/Config.cs
+++ b/src/csharp/Config.cs
@@ -11,7 +11,9 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         private bool _disposed = false;
         public Config(string modelPath)
         {
-            Result.VerifySuccess(NativeMethods.OgaCreateConfig(StringUtils.ToUtf8(modelPath), out _configHandle));
+            Result.VerifySuccess(NativeMethods.OgaCreateConfig(
+                StringUtils.ToNullTerminatedUtf8(modelPath),
+                out _configHandle));
         }
 
         internal IntPtr Handle { get { return _configHandle; } }
@@ -22,12 +24,18 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         public void AppendProvider(string provider)
         {
-            Result.VerifySuccess(NativeMethods.OgaConfigAppendProvider(_configHandle, StringUtils.ToUtf8(provider)));
+            Result.VerifySuccess(NativeMethods.OgaConfigAppendProvider(
+                _configHandle, 
+                StringUtils.ToNullTerminatedUtf8(provider)));
         }
 
         public void SetProviderOption(string provider, string option, string value)
         {
-            Result.VerifySuccess(NativeMethods.OgaConfigSetProviderOption(_configHandle, StringUtils.ToUtf8(provider), StringUtils.ToUtf8(option), StringUtils.ToUtf8(value)));
+            Result.VerifySuccess(NativeMethods.OgaConfigSetProviderOption(
+                _configHandle, 
+                StringUtils.ToNullTerminatedUtf8(provider), 
+                StringUtils.ToNullTerminatedUtf8(option), 
+                StringUtils.ToNullTerminatedUtf8(value)));
         }
 
         ~Config()

--- a/src/csharp/Generator.cs
+++ b/src/csharp/Generator.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         public Tensor GetOutput(string outputName)
         {
             Result.VerifySuccess(NativeMethods.OgaGenerator_GetOutput(_generatorHandle,
-                                                                      StringUtils.ToUtf8(outputName),
+                                                                      StringUtils.ToNullTerminatedUtf8(outputName),
                                                                       out IntPtr outputTensor));
             return new Tensor(outputTensor);
         }
@@ -85,7 +85,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         {
             Result.VerifySuccess(NativeMethods.OgaSetActiveAdapter(_generatorHandle,
                                                                    adapters.Handle,
-                                                                   StringUtils.ToUtf8(adapterName)));
+                                                                   StringUtils.ToNullTerminatedUtf8(adapterName)));
         }
 
         ~Generator()

--- a/src/csharp/GeneratorParams.cs
+++ b/src/csharp/GeneratorParams.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.ML.OnnxRuntimeGenAI
 {
@@ -21,12 +18,16 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         public void SetSearchOption(string searchOption, double value)
         {
-            Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetSearchNumber(_generatorParamsHandle, StringUtils.ToUtf8(searchOption), value));
+            Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetSearchNumber(
+                _generatorParamsHandle, 
+                StringUtils.ToNullTerminatedUtf8(searchOption), value));
         }
 
         public void SetSearchOption(string searchOption, bool value)
         {
-            Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetSearchBool(_generatorParamsHandle, StringUtils.ToUtf8(searchOption), value));
+            Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetSearchBool(
+                _generatorParamsHandle,
+                StringUtils.ToNullTerminatedUtf8(searchOption), value));
         }
 
         public void TryGraphCaptureWithMaxBatchSize(int maxBatchSize)
@@ -36,12 +37,17 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         public void SetModelInput(string name, Tensor value)
         {
-            Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetModelInput(_generatorParamsHandle, StringUtils.ToUtf8(name), value.Handle));
+            Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetModelInput(
+                _generatorParamsHandle, 
+                StringUtils.ToNullTerminatedUtf8(name),
+                value.Handle));
         }
 
         public void SetInputs(NamedTensors namedTensors)
         {
-            Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetInputs(_generatorParamsHandle, namedTensors.Handle));
+            Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetInputs(
+                _generatorParamsHandle, 
+                namedTensors.Handle));
         }
 
         ~GeneratorParams()

--- a/src/csharp/Images.cs
+++ b/src/csharp/Images.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.ML.OnnxRuntimeGenAI
 {
@@ -23,7 +22,9 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             Result.VerifySuccess(NativeMethods.OgaCreateStringArray(out IntPtr stringArray));
             foreach (string imagePath in imagePaths)
             {
-                Result.VerifySuccess(NativeMethods.OgaStringArrayAddString(stringArray, StringUtils.ToUtf8(imagePath)));
+                Result.VerifySuccess(NativeMethods.OgaStringArrayAddString(
+                    stringArray,
+                    StringUtils.ToNullTerminatedUtf8(imagePath)));
             }
             Result.VerifySuccess(NativeMethods.OgaLoadImages(stringArray, out IntPtr imagesHandle));
             NativeMethods.OgaDestroyStringArray(stringArray);

--- a/src/csharp/Microsoft.ML.OnnxRuntimeGenAI.csproj
+++ b/src/csharp/Microsoft.ML.OnnxRuntimeGenAI.csproj
@@ -123,6 +123,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.4.0-preview.1.25207.5" />
+    <PackageReference Include="Microsoft.ML.Tokenizers" Version="1.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/csharp/Model.cs
+++ b/src/csharp/Model.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.ML.OnnxRuntimeGenAI
 {
@@ -13,7 +12,9 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         public Model(string modelPath)
         {
-            Result.VerifySuccess(NativeMethods.OgaCreateModel(StringUtils.ToUtf8(modelPath), out _modelHandle));
+            Result.VerifySuccess(NativeMethods.OgaCreateModel(
+                StringUtils.ToNullTerminatedUtf8(modelPath), 
+                out _modelHandle));
         }
 
         public Model(Config config)

--- a/src/csharp/MultiModalProcessor.cs
+++ b/src/csharp/MultiModalProcessor.cs
@@ -20,8 +20,11 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         public NamedTensors ProcessImages(string prompt, Images images)
         {
             IntPtr imagesHandle = images == null ? IntPtr.Zero : images.Handle;
-            Result.VerifySuccess(NativeMethods.OgaProcessorProcessImages(_processorHandle, StringUtils.ToUtf8(prompt),
-                                                                         imagesHandle, out IntPtr namedTensorsHandle));
+            Result.VerifySuccess(NativeMethods.OgaProcessorProcessImages(
+                _processorHandle, 
+                StringUtils.ToNullTerminatedUtf8(prompt),
+                imagesHandle, 
+                out IntPtr namedTensorsHandle));
             return new NamedTensors(namedTensorsHandle);
         }
 
@@ -41,8 +44,12 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         {
             IntPtr imagesHandle = images == null ? IntPtr.Zero : images.Handle;
             IntPtr audiosHandle = audios == null ? IntPtr.Zero : audios.Handle;
-            Result.VerifySuccess(NativeMethods.OgaProcessorProcessImagesAndAudios(_processorHandle, StringUtils.ToUtf8(prompt),
-                                                                         imagesHandle, audiosHandle, out IntPtr namedTensorsHandle));
+            Result.VerifySuccess(NativeMethods.OgaProcessorProcessImagesAndAudios(
+                _processorHandle, 
+                StringUtils.ToNullTerminatedUtf8(prompt),
+                imagesHandle, 
+                audiosHandle, 
+                out IntPtr namedTensorsHandle));
             return new NamedTensors(namedTensorsHandle);
         }
 
@@ -68,7 +75,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             }
             try
             {
-                return StringUtils.FromUtf8(outStr);
+                return StringUtils.FromNullTerminatedUtf8(outStr);
             }
             finally
             {

--- a/src/csharp/Result.cs
+++ b/src/csharp/Result.cs
@@ -6,18 +6,22 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.ML.OnnxRuntimeGenAI
 {
-    class Result
+    internal static class Result
     {
-        private static string GetErrorMessage(IntPtr nativeResult)
+        internal static string GetErrorMessage(IntPtr nativeResult)
         {
-
-            return StringUtils.FromUtf8(NativeMethods.OgaResultGetError(nativeResult));
+            return StringUtils.FromNullTerminatedUtf8(NativeMethods.OgaResultGetError(nativeResult));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void VerifySuccess(IntPtr nativeResult)
         {
             if (nativeResult != IntPtr.Zero)
+            {
+                Throw(nativeResult);
+            }
+
+            static void Throw(IntPtr nativeResult)
             {
                 try
                 {

--- a/src/csharp/Tokenizer.cs
+++ b/src/csharp/Tokenizer.cs
@@ -2,27 +2,42 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Microsoft.ML.Tokenizers;
 
 namespace Microsoft.ML.OnnxRuntimeGenAI
 {
-    public class Tokenizer : IDisposable
+    public sealed class Tokenizer : Tokenizers.Tokenizer, IDisposable
     {
         private IntPtr _tokenizerHandle;
-        private bool _disposed = false;
 
         public Tokenizer(Model model)
         {
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
             Result.VerifySuccess(NativeMethods.OgaCreateTokenizer(model.Handle, out _tokenizerHandle));
         }
 
         public Sequences EncodeBatch(string[] strings)
         {
+            if (strings is null)
+            {
+                throw new ArgumentNullException(nameof(strings));
+            }
+
             Result.VerifySuccess(NativeMethods.OgaCreateSequences(out IntPtr nativeSequences));
             try
             {
                 foreach (string str in strings)
                 {
-                    Result.VerifySuccess(NativeMethods.OgaTokenizerEncode(_tokenizerHandle, StringUtils.ToUtf8(str), nativeSequences));
+                    Result.VerifySuccess(NativeMethods.OgaTokenizerEncode(_tokenizerHandle, StringUtils.ToNullTerminatedUtf8(str), nativeSequences));
                 }
 
                 return new Sequences(nativeSequences);
@@ -36,6 +51,11 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         public string[] DecodeBatch(Sequences sequences)
         {
+            if (sequences is null)
+            {
+                throw new ArgumentNullException(nameof(sequences));
+            }
+
             string[] result = new string[sequences.NumSequences];
             for (ulong i = 0; i < sequences.NumSequences; i++)
             {
@@ -47,10 +67,20 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         public Sequences Encode(string str)
         {
+            if (str is null)
+            {
+                throw new ArgumentNullException(nameof(str));
+            }
+
+            return Encode(str.AsSpan());
+        }
+
+        public Sequences Encode(ReadOnlySpan<char> str)
+        {
             Result.VerifySuccess(NativeMethods.OgaCreateSequences(out IntPtr nativeSequences));
             try
             {
-                Result.VerifySuccess(NativeMethods.OgaTokenizerEncode(_tokenizerHandle, StringUtils.ToUtf8(str), nativeSequences));
+                Result.VerifySuccess(NativeMethods.OgaTokenizerEncode(_tokenizerHandle, StringUtils.ToNullTerminatedUtf8(str), nativeSequences));
                 return new Sequences(nativeSequences);
             }
             catch
@@ -60,19 +90,18 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             }
         }
 
-        public string Decode(ReadOnlySpan<int> sequence)
+        public unsafe string Decode(ReadOnlySpan<int> sequence)
         {
-            IntPtr outStr = IntPtr.Zero;
-            unsafe
+            IntPtr outStr;
+
+            fixed (int* sequencePtr = sequence)
             {
-                fixed (int* sequencePtr = sequence)
-                {
-                    Result.VerifySuccess(NativeMethods.OgaTokenizerDecode(_tokenizerHandle, sequencePtr, (UIntPtr)sequence.Length, out outStr));
-                }
+                Result.VerifySuccess(NativeMethods.OgaTokenizerDecode(_tokenizerHandle, sequencePtr, (UIntPtr)sequence.Length, out outStr));
             }
+
             try
             {
-                return StringUtils.FromUtf8(outStr);
+                return StringUtils.FromNullTerminatedUtf8(outStr);
             }
             finally
             {
@@ -82,32 +111,151 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         public TokenizerStream CreateStream()
         {
-            IntPtr tokenizerStreamHandle = IntPtr.Zero;
-            Result.VerifySuccess(NativeMethods.OgaCreateTokenizerStream(_tokenizerHandle, out tokenizerStreamHandle));
+            Result.VerifySuccess(NativeMethods.OgaCreateTokenizerStream(_tokenizerHandle, out nint tokenizerStreamHandle));
             return new TokenizerStream(tokenizerStreamHandle);
         }
 
-
         ~Tokenizer()
         {
-            Dispose(false);
+            Dispose();
         }
 
         public void Dispose()
         {
-            Dispose(true);
+            if (_tokenizerHandle != IntPtr.Zero)
+            {
+                NativeMethods.OgaDestroyTokenizer(_tokenizerHandle);
+                _tokenizerHandle = IntPtr.Zero;
+            }
+
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        #region Base Tokenizer Overrides
+        private static int GetMaxTokenCount(EncodeSettings settings)
         {
-            if (_disposed)
+            if (settings.MaxTokenCount <= 0)
             {
-                return;
+                throw new ArgumentOutOfRangeException(nameof(settings.MaxTokenCount), "The maximum number of tokens must be greater than zero.");
             }
-            NativeMethods.OgaDestroyTokenizer(_tokenizerHandle);
-            _tokenizerHandle = IntPtr.Zero;
-            _disposed = true;
+
+            return settings.MaxTokenCount;
         }
+
+        /// <inheritdoc />
+        protected override int CountTokens(string text, ReadOnlySpan<char> textSpan, EncodeSettings settings)
+        {
+            Debug.Assert(text is null || textSpan.SequenceEqual(text.AsSpan()));
+
+            using Sequences sequences = Encode(textSpan);
+            Debug.Assert(sequences.NumSequences == 1);
+
+            return Math.Min(GetMaxTokenCount(settings), sequences[0].Length);
+        }
+
+        /// <inheritdoc />
+        protected override EncodeResults<EncodedToken> EncodeToTokens(string text, ReadOnlySpan<char> textSpan, EncodeSettings settings)
+        {
+            Debug.Assert(text is null || textSpan.SequenceEqual(text.AsSpan()));
+
+            int maxTokenCount = GetMaxTokenCount(settings);
+
+            using Sequences sequences = Encode(textSpan);
+            if (sequences.NumSequences != 1)
+            {
+                throw new InvalidOperationException("Expected exactly one sequence.");
+            }
+
+            ReadOnlySpan<int> sequence = sequences[0];
+            if (sequence.Length > maxTokenCount)
+            {
+                sequence = sequence.Slice(0, maxTokenCount);
+            }
+
+            // Only the token IDs are returned. The Sequences doesn't contain offset information about each token.
+            EncodedToken[] tokens = new EncodedToken[sequence.Length];
+            for (int i = 0; i < sequence.Length; i++)
+            {
+                tokens[i] = new EncodedToken(sequence[i], string.Empty, default);
+            }
+
+            return new EncodeResults<EncodedToken>() { Tokens = tokens };
+        }
+
+        /// <inheritdoc />
+        protected override EncodeResults<int> EncodeToIds(string text, ReadOnlySpan<char> textSpan, EncodeSettings settings)
+        {
+            Debug.Assert(text is null || textSpan.SequenceEqual(text.AsSpan()));
+
+            int maxTokenCount = GetMaxTokenCount(settings);
+
+            using Sequences sequences = Encode(textSpan);
+            Debug.Assert(sequences.NumSequences == 1);
+
+            ReadOnlySpan<int> sequence = sequences[0];
+            if (sequence.Length > maxTokenCount)
+            {
+                sequence = sequence.Slice(0, maxTokenCount);
+            }
+
+            return new EncodeResults<int>() { Tokens = sequence.ToArray() };
+        }
+
+        /// <inheritdoc />
+        public override string Decode(IEnumerable<int> ids)
+        {
+            if (ids is null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
+            return Decode(ids as int[] ?? ids.ToArray());
+        }
+
+        /// <inheritdoc />
+        public override unsafe OperationStatus Decode(IEnumerable<int> ids, Span<char> destination, out int idsConsumed, out int charsWritten)
+        {
+            if (ids is null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
+            IntPtr outStr;
+
+            int[] idsArray = ids as int[] ?? ids.ToArray();
+            fixed (int* sequencePtr = idsArray)
+            {
+                try
+                {
+                    Result.VerifySuccess(NativeMethods.OgaTokenizerDecode(_tokenizerHandle, sequencePtr, (UIntPtr)idsArray.Length, out outStr));
+                }
+                catch
+                {
+                    idsConsumed = charsWritten = 0;
+                    return OperationStatus.InvalidData;
+                }
+            }
+
+            try
+            {
+                fixed (char* pDest = destination)
+                {
+                    charsWritten = Encoding.UTF8.GetChars((byte*)outStr, StringUtils.GetNullTerminatedUtf8Length(outStr), pDest, destination.Length);
+                    idsConsumed = idsArray.Length;
+                }
+            }
+            catch (ArgumentException)
+            {
+                idsConsumed = charsWritten = 0;
+                return OperationStatus.DestinationTooSmall;
+            }
+            finally
+            {
+                NativeMethods.OgaDestroyString(outStr);
+            }
+
+            return OperationStatus.Done;
+        }
+#endregion
     }
 }

--- a/src/csharp/TokenizerStream.cs
+++ b/src/csharp/TokenizerStream.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         {
             IntPtr decodedStr = IntPtr.Zero;
             Result.VerifySuccess(NativeMethods.OgaTokenizerStreamDecode(_tokenizerStreamHandle, token, out decodedStr));
-            return StringUtils.FromUtf8(decodedStr);
+            return StringUtils.FromNullTerminatedUtf8(decodedStr);
         }
 
         ~TokenizerStream()


### PR DESCRIPTION
This enables an ONNX Runtime GenAI tokenizer instance to be used anywhere a Microsoft.ML.Tokenizers tokenizer is accepted. If we'd prefer, rather than having Tokenizer be a base class for the ONNX Runtime one, we could instead expose some sort of `public Microsoft.ML.Tokenizer.Tokenizer AsTokenizer()` conversion method that returns a wrapper object (though that's a bit confusing given the names of the type are the same, just different namespaces).

cc: @luisquintanilla, @tarekgh