### PR TITLE
Fix release pipeline issues for the next release

### DIFF
--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -70,7 +70,7 @@ jobs:
           python3 -m pip install -r test/python/requirements.txt --user
           python3 -m pip install -r test/python/cpu/torch/requirements.txt --user
           python3 -m pip install -r test/python/cpu/ort/requirements.txt --user
-          python3 -m pip install --user --no-index --find-links build/cpu/wheel onnxruntime_genai
+          python3 -m pip install build/cpu/wheel/onnxruntime_genai*manylinux*.whl --no-deps --user
 
       - name: Use Dummy HuggingFace Token
         run: |

--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -70,7 +70,7 @@ jobs:
           python3 -m pip install -r test/python/requirements.txt --user
           python3 -m pip install -r test/python/cpu/torch/requirements.txt --user
           python3 -m pip install -r test/python/cpu/ort/requirements.txt --user
-          python3 -m pip install build/cpu/wheel/onnxruntime_genai*manylinux*.whl --no-deps --user
+          python3 -m pip install --user --no-index --no-deps --find-links build/cpu/wheel onnxruntime_genai
 
       - name: Use Dummy HuggingFace Token
         run: |
@@ -81,6 +81,7 @@ jobs:
         continue-on-error: true
         run: |
           ls -l ${{ github.workspace }}/build/cpu
+          ls -l ${{ github.workspace }}/build/cpu/wheel
 
       # This will also download all the test models to the test/test_models directory
       # These models are used by the python tests as well as C#, C++ and others.

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   linux-cuda-x64-build:
     env :
-      PYTHON_EXECUTABLE: "/opt/python/cp38-cp38/bin/python3.8"
+      PYTHON_EXECUTABLE: "/opt/python/cp310-cp310/bin/python3.10"
     runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-A10" ]
     steps:
       - name: Checkout OnnxRuntime GenAI repo

--- a/.github/workflows/mac-cpu-arm64-build.yml
+++ b/.github/workflows/mac-cpu-arm64-build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get the Latest OnnxRuntime Nightly Version
         run: |
           ORT_NIGHTLY_VERSION=$(curl -s "${{ env.ORT_NIGHTLY_REST_API }}" | jq -r '.value[0].versions[0].normalizedVersion')
-          echo "$ORT_NIGHTLY_VERSION" 
+          echo "$ORT_NIGHTLY_VERSION"
           echo "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" >> $GITHUB_ENV
       - name: Download OnnxRuntime Nightly
         run: |
@@ -67,6 +67,7 @@ jobs:
         continue-on-error: true
         run: |
           ls -l ${{ github.workspace }}/build/cpu/osx-arm64
+          ls -l ${{ github.workspace }}/build/cpu/osx-arm64/wheel
 
       # This will also download all the test models to the test/test_models directory
       # These models are used by the python tests as well as C#, C++ and others.

--- a/.pipelines/codeql.yaml
+++ b/.pipelines/codeql.yaml
@@ -41,6 +41,7 @@ stages:
     - task: onebranch.pipeline.tsaoptions@1
       displayName: 'OneBranch TSAOptions'
       inputs:
+        tsaConfigFilePath: '$(Build.Repository.LocalPath)/.config/tsaoptions.json'
         appendSourceBranchName: false
     - task: CredScan@3
       displayName: 🔍 Run CredScan
@@ -63,4 +64,5 @@ stages:
       condition: and (succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
       continueOnError: true
       inputs:
+        tsaConfigFilePath: '$(Build.Repository.LocalPath)/.config/tsaoptions.json'
         GdnPublishTsaOnboard: true

--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -51,17 +51,17 @@ parameters:
 - name: ort_version
   displayName: 'OnnxRuntime version'
   type: string
-  default: '1.19.0-dev-20240805-1630-ee2fe87e2d'
+  default: '1.20.0-dev-20241022-2122-2d00351d'
 
 - name: ort_cuda_version
   displayName: 'OnnxRuntime GPU version'
   type: string
-  default: '1.19.0-dev-20240805-0337-88c811b638'
+  default: '1.20.0-dev-20241022-2122-2d00351d'
 
 - name: ort_dml_version
   displayName: 'OnnxRuntime DML version'
   type: string
-  default: '1.19.0-dev-20240805-1630-ee2fe87e2d'
+  default: '1.20.0-dev-20241022-2122-2d00351d'
 
 - name: cuda_version
   displayName: 'CUDA version'

--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -51,7 +51,7 @@ parameters:
 - name: ort_version
   displayName: 'OnnxRuntime version'
   type: string
-  default: '1.20.0-dev-20241022-1606-2d00351d7b'
+  default: '1.20.0-dev-20241023-1635-2d00351d7b'
 
 - name: ort_cuda_version
   displayName: 'OnnxRuntime GPU version'
@@ -61,7 +61,7 @@ parameters:
 - name: ort_dml_version
   displayName: 'OnnxRuntime DML version'
   type: string
-  default: '1.20.0-dev-20241022-1606-2d00351d7b'
+  default: '1.20.0-dev-20241023-1635-2d00351d7b'
 
 - name: cuda_version
   displayName: 'CUDA version'

--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -51,17 +51,17 @@ parameters:
 - name: ort_version
   displayName: 'OnnxRuntime version'
   type: string
-  default: '1.20.0-dev-20241022-2122-2d00351d'
+  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
 
 - name: ort_cuda_version
   displayName: 'OnnxRuntime GPU version'
   type: string
-  default: '1.20.0-dev-20241022-2122-2d00351d'
+  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
 
 - name: ort_dml_version
   displayName: 'OnnxRuntime DML version'
   type: string
-  default: '1.20.0-dev-20241022-2122-2d00351d'
+  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
 
 - name: cuda_version
   displayName: 'CUDA version'

--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -51,17 +51,17 @@ parameters:
 - name: ort_version
   displayName: 'OnnxRuntime version'
   type: string
-  default: '1.20.0-dev-20241023-1635-2d00351d7b'
+  default: '1.20.0-dev-20241023-1207-2d00351d7b'
 
 - name: ort_cuda_version
   displayName: 'OnnxRuntime GPU version'
   type: string
-  default: '1.20.0-dev-20241023-1635-2d00351d7b'
+  default: '1.20.0-dev-20241023-1207-2d00351d7b'
 
 - name: ort_dml_version
   displayName: 'OnnxRuntime DML version'
   type: string
-  default: '1.20.0-dev-20241023-1635-2d00351d7b'
+  default: '1.20.0-dev-20241023-1207-2d00351d7b'
 
 - name: cuda_version
   displayName: 'CUDA version'

--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -51,17 +51,17 @@ parameters:
 - name: ort_version
   displayName: 'OnnxRuntime version'
   type: string
-  default: '1.20.0-dev-20241023-1207-2d00351d7b'
+  default: '1.20.0-dev-20241022-1606-2d00351d7b'
 
 - name: ort_cuda_version
   displayName: 'OnnxRuntime GPU version'
   type: string
-  default: '1.20.0-dev-20241023-1207-2d00351d7b'
+  default: '1.20.0-dev-20241022-1606-2d00351d7b'
 
 - name: ort_dml_version
   displayName: 'OnnxRuntime DML version'
   type: string
-  default: '1.20.0-dev-20241023-1207-2d00351d7b'
+  default: '1.20.0-dev-20241022-1606-2d00351d7b'
 
 - name: cuda_version
   displayName: 'CUDA version'

--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -51,17 +51,17 @@ parameters:
 - name: ort_version
   displayName: 'OnnxRuntime version'
   type: string
-  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
+  default: '1.20.0-dev-20241023-1635-2d00351d7b'
 
 - name: ort_cuda_version
   displayName: 'OnnxRuntime GPU version'
   type: string
-  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
+  default: '1.20.0-dev-20241023-1635-2d00351d7b'
 
 - name: ort_dml_version
   displayName: 'OnnxRuntime DML version'
   type: string
-  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
+  default: '1.20.0-dev-20241023-1635-2d00351d7b'
 
 - name: cuda_version
   displayName: 'CUDA version'

--- a/.pipelines/pypl-publishing.yml
+++ b/.pipelines/pypl-publishing.yml
@@ -47,7 +47,7 @@ parameters:
 - name: ort_version
   displayName: 'OnnxRuntime version'
   type: string
-  default: '1.20.0-dev-20241022-2122-2d00351d'
+  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
 
 - name: ort_cuda_118_version
   displayName: 'OnnxRuntime GPU version for CUDA 11.8'
@@ -57,17 +57,17 @@ parameters:
 - name: ort_cuda_122_version
   displayName: 'OnnxRuntime GPU version for CUDA 12.2'
   type: string
-  default: '1.20.0-dev-20241022-2122-2d00351d'
+  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
 
 - name: ort_dml_version
   displayName: 'OnnxRuntime DML version'
   type: string
-  default: '1.20.0-dev-20241022-2122-2d00351d'
+  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
 
 - name: ort_rocm_version
   displayName: 'OnnxRuntime ROCm version'
   type: string
-  default: '1.20.0-dev-20241022-2122-2d00351d'
+  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
 
 - name: cuda_versions
   displayName: 'CUDA versions'

--- a/.pipelines/pypl-publishing.yml
+++ b/.pipelines/pypl-publishing.yml
@@ -44,31 +44,6 @@ parameters:
   type: boolean
   default: true
 
-- name: ort_version
-  displayName: 'OnnxRuntime version'
-  type: string
-  default: '1.20.0-dev-20241023-1635-2d00351d7b'
-
-- name: ort_cuda_118_version
-  displayName: 'OnnxRuntime GPU version for CUDA 11.8'
-  type: string
-  default: '1.18.0-dev-20240426-0614-b842effa29'
-
-- name: ort_cuda_122_version
-  displayName: 'OnnxRuntime GPU version for CUDA 12.2'
-  type: string
-  default: '1.20.0-dev-20241023-1635-2d00351d7b'
-
-- name: ort_dml_version
-  displayName: 'OnnxRuntime DML version'
-  type: string
-  default: '1.20.0-dev-20241023-1635-2d00351d7b'
-
-- name: ort_rocm_version
-  displayName: 'OnnxRuntime ROCm version'
-  type: string
-  default: '1.20.0-dev-20241023-1635-2d00351d7b'
-
 - name: cuda_versions
   displayName: 'CUDA versions'
   type: string
@@ -103,11 +78,6 @@ stages:
     enable_win_dml: ${{ parameters.enable_win_dml }}
     enable_win_arm64_cpu: ${{ parameters.enable_win_arm64_cpu }}
     enable_macos_cpu: ${{ parameters.enable_macos_cpu }}
-    ort_version: ${{ parameters.ort_version }}
-    ort_cuda_118_version: ${{ parameters.ort_cuda_118_version }}
-    ort_cuda_122_version: ${{ parameters.ort_cuda_122_version }}
-    ort_rocm_version: ${{ parameters.ort_rocm_version }}
-    ort_dml_version: ${{ parameters.ort_dml_version }}
     cuda_versions: ${{ parameters.cuda_versions }}
     build_config: ${{ parameters.build_config }}
 - ${{ if eq(parameters.enable_post_packaging_validation, true) }}:
@@ -120,10 +90,5 @@ stages:
       enable_win_dml: ${{ parameters.enable_win_dml }}
       enable_win_arm64_cpu: ${{ parameters.enable_win_arm64_cpu }}
       enable_macos_cpu: ${{ parameters.enable_macos_cpu }}
-      ort_version: ${{ parameters.ort_version }}
-      ort_cuda_118_version: ${{ parameters.ort_cuda_118_version }}
-      ort_cuda_122_version: ${{ parameters.ort_cuda_122_version }}
-      ort_rocm_version: ${{ parameters.ort_rocm_version }}
-      ort_dml_version: ${{ parameters.ort_dml_version }}
       cuda_versions: ${{ parameters.cuda_versions }}
       SpecificArtifact: false

--- a/.pipelines/pypl-publishing.yml
+++ b/.pipelines/pypl-publishing.yml
@@ -37,7 +37,7 @@ parameters:
 - name: enable_linux_rocm
   displayName: 'Whether Linux ROCm package is built.'
   type: boolean
-  default: true
+  default: false
 
 - name: enable_macos_cpu
   displayName: 'Whether MacOS CPU package is built.'

--- a/.pipelines/pypl-publishing.yml
+++ b/.pipelines/pypl-publishing.yml
@@ -47,7 +47,7 @@ parameters:
 - name: ort_version
   displayName: 'OnnxRuntime version'
   type: string
-  default: '1.19.0-dev-20240805-1630-ee2fe87e2d'
+  default: '1.20.0-dev-20241022-2122-2d00351d'
 
 - name: ort_cuda_118_version
   displayName: 'OnnxRuntime GPU version for CUDA 11.8'
@@ -57,17 +57,17 @@ parameters:
 - name: ort_cuda_122_version
   displayName: 'OnnxRuntime GPU version for CUDA 12.2'
   type: string
-  default: '1.19.0-dev-20240805-0337-88c811b638'
+  default: '1.20.0-dev-20241022-2122-2d00351d'
 
 - name: ort_dml_version
   displayName: 'OnnxRuntime DML version'
   type: string
-  default: '1.19.0-dev-20240805-1630-ee2fe87e2d'
+  default: '1.20.0-dev-20241022-2122-2d00351d'
 
 - name: ort_rocm_version
   displayName: 'OnnxRuntime ROCm version'
   type: string
-  default: '1.19.0-dev-20240805-0337-88c811b638'
+  default: '1.20.0-dev-20241022-2122-2d00351d'
 
 - name: cuda_versions
   displayName: 'CUDA versions'

--- a/.pipelines/pypl-publishing.yml
+++ b/.pipelines/pypl-publishing.yml
@@ -47,7 +47,7 @@ parameters:
 - name: ort_version
   displayName: 'OnnxRuntime version'
   type: string
-  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
+  default: '1.20.0-dev-20241023-1635-2d00351d7b'
 
 - name: ort_cuda_118_version
   displayName: 'OnnxRuntime GPU version for CUDA 11.8'
@@ -57,17 +57,17 @@ parameters:
 - name: ort_cuda_122_version
   displayName: 'OnnxRuntime GPU version for CUDA 12.2'
   type: string
-  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
+  default: '1.20.0-dev-20241023-1635-2d00351d7b'
 
 - name: ort_dml_version
   displayName: 'OnnxRuntime DML version'
   type: string
-  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
+  default: '1.20.0-dev-20241023-1635-2d00351d7b'
 
 - name: ort_rocm_version
   displayName: 'OnnxRuntime ROCm version'
   type: string
-  default: '1.20.0-dev-20241007-1101-407c1ab2e2'
+  default: '1.20.0-dev-20241023-1635-2d00351d7b'
 
 - name: cuda_versions
   displayName: 'CUDA versions'

--- a/.pipelines/stages/jobs/capi-packaging-job.yml
+++ b/.pipelines/stages/jobs/capi-packaging-job.yml
@@ -62,20 +62,6 @@ jobs:
     value: ${{ parameters.os }}
   - name: feed_name
     value: '7982ae20-ed19-4a35-a362-a96ac99897b7'
-  - name: ort_filename
-    ${{ if eq(parameters.ep, 'cpu') }}:
-      value: 'Microsoft.ML.OnnxRuntime'
-    ${{ elseif eq(parameters.ep, 'cuda') }}:
-      ${{if eq(parameters.os, 'win') }}:
-        value: 'Microsoft.ML.OnnxRuntime.Gpu.Windows'
-      ${{ else }}:
-        value: 'Microsoft.ML.OnnxRuntime.Gpu.Linux'
-    ${{ elseif eq(parameters.ep, 'directml')}}:
-      value: 'Microsoft.ML.OnnxRuntime.DirectML'
-    ${{ elseif eq(parameters.ep, 'rocm')}}:
-      value: 'Microsoft.ML.OnnxRuntime.ROCm'
-    ${{ else }}:
-      value: 'Microsoft.ML.OnnxRuntime'
 
   workspace:
     clean: all
@@ -91,18 +77,11 @@ jobs:
     displayName: Copy python 3.11.0 version to agent tools directory
     condition: and(eq(variables['arch'], 'arm64'), eq(variables['os'], 'win'))
 
-  - ${{ if eq(parameters.arch, 'arm64') }}:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: 3.11
-        addToPath: true
-        architecture: $(arch)
-  - ${{ else }}:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: 3.10
-        addToPath: true
-        architecture: $(arch)
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: 3.11
+      addToPath: true
+      architecture: $(arch)
 
   - ${{ if eq(parameters.os, 'linux') }}:
     - template: steps/capi-linux-step.yml

--- a/.pipelines/stages/jobs/capi-packaging-job.yml
+++ b/.pipelines/stages/jobs/capi-packaging-job.yml
@@ -77,22 +77,6 @@ jobs:
     ${{ else }}:
       value: 'Microsoft.ML.OnnxRuntime'
 
-  - name: ortHome
-    value: 'ort'
-  - name: dml_dir
-    value: 'Microsoft.AI.DirectML.1.15.1'
-  - name: dml_zip
-    value: 'Microsoft.AI.DirectML.1.15.1.zip'
-  - name: dml_url
-    value: "https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.15.1"
-
-  - name: d3d12_dir
-    value: 'Microsoft.Direct3D.D3D12.1.614.0'
-  - name: d3d12_zip
-    value: 'Microsoft.Direct3D.D3D12.1.614.0.zip'
-  - name: d3d12_url
-    value: "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.614.0"
-
   workspace:
     clean: all
   steps:

--- a/.pipelines/stages/jobs/py-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-packaging-job.yml
@@ -51,9 +51,6 @@ jobs:
         Python312:
           PyDotVer: '3.12'
           PyNoDotVer: '312'
-        Python313:
-          PyDotVer: '3.13'
-          PyNoDotVer: '313'
     ${{ else }}:
       matrix:
         Python310:

--- a/.pipelines/stages/jobs/py-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-packaging-job.yml
@@ -51,14 +51,11 @@ jobs:
         Python312:
           PyDotVer: '3.12'
           PyNoDotVer: '312'
+        Python313:
+          PyDotVer: '3.13'
+          PyNoDotVer: '313'
     ${{ else }}:
       matrix:
-        Python38:
-          PyDotVer: '3.8'
-          PyNoDotVer: '38'
-        Python39:
-          PyDotVer: '3.9'
-          PyNoDotVer: '39'
         Python310:
           PyDotVer: '3.10'
           PyNoDotVer: '310'
@@ -68,6 +65,9 @@ jobs:
         Python312:
           PyDotVer: '3.12'
           PyNoDotVer: '312'
+        Python313:
+          PyDotVer: '3.13'
+          PyNoDotVer: '313'
 
   timeoutInMinutes: 240
   workspace:
@@ -100,21 +100,6 @@ jobs:
 
   - name: feed_name
     value: '7982ae20-ed19-4a35-a362-a96ac99897b7'
-
-  - name: ort_filename
-    ${{ if eq(parameters.ep, 'cpu') }}:
-      value: 'Microsoft.ML.OnnxRuntime'
-    ${{ elseif eq(parameters.ep, 'cuda') }}:
-      ${{if eq(parameters.os, 'win') }}:
-        value: 'Microsoft.ML.OnnxRuntime.Gpu.Windows'
-      ${{ else }}:
-        value: 'Microsoft.ML.OnnxRuntime.Gpu.Linux'
-    ${{ elseif eq(parameters.ep, 'directml')}}:
-      value: 'Microsoft.ML.OnnxRuntime.DirectML'
-    ${{ elseif eq(parameters.ep, 'rocm')}}:
-      value: 'Microsoft.ML.OnnxRuntime.ROCm'
-    ${{ else }}:
-      value: 'Microsoft.ML.OnnxRuntime'
 
   steps:
   - script: |

--- a/.pipelines/stages/jobs/py-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-packaging-job.yml
@@ -3,8 +3,6 @@ parameters:
   type: string
 - name: ep
   type: string
-- name: ort_version
-  type: string
 - name: cuda_version
   type: string
   default: ''
@@ -90,8 +88,6 @@ jobs:
     value: ${{ parameters.cuda_version }}
   - name: ep
     value: ${{ parameters.ep }}
-  - name: ort_version
-    value: ${{ parameters.ort_version }}
   - name: os
     value: ${{ parameters.os }}
 

--- a/.pipelines/stages/jobs/py-packaging-job.yml
+++ b/.pipelines/stages/jobs/py-packaging-job.yml
@@ -68,7 +68,7 @@ jobs:
         Python312:
           PyDotVer: '3.12'
           PyNoDotVer: '312'
-    
+
   timeoutInMinutes: 240
   workspace:
     clean: all
@@ -116,23 +116,9 @@ jobs:
     ${{ else }}:
       value: 'Microsoft.ML.OnnxRuntime'
 
-  - name: dml_dir
-    value: 'Microsoft.AI.DirectML.1.15.1'
-  - name: dml_zip
-    value: 'Microsoft.AI.DirectML.1.15.1.zip'
-  - name: dml_url
-    value: "https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.15.1"
-
-  - name: d3d12_dir
-    value: 'Microsoft.Direct3D.D3D12.1.614.0'
-  - name: d3d12_zip
-    value: 'Microsoft.Direct3D.D3D12.1.614.0.zip'
-  - name: d3d12_url
-    value: "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.614.0"
-
   steps:
   - script: |
-      MKDIR $(Agent.ToolsDirectory)\Python\3.12.3\arm64 
+      MKDIR $(Agent.ToolsDirectory)\Python\3.12.3\arm64
       XCOPY /s /y /h /e /c /q "C:\Python\Python312\*.*" $(Agent.ToolsDirectory)\Python\3.12.3\arm64\
       COPY NUL $(Agent.ToolsDirectory)\Python\3.12.3\arm64.complete
       DIR $(Agent.ToolsDirectory)\Python

--- a/.pipelines/stages/jobs/py-validation-job.yml
+++ b/.pipelines/stages/jobs/py-validation-job.yml
@@ -11,8 +11,6 @@ parameters:
   type: string
 - name: ep
   type: string
-- name: ort_version
-  type: string
 - name: cuda_version
   type: string
   default: ''
@@ -73,8 +71,6 @@ jobs:
     value: ${{ parameters.cuda_version }}
   - name: ep
     value: ${{ parameters.ep }}
-  - name: ort_version
-    value: ${{ parameters.ort_version }}
   - name: os
     value: ${{ parameters.os }}
 

--- a/.pipelines/stages/jobs/py-validation-job.yml
+++ b/.pipelines/stages/jobs/py-validation-job.yml
@@ -79,17 +79,7 @@ jobs:
     value: ${{ parameters.os }}
 
   - name: py_dot_ver
-    ${{ if eq(parameters.ep, 'cpu') }}:
-      ${{ if eq(parameters.arch, 'arm64') }}:
-        value: '3.12'
-      ${{ else }}:
-        value: '3.9'
-    ${{ elseif eq(parameters.ep, 'cuda') }}:
-      value: '3.10'
-    ${{ elseif eq(parameters.ep, 'directml')}}:
-      value: '3.11'
-    ${{ else }}:
-      value: '3.9'
+    value: '3.12'
 
   - name: pip_package_name
     ${{ if eq(parameters.ep, 'cpu') }}:

--- a/.pipelines/stages/jobs/py-validation-job.yml
+++ b/.pipelines/stages/jobs/py-validation-job.yml
@@ -221,8 +221,8 @@ jobs:
           python -m pip install -r test/python/cuda/ort/requirements.txt
         }
         elseif ("$(ep)" -eq "directml") {
-          python -m pip install -r test/python/requirements-torch-directml.txt
-          python -m pip install -r test/python/requirements-torch-directml.txt
+          python -m pip install -r test/python/directml/torch/requirements.txt
+          python -m pip install -r test/python/directml/ort/requirements.txt
         }
         else {
           python -m pip install -r test/python/cpu/torch/requirements.txt

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -34,7 +34,6 @@ steps:
 
 - bash: |
     echo "arch=$(arch)"
-    echo "ort_filename=$(ort_filename)"
     echo "ort_version=$(ort_version)"
     echo "ep=$(ep)"
     echo "cuda_version=$(cuda_version)"

--- a/.pipelines/stages/jobs/steps/capi-macos-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-macos-step.yml
@@ -22,7 +22,6 @@ steps:
 
 - bash: |
     echo "arch=$(arch)"
-    echo "ort_filename=$(ort_filename)"
     echo "ort_version=$(ort_version)"
     echo "ep=$(ep)"
     echo "cuda_version=$(cuda_version)"

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -26,6 +26,7 @@ steps:
 - task: onebranch.pipeline.tsaoptions@1
   displayName: 'OneBranch TSAOptions'
   inputs:
+    tsaConfigFilePath: '$(Build.Repository.LocalPath)\.config\tsaoptions.json'
     appendSourceBranchName: false
 
 - template: utils/set-nightly-build-option-variable.yml
@@ -39,24 +40,6 @@ steps:
     echo "target=${{ parameters.target }}"
     echo "build_config=${{ parameters.build_config }}"
   displayName: 'Print Parameters'
-
-- ${{ if eq(parameters.ep, 'directml') }}:
-  - powershell: |
-      Invoke-WebRequest -Uri $(dml_url) -OutFile $(dml_zip)
-      Expand-Archive $(dml_zip) -DestinationPath $(dml_dir)
-      Remove-Item -Path $(dml_zip)
-      Get-ChildItem -Recurse $(dml_dir)
-      mv $(dml_dir)\bin\$(arch)-win\DirectML.dll ort\lib
-      mv $(dml_dir)\include\DirectML.h ort\include
-
-      Invoke-WebRequest -Uri $(d3d12_url) -OutFile $(d3d12_zip)
-      Expand-Archive $(d3d12_zip) -DestinationPath $(d3d12_dir)
-      Remove-Item -Path $(d3d12_zip)
-      Get-ChildItem -Recurse $(d3d12_dir)
-      mv $(d3d12_dir)\build\native\bin\$(arch)\D3D12Core.dll ort\lib
-    workingDirectory: '$(Build.Repository.LocalPath)'
-    displayName: 'Download DirectML & Direct3D DLLs'
-    continueOnError: true
 
 - powershell: |
     azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v$(cuda_version)" 'cuda_sdk'

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -33,7 +33,6 @@ steps:
 
 - script: |
     echo "arch=$(arch)"
-    echo "ort_filename=$(ort_filename)"
     echo "ort_version=$(ort_version)"
     echo "ep=$(ep)"
     echo "cuda_version=$(cuda_version)"

--- a/.pipelines/stages/py-packaging-stage.yml
+++ b/.pipelines/stages/py-packaging-stage.yml
@@ -15,16 +15,6 @@ parameters:
   type: boolean
 - name: enable_macos_cpu
   type: boolean
-- name: ort_version
-  type: string
-- name: ort_cuda_118_version
-  type: string
-- name: ort_cuda_122_version
-  type: string
-- name: ort_rocm_version
-  type: string
-- name: ort_dml_version
-  type: string
 - name: cuda_versions
   type: string
   default: '11.8,12.2'
@@ -41,7 +31,6 @@ stages:
       parameters:
         arch: 'x64'
         ep: 'cpu'
-        ort_version: ${{ parameters.ort_version }}
         os: 'win'
         build_config: ${{ parameters.build_config }}
 
@@ -50,7 +39,6 @@ stages:
       parameters:
         arch: 'arm64'
         ep: 'cpu'
-        ort_version: ${{ parameters.ort_version }}
         os: 'win'
         build_config: ${{ parameters.build_config }}
 
@@ -59,7 +47,6 @@ stages:
       parameters:
         arch: 'x64'
         ep: 'directml'
-        ort_version: ${{ parameters.ort_dml_version }}
         os: 'win'
         build_config: ${{ parameters.build_config }}
 
@@ -70,7 +57,6 @@ stages:
         cuda_version: '11.8'
         cuda_display_version: '118'
         ep: 'cuda'
-        ort_version: ${{ parameters.ort_cuda_118_version }}
         os: 'win'
         build_config: ${{ parameters.build_config }}
 
@@ -81,7 +67,6 @@ stages:
         cuda_version: '12.2'
         cuda_display_version: '122'
         ep: 'cuda'
-        ort_version: ${{ parameters.ort_cuda_122_version }}
         os: 'win'
         build_config: ${{ parameters.build_config }}
 
@@ -90,7 +75,6 @@ stages:
       parameters:
         arch: 'x64'
         ep: 'cpu'
-        ort_version: ${{ parameters.ort_version }}
         os: 'linux'
         build_config: ${{ parameters.build_config }}
 
@@ -101,7 +85,6 @@ stages:
         cuda_version: '11.8'
         cuda_display_version: '118'
         ep: 'cuda'
-        ort_version: ${{ parameters.ort_cuda_118_version }}
         os: 'linux'
 
   - ${{ if and(eq(parameters.enable_linux_cuda, true), contains(parameters.cuda_versions, '12.2')) }}:
@@ -111,7 +94,6 @@ stages:
         cuda_version: '12.2'
         cuda_display_version: '122'
         ep: 'cuda'
-        ort_version: ${{ parameters.ort_cuda_122_version }}
         os: 'linux'
         build_config: ${{ parameters.build_config }}
 
@@ -120,7 +102,6 @@ stages:
       parameters:
         arch: 'x64'
         ep: 'rocm'
-        ort_version: ${{ parameters.ort_rocm_version }}
         os: 'linux'
         build_config: ${{ parameters.build_config }}
   - ${{ if eq(parameters.enable_macos_cpu, true) }}:
@@ -128,13 +109,11 @@ stages:
       parameters:
         arch: 'x64'
         ep: 'cpu'
-        ort_version: ${{ parameters.ort_version }}
         os: 'osx'
         build_config: ${{ parameters.build_config }}
     - template: jobs/py-packaging-job.yml
       parameters:
         arch: 'arm64'
         ep: 'cpu'
-        ort_version: ${{ parameters.ort_version }}
         os: 'osx'
         build_config: ${{ parameters.build_config }}

--- a/.pipelines/stages/py-validation-stage.yml
+++ b/.pipelines/stages/py-validation-stage.yml
@@ -21,16 +21,6 @@ parameters:
   type: boolean
 - name: enable_macos_cpu
   type: boolean
-- name: ort_version
-  type: string
-- name: ort_cuda_118_version
-  type: string
-- name: ort_cuda_122_version
-  type: string
-- name: ort_rocm_version
-  type: string
-- name: ort_dml_version
-  type: string
 - name: cuda_versions
   type: string
   default: '11.8,12.2'
@@ -76,7 +66,6 @@ stages:
         cuda_version: '11.8'
         cuda_display_version: '118'
         ep: 'cuda'
-        ort_version: ${{ parameters.ort_cuda_118_version }}
         os: 'win'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
@@ -88,7 +77,6 @@ stages:
         cuda_version: '12.2'
         cuda_display_version: '122'
         ep: 'cuda'
-        ort_version: ${{ parameters.ort_cuda_122_version }}
         os: 'win'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}

--- a/.pipelines/stages/py-validation-stage.yml
+++ b/.pipelines/stages/py-validation-stage.yml
@@ -34,7 +34,6 @@ stages:
       parameters:
         arch: 'x64'
         ep: 'cpu'
-        ort_version: ${{ parameters.ort_version }}
         os: 'win'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
@@ -44,7 +43,6 @@ stages:
       parameters:
         arch: 'arm64'
         ep: 'cpu'
-        ort_version: ${{ parameters.ort_version }}
         os: 'win'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
@@ -54,7 +52,6 @@ stages:
       parameters:
         arch: 'x64'
         ep: 'directml'
-        ort_version: ${{ parameters.ort_dml_version }}
         os: 'win'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
@@ -86,7 +83,6 @@ stages:
       parameters:
         arch: 'x64'
         ep: 'cpu'
-        ort_version: ${{ parameters.ort_version }}
         os: 'linux'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
@@ -98,7 +94,6 @@ stages:
         cuda_version: '11.8'
         cuda_display_version: '118'
         ep: 'cuda'
-        ort_version: ${{ parameters.ort_cuda_118_version }}
         os: 'linux'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
@@ -109,7 +104,6 @@ stages:
         cuda_version: '12.2'
         cuda_display_version: '122'
         ep: 'cuda'
-        ort_version: ${{ parameters.ort_cuda_122_version }}
         os: 'linux'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}
@@ -119,7 +113,6 @@ stages:
       parameters:
         arch: 'x64'
         ep: 'cpu'
-        ort_version: ${{ parameters.ort_version }}
         os: 'osx'
         SpecificArtifact: ${{ parameters.SpecificArtifact }}
         BuildId: ${{ parameters.BuildId }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.28)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  # For xcframework support
+  cmake_minimum_required(VERSION 3.28)
+else()
+  cmake_minimum_required(VERSION 3.26)
+endif()
 include(FetchContent)
 include(CMakeDependentOption)
 project(Generators LANGUAGES C CXX)

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -14,6 +14,14 @@ install(TARGETS
   PUBLIC_HEADER DESTINATION include
   FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+if(USE_CUDA)
+  install(TARGETS
+    onnxruntime-genai-cuda
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION lib
+    ARCHIVE DESTINATION lib
+  )
+endif()
 
 if (WIN32)
   install(FILES $<TARGET_PDB_FILE:onnxruntime-genai> DESTINATION lib CONFIGURATIONS RelWithDebInfo Debug)

--- a/examples/csharp/HelloPhi/HelloPhi.csproj
+++ b/examples/csharp/HelloPhi/HelloPhi.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="[0.4.0]" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' " />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="[0.4.0]" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.4.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="[0.5.0-dev]" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' " />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="[0.5.0-dev]" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.5.0-dev" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/csharp/HelloPhi/HelloPhi.csproj
+++ b/examples/csharp/HelloPhi/HelloPhi.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="[0.5.0-dev]" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' " />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="[0.5.0-dev]" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.5.0-dev" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.5.0-dev" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -26,22 +26,22 @@ package_name = '@TARGET_NAME@'
 def _onnxruntime_dependency() -> str:
     dependency = None
     # Use stable version as default
-    ort_version = os.environ.get("ONNXRUNTIME_VERSION", "1.19.0")
+    ort_version = os.environ.get("ONNXRUNTIME_VERSION", "1.20.0")
     is_nightly = True if "dev" in ort_version else False
 
     if package_name == "onnxruntime-genai":
-        dependency = "onnxruntime" if not is_nightly else "ort-nightly"
+        dependency = "onnxruntime"
 
         import platform
         # win arm64 whls are only available in onnxruntime-qnn
         if platform.machine() == "ARM64" and sys.platform.startswith("win"):
-            dependency = "onnxruntime-qnn" if not is_nightly else "ort-nightly-qnn"
+            dependency = "onnxruntime-qnn"
     elif package_name == "onnxruntime-genai-cuda":
-        dependency = "onnxruntime-gpu" if not is_nightly else "ort-nightly-gpu"
+        dependency = "onnxruntime-gpu"
     elif package_name == "onnxruntime-genai-directml":
-        dependency = "onnxruntime-directml" if not is_nightly else "ort-nightly-directml"
+        dependency = "onnxruntime-directml"
     elif package_name == "onnxruntime-genai-rocm":
-        dependency = "onnxruntime-rocm" if not is_nightly else "ort-nightly-rocm"
+        dependency = "onnxruntime-rocm"
     else:
         raise ValueError(f'Unable to determine the onnxruntime dependency for {package_name}.')
 

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -27,7 +27,6 @@ def _onnxruntime_dependency() -> str:
     dependency = None
     # Use stable version as default
     ort_version = os.environ.get("ONNXRUNTIME_VERSION", "1.20.0")
-    is_nightly = True if "dev" in ort_version else False
 
     if package_name == "onnxruntime-genai":
         dependency = "onnxruntime"

--- a/test/python/requirements-cpu.txt
+++ b/test/python/requirements-cpu.txt
@@ -1,4 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
 torch==2.2.1+cpu
-ort-nightly==1.20.0.dev20241006001
+onnxruntime==1.20.0.dev20241016004
+

--- a/test/python/requirements-cuda.txt
+++ b/test/python/requirements-cuda.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
 torch==2.2.1+cu121
-ort-nightly-gpu==1.20.0.dev20241007001
+onnxruntime-gpu==1.20.0.dev20241016001

--- a/test/python/requirements-directml.txt
+++ b/test/python/requirements-directml.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
 torch==2.2.1+cpu
-ort-nightly-directml==1.20.0.dev20241006001
+onnxruntime-directml==1.20.0.dev20241016004

--- a/test/python/requirements-macos.txt
+++ b/test/python/requirements-macos.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
 torch==2.2.1
-ort-nightly==1.20.0.dev20241006001
+onnxruntime==1.20.0.dev20241016004

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -103,7 +103,7 @@ def generate_dependencies(xml_text, package_version, ort_package_name, ort_packa
         xml_text.append(f'<dependency id="Microsoft.ML.OnnxRuntimeGenAI.Managed" version="{package_version}" />')
         xml_text.append(f'<dependency id="{ort_package_name}" version="{ort_package_version}" />')
         if ort_package_name.endswith("DirectML"):
-            xml_text.append(f'<dependency id="Microsoft.AI.DirectML" version="1.15.1" />')
+            xml_text.append(f'<dependency id="Microsoft.AI.DirectML" version="1.15.2" />')
         xml_text.append("</group>")
 
     xml_text.append("</dependencies>")

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -127,9 +127,12 @@ def generate_files(lines, args):
       if runtime.startswith("win"):
           add_native_artifact_if_exists(lines, runtime, "onnxruntime-genai.lib")
           add_native_artifact_if_exists(lines, runtime, "onnxruntime-genai.dll")
+          add_native_artifact_if_exists(lines, runtime, "onnxruntime-genai-cuda.lib")
+          add_native_artifact_if_exists(lines, runtime, "onnxruntime-genai-cuda.dll")
           add_native_artifact_if_exists(lines, runtime, "d3d12core.dll")
       elif runtime.startswith("linux"):
           add_native_artifact_if_exists(lines, runtime, "libonnxruntime-genai.so")
+          add_native_artifact_if_exists(lines, runtime, "libonnxruntime-genai-cuda.so")
       elif runtime.startswith("osx"):
           add_native_artifact_if_exists(lines, runtime, "libonnxruntime-genai.dylib")
       elif runtime.startswith("ios"):


### PR DESCRIPTION
Preparing for 0.5.0 release:

* Drop Python 3.8 & 3.9 support
* Add Python 3.13 support.
* Remove `ort-nightly` across pipelines.

---

NuGet validation run:
* https://aiinfra.visualstudio.com/ONNX%20Runtime/_build/results?buildId=592239&view=results

Python validation run:
* https://aiinfra.visualstudio.com/ONNX%20Runtime/_build/results?buildId=591237&view=results