### PR TITLE
Fix comments and function names/arguments for rewind and continuous api's

### DIFF
--- a/src/csharp/Generator.cs
+++ b/src/csharp/Generator.cs
@@ -20,13 +20,13 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             return NativeMethods.OgaGenerator_IsDone(_generatorHandle) != 0;
         }
 
-        public void AppendTokens(ReadOnlySpan<int> tokens)
+        public void AppendTokens(ReadOnlySpan<int> inputIDs)
         {
             unsafe
             {
-                fixed (int* tokenIDsPtr = tokens)
+                fixed (int* inputIDsPtr = inputIDs)
                 {
-                    Result.VerifySuccess(NativeMethods.OgaGenerator_AppendTokens(_generatorHandle, tokenIDsPtr, (UIntPtr)tokens.Length));
+                    Result.VerifySuccess(NativeMethods.OgaGenerator_AppendTokens(_generatorHandle, inputIDsPtr, (UIntPtr)inputIDs.Length));
                 }
             }
         }

--- a/src/csharp/Generator.cs
+++ b/src/csharp/Generator.cs
@@ -41,9 +41,14 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             Result.VerifySuccess(NativeMethods.OgaGenerator_GenerateNextToken(_generatorHandle));
         }
 
-        public void RewindTo(ulong index)
+        /// <summary>
+        /// Rewinds the generator to the given newLength.
+        /// Throw on error
+        /// </summary>
+        /// <param name="newLength"></param>
+        public void RewindTo(ulong newLength)
         {
-            Result.VerifySuccess(NativeMethods.OgaGenerator_RewindTo(_generatorHandle, (UIntPtr)index));
+            Result.VerifySuccess(NativeMethods.OgaGenerator_RewindTo(_generatorHandle, (UIntPtr)newLength));
         }
 
         public ReadOnlySpan<int> GetSequence(ulong index)

--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         // This function is used to append tokens to the sequence.
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern unsafe IntPtr /* OgaResult* */ OgaGenerator_AppendTokens(IntPtr /* OgaGenerator* */ generator,
-                                                                                      int* /* const int32_t* */ tokens,
+                                                                                      int* /* const int32_t* */ inputIDs,
                                                                                       UIntPtr /* size_t */ tokenCount);
 
         // This function is used to append a Sequences

--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -123,10 +123,10 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
                                                                                        IntPtr /* const OgaSequences* */ sequences);
                                                                                        
 
-        // This function is used to rewind the generator to the given index.
+        // This function is used to rewind the generator to the given newLength.
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaGenerator_RewindTo(IntPtr /* OgaGenerator* */ generator,
-                                                                            UIntPtr /* size_t */ index);
+                                                                            UIntPtr /* size_t */ newLength);
 
         // This function returns the length of the sequence at the given index.
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]

--- a/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
@@ -64,7 +64,7 @@ public final class Generator implements AutoCloseable, Iterable<Integer> {
   /**
    * Appends tokens to the generator.
    *
-   * @param tokens The tokens to append.
+   * @param inputIDs The tokens to append.
    * @throws GenAIException If the call to the GenAI native API fails.
    */
   public void appendTokens(int[] inputIDs) throws GenAIException {

--- a/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
@@ -96,15 +96,15 @@ public final class Generator implements AutoCloseable, Iterable<Integer> {
   /**
    * Rewinds the generator by the specified number of tokens.
    *
-   * @param numTokens The number of tokens to rewind.
+   * @param newLength The desired length in tokens after rewinding.
    * @throws GenAIException If the call to the GenAI native API fails.
    */
-  public void rewindTokens(int numTokens) throws GenAIException {
+  public void rewindTo(int newLength) throws GenAIException {
     if (nativeHandle == 0) {
       throw new IllegalStateException("Instance has been freed and is invalid");
     }
 
-    rewindTokens(nativeHandle, numTokens);
+    rewindTo(nativeHandle, newLength);
   }
 
   /**
@@ -223,7 +223,7 @@ public final class Generator implements AutoCloseable, Iterable<Integer> {
   private native void appendTokenSequences(long nativeHandle, long sequencesHandle)
       throws GenAIException;
 
-  private native void rewindTokens(long nativeHandle, int numTokens) throws GenAIException;
+  private native void rewindTo(long nativeHandle, int newLength) throws GenAIException;
 
   private native void generateNextTokenNative(long nativeHandle) throws GenAIException;
 

--- a/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
@@ -67,12 +67,12 @@ public final class Generator implements AutoCloseable, Iterable<Integer> {
    * @param tokens The tokens to append.
    * @throws GenAIException If the call to the GenAI native API fails.
    */
-  public void appendTokens(int[] tokens) throws GenAIException {
+  public void appendTokens(int[] inputIDs) throws GenAIException {
     if (nativeHandle == 0) {
       throw new IllegalStateException("Instance has been freed and is invalid");
     }
 
-    appendTokens(nativeHandle, tokens);
+    appendTokens(nativeHandle, inputIDs);
   }
 
   /**

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -36,7 +36,7 @@
  * }
  * auto output_sequence = generator->GetSequenceData(0);
  * auto output_string = tokenizer->Decode(output_sequence, generator->GetSequenceCount(0));
- * 
+ *
  * std::cout << "Output: " << std::endl << output_string << std::endl;
  */
 

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -26,13 +26,18 @@
  * tokenizer->Encode("A great recipe for Kung Pao chicken is ", *sequences);
  *
  * auto params = OgaGeneratorParams::Create(*model);
- * params->SetInputSequences(*sequences);
  * params->SetSearchOption("max_length", 200);
+ * params->SetSearchOption("batch_size", 1);
  *
- * auto output_sequences = model->Generate(*params);
- * auto out_string = tokenizer->Decode(output_sequences->Get(0));
- *
- * std::cout << "Output: " << std::endl << out_string << std::endl;
+ * auto generator = OgaGenerator::Create(*model, *params);
+ * generator->AppendTokenSequences(*sequences);
+ * while (!generator->IsDone()) {
+ *  generator->GenerateNextToken();
+ * }
+ * auto output_sequence = generator->GetSequenceData(0);
+ * auto output_string = tokenizer->Decode(output_sequence, generator->GetSequenceCount(0));
+ * 
+ * std::cout << "Output: " << std::endl << output_string << std::endl;
  */
 
 // The types defined in this file are to give us zero overhead C++ style interfaces around an opaque C pointer.

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -287,8 +287,8 @@ struct OgaGenerator : OgaAbstract {
     OgaCheckResult(OgaGenerator_GenerateNextToken(this));
   }
 
-  void RewindTo(size_t length) {
-    OgaCheckResult(OgaGenerator_RewindTo(this, length));
+  void RewindTo(size_t new_length) {
+    OgaCheckResult(OgaGenerator_RewindTo(this, new_length));
   }
 
   void SetRuntimeOption(const char* key, const char* value) {

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -328,7 +328,7 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_SetRuntimeOption(OgaGenerator* g
  * \brief Rewinds the generator to the given length. This is useful when the user wants to rewind the generator to a specific length
  *        and continue generating from that point.
  * \param[in] generator The generator to rewind to the given length.
- * \param[in] new_length The new length to rewind the generator to.
+ * \param[in] new_length The desired length in tokens after rewinding.
  * \return OgaResult containing the error message if the rewinding failed.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_RewindTo(OgaGenerator* generator, size_t new_length);


### PR DESCRIPTION
Comments and function names / arguments were confusing. This PR fixes them by aligning them with each other.