### PR TITLE
Fix up projection bias calculation

### DIFF
--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -333,7 +333,7 @@ class QuantizedModel:
                             # model.layers.layer_id.mlp.gate_up_proj.bias
                             # model.layers.layer_id.mlp.dense_h_to_4h.bias
                             module.mlp.gate_proj.bias = tensor[: intermediate_size]
-                            module.mlp.down_proj.bias = tensor[intermediate_size: ]
+                            module.mlp.up_proj.bias = tensor[intermediate_size: ]
                         else:
                             raise NotImplementedError(f"{name} in your quantized model is not recognized.")
 


### PR DESCRIPTION
### Description

This PR fixes which attribute the tensor containing the bias for the up projection is assigned to.

### Motivation and Context

Previously, the calculated bias was incorrectly being assigned to the down projection's bias instead of the up projection's bias.