### PR TITLE
Fix C# phi-2 test

### DIFF
--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           export ORTGENAI_LOG_ORT_LIB=1
           cd test/csharp
-          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/" /p:OrtLibDir="../../ort/lib/"
+          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/" /p:OrtLibDir="../../ort/lib/" --verbosity normal
 
       - name: Run tests
         run: |

--- a/.github/workflows/mac-cpu-arm64-build.yml
+++ b/.github/workflows/mac-cpu-arm64-build.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           export ORTGENAI_LOG_ORT_LIB=1
           cd test/csharp
-          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/osx-arm64"
+          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/osx-arm64" --verbosity normal
 
       - name: Run tests
         run: |

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Build the C# API and Run the C# Tests
       run: |
         cd test\csharp
-        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib"
+        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib" --verbosity normal
 
     - name: Verify Build Artifacts
       if: always()

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -28,6 +29,15 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
     {
         private readonly ITestOutputHelper output;
 
+        // From https://stackoverflow.com/a/47841442
+        private static string GetThisFilePath([CallerFilePath] string path = null)
+        {
+            return path;
+        }
+
+        private static readonly string _phi2Path = Path.GetFullPath(Path.Combine(
+            GetThisFilePath(),"../..", "test_models", "phi-2", "int4", "cpu"));
+
         public OnnxRuntimeGenAITests(ITestOutputHelper o)
         {
             this.output = o;
@@ -37,7 +47,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
         {
             public IgnoreOnModelAbsenceFact()
             {
-                string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "cpu", "phi-2");
+                string modelPath = _phi2Path;
                 bool exists = System.IO.Directory.Exists(modelPath);
                 if (!System.IO.Directory.Exists(modelPath))
                 {
@@ -106,7 +116,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
             float temp = 0.6f;
             ulong maxLength = 20;
 
-            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "cpu", "phi-2");
+            string modelPath = _phi2Path;
             using (var model = new Model(modelPath))
             {
                 Assert.NotNull(model);
@@ -148,7 +158,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
             float temp = 0.6f;
             ulong maxLength = 20;
 
-            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "cpu", "phi-2");
+            string modelPath = _phi2Path;
             using (var model = new Model(modelPath))
             {
                 Assert.NotNull(model);
@@ -191,7 +201,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
             float temp = 0.6f;
             ulong maxLength = 20;
 
-            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "cpu", "phi-2");
+            string modelPath = _phi2Path;
             using (var model = new Model(modelPath))
             {
                 Assert.NotNull(model);
@@ -230,7 +240,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
         [IgnoreOnModelAbsenceFact(DisplayName = "TestTokenizerBatchEncodeDecode")]
         public void TestTokenizerBatchEncodeDecode()
         {
-            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "cpu", "phi-2");
+            string modelPath = _phi2Path;
             using (var model = new Model(modelPath))
             {
                 Assert.NotNull(model);
@@ -259,7 +269,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
         [IgnoreOnModelAbsenceFact(DisplayName = "TestTokenizerBatchEncodeSingleDecode")]
         public void TestTokenizerBatchEncodeSingleDecode()
         {
-            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "cpu", "phi-2");
+            string modelPath = _phi2Path;
             using (var model = new Model(modelPath))
             {
                 Assert.NotNull(model);
@@ -290,7 +300,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
         [IgnoreOnModelAbsenceFact(DisplayName = "TestTokenizerBatchEncodeStreamDecode")]
         public void TestTokenizerBatchEncodeStreamDecode()
         {
-            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "cpu", "phi-2");
+            string modelPath = _phi2Path;
             using (var model = new Model(modelPath))
             {
                 Assert.NotNull(model);
@@ -326,7 +336,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
         [IgnoreOnModelAbsenceFact(DisplayName = "TestTokenizerSingleEncodeDecode")]
         public void TestTokenizerSingleEncodeDecode()
         {
-            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "cpu", "phi-2");
+            string modelPath = _phi2Path;
             using (var model = new Model(modelPath))
             {
                 Assert.NotNull(model);
@@ -350,7 +360,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
         [IgnoreOnModelAbsenceFact(DisplayName = "TestPhi2")]
         public void TestPhi2()
         {
-            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_models", "cpu", "phi-2");
+            string modelPath = _phi2Path;
             using (var model = new Model(modelPath))
             {
                 Assert.NotNull(model);

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -11,21 +11,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
 {
-    public class TestsFixture : IDisposable
-    {
-        private OgaHandle _handle;
-        public TestsFixture()
-        {
-            _handle = new OgaHandle();
-        }
-
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
-    }
-
-    public class OnnxRuntimeGenAITests : IClassFixture<TestsFixture>
+    public class OnnxRuntimeGenAITests
     {
         private readonly ITestOutputHelper output;
 


### PR DESCRIPTION
The C# phi-2 test was skipped due to the wrong model path. This PR intends to fix it.