### PR TITLE
use memset on cpu only

### DIFF
--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -177,10 +177,8 @@ KV_Cache::KV_Cache(State& state)
     } else
 #endif
     {
-      if (model_.device_type_ != DeviceType::WEBGPU) {
-        // FIXME: GetTensorMutableRawData might (depending on device) return device memory.
-        // In that case one can not memset on it.
-        // For now remove this for WebGPU but it should be fixed for other devices as well.
+      if (model_.device_type_ == DeviceType::CPU) {
+        // FIXME: this is a device ternsor and we can only use memset for cpu. Revisit for other EPs.
         memset(presents_.back()->GetTensorMutableRawData(), 0, kv_cache_size_bytes);
       }
     }


### PR DESCRIPTION
memset on a device tensor. I had previously skip the memset for webgpu but same crash shows with dml as well.
Changing to do the memset only on cpu.