### PR TITLE
Fix destructor mismatch that caused random heap corruption

### DIFF
--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -544,7 +544,7 @@ void OGA_API_CALL OgaDestroyString(const char* p) {
 }
 
 void OGA_API_CALL OgaDestroySequences(OgaSequences* p) {
-  delete reinterpret_cast<Generators::Sequences*>(p);
+  delete reinterpret_cast<Generators::TokenSequences*>(p);
 }
 
 void OGA_API_CALL OgaDestroyModel(OgaModel* p) {


### PR DESCRIPTION
I don't know how this ever worked, but it's totally fair that I was the one to suffer for it since I wrote the original line of code.

In something I was working on, genai would crash randomly with heap corruption. I finally figured out it was this line that was the culprit.

I'll think about renaming things so nobody else gets confused like I did.