### PR TITLE
Add ability to modify provider options at runtime

### DIFF
--- a/benchmark/c/options.h
+++ b/benchmark/c/options.h
@@ -8,13 +8,13 @@
 namespace benchmark {
 
 struct Options {
-  std::string model_path{};
+  std::string model_path;
   size_t num_prompt_tokens{16};
   size_t num_tokens_to_generate{128};
   size_t batch_size{1};
   size_t num_iterations{5};
   size_t num_warmup_iterations{1};
-  bool verbose{false};
+  bool verbose{};
 };
 
 Options ParseOptionsFromCommandLine(int argc, const char* const* argv);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -592,6 +592,21 @@ void SetSearchBool(Config::Search& search, std::string_view name, bool value) {
   Search_Element(search).OnBool(name, value);
 }
 
+void ClearProviders(Config& config) {
+  config.model.decoder.session_options.provider_options.clear();
+}
+
+void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value) {
+  std::ostringstream json;
+  json << R"({")" << provider_name << R"(":{)";
+  if (!option_name.empty()) {
+    json << R"(")" << option_name << R"(":")" << option_value << R"(")";
+  }
+  json << R"(}})";
+  ProviderOptionsArray_Element element{config.model.decoder.session_options.provider_options};
+  JSON::Parse(element, json.str());
+}
+
 bool IsCudaGraphEnabled(Config::SessionOptions& session_options) {
   for (const auto& provider_options : session_options.provider_options) {
     if (provider_options.name == "cuda") {

--- a/src/config.h
+++ b/src/config.h
@@ -171,7 +171,6 @@ struct Config {
 void SetSearchNumber(Config::Search& search, std::string_view name, double value);
 void SetSearchBool(Config::Search& search, std::string_view name, bool value);
 void ClearProviders(Config& config);
-void SetProvider(Config& config, std::string_view provider_name);
 void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value);
 bool IsCudaGraphEnabled(Config::SessionOptions& session_options);
 

--- a/src/config.h
+++ b/src/config.h
@@ -44,7 +44,7 @@ struct Config {
     std::optional<std::string> enable_profiling;
     // TODO(baijumeswani): Sharing env allocators across sessions leads to crashes on windows and iOS.
     //                     Identify the reason for the crash to enable allocator sharing by default.
-    bool use_env_allocators{false};
+    bool use_env_allocators{};
 
     std::vector<ProviderOptions> provider_options;
   };
@@ -170,6 +170,9 @@ struct Config {
 
 void SetSearchNumber(Config::Search& search, std::string_view name, double value);
 void SetSearchBool(Config::Search& search, std::string_view name, bool value);
+void ClearProviders(Config& config);
+void SetProvider(Config& config, std::string_view provider_name);
+void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value);
 bool IsCudaGraphEnabled(Config::SessionOptions& session_options);
 
 }  // namespace Generators

--- a/src/csharp/Config.cs
+++ b/src/csharp/Config.cs
@@ -20,9 +20,9 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             Result.VerifySuccess(NativeMethods.OgaConfigClearProviders(_configHandle));
         }
 
-        public void SetProvider(string provider)
+        public void AppendProvider(string provider)
         {
-            Result.VerifySuccess(NativeMethods.OgaConfigSetProvider(_configHandle, StringUtils.ToUtf8(provider)));
+            Result.VerifySuccess(NativeMethods.OgaConfigAppendProvider(_configHandle, StringUtils.ToUtf8(provider)));
         }
 
         public void SetProviderOption(string provider, string option, string value)

--- a/src/csharp/Config.cs
+++ b/src/csharp/Config.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.ML.OnnxRuntimeGenAI
+{
+    public class Config : IDisposable
+    {
+        private IntPtr _configHandle;
+        private bool _disposed = false;
+
+        internal Config(string modelPath)
+        {
+            Result.VerifySuccess(NativeMethods.OgaCreateConfig(StringUtils.ToUtf8(modelPath), out _configHandle));
+        }
+
+        internal IntPtr Handle { get { return _configHandle; } }
+        public void ClearProviders()
+        {
+            Result.VerifySuccess(NativeMethods.OgaConfigClearProviders(_configHandle));
+        }
+
+        public void SetProvider(string provider)
+        {
+            Result.VerifySuccess(NativeMethods.OgaConfigSetProvider(_configHandle, StringUtils.ToUtf8(provider)));
+        }
+
+        public void SetProviderOption(string provider, string option, string value)
+        {
+            Result.VerifySuccess(NativeMethods.OgaConfigSetProviderOption(_configHandle, StringUtils.ToUtf8(provider), StringUtils.ToUtf8(option), StringUtils.ToUtf8(value)));
+        }
+
+        ~Config()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            NativeMethods.OgaDestroyConfig(_configHandle);
+            _configHandle = IntPtr.Zero;
+            _disposed = true;
+        }
+    }
+}

--- a/src/csharp/Config.cs
+++ b/src/csharp/Config.cs
@@ -9,8 +9,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
     {
         private IntPtr _configHandle;
         private bool _disposed = false;
-
-        internal Config(string modelPath)
+        public Config(string modelPath)
         {
             Result.VerifySuccess(NativeMethods.OgaCreateConfig(StringUtils.ToUtf8(modelPath), out _configHandle));
         }

--- a/src/csharp/Model.cs
+++ b/src/csharp/Model.cs
@@ -15,6 +15,10 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         {
             Result.VerifySuccess(NativeMethods.OgaCreateModel(StringUtils.ToUtf8(modelPath), out _modelHandle));
         }
+        public Model(Config config)
+        {
+            Result.VerifySuccess(NativeMethods.OgaCreateModelFromConfig(config.Handle, out _modelHandle));
+        }
 
         internal IntPtr Handle { get { return _modelHandle; } }
 

--- a/src/csharp/Model.cs
+++ b/src/csharp/Model.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         {
             Result.VerifySuccess(NativeMethods.OgaCreateModel(StringUtils.ToUtf8(modelPath), out _modelHandle));
         }
+
         public Model(Config config)
         {
             Result.VerifySuccess(NativeMethods.OgaCreateModelFromConfig(config.Handle, out _modelHandle));

--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -38,8 +38,29 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         public static extern void OgaDestroyResult(IntPtr /* OgaResult* */ result);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern IntPtr /* OgaResult* */ OgaCreateConfig(byte[] /* const char* */ configPath,
+                                                                     out IntPtr /* OgaConfig** */ config);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern void OgaDestroyConfig(IntPtr /* OgaConfig* */ config);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern IntPtr /* OgaResult* */ OgaConfigClearProviders(IntPtr /* OgaConfig* */ config);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern IntPtr /* OgaResult* */ OgaConfigSetProvider(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ provider_name);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern IntPtr /* OgaResult* */ OgaConfigSetProviderOption(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ provider_name,
+                                                                                byte[] /* const char* */ option_name, byte[] /* const char* */ option_value);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaCreateModel(byte[] /* const char* */ configPath,
                                                                     out IntPtr /* OgaModel** */ model);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern IntPtr /* OgaResult* */ OgaCreateModelFromConfig(IntPtr /* const OgaConfig* */ config,
+                                                                              out IntPtr /* OgaModel** */ model);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern void OgaDestroyModel(IntPtr /* OgaModel* */ model);

--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         public static extern IntPtr /* OgaResult* */ OgaConfigClearProviders(IntPtr /* OgaConfig* */ config);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
-        public static extern IntPtr /* OgaResult* */ OgaConfigSetProvider(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ provider_name);
+        public static extern IntPtr /* OgaResult* */ OgaConfigAppendProvider(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ provider_name);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaConfigSetProviderOption(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ provider_name,

--- a/src/generators.h
+++ b/src/generators.h
@@ -147,6 +147,7 @@ void Shutdown();  // Do this once at exit, Ort code will fail after this call
 OrtEnv& GetOrtEnv();
 
 std::shared_ptr<Model> CreateModel(OrtEnv& ort_env, const char* config_path, const RuntimeSettings* settings = nullptr);
+std::shared_ptr<Model> CreateModel(OrtEnv& ort_env, std::unique_ptr<Config> config);
 std::shared_ptr<GeneratorParams> CreateGeneratorParams(const Model& model);
 std::shared_ptr<GeneratorParams> CreateGeneratorParams(const Config& config);  // For benchmarking purposes only
 std::unique_ptr<Generator> CreateGenerator(const Model& model, const GeneratorParams& params);

--- a/src/java/src/main/java/ai/onnxruntime/genai/Config.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Config.java
@@ -17,11 +17,11 @@ public final class Config implements AutoCloseable {
 	clearProviders(nativeHandle);
   }
 
-  public void setProvider(String provider_name) {
+  public void appendProvider(String provider_name) {
     if (nativeHandle == 0) {
 	  throw new IllegalStateException("Instance has been freed and is invalid");
     }
-	setProvider(nativeHandle, provider_name);
+	appendProvider(nativeHandle, provider_name);
   }
 
   public void setProviderOption(String provider_name, String option_name, String option_value) {
@@ -54,6 +54,6 @@ public final class Config implements AutoCloseable {
   private native long createConfig(String modelPath) throws GenAIException;
   private native void destroyConfig(long configHandle);
   private native void clearProviders(long configHandle);
-  private native void setProvider(long configHandle, String provider_name);
+  private native void appendProvider(long configHandle, String provider_name);
   private native void setProviderOption(long configHandle, String provider_name, String option_name, String option_value);
 }

--- a/src/java/src/main/java/ai/onnxruntime/genai/Config.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Config.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
+ */
+package ai.onnxruntime.genai;
+
+public final class Config implements AutoCloseable {
+  private long nativeHandle;
+
+  public Config(String modelPath) throws GenAIException {
+    nativeHandle = createConfig(modelPath);
+  }
+
+  public void clearProviders() {
+	if (nativeHandle == 0) {
+	  throw new IllegalStateException("Instance has been freed and is invalid");
+	}
+	clearProviders(nativeHandle);
+  }
+
+  public void setProvider(String provider_name) {
+    if (nativeHandle == 0) {
+	  throw new IllegalStateException("Instance has been freed and is invalid");
+    }
+	setProvider(nativeHandle, provider_name);
+  }
+
+  public void setProviderOption(String provider_name, String option_name, String option_value) {
+    if (nativeHandle == 0) {
+	  throw new IllegalStateException("Instance has been freed and is invalid");
+	}
+    setProviderOption(nativeHandle, provider_name, option_name, option_value);
+  }
+
+  @Override
+  public void close() {
+    if (nativeHandle != 0) {
+      destroyConfig(nativeHandle);
+      nativeHandle = 0;
+    }
+  }
+
+  long nativeHandle() {
+    return nativeHandle;
+  }
+
+  static {
+    try {
+      GenAI.init();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load onnxruntime-genai native libraries", e);
+    }
+  }
+
+  private native long createConfig(String modelPath) throws GenAIException;
+  private native void destroyConfig(long configHandle);
+  private native void clearProviders(long configHandle);
+  private native void setProvider(long configHandle, String provider_name);
+  private native void setProviderOption(long configHandle, String provider_name, String option_name, String option_value);
+}

--- a/src/java/src/main/java/ai/onnxruntime/genai/Model.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Model.java
@@ -89,6 +89,7 @@ public final class Model implements AutoCloseable {
   }
 
   private native long createModel(String modelPath) throws GenAIException;
+  private native long createModelFromConfig(long configHandle) throws GenAIException;
 
   private native void destroyModel(long modelHandle);
 

--- a/src/java/src/main/java/ai/onnxruntime/genai/Model.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Model.java
@@ -10,6 +10,10 @@ public final class Model implements AutoCloseable {
     nativeHandle = createModel(modelPath);
   }
 
+  public Model(Config config) throws GenAIException {
+    nativeHandle = createModelFromConfig(config.nativeHandle());
+  }
+
   /**
    * Creates a Tokenizer instance for this model. The model contains the configuration information
    * that determines the tokenizer to use.

--- a/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-#include "ai_onnxruntime_genai_Model.h"
+#include "ai_onnxruntime_genai_Config.h"
 
 #include "ort_genai_c.h"
 #include "utils.h"

--- a/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
@@ -29,14 +29,14 @@ Java_ai_onnxruntime_genai_Config_destroyConfig(JNIEnv* env, jobject thiz, jlong 
 
 JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Config_clearProviders(JNIEnv* env, jobject thiz, jlong native_handle) {
-  OgaConfig* config = reinterpret_cast<OgaConfig*>(config_handle);
+  OgaConfig* config = reinterpret_cast<OgaConfig*>(native_handle);
   ThrowIfError(env, OgaConfigClearProviders(config));
 }
 
 JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Config_setProvider(JNIEnv* env, jobject thiz, jlong native_handle, jstring provider_name) {
   CString c_provider_name{env, provider_name};
-  OgaConfig* config = reinterpret_cast<OgaConfig*>(config_handle);
+  OgaConfig* config = reinterpret_cast<OgaConfig*>(native_handle);
 
   ThrowIfError(env, OgaConfigSetProvider(config, c_provider_name));
 }
@@ -46,7 +46,7 @@ Java_ai_onnxruntime_genai_Config_setProvider(JNIEnv* env, jobject thiz, jlong na
   CString c_provider_name{env, provider_name};
   CString c_option_name{env, option_name};
   CString c_option_value{env, option_value};
-  OgaConfig* config = reinterpret_cast<OgaConfig*>(config_handle);
+  OgaConfig* config = reinterpret_cast<OgaConfig*>(native_handle);
 
   ThrowIfError(env, OgaConfigSetProviderOption(config, c_provider_name, c_option_name, c_option_value));
 }

--- a/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "ai_onnxruntime_genai_Model.h"
+
+#include "ort_genai_c.h"
+#include "utils.h"
+
+using namespace Helpers;
+
+JNIEXPORT jlong JNICALL
+Java_ai_onnxruntime_genai_Config_createConfig(JNIEnv* env, jobject thiz, jstring model_path) {
+  CString path{env, model_path};
+
+  OgaConfig* config = nullptr;
+  if (ThrowIfError(env, OgaCreateConfig(path, &config))) {
+    return 0;
+  }
+
+  return reinterpret_cast<jlong>(config);
+}
+
+JNIEXPORT void JNICALL
+Java_ai_onnxruntime_genai_Config_destroyConfig(JNIEnv* env, jobject thiz, jlong native_handle) {
+  OgaConfig* config = reinterpret_cast<OgaConfig*>(native_handle);
+  OgaDestroyConfig(config);
+}
+
+JNIEXPORT void JNICALL
+Java_ai_onnxruntime_genai_Config_clearProviders(JNIEnv* env, jobject thiz, jlong native_handle) {
+  OgaConfig* config = reinterpret_cast<OgaConfig*>(config_handle);
+  ThrowIfError(env, OgaConfig_ClearProviders(config));
+}
+
+JNIEXPORT void JNICALL
+Java_ai_onnxruntime_genai_Config_setProvider(JNIEnv* env, jobject thiz, jlong native_handle, jstring provider_name) {
+  CString c_provider_name{env, provider_name};
+  OgaConfig* config = reinterpret_cast<OgaConfig*>(config_handle);
+
+  ThrowIfError(env, OgaConfig_SetProvider(config, c_provider_name));
+}
+
+JNIEXPORT void JNICALL
+Java_ai_onnxruntime_genai_Config_setProvider(JNIEnv* env, jobject thiz, jlong native_handle, jstring provider_name, jstring option_name, jstring option_value) {
+  CString c_provider_name{env, provider_name};
+  CString c_option_name{env, option_name};
+  CString c_option_value{env, option_value};
+  OgaConfig* config = reinterpret_cast<OgaConfig*>(config_handle);
+
+  ThrowIfError(env, OgaConfig_SetProviderOption(config, c_provider_name, c_option_name, c_option_value));
+}

--- a/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
@@ -34,11 +34,11 @@ Java_ai_onnxruntime_genai_Config_clearProviders(JNIEnv* env, jobject thiz, jlong
 }
 
 JNIEXPORT void JNICALL
-Java_ai_onnxruntime_genai_Config_setProvider(JNIEnv* env, jobject thiz, jlong native_handle, jstring provider_name) {
+Java_ai_onnxruntime_genai_Config_appendProvider(JNIEnv* env, jobject thiz, jlong native_handle, jstring provider_name) {
   CString c_provider_name{env, provider_name};
   OgaConfig* config = reinterpret_cast<OgaConfig*>(native_handle);
 
-  ThrowIfError(env, OgaConfigSetProvider(config, c_provider_name));
+  ThrowIfError(env, OgaConfigAppendProvider(config, c_provider_name));
 }
 
 JNIEXPORT void JNICALL

--- a/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
@@ -30,7 +30,7 @@ Java_ai_onnxruntime_genai_Config_destroyConfig(JNIEnv* env, jobject thiz, jlong 
 JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Config_clearProviders(JNIEnv* env, jobject thiz, jlong native_handle) {
   OgaConfig* config = reinterpret_cast<OgaConfig*>(config_handle);
-  ThrowIfError(env, OgaConfig_ClearProviders(config));
+  ThrowIfError(env, OgaConfigClearProviders(config));
 }
 
 JNIEXPORT void JNICALL
@@ -38,7 +38,7 @@ Java_ai_onnxruntime_genai_Config_setProvider(JNIEnv* env, jobject thiz, jlong na
   CString c_provider_name{env, provider_name};
   OgaConfig* config = reinterpret_cast<OgaConfig*>(config_handle);
 
-  ThrowIfError(env, OgaConfig_SetProvider(config, c_provider_name));
+  ThrowIfError(env, OgaConfigSetProvider(config, c_provider_name));
 }
 
 JNIEXPORT void JNICALL
@@ -48,5 +48,5 @@ Java_ai_onnxruntime_genai_Config_setProvider(JNIEnv* env, jobject thiz, jlong na
   CString c_option_value{env, option_value};
   OgaConfig* config = reinterpret_cast<OgaConfig*>(config_handle);
 
-  ThrowIfError(env, OgaConfig_SetProviderOption(config, c_provider_name, c_option_name, c_option_value));
+  ThrowIfError(env, OgaConfigSetProviderOption(config, c_provider_name, c_option_name, c_option_value));
 }

--- a/src/java/src/main/native/ai_onnxruntime_genai_Model.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Model.cpp
@@ -21,6 +21,18 @@ Java_ai_onnxruntime_genai_Model_createModel(JNIEnv* env, jobject thiz, jstring m
   return reinterpret_cast<jlong>(model);
 }
 
+JNIEXPORT jlong JNICALL
+Java_ai_onnxruntime_genai_Model_createModelFromConfig(JNIEnv* env, jobject thiz, jlong config_handle) {
+  const OgaConfig* config = reinterpret_cast<const OgaConfig*>(config_handle);
+
+  OgaModel* model = nullptr;
+  if (ThrowIfError(env, OgaCreateModelFromConfig(config, &model))) {
+    return 0;
+  }
+
+  return reinterpret_cast<jlong>(model);
+}
+
 JNIEXPORT void JNICALL
 Java_ai_onnxruntime_genai_Model_destroyModel(JNIEnv* env, jobject thiz, jlong model_handle) {
   OgaModel* model = reinterpret_cast<OgaModel*>(model_handle);

--- a/src/java/src/test/java/ai/onnxruntime/genai/GenerationTest.java
+++ b/src/java/src/test/java/ai/onnxruntime/genai/GenerationTest.java
@@ -70,7 +70,8 @@ public class GenerationTest {
   public void testWithInputIds() throws GenAIException {
     // test using the HF model. input id values must be < 1000 so we use manually created input.
     // Input/expected output copied from the C# unit tests
-    Model model = new Model(TestUtils.testModelPath());
+    Config config = new Config(TestUtils.testModelPath());
+    Model model = new Model(config);
     GeneratorParams params = new GeneratorParams(model);
     int batchSize = 2;
     int sequenceLength = 4;

--- a/src/models/debugging.cpp
+++ b/src/models/debugging.cpp
@@ -19,7 +19,7 @@ static constexpr size_t c_value_count = 10;  // Dump this many values from the s
 template <typename... Types>
 const char* TypeToString(ONNXTensorElementDataType type, Ort::TypeList<Types...>) {
   const char* name = "(please add type to list)";
-  ((type == Ort::TypeToTensorType<Types> ? name = typeid(Types).name(), true : false) || ...);
+  (void)((type == Ort::TypeToTensorType<Types> ? name = typeid(Types).name(), true : false) || ...);
   return name;
 }
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -538,7 +538,10 @@ std::shared_ptr<Model> CreateModel(OrtEnv& ort_env, const char* config_path, con
     config_overlay = settings->GenerateConfigOverlay();
   }
   auto config = std::make_unique<Config>(fs::path(config_path), config_overlay);
+  return CreateModel(ort_env, std::move(config));
+}
 
+std::shared_ptr<Model> CreateModel(OrtEnv& ort_env, std::unique_ptr<Config> config) {
   if (config->model.type == "gpt2")
     return std::make_shared<Gpt_Model>(std::move(config), ort_env);
   if (config->model.type == "llama" || config->model.type == "gemma" || config->model.type == "gemma2" || config->model.type == "mistral" || config->model.type == "phi" || config->model.type == "phi3" || config->model.type == "phi3small" || config->model.type == "phimoe" || config->model.type == "qwen2" || config->model.type == "nemotron" || config->model.type == "chatglm")

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -101,6 +101,7 @@ p_session_->Run(nullptr, input_names, inputs, std::size(inputs), output_names, o
 #define PATH_MAX (4096)
 #endif
 
+#if !defined(__ANDROID__)
 #define LOG_WHEN_ENABLED(LOG_FUNC) \
   if (Generators::g_log.enabled && Generators::g_log.ort_lib) LOG_FUNC
 
@@ -109,6 +110,7 @@ p_session_->Run(nullptr, input_names, inputs, std::size(inputs), output_names, o
 #define LOG_WARN(...) LOG_WHEN_ENABLED(Generators::Log("warning", __VA_ARGS__))
 #define LOG_ERROR(...) LOG_WHEN_ENABLED(Generators::Log("error", __VA_ARGS__))
 #define LOG_FATAL(...) LOG_WHEN_ENABLED(Generators::Log("fatal", __VA_ARGS__))
+#endif
 
 /** \brief Free functions and a few helpers are defined inside this namespace. Otherwise all types are the C API types
  *

--- a/src/models/position_inputs.h
+++ b/src/models/position_inputs.h
@@ -38,8 +38,8 @@ struct PositionInputs {
 
   ONNXTensorElementDataType type_;  // Common type for position_ids and attention_mask
 
-  bool has_mask_input_{false};
-  bool has_posid_input_{false};
+  bool has_mask_input_{};
+  bool has_posid_input_{};
 
   std::array<int64_t, 2> position_ids_shape_{};  // {params.batch_size*params.beam_size, params.sequence_length}
   std::unique_ptr<OrtValue> position_ids_;

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -87,8 +87,8 @@ struct OgaConfig : OgaAbstract {
     OgaCheckResult(OgaConfigClearProviders(this));
   }
 
-  void SetProvider(const char* provider) {
-    OgaCheckResult(OgaConfigSetProvider(this, provider));
+  void AppendProvider(const char* provider) {
+    OgaCheckResult(OgaConfigAppendProvider(this, provider));
   }
 
   void SetProviderOption(const char* provider, const char* name, const char* value) {

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -76,6 +76,28 @@ struct OgaRuntimeSettings : OgaAbstract {
   static void operator delete(void* p) { OgaDestroyRuntimeSettings(reinterpret_cast<OgaRuntimeSettings*>(p)); }
 };
 
+struct OgaConfig : OgaAbstract {
+  static std::unique_ptr<OgaConfig> Create(const char* config_path) {
+    OgaConfig* p;
+    OgaCheckResult(OgaCreateConfig(config_path, &p));
+    return std::unique_ptr<OgaConfig>(p);
+  }
+
+  void ClearProviders() {
+    OgaCheckResult(OgaConfigClearProviders(this));
+  }
+
+  void SetProvider(const char* provider) {
+    OgaCheckResult(OgaConfigSetProvider(this, provider));
+  }
+
+  void SetProviderOption(const char* provider, const char* name, const char* value) {
+    OgaCheckResult(OgaConfigSetProviderOption(this, provider, name, value));
+  }
+
+  static void operator delete(void* p) { OgaDestroyConfig(reinterpret_cast<OgaConfig*>(p)); }
+};
+
 struct OgaModel : OgaAbstract {
   static std::unique_ptr<OgaModel> Create(const char* config_path) {
     OgaModel* p;
@@ -85,6 +107,11 @@ struct OgaModel : OgaAbstract {
   static std::unique_ptr<OgaModel> Create(const char* config_path, const OgaRuntimeSettings& settings) {
     OgaModel* p;
     OgaCheckResult(OgaCreateModelWithRuntimeSettings(config_path, &settings, &p));
+    return std::unique_ptr<OgaModel>(p);
+  }
+  static std::unique_ptr<OgaModel> Create(OgaConfig& config) {
+    OgaModel* p;
+    OgaCheckResult(OgaCreateModelFromConfig(&config, &p));
     return std::unique_ptr<OgaModel>(p);
   }
 

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -151,6 +151,44 @@ OgaResult* OGA_API_CALL OgaCreateModelWithRuntimeSettings(const char* config_pat
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaCreateConfig(const char* config_path, OgaConfig** out) {
+  OGA_TRY
+  *out = reinterpret_cast<OgaConfig*>(std::make_unique<Generators::Config>(fs::path(config_path), std::string_view{}).release());
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OGA_API_CALL OgaConfigClearProviders(OgaConfig* config) {
+  OGA_TRY
+  Generators::ClearProviders(*reinterpret_cast<Generators::Config*>(config));
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OGA_API_CALL OgaConfigSetProvider(OgaConfig* config, const char* provider) {
+  OGA_TRY
+  Generators::SetProviderOption(*reinterpret_cast<Generators::Config*>(config), provider, {}, {});
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config, const char* provider, const char* key, const char* value) {
+  OGA_TRY
+  Generators::SetProviderOption(*reinterpret_cast<Generators::Config*>(config), provider, key, value);
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OGA_API_CALL OgaCreateModelFromConfig(OgaConfig* config, OgaModel** out) {
+  OGA_TRY
+  auto config_copy = std::make_unique<Generators::Config>(*reinterpret_cast<Generators::Config*>(config));
+  auto model = Generators::CreateModel(Generators::GetOrtEnv(), std::move(config_copy));
+  model->external_owner_ = model;
+  *out = reinterpret_cast<OgaModel*>(model.get());
+  return nullptr;
+  OGA_CATCH
+}
+
 OgaResult* OGA_API_CALL OgaCreateModel(const char* config_path, OgaModel** out) {
   return OgaCreateModelWithRuntimeSettings(config_path, nullptr, out);
 }
@@ -601,6 +639,10 @@ void OGA_API_CALL OgaDestroySequences(OgaSequences* p) {
   delete reinterpret_cast<Generators::TokenSequences*>(p);
 }
 
+void OGA_API_CALL OgaDestroyConfig(OgaConfig* p) {
+  delete reinterpret_cast<Generators::Config*>(p);
+}
+
 void OGA_API_CALL OgaDestroyModel(OgaModel* p) {
   reinterpret_cast<Generators::Model*>(p)->external_owner_ = nullptr;
 }
@@ -648,4 +690,5 @@ void OGA_API_CALL OgaDestroyAdapters(OgaAdapters* p) {
 void OGA_API_CALL OgaDestroyRuntimeSettings(OgaRuntimeSettings* p) {
   delete reinterpret_cast<Generators::RuntimeSettings*>(p);
 }
-}
+
+}  // extern "C"

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -179,9 +179,9 @@ OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config, const char
   OGA_CATCH
 }
 
-OgaResult* OGA_API_CALL OgaCreateModelFromConfig(OgaConfig* config, OgaModel** out) {
+OgaResult* OGA_API_CALL OgaCreateModelFromConfig(const OgaConfig* config, OgaModel** out) {
   OGA_TRY
-  auto config_copy = std::make_unique<Generators::Config>(*reinterpret_cast<Generators::Config*>(config));
+  auto config_copy = std::make_unique<Generators::Config>(*reinterpret_cast<const Generators::Config*>(config));
   auto model = Generators::CreateModel(Generators::GetOrtEnv(), std::move(config_copy));
   model->external_owner_ = model;
   *out = reinterpret_cast<OgaModel*>(model.get());

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -165,7 +165,7 @@ OgaResult* OGA_API_CALL OgaConfigClearProviders(OgaConfig* config) {
   OGA_CATCH
 }
 
-OgaResult* OGA_API_CALL OgaConfigSetProvider(OgaConfig* config, const char* provider) {
+OgaResult* OGA_API_CALL OgaConfigAppendProvider(OgaConfig* config, const char* provider) {
   OGA_TRY
   Generators::SetProviderOption(*reinterpret_cast<Generators::Config*>(config), provider, {}, {});
   return nullptr;

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -51,6 +51,7 @@ typedef struct OgaResult OgaResult;
 typedef struct OgaGeneratorParams OgaGeneratorParams;
 typedef struct OgaGenerator OgaGenerator;
 typedef struct OgaRuntimeSettings OgaRuntimeSettings;
+typedef struct OgaConfig OgaConfig;
 typedef struct OgaModel OgaModel;
 // OgaSequences is an array of token arrays where the number of token arrays can be obtained using
 // OgaSequencesCount and the number of tokens in each token array can be obtained using OgaSequencesGetSequenceCount.
@@ -171,6 +172,12 @@ OGA_EXPORT void OGA_API_CALL OgaDestroyRuntimeSettings(OgaRuntimeSettings* setti
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaRuntimeSettingsSetHandle(OgaRuntimeSettings* settings, const char* handle_name, void* handle);
 
+OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateConfig(const char* config_path, OgaConfig** out);
+
+OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigClearProviders(OgaConfig* config);
+OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProvider(OgaConfig* config, const char* provider);
+OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config, const char* provider, const char* key, const char* value);
+
 /*
  * \brief Creates a model from the given configuration directory and device type.
  * \param[in] config_path The path to the model configuration directory. The path is expected to be encoded in UTF-8.
@@ -181,6 +188,15 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaRuntimeSettingsSetHandle(OgaRuntimeSetting
 OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModel(const char* config_path, OgaModel** out);
 
 /*
+ * \brief Creates a model from the given configuration directory and device type.
+ * \param[in] config_path The path to the model configuration directory. The path is expected to be encoded in UTF-8.
+ * \param[in] device_type The device type to use for the model.
+ * \param[out] out The created model.
+ * \return OgaResult containing the error message if the model creation failed.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModelFromConfig(OgaConfig* config, OgaModel** out);
+
+/*
  * \brief Creates a model from the given configuration directory, runtime settings and device type.
  * \param[in] config_path The path to the model configuration directory. The path is expected to be encoded in UTF-8.
  * \param[in] settings The runtime settings to use for the model.
@@ -189,6 +205,13 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModel(const char* config_path, OgaMo
  * \return OgaResult containing the error message if the model creation failed.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModelWithRuntimeSettings(const char* config_path, const OgaRuntimeSettings* settings, OgaModel** out);
+
+
+/*
+ * \brief Destroys the given config
+ * \param[in] config The config to be destroyed.
+ */
+OGA_EXPORT void OGA_API_CALL OgaDestroyConfig(OgaConfig* config);
 
 /*
  * \brief Destroys the given model.

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -172,14 +172,41 @@ OGA_EXPORT void OGA_API_CALL OgaDestroyRuntimeSettings(OgaRuntimeSettings* setti
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaRuntimeSettingsSetHandle(OgaRuntimeSettings* settings, const char* handle_name, void* handle);
 
+/*
+ * \brief Creates an OgaConfig from the given configuration directory.
+ * \param[in] config_path The path to the configuration directory. The path is expected to be encoded in UTF-8.
+ * \param[out] out The created config.
+ * \return OgaResult containing the error message if the creation of the config failed.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateConfig(const char* config_path, OgaConfig** out);
 
+/*
+ * \brief Clear the list of providers in the given config
+ * \param[in] config The config to clear the providers from.
+ * \return OgaResult containing the error message if the clearing of the providers failed.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigClearProviders(OgaConfig* config);
+
+/*
+ * \brief Add the provider at the end of the list of providers in the given config if it doesn't already exist
+ * \param[in] config The config to set the provider on.
+ * \param[in] provider The provider to set on the config.
+ * \return OgaResult containing the error message if the setting of the provider failed.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProvider(OgaConfig* config, const char* provider);
+
+/*
+ * \brief Set a provider option
+ * \param[in] config The config to set the provider option on.
+ * \param[in] provider The provider to set the option on.
+ * \param[in] key The key of the option to set.
+ * \param[in] value The value of the option to set.
+ * \return OgaResult containing the error message if the setting of the provider option failed.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config, const char* provider, const char* key, const char* value);
 
 /*
- * \brief Creates a model from the given configuration directory and device type.
+ * \brief Creates a model from the given configuration directory.
  * \param[in] config_path The path to the model configuration directory. The path is expected to be encoded in UTF-8.
  * \param[in] device_type The device type to use for the model.
  * \param[out] out The created model.
@@ -194,7 +221,7 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModel(const char* config_path, OgaMo
  * \param[out] out The created model.
  * \return OgaResult containing the error message if the model creation failed.
  */
-OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModelFromConfig(OgaConfig* config, OgaModel** out);
+OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModelFromConfig(const OgaConfig* config, OgaModel** out);
 
 /*
  * \brief Creates a model from the given configuration directory, runtime settings and device type.
@@ -205,7 +232,6 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModelFromConfig(OgaConfig* config, O
  * \return OgaResult containing the error message if the model creation failed.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModelWithRuntimeSettings(const char* config_path, const OgaRuntimeSettings* settings, OgaModel** out);
-
 
 /*
  * \brief Destroys the given config

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -189,11 +189,12 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigClearProviders(OgaConfig* config);
 
 /*
  * \brief Add the provider at the end of the list of providers in the given config if it doesn't already exist
+ * if it already exists, does nothing.
  * \param[in] config The config to set the provider on.
  * \param[in] provider The provider to set on the config.
  * \return OgaResult containing the error message if the setting of the provider failed.
  */
-OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProvider(OgaConfig* config, const char* provider);
+OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigAppendProvider(OgaConfig* config, const char* provider);
 
 /*
  * \brief Set a provider option

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -208,16 +208,14 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config,
 /*
  * \brief Creates a model from the given configuration directory.
  * \param[in] config_path The path to the model configuration directory. The path is expected to be encoded in UTF-8.
- * \param[in] device_type The device type to use for the model.
  * \param[out] out The created model.
  * \return OgaResult containing the error message if the model creation failed.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateModel(const char* config_path, OgaModel** out);
 
 /*
- * \brief Creates a model from the given configuration directory and device type.
- * \param[in] config_path The path to the model configuration directory. The path is expected to be encoded in UTF-8.
- * \param[in] device_type The device type to use for the model.
+ * \brief Creates a model from the given configuration.
+ * \param[in] config The configuration to use for the model.
  * \param[out] out The created model.
  * \return OgaResult containing the error message if the model creation failed.
  */

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -5,6 +5,7 @@
 #include <pybind11/numpy.h>
 #include <iostream>
 #include "../generators.h"
+#include "../ort_genai.h"
 #include "../json.h"
 #include "../search.h"
 #include "../models/model.h"
@@ -433,7 +434,18 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       })
       .def("create_stream", [](const Tokenizer& t) { return t.CreateStream(); });
 
+  // Pybind class using the C API for OgaConfig
+  pybind11::class_<OgaConfig>(m, "Config")
+      .def(pybind11::init([](const std::string& config_path) { return OgaConfig::Create(config_path.c_str()); }))
+      .def("set_provider", &OgaConfig::SetProvider)
+      .def("set_provider_option", &OgaConfig::SetProviderOption)
+      .def("clear_providers", &OgaConfig::ClearProviders);
+
   pybind11::class_<Model, std::shared_ptr<Model>>(m, "Model")
+      .def(pybind11::init([](const OgaConfig& config) {
+        auto config_copy = std::make_unique<Config>(*reinterpret_cast<const Config*>(&config));
+        return CreateModel(GetOrtEnv(), std::move(config_copy));
+      }))
       .def(pybind11::init([](const std::string& config_path) {
         return CreateModel(GetOrtEnv(), config_path.c_str());
       }))

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -437,7 +437,7 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
   // Pybind class using the C API for OgaConfig
   pybind11::class_<OgaConfig>(m, "Config")
       .def(pybind11::init([](const std::string& config_path) { return OgaConfig::Create(config_path.c_str()); }))
-      .def("set_provider", &OgaConfig::SetProvider)
+      .def("append_provider", &OgaConfig::AppendProvider)
       .def("set_provider_option", &OgaConfig::SetProviderOption)
       .def("clear_providers", &OgaConfig::ClearProviders);
 

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -18,9 +18,24 @@
 #define PHI2_PATH MODEL_PATH "phi-2/int4/cpu"
 #endif
 #endif
+TEST(CAPITests, Config) {
+#if TEST_PHI2
+  // Test modifying config settings
+  auto config = OgaConfig::Create(PHI2_PATH);
+  config->SetProvider("brainium");
+  config->SetProviderOption("super_ai", "custom_field", "hello");
+  config->SetProvider("human");
+  config->SetProviderOption("brainium", "custom_field1", "hello1");
+  config->SetProviderOption("brainium", "custom_field2", "hello2");
+  config->ClearProviders();
+  config->SetProvider("cuda");
+#endif
+}
+
 TEST(CAPITests, TokenizerCAPI) {
 #if TEST_PHI2
-  auto model = OgaModel::Create(PHI2_PATH);
+  auto config = OgaConfig::Create(PHI2_PATH);
+  auto model = OgaModel::Create(*config);
   auto tokenizer = OgaTokenizer::Create(*model);
 
   // Encode single decode single
@@ -299,8 +314,7 @@ TEST(CAPITests, SetTerminate) {
         generator->ComputeLogits();
         generator->GenerateNextToken();
       }
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
       EXPECT_EQ(generator->IsSessionTerminated(), true);
       std::cout << "Session Terminated: " << e.what() << std::endl;
     }
@@ -427,13 +441,11 @@ TEST(CAPITests, TopKTopPCAPI) {
 
 #if TEST_PHI2
 TEST(CAPITests, AdaptersTest) {
-
 #ifdef USE_CUDA
-using OutputType = Ort::Float16_t;
+  using OutputType = Ort::Float16_t;
 #else
-using OutputType = float;
+  using OutputType = float;
 #endif
-
 
   // The python unit tests create the adapter model.
   // In order to run this test, the python unit test must have been run first.
@@ -498,7 +510,7 @@ using OutputType = float;
     ASSERT_TRUE(std::equal(output_shape.begin(), output_shape.end(), shape.begin(), shape.end()));
 
     const auto size = static_cast<size_t>(std::accumulate(shape.begin(), shape.end(), 1LL,
-                                                    std::multiplies<int64_t>()));
+                                                          std::multiplies<int64_t>()));
     ASSERT_EQ(output_size, size);
     std::span<const OutputType> src(reinterpret_cast<const OutputType*>(logits->Data()), size);
     ASSERT_FALSE(std::equal(base_output.begin(), base_output.end(), src.begin(), src.end()));

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -22,13 +22,13 @@ TEST(CAPITests, Config) {
 #if TEST_PHI2
   // Test modifying config settings
   auto config = OgaConfig::Create(PHI2_PATH);
-  config->SetProvider("brainium");
+  config->AppendProvider("brainium");
   config->SetProviderOption("super_ai", "custom_field", "hello");
-  config->SetProvider("human");
+  config->AppendProvider("human");
   config->SetProviderOption("brainium", "custom_field1", "hello1");
   config->SetProviderOption("brainium", "custom_field2", "hello2");
   config->ClearProviders();
-  config->SetProvider("cuda");
+  config->AppendProvider("cuda");
 #endif
 }
 

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
                 config.ClearProviders();
                 config.SetProviderOption("cuda", "device_id", "0");
                 config.SetProviderOption("cuda", "catch_fire", "false");
-                config.SetProvider("pigeon");
+                config.AppendProvider("pigeon");
                 // At this point the providers is 'cuda' first and 'pigeon' as secondary.
                 // Given some provider options are made up and there is no pigeon provider, the model won't load.
                 // This tests the API

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
             {
                 config.ClearProviders();
                 config.SetProviderOption("cuda", "device_id", "0");
-                config.SetProviderOption("cuda", "catch_fire", "false")
+                config.SetProviderOption("cuda", "catch_fire", "false");
                 config.SetProvider("pigeon");
                 // At this point the providers is 'cuda' first and 'pigeon' as secondary.
                 // Given some provider options are made up and there is no pigeon provider, the model won't load.

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -50,6 +50,22 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
         [Fact(DisplayName = "TestGreedySearch")]
         public void TestGreedySearch()
         {
+            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "hf-internal-testing", "tiny-random-gpt2-fp32");
+            using (var config = new Config(modelPath))
+            {
+                config.ClearProviders();
+                config.SetProviderOption("cuda", "device_id", "0");
+                config.SetProviderOption("cuda", "catch_fire", "false")
+                config.SetProvider("pigeon");
+                // At this point the providers is 'cuda' first and 'pigeon' as secondary.
+                // Given some provider options are made up and there is no pigeon provider, the model won't load.
+                // This tests the API
+            }
+        }
+
+        [Fact(DisplayName = "TestGreedySearch")]
+        public void TestGreedySearch()
+        {
             ulong maxLength = 10;
             int[] inputIDs = new int[] { 0, 0, 0, 52, 0, 0, 195, 731 };
             var inputIDsShape = new ulong[] { 2, 4 };
@@ -59,41 +75,44 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
                                              0, 0, 195, 731, 731, 114, 114, 114, 114, 114 };
 
             string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "hf-internal-testing", "tiny-random-gpt2-fp32");
-            using (var model = new Model(modelPath))
+            using (var config = new Config(modelPath))
             {
-                Assert.NotNull(model);
-                using (var generatorParams = new GeneratorParams(model))
+                Assert.NotNull(config);
+                using (var model = new Model(config))
                 {
-                    Assert.NotNull(generatorParams);
-
-                    generatorParams.SetSearchOption("max_length", maxLength);
-                    generatorParams.SetInputIDs(inputIDs, sequenceLength, batchSize);
-
-                    using (var generator = new Generator(model, generatorParams))
+                    using (var generatorParams = new GeneratorParams(model))
                     {
-                        Assert.NotNull(generator);
+                        Assert.NotNull(generatorParams);
 
-                        while (!generator.IsDone())
+                        generatorParams.SetSearchOption("max_length", maxLength);
+                        generatorParams.SetInputIDs(inputIDs, sequenceLength, batchSize);
+
+                        using (var generator = new Generator(model, generatorParams))
                         {
-                            generator.ComputeLogits();
-                            generator.GenerateNextToken();
+                            Assert.NotNull(generator);
+
+                            while (!generator.IsDone())
+                            {
+                                generator.ComputeLogits();
+                                generator.GenerateNextToken();
+                            }
+
+                            for (ulong i = 0; i < batchSize; i++)
+                            {
+                                var sequence = generator.GetSequence(i).ToArray();
+                                var expectedSequence = expectedOutput.Skip((int)i * (int)maxLength).Take((int)maxLength);
+                                Assert.Equal(expectedSequence, sequence);
+                            }
                         }
+
+                        var sequences = model.Generate(generatorParams);
+                        Assert.NotNull(sequences);
 
                         for (ulong i = 0; i < batchSize; i++)
                         {
-                            var sequence = generator.GetSequence(i).ToArray();
                             var expectedSequence = expectedOutput.Skip((int)i * (int)maxLength).Take((int)maxLength);
-                            Assert.Equal(expectedSequence, sequence);
+                            Assert.Equal(expectedSequence, sequences[i].ToArray());
                         }
-                    }
-
-                    var sequences = model.Generate(generatorParams);
-                    Assert.NotNull(sequences);
-
-                    for (ulong i = 0; i < batchSize; i++)
-                    {
-                        var expectedSequence = expectedOutput.Skip((int)i * (int)maxLength).Take((int)maxLength);
-                        Assert.Equal(expectedSequence, sequences[i].ToArray());
                     }
                 }
             }

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -47,8 +47,8 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
             }
         }
 
-        [Fact(DisplayName = "TestGreedySearch")]
-        public void TestGreedySearch()
+        [Fact(DisplayName = "TestConfig")]
+        public void TestConfig()
         {
             string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "hf-internal-testing", "tiny-random-gpt2-fp32");
             using (var config = new Config(modelPath))

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -29,7 +29,7 @@ if og.is_dml_available():
 if og.is_rocm_available():
     devices.append("rocm")
 
-def config_test(test_data_path):
+def test_config(test_data_path):
     model_path = os.fspath(Path(test_data_path) / "hf-internal-testing" / "tiny-random-gpt2-fp32")
     config = og.Config(model_path)
     config.clear_providers()

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -29,6 +29,15 @@ if og.is_dml_available():
 if og.is_rocm_available():
     devices.append("rocm")
 
+def config_test(test_data_path):
+    model_path = os.fspath(Path(test_data_path) / "hf-internal-testing" / "tiny-random-gpt2-fp32";
+    config = og.Config(model_path)
+    config.clear_providers()
+    config.set_provider("cuda")
+    config.clear_providers()
+    config.set_provider_option("cuda", "infinite_clock", "1")
+    config.set_provider_option("quantum", "break_universe", "true")
+    config.set_provider("slide rule")
 
 @pytest.mark.parametrize(
     "relative_model_path",
@@ -45,7 +54,8 @@ if og.is_rocm_available():
 def test_greedy_search(test_data_path, relative_model_path):
     model_path = os.fspath(Path(test_data_path) / relative_model_path)
 
-    model = og.Model(model_path)
+    config = og.Config(model_path) # Test using config vs path directly
+    model = og.Model(config)
 
     search_params = og.GeneratorParams(model)
     search_params.input_ids = np.array(

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -30,7 +30,7 @@ if og.is_rocm_available():
     devices.append("rocm")
 
 def config_test(test_data_path):
-    model_path = os.fspath(Path(test_data_path) / "hf-internal-testing" / "tiny-random-gpt2-fp32";
+    model_path = os.fspath(Path(test_data_path) / "hf-internal-testing" / "tiny-random-gpt2-fp32")
     config = og.Config(model_path)
     config.clear_providers()
     config.set_provider("cuda")

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -33,11 +33,11 @@ def test_config(test_data_path):
     model_path = os.fspath(Path(test_data_path) / "hf-internal-testing" / "tiny-random-gpt2-fp32")
     config = og.Config(model_path)
     config.clear_providers()
-    config.set_provider("cuda")
+    config.append_provider("cuda")
     config.clear_providers()
     config.set_provider_option("cuda", "infinite_clock", "1")
     config.set_provider_option("quantum", "break_universe", "true")
-    config.set_provider("slide rule")
+    config.append_provider("slide rule")
 
 @pytest.mark.parametrize(
     "relative_model_path",


### PR DESCRIPTION
Now a provider can be chosen and configured purely at runtime, to override what the genai_config.json specifies.
`
  auto config = OgaConfig::Create("path\to\model");
  config->SetProviderOption("cuda", "enable_quantum_drive", "1");
  auto model = OgaModel::Create(*config);
`
vs this if no runtime changes are needed (this is also the current API):
`
  auto model = OgaModel::Create("path\to\model");
`

This will solve the following use cases:
* User wants to change a runtime option for a provider already specified in the genai_config.json
* User wants to switch which provider is used vs what the genai_config.json specifies
* The genai_config.json specifies no provider, and one is completely chosen at runtime.

The OgaConfig provides these methods:
* ClearProviders() - Remove all providers currently specified (will default to cpu if nothing else happens)
* SetProvider("provider_name") - If provider is already exists, does nothing, otherwise adds to end of provider list
* SetProviderOption("provider_name", "option_name", "option_value") - If provider doesn't exist, adds it to end of list. Then sets an option on the provider.
