### PR TITLE
fix memset to on-device memory

### DIFF
--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -179,7 +179,7 @@ KV_Cache::KV_Cache(State& state)
     {
       if (model_.device_type_ != DeviceType::WEBGPU) {
         // FIXME: GetTensorMutableRawData might (depending on device) return device memory.
-        // In that case one can not memset on it. 
+        // In that case one can not memset on it.
         // For now remove this for WebGPU but it should be fixed for other devices as well.
         memset(presents_.back()->GetTensorMutableRawData(), 0, kv_cache_size_bytes);
       }

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -177,7 +177,12 @@ KV_Cache::KV_Cache(State& state)
     } else
 #endif
     {
-      memset(presents_.back()->GetTensorMutableRawData(), 0, kv_cache_size_bytes);
+      if (model_.device_type_ != DeviceType::WEBGPU) {
+        // FIXME: GetTensorMutableRawData might (depending on device) return device memory.
+        // In that case one can not memset on it. 
+        // For now remove this for WebGPU but it should be fixed for other devices as well.
+        memset(presents_.back()->GetTensorMutableRawData(), 0, kv_cache_size_bytes);
+      }
     }
   }
 }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -495,9 +495,8 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
       throw std::runtime_error("Unknown provider type: " + provider_options.name);
   }
 
-  // If no device gets set, default to CPU
+  // If no device is set, create it, default to CPU
   if (!p_device_) {
-    assert(device_type_ != DeviceType::CUDA);
     p_device_ = GetDeviceInterface(device_type_);
   }
 }


### PR DESCRIPTION
GetTensorMutableRawData might (depending on device) return device memory.
In that case one can not memset on it.
For now remove this for WebGPU but it should be fixed for other devices as well.
