### PR TITLE
Explicitly cast `jlong*` to `int64_t*` for clarity and type safety

### DIFF
--- a/src/java/src/main/native/ai_onnxruntime_genai_Tensor.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Tensor.cpp
@@ -18,7 +18,7 @@ JNIEXPORT jlong JNICALL
 Java_ai_onnxruntime_genai_Tensor_createTensor(JNIEnv* env, jobject thiz, jobject tensor_data,
                                               jlongArray shape_dims_in, jint element_type_in) {
   void* data = env->GetDirectBufferAddress(tensor_data);
-  const int64_t* shape_dims = env->GetLongArrayElements(shape_dims_in, /*isCopy*/ 0);
+  const int64_t* shape_dims = reinterpret_cast<const int64_t*>(env->GetLongArrayElements(shape_dims_in, /*isCopy*/ 0));
   size_t shape_dims_count = env->GetArrayLength(shape_dims_in);
   OgaElementType element_type = static_cast<OgaElementType>(element_type_in);
   OgaTensor* tensor = nullptr;


### PR DESCRIPTION
Fixes:
```
src/java/src/main/native/ai_onnxruntime_genai_Tensor.cpp:21:18: error: cannot initialize a variable of type 'const int64_t *' (aka 'const long long *') with an rvalue of type 'jlong *' (aka 'long *')
  const int64_t* shape_dims = env->GetLongArrayElements(shape_dims_in, /*isCopy*/ 0);
                 ^            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [src/java/CMakeFiles/onnxruntime-genai-jni.dir/src/main/native/ai_onnxruntime_genai_Tensor.cpp.o] Error 1
make[1]: *** [src/java/CMakeFiles/onnxruntime-genai-jni.dir/all] Error 2
make: *** [all] Error 2
Traceback (most recent call last):
  File "/onnxruntime-genai/build.py", line 653, in <module>
    build(arguments, environment)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/onnxruntime-genai/build.py", line 585, in build
    util.run(make_command, env=env)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/onnxruntime-genai/tools/python/util/run.py", line 56, in run
    completed_process = subprocess.run(
        cmd,
    ...<6 lines>...
        shell=shell,
    )
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/opt/homebrew/bin/cmake', '--build', '/onnxruntime-genai/build/macOS/Release', '--config', 'Release']' returned non-zero exit status 2.
```


when executing: `python build.py --build_java --config Release`