### PR TITLE
Fix model path in Phi-3 QA example

### DIFF
--- a/examples/python/phi-3-tutorial.md
+++ b/examples/python/phi-3-tutorial.md
@@ -70,7 +70,7 @@ Are you on a Windows machine with GPU?
 
    ```bash
    curl https://raw.githubusercontent.com/microsoft/onnxruntime-genai/main/examples/python/phi3-qa.py -o phi3-qa.py
-   python phi3-qa.py -m directml\directml-int4-awq-block-128
+   python phi3-qa.py -m directml\directml-int4-awq-block-128 -e dml
    ```
 
    Once the script has loaded the model, it will ask you for input in a loop, streaming the output as it is produced the model. For example:
@@ -109,7 +109,7 @@ Are you on a Windows machine with GPU?
 
    ```bash
    curl https://raw.githubusercontent.com/microsoft/onnxruntime-genai/main/examples/python/phi3-qa.py -o phi3-qa.py
-   python phi3-qa.py -m cuda/cuda-int4-rtn-block-32 
+   python phi3-qa.py -m cuda/cuda-int4-rtn-block-32 -e cuda
    ```
 
       Once the script has loaded the model, it will ask you for input in a loop, streaming the output as it is produced the model. For example:
@@ -142,7 +142,7 @@ Are you on a Windows machine with GPU?
 
    ```bash
    curl https://raw.githubusercontent.com/microsoft/onnxruntime-genai/main/examples/python/phi3-qa.py -o phi3-qa.py
-   python phi3-qa.py -m cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4
+   python phi3-qa.py -m cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4 -p cpu
    ```
 
    Once the script has loaded the model, it will ask you for input in a loop, streaming the output as it is produced the model. For example:

--- a/examples/python/phi-3-tutorial.md
+++ b/examples/python/phi-3-tutorial.md
@@ -142,7 +142,7 @@ Are you on a Windows machine with GPU?
 
    ```bash
    curl https://raw.githubusercontent.com/microsoft/onnxruntime-genai/main/examples/python/phi3-qa.py -o phi3-qa.py
-   python phi3-qa.py -m cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4 -p cpu
+   python phi3-qa.py -m cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4 -e cpu
    ```
 
    Once the script has loaded the model, it will ask you for input in a loop, streaming the output as it is produced the model. For example:

--- a/examples/python/phi3-qa.py
+++ b/examples/python/phi3-qa.py
@@ -8,7 +8,7 @@ def main(args):
         started_timestamp = 0
         first_token_timestamp = 0
 
-    config = og.Config(args.model)
+    config = og.Config(args.model_path)
     config.clear_providers()
     if args.execution_provider != "cpu":
         if args.verbose: print(f"Setting model to {args.execution_provider}")


### PR DESCRIPTION
### Description

This PR fixes a typo with accessing the model path in the Phi-3 QA example.

### Motivation and Context

With this change, the config object is loaded correctly now.