### PR TITLE
Fix debug build. device_type_ is set only when device type is CUDA.

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -497,7 +497,7 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
 
   // If no device gets set, default to CPU
   if (!p_device_) {
-    assert(device_type_ == DeviceType::CPU);
+    assert(device_type_ != DeviceType::CUDA);
     p_device_ = GetDeviceInterface(device_type_);
   }
 }


### PR DESCRIPTION
The webgpu Debug build fails with this assertion.