### PR TITLE
Allow for multiple provider configs, and for merging multiple configs.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -33,8 +33,13 @@ struct ProviderOptionsObject_Element : JSON::Element {
   explicit ProviderOptionsObject_Element(std::vector<Config::ProviderOptions>& v) : v_{v} {}
 
   JSON::Element& OnObject(std::string_view name) override {
-    if (options_element_)
-      throw std::runtime_error("Each object in the provider_options array can only have one member (named value)");
+    for (auto& v : v_) {
+      if (v.name == name) {
+        options_element_ = std::make_unique<ProviderOptions_Element>(v);
+        return *options_element_;
+      }
+    }
+
     auto& options = v_.emplace_back();
     options.name = name;
     options_element_ = std::make_unique<ProviderOptions_Element>(options);

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -307,12 +307,18 @@ struct Phi2Test {
   void Run() {
     // Low level loop
     {
+      std::cout << "Creating generator..." << std::endl;
+
       auto generator = OgaGenerator::Create(*model_, *params_);
+
+      std::cout << "Generation loop..." << std::endl;
 
       while (!generator->IsDone()) {
         generator->ComputeLogits();
         generator->GenerateNextToken();
       }
+
+      std::cout << "Decode one at a time" << std::endl;
 
       // Decode One at a time
       for (size_t i = 0; i < 3; i++) {
@@ -323,7 +329,11 @@ struct Phi2Test {
 
     // High level
     {
+      std::cout << "High level generate" << std::endl;
+
       auto output_sequences = model_->Generate(*params_);
+
+      std::cout << "Decode the batch" << std::endl;
 
       // Decode The Batch
       for (size_t i = 0; i < output_sequences->Count(); i++) {

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -307,18 +307,12 @@ struct Phi2Test {
   void Run() {
     // Low level loop
     {
-      std::cout << "Creating generator..." << std::endl;
-
       auto generator = OgaGenerator::Create(*model_, *params_);
-
-      std::cout << "Generation loop..." << std::endl;
 
       while (!generator->IsDone()) {
         generator->ComputeLogits();
         generator->GenerateNextToken();
       }
-
-      std::cout << "Decode one at a time" << std::endl;
 
       // Decode One at a time
       for (size_t i = 0; i < 3; i++) {
@@ -329,11 +323,7 @@ struct Phi2Test {
 
     // High level
     {
-      std::cout << "High level generate" << std::endl;
-
       auto output_sequences = model_->Generate(*params_);
-
-      std::cout << "Decode the batch" << std::endl;
 
       // Decode The Batch
       for (size_t i = 0; i < output_sequences->Count(); i++) {


### PR DESCRIPTION
This is mostly to enable overlaying a second config on top of the first through runtime options.

This now works:
```
      "session_options": {
        "provider_options": [
          {
            "cuda": {}
          },
          {
            "rocm": {}
          }
        ]
      },
```
