### PR TITLE
Allow OgaShutdown to be called multiple times

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -67,11 +67,10 @@ static auto g_validate_shutdown = std::make_unique<ValidateShutdown>();  // Must
 
 std::unique_ptr<OrtGlobals>&
 GetOrtGlobals() {
-
   // Initialize g_globals using the g_globals_mutex
   if (!g_globals) {
     std::lock_guard<std::mutex> lock(g_globals_mutex);
-    if (!g_globals) // Now that we're in the mutex, double check
+    if (!g_globals)  // Now that we're in the mutex, double check
       g_globals = std::make_unique<OrtGlobals>();
   }
 

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -348,6 +348,10 @@ TEST(CAPITests, SetTerminate) {
 #endif
 }
 
+TEST(CAPITests, Shutdown) {
+  OgaShutdown(); // Shutdown in the middle, and see if the next test works properly
+}
+
 #if TEST_PHI2
 
 struct Phi2Test {


### PR DESCRIPTION
It's nice to be able to call OgaShutdown() then call more Oga* APIs and call OgaShutdown() again, vs just one OgaShutdown() being the permanent end of Oga for a process.

This makes it easier to implement some tests and language bindings.