### PR TITLE
Avoid potential desynchronization of cpu and device memory

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -297,6 +297,7 @@ void Generator::ComputeLogits(DeviceSpan<int32_t> next_tokens) {
   if (computed_logits_)
     throw std::runtime_error("ComputeLogits called again without calling AppendTokens or GenerateNextToken first");
 
+  next_tokens.CopyDeviceToCpu();
   auto logits = state_->Run(search_->GetSequenceLength(), next_tokens, search_->GetNextIndices());
   if (g_log.enabled && g_log.model_logits) {
     auto& stream = Log("model_logits");


### PR DESCRIPTION
A possible desynchronization of cpu and device memory of new_tokens could result in bugs. This PR guards against any potential bugs, although no issues have been reported thus far to the best of my knowledge.