### PR TITLE
Update Java Tensor

### DIFF
--- a/src/java/src/main/java/ai/onnxruntime/genai/Tensor.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Tensor.java
@@ -57,7 +57,7 @@ public final class Tensor implements AutoCloseable {
 
     // for now, require native byte order as the bytes will be used directly.
     if (data.order() != ByteOrder.nativeOrder()) {
-      throw new GenAIException("Tensor data must have native byte order.")
+      throw new GenAIException("Tensor data must have native byte order.");
     }
 
     this.elementType = elementType;

--- a/src/java/src/main/java/ai/onnxruntime/genai/Tensor.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Tensor.java
@@ -55,14 +55,14 @@ public final class Tensor implements AutoCloseable {
           "Tensor data must be direct. Allocate with ByteBuffer.allocateDirect");
     }
 
-    // for now, require native byte order as the bytes will used directly.
+    // for now, require native byte order as the bytes will be used directly.
     if (data.order() != ByteOrder.nativeOrder()) {
       throw new GenAIException("Tensor data must have native byte order.")
     }
 
     this.elementType = elementType;
     this.shape = shape;
-    this.dataBuffer = data;  // save a reference so the owning buffer will stay around
+    this.dataBuffer = data;  // save a reference so the owning buffer will stay around.
 
     nativeHandle = createTensor(data, shape, elementType.ordinal());
   }

--- a/src/java/src/main/java/ai/onnxruntime/genai/Tensor.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Tensor.java
@@ -5,11 +5,15 @@
 package ai.onnxruntime.genai;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 public final class Tensor implements AutoCloseable {
-  private long nativeHandle = -1;
+  private long nativeHandle = 0;
   private final ElementType elementType;
   private final long[] shape;
+
+  // Buffer that owns the Tensor data.
+  private ByteBuffer dataBuffer = null;
 
   // The values in this enum must match ONNX values
   // https://github.com/onnx/onnx/blob/159fa47b7c4d40e6d9740fcf14c36fff1d11ccd8/onnx/onnx.proto#L499-L544
@@ -33,7 +37,7 @@ public final class Tensor implements AutoCloseable {
   /**
    * Constructs a Tensor with the given data, shape and element type.
    *
-   * @param data The data for the Tensor. Must be a direct ByteBuffer.
+   * @param data The data for the Tensor. Must be a direct ByteBuffer with native byte order.
    * @param shape The shape of the Tensor.
    * @param elementType The type of elements in the Tensor.
    * @throws GenAIException
@@ -51,8 +55,14 @@ public final class Tensor implements AutoCloseable {
           "Tensor data must be direct. Allocate with ByteBuffer.allocateDirect");
     }
 
+    // for now, require native byte order as the bytes will used directly.
+    if (data.order() != ByteOrder.nativeOrder()) {
+      throw new GenAIException("Tensor data must have native byte order.")
+    }
+
     this.elementType = elementType;
     this.shape = shape;
+    this.dataBuffer = data;  // save a reference so the owning buffer will stay around
 
     nativeHandle = createTensor(data, shape, elementType.ordinal());
   }


### PR DESCRIPTION
- Save reference to ByteBuffer that owns the data so it won't get garbage collected while the Tensor is around.
- Verify the passed in ByteBuffer has native byte order.
- Change default nativeHandle value to 0.