### PR TITLE
Switch to self-hosted pool to fix Android CI

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           submodules: true
 
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Setup Java 17
         uses: actions/setup-java@v4
         with:
@@ -53,10 +57,6 @@ jobs:
       - name: Install jq
         run: |
           sudo apt-get install jq
-
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
 
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v4

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           gradle-version: '8.6'
 
-      # Check the NDK that we're using
+      # Check the Android SDK and NDK that we're using
       - name: Check Android SDK and NDK
         run: |
           set -e -x
@@ -54,9 +54,9 @@ jobs:
           echo "ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME"
           ls -l $ANDROID_HOME/ndk
 
-      - name: Check if emulator are installed and install if needed
+      - name: Check if emulator is installed and install it if needed
         run: |
-          if [ -d "${ANDROID_SDK_ROOT}/emulator" ] then
+          if [ -d "${ANDROID_SDK_ROOT}/emulator" ]; then
               echo "${ANDROID_SDK_ROOT}/emulator exists"
           else
               ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "emulator"

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -21,7 +21,7 @@ jobs:
     #       it doesn't work on macos-14.
     #         HVF error: HV_UNSUPPORTED
     #       it works on macos-13 but with macos-15 being released soon that isn't a long term solution.
-    runs-on: ubuntu-24.04
+    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-AMD-CPU" ]
     steps:
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v4

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -41,13 +41,26 @@ jobs:
           gradle-version: '8.6'
 
       # Check the NDK that we're using
-      - name: Check Android NDKs
+      - name: Check Android SDK and NDK
         run: |
           set -e -x
           uname -m
+          echo "ANDROID_HOME=$ANDROID_HOME"
+          ls -l $ANDROID_HOME
+
+          echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+
           echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME"
           echo "ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME"
           ls -l $ANDROID_HOME/ndk
+
+      - name: Check if emulator are installed and install if needed
+        run: |
+          if [ -d "${ANDROID_SDK_ROOT}/emulator" ] then
+              echo "${ANDROID_SDK_ROOT}/emulator exists"
+          else
+              ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "emulator"
+          fi
 
       # Needed for linux
       - name: Install jq

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -21,7 +21,7 @@ jobs:
     #       it doesn't work on macos-14.
     #         HVF error: HV_UNSUPPORTED
     #       it works on macos-13 but with macos-15 being released soon that isn't a long term solution.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v4

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -28,10 +28,6 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
-
       - name: Setup Java 17
         uses: actions/setup-java@v4
         with:
@@ -62,25 +58,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Get the Latest OnnxRuntime Nightly Version
-        run: |
-          ORT_NIGHTLY_VERSION=$(curl -s "${{ env.ORT_NIGHTLY_REST_API }}" | jq -r '.value[0].versions[0].normalizedVersion')
-          echo "$ORT_NIGHTLY_VERSION"
-          echo "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" >> $GITHUB_ENV
-
-      # have to create a dummy project to use `add package`
-      - name: Download OnnxRuntime Nightly
-        run: |
-          dotnet new console
-          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
-
-      - name: Extract ONNX Runtime AAR
-        run: |
-          set -e -x
-          ls -l
-          unzip microsoft.ml.onnxruntime/${{ env.ORT_NIGHTLY_VERSION }}/runtimes/android/native/onnxruntime.aar -d ort
-          ls -lR ort
 
       - name: Create Android build
         run: |

--- a/src/java/src/test/android/app/src/androidTest/java/ai/onnxruntime_genai/example/javavalidator/SimpleTest.kt
+++ b/src/java/src/test/android/app/src/androidTest/java/ai/onnxruntime_genai/example/javavalidator/SimpleTest.kt
@@ -90,7 +90,7 @@ class SimpleTest {
         // the test model requires manual input as the token ids have to be < 1000 but the configured tokenizer
         // has a larger vocab size and the input ids it generates are not valid.
         val model = Model(newModelPath)
-        val params = model.createGeneratorParams()
+        val params = GeneratorParams(model)
 
         val sequenceLength = 4
         val batchSize = 2


### PR DESCRIPTION
* Switch to internal pool to avoid being hit by GHA image updates.
* Add script to install Android emulator if needed.