### PR TITLE
Extend builder support for quantized lm_head

### DIFF
--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -622,13 +622,12 @@ class AWQModel(QuantizedModel):
 
                     # Set `g_idx` to None since it's not used in `MatMulNBits`
                     q_tensors.g_idx = None
-        if isinstance(self.lm_head, QuantizedTensorModule):
-            if self.lm_head.qweight is not None:
-                self.unpack(self.lm_head)
-                self.repack(self.lm_head)
+        if isinstance(self.lm_head, QuantizedTensorModule) and self.lm_head.qweight is not None:
+            self.unpack(self.lm_head)
+            self.repack(self.lm_head)
 
-                # Set `g_idx` to None since it's not used in `MatMulNBits`
-                self.lm_head.g_idx = None
+            # Set `g_idx` to None since it's not used in `MatMulNBits`
+            self.lm_head.g_idx = None
 
     def unpack_qweight(self, module):
         """

--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -373,17 +373,7 @@ class QuantizedModel:
             self.lm_head.out_features = self.lm_head.scales.shape[1]
             self.lm_head.in_features = self.lm_head.qweight.shape[0]
             # Set g_idx if not already set
-            self.lm_head.g_idx = (
-                self.lm_head.g_idx
-                if self.lm_head.g_idx is not None
-                else torch.tensor(
-                    [
-                        i // self.lm_head.group_size
-                        for i in range(self.lm_head.in_features)
-                    ],
-                    dtype=torch.int32,
-                )
-            )
+            self.lm_head.g_idx = self.lm_head.g_idx if self.lm_head.g_idx is not None else torch.tensor([i // self.lm_head.group_size for i in range(self.lm_head.in_features)], dtype=torch.int32)
         for module in self.layers:
             if self.quant_type == "awq":
                 # Set in_features and out_features
@@ -622,6 +612,7 @@ class AWQModel(QuantizedModel):
 
                     # Set `g_idx` to None since it's not used in `MatMulNBits`
                     q_tensors.g_idx = None
+
         if isinstance(self.lm_head, QuantizedTensorModule) and self.lm_head.qweight is not None:
             self.unpack(self.lm_head)
             self.repack(self.lm_head)

--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -88,7 +88,7 @@ class QuantizedModel:
         self.quant_type = quant_type
         self.embedding = TensorModule()
         self.final_norm = TensorModule()
-        self.lm_head = TensorModule()
+        self.lm_head: TensorModule | QuantizedTensorModule = TensorModule()
         self.layers = {}
         self.num_layers = num_layers
 
@@ -117,6 +117,18 @@ class QuantizedModel:
                         # transformer.rotary_pos_emb.inv_freq in ChatGLM3.
                         # Skip rotary embedding weights since they can be re-calculated when looping through the model
                         continue
+                    elif name == "lm_head.qweight" or name == "transformer.output_layer.qweight":
+                        self._initialize_quantized_lm_head(bits, group_size)
+                        self.lm_head.qweight = tensor
+                    elif name == "lm_head.qzeros" or name == "transformer.output_layer.qzeros":
+                        self._initialize_quantized_lm_head(bits, group_size)
+                        self.lm_head.qzeros = tensor
+                    elif name == "lm_head.scales" or name == "transformer.output_layer.scales":
+                        self._initialize_quantized_lm_head(bits, group_size)
+                        self.lm_head.scales = tensor
+                    elif name == "lm_head.g_idx" or name == "transformer.output_layer.g_idx":
+                        self._initialize_quantized_lm_head(bits, group_size)
+                        self.lm_head.g_idx = tensor
                     else:
                         if name.startswith("transformer.encoder"):
                             # Chatglm3, e.g., transformer.encoder.layers.0.input_layernorm.weight
@@ -326,7 +338,7 @@ class QuantizedModel:
                             raise NotImplementedError(f"{name} in your quantized model is not recognized.")
 
         # Set LM head weights + biases if not already set
-        if self.lm_head.weight is None:
+        if isinstance(self.lm_head, TensorModule) and self.lm_head.weight is None:
             # Embedding and LM head share same weights + biases (lm_head.weight == embedding.weight and lm_head.bias == embedding.bias)
             self.lm_head.weight = self.embedding.weight
             if self.lm_head.bias is not None:
@@ -339,10 +351,39 @@ class QuantizedModel:
         # Set properties of each layer based on quantization type
         self.set_properties()
 
+    def _initialize_quantized_lm_head(self, bits, group_size):
+        """
+        Initialize `QuantizedTensorModule` for LM head if not already set
+        """
+        if isinstance(self.lm_head, TensorModule):
+            assert self.lm_head.weight is None
+            assert self.lm_head.bias is None
+        if not isinstance(self.lm_head, QuantizedTensorModule):
+            self.lm_head = QuantizedTensorModule(bits, group_size)
+
     def set_properties(self):
         """
         Set in_features, out_features, and g_idx based on quantization type
         """
+        if isinstance(self.lm_head, QuantizedTensorModule):
+            if self.quant_type != "awq":
+                raise NotImplementedError(
+                    "lm_head quantization is only supported for awq."
+                )
+            self.lm_head.out_features = self.lm_head.scales.shape[1]
+            self.lm_head.in_features = self.lm_head.qweight.shape[0]
+            # Set g_idx if not already set
+            self.lm_head.g_idx = (
+                self.lm_head.g_idx
+                if self.lm_head.g_idx is not None
+                else torch.tensor(
+                    [
+                        i // self.lm_head.group_size
+                        for i in range(self.lm_head.in_features)
+                    ],
+                    dtype=torch.int32,
+                )
+            )
         for module in self.layers:
             if self.quant_type == "awq":
                 # Set in_features and out_features
@@ -396,7 +437,7 @@ class QuantizedModel:
         """
         return [self.embedding] + self.layers + [self.final_norm, self.lm_head]
 
-    def unpack(self, module):
+    def unpack(self, module: QuantizedTensorModule):
         """
         Unpack `qzeros` and `qweight` to standard format
         """
@@ -581,6 +622,13 @@ class AWQModel(QuantizedModel):
 
                     # Set `g_idx` to None since it's not used in `MatMulNBits`
                     q_tensors.g_idx = None
+        if isinstance(self.lm_head, QuantizedTensorModule):
+            if self.lm_head.qweight is not None:
+                self.unpack(self.lm_head)
+                self.repack(self.lm_head)
+
+                # Set `g_idx` to None since it's not used in `MatMulNBits`
+                self.lm_head.g_idx = None
 
     def unpack_qweight(self, module):
         """
@@ -604,12 +652,12 @@ class AWQModel(QuantizedModel):
         """
         compress_ratio = 32 // bits
         assert tensor.shape[-1] % compress_ratio == 0
-        
+
         if bits == 4:
             order_map = [0, 2, 4, 6, 1, 3, 5, 7]
         else:
             raise NotImplementedError(f"Unpacking for {bits}-bit quantization is not currently supported.")
-        
+
         order_tensor = torch.tensor(order_map, dtype=torch.int32).reshape(1, -1)
         order_tensor = order_tensor.repeat(tensor.shape[1] // compress_ratio, 1)
         order_tensor = order_tensor + torch.arange(0, tensor.shape[1], compress_ratio, dtype=torch.int32).reshape(-1, 1)
@@ -652,7 +700,7 @@ class GPTQModel(QuantizedModel):
                     if not use_g_idx:
                         # Set `g_idx` to None since it's not used in `MatMulNBits`
                         q_tensors.g_idx = None
-    
+
     def handle_qzeros(self, module):
         """
         Re-pack `qzeros` to handle extra `-1`s

--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -88,7 +88,7 @@ class QuantizedModel:
         self.quant_type = quant_type
         self.embedding = TensorModule()
         self.final_norm = TensorModule()
-        self.lm_head: TensorModule | QuantizedTensorModule = TensorModule()
+        self.lm_head = TensorModule()
         self.layers = {}
         self.num_layers = num_layers
 
@@ -437,7 +437,7 @@ class QuantizedModel:
         """
         return [self.embedding] + self.layers + [self.final_norm, self.lm_head]
 
-    def unpack(self, module: QuantizedTensorModule):
+    def unpack(self, module):
         """
         Unpack `qzeros` and `qweight` to standard format
         """


### PR DESCRIPTION
As title. This enables support for further reduced quantized model size and improved runtime efficiency, within acceptable range of accuracy degradation.

Orthogonal to #940. This PR targets already quantized models in autoawq/autogptq format that **has** lmhead quantized.