### PR TITLE
Fix buffer overrun on Linux

### DIFF
--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -372,12 +372,7 @@ OgaResult* OGA_API_CALL OgaTokenizerDecode(const OgaTokenizer* p, const int32_t*
   auto string = tokenizer.Decode({tokens, token_count});
   auto length = string.length() + 1;
   auto cstr_buffer = std::make_unique<char[]>(length);
-#if _MSC_VER
-  strcpy_s(cstr_buffer.get(), length, string.c_str());
-#else
-  strncpy(cstr_buffer.get(), string.c_str(), length);
-  cstr_buffer[length] = 0;
-#endif
+  memcpy(cstr_buffer.get(), string.c_str(), length);
   *out_string = cstr_buffer.release();
   return nullptr;
   OGA_CATCH
@@ -390,12 +385,7 @@ OgaResult* OGA_API_CALL OgaProcessorDecode(const OgaMultiModalProcessor* p, cons
   auto string = processor.tokenizer_->Decode({tokens, token_count});
   auto length = string.length() + 1;
   auto cstr_buffer = std::make_unique<char[]>(length);
-#if _MSC_VER
-  strcpy_s(cstr_buffer.get(), length, string.c_str());
-#else
-  strncpy(cstr_buffer.get(), string.c_str(), length);
-  cstr_buffer[length] = 0;
-#endif
+  memcpy(cstr_buffer.get(), string.c_str(), length);
   *out_string = cstr_buffer.release();
   return nullptr;
   OGA_CATCH


### PR DESCRIPTION
`cstr_buffer[length] = 0;` was writing past the end of the buffer as length was already including the null.

Rewrote it so there's just one simpler codepath on all OS's. Plus memcpy is well understood as it avoids the 'is null included' issue entirely.

Thanks to @aciddelgado & @baijumeswani for narrowing down the cause.