### PR TITLE
Fix past_present_share_buffer=false kv cache bug and asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,54 @@ See https://onnxruntime.ai/docs/genai/howto/install
 
 3. Run the model
 
+   ## Build from source / Next release (0.6.0)
+
+   ```python
+   import onnxruntime_genai as og
+
+   model = og.Model('cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4')
+   tokenizer = og.Tokenizer(model)
+   tokenizer_stream = tokenizer.create_stream()
+    
+   # Set the max length to something sensible by default,
+   # since otherwise it will be set to the entire context length
+   search_options = {}
+   search_options['max_length'] = 2048
+   search_options['batch_size'] = 1
+
+   chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
+
+   text = input("Input: ")
+   if not text:
+      print("Error, input cannot be empty")
+      exit
+
+   prompt = f'{chat_template.format(input=text)}'
+
+   input_tokens = tokenizer.encode(prompt)
+
+   params = og.GeneratorParams(model)
+   params.set_search_options(**search_options)
+   generator = og.Generator(model, params)
+  
+   print("Output: ", end='', flush=True)
+
+   try:
+      generator.append_tokens(input_tokens)
+      while not generator.is_done():
+        generator.generate_next_token()
+
+        new_token = generator.get_next_tokens()[0]
+        print(tokenizer_stream.decode(new_token), end='', flush=True)
+   except KeyboardInterrupt:
+       print("  --control+c pressed, aborting generation--")
+
+   print()
+   del generator
+   ```
+
+   ## Current release (until 0.5.x)
+
    ```python
    import onnxruntime_genai as og
 

--- a/src/cuda/search_cuda.cpp
+++ b/src/cuda/search_cuda.cpp
@@ -145,7 +145,7 @@ void BeamSearch_Cuda::SelectTop() {
 
 void GreedySearch_Cuda::SampleTopKTopP(int k, float p, float temperature) {
   std::span<float> scores = next_token_scores_.Span();
-  assert(scores.size() == params_->batch_size * params_->config.model.vocab_size);
+  assert(scores.size() == params_->search.batch_size * params_->config.model.vocab_size);
   cuda::GetSample(samplingdata_.get(), params_->cuda_stream, next_tokens_.data(), scores.data(), int(scores.size() / params_->search.batch_size),
                   params_->search.batch_size, k, p, temperature);
 

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -266,7 +266,7 @@ Generator::Generator(const Model& model, const GeneratorParams& params) : model_
   }
 }
 
-DeviceSpan<int32_t> Generator::AllocateInputIdsOnDevice(const cpu_span<int32_t>& input_ids) {
+DeviceSpan<int32_t> Generator::AllocateInputIdsOnDevice(const cpu_span<int32_t> input_ids) {
   auto input_ids_device = state_->params_->p_device->Allocate<int32_t>(input_ids.size());
   auto cpu_span = input_ids_device.CpuSpan();
   std::copy(input_ids.begin(), input_ids.end(), cpu_span.begin());
@@ -274,7 +274,7 @@ DeviceSpan<int32_t> Generator::AllocateInputIdsOnDevice(const cpu_span<int32_t>&
   return input_ids_device;
 }
 
-void Generator::AppendTokens(const cpu_span<int32_t>& input_ids) {
+void Generator::AppendTokens(const cpu_span<int32_t> input_ids) {
   ThrowErrorIfSessionTerminated(state_->session_terminated_);
   if (input_ids.size() == 0)
     throw std::runtime_error("input_ids is empty");
@@ -283,20 +283,17 @@ void Generator::AppendTokens(const cpu_span<int32_t>& input_ids) {
   if (search_->GetSequenceLength() != 0 && state_->params_->search.batch_size > 1)
     throw std::runtime_error("AppendTokens can only be called once for batch_size > 1. To call AppendTokens again, use RewindToLength(0)");
 
-  if (just_generated_) {
-    just_generated_ = false;
-    auto next_tokens = search_->GetNextTokens();
-    ComputeLogits(next_tokens);
+  if (last_action_ == Action::generated) {
+    ComputeLogits(search_->GetNextTokens());
   }
 
   auto input_ids_device = AllocateInputIdsOnDevice(input_ids);
   search_->AppendTokens(input_ids_device);
-
   computed_logits_ = false;
   ComputeLogits(input_ids_device);
 }
 
-void Generator::ComputeLogits(DeviceSpan<int32_t>& next_tokens) {
+void Generator::ComputeLogits(DeviceSpan<int32_t> next_tokens) {
   if (computed_logits_)
     throw std::runtime_error("ComputeLogits called again without calling AppendTokens or GenerateNextToken first");
 
@@ -307,7 +304,7 @@ void Generator::ComputeLogits(DeviceSpan<int32_t>& next_tokens) {
     stream << std::endl;
   }
   SetLogits(logits);
-  just_rewinded_ = false;
+  last_action_ = Action::standard;
   computed_logits_ = true;
 }
 
@@ -357,7 +354,7 @@ void Generator::GenerateNextToken() {
     throw std::runtime_error("GenerateNextToken called with no prior state. Please call AppendTokens, SetLogits, or params.SetInputs before calling GenerateNextToken.");
   if (!computed_logits_) {
     auto next_tokens = search_->GetNextTokens();
-    if (just_rewinded_)
+    if (last_action_ == Action::rewound)
       search_->AppendTokens(next_tokens);
     ComputeLogits(next_tokens);
   }
@@ -376,7 +373,7 @@ void Generator::GenerateNextToken() {
            << std::endl;
   }
 
-  just_generated_ = true;
+  last_action_ = Action::generated;
   if (!search.do_sample || search.top_k == 1) {
     search_->SelectTop();
     return;
@@ -415,14 +412,12 @@ void Generator::RewindToLength(size_t new_length) {
   search_->RewindTo(new_length);
   state_->RewindTo(new_length);
   computed_logits_ = false;
-  just_generated_ = false;
-  just_rewinded_ = true;
+  last_action_ = Action::rewound;
 }
 
 DeviceSpan<float> Generator::GetLogits() {
   if (!computed_logits_) {
-    auto next_tokens = search_->GetNextTokens();
-    ComputeLogits(next_tokens);
+    ComputeLogits(search_->GetNextTokens());
   }
   return search_->GetLogits();
 }

--- a/src/generators.h
+++ b/src/generators.h
@@ -129,7 +129,9 @@ struct Generator : LeakChecked<Generator> {
  private:
   DeviceSpan<int32_t> AllocateInputIdsOnDevice(const cpu_span<int32_t> input_ids);
   void ComputeLogits(DeviceSpan<int32_t> next_tokens);
-  enum Action { standard, generated, rewound };
+  enum Action { standard,
+                generated,
+                rewound };
   Action last_action_{standard};
 };
 

--- a/src/generators.h
+++ b/src/generators.h
@@ -129,9 +129,9 @@ struct Generator : LeakChecked<Generator> {
  private:
   DeviceSpan<int32_t> AllocateInputIdsOnDevice(const cpu_span<int32_t> input_ids);
   void ComputeLogits(DeviceSpan<int32_t> next_tokens);
-  enum Action { standard,
-                generated,
-                rewound };
+  enum Action { standard,   // Default, set in any other case
+                generated,  // Set after GenerateNextToken
+                rewound };  // Set after RewindToLength
   Action last_action_{standard};
 };
 

--- a/src/generators.h
+++ b/src/generators.h
@@ -129,7 +129,8 @@ struct Generator : LeakChecked<Generator> {
  private:
   DeviceSpan<int32_t> AllocateInputIdsOnDevice(const cpu_span<int32_t>& input_ids);
   void ComputeLogits(DeviceSpan<int32_t>& next_tokens);
-  bool just_rewinded_{false};
+  bool just_rewinded_{};
+  bool just_generated_{};
 };
 
 struct OrtGlobals {

--- a/src/generators.h
+++ b/src/generators.h
@@ -111,7 +111,7 @@ struct Generator : LeakChecked<Generator> {
   Generator(const Model& model, const GeneratorParams& params);
 
   bool IsDone() const;
-  void AppendTokens(const cpu_span<int32_t>& input_ids);
+  void AppendTokens(const cpu_span<int32_t> input_ids);
   void GenerateNextToken();
   void RewindToLength(size_t new_length);  // Rewind state to new_length
   DeviceSpan<float> GetLogits();
@@ -127,10 +127,10 @@ struct Generator : LeakChecked<Generator> {
   bool computed_logits_{};  // Set to true in ComputeLogits() and false after appending a token to ensure a 1 to 1 call ratio
 
  private:
-  DeviceSpan<int32_t> AllocateInputIdsOnDevice(const cpu_span<int32_t>& input_ids);
-  void ComputeLogits(DeviceSpan<int32_t>& next_tokens);
-  bool just_rewinded_{};
-  bool just_generated_{};
+  DeviceSpan<int32_t> AllocateInputIdsOnDevice(const cpu_span<int32_t> input_ids);
+  void ComputeLogits(DeviceSpan<int32_t> next_tokens);
+  enum Action { standard, generated, rewound };
+  Action last_action_{standard};
 };
 
 struct OrtGlobals {

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -137,8 +137,6 @@ DeviceSpan<float> Logits::Get() {
     }
   }
 
-  assert(shape_[1] == 1);
-
 #if USE_DML
   // DML doesn't support on-device scoring yet, so we need to download some data to the CPU
   if (model_.device_type_ == DeviceType::DML) {


### PR DESCRIPTION
This PR fixes a bug where, when using continuous decoding, the output would differ depending on whether past_present_share_buffer was on or off. The bug was actually deeper than this, as the KV-Cache was missing the last generated token when using continuous decoding, regardless of share buffer.

It also fixes a few assert statements.