### PR TITLE
Add Error Checking for Prompt Length vs. Max Length

### DIFF
--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Print verbose output and timing information. Defaults to false')
     parser.add_argument('-g', '--timings', action='store_true', default=False, help='Print timing information for each generation step. Defaults to false')
     parser.add_argument('-c', '--chat_template', type=str, default='', help='Chat template to use for the prompt. User input will be injected into {input}')
-    parser.add_argument('-s', '--system_prompt', type=str, default='You are a helpful assistant. You are friendly, courteous, and professional. All your responses must end with an exclamation point!', help='System prompt to use for the prompt.')
+    parser.add_argument('-s', '--system_prompt', type=str, default='You are a helpful AI assistant.', help='System prompt to use for the prompt.')
     parser.add_argument('-r', '--rewind', action='store_true', default=False, help='Rewind to the system prompt after each generation. Defaults to false')
     args = parser.parse_args()
     main(args)

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -237,7 +237,7 @@ void GeneratorParams::SetInputs(const NamedTensors& named_tensors) {
     if (name == Config::Defaults::InputIdsName) {
       aux_input_ids = cpu_span<int32_t>(tensor->ort_tensor_->GetTensorMutableData<int32_t>(),
                                         tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetElementCount());
-      if (aux_input_ids.size() > search.max_length)
+      if (aux_input_ids.size() / search.batch_size > search.max_length)
         throw std::runtime_error("input_ids size (" + std::to_string(aux_input_ids.size()) + ") exceeds max length (" + std::to_string(search.max_length) + ")");
       else if (aux_input_ids.size() == 0)
         throw std::runtime_error("input_ids is empty");
@@ -313,7 +313,7 @@ void Generator::AppendTokens(cpu_span<const int32_t> input_ids) {
   ThrowErrorIfSessionTerminated(state_->session_terminated_);
   if (input_ids.size() == 0)
     throw std::runtime_error("input_ids is empty");
-  if (input_ids.size() + search_->GetSequenceLength() > state_->params_->search.max_length)
+  if ((input_ids.size() / state_->params_->search.batch_size) + search_->GetSequenceLength() > state_->params_->search.max_length)
     throw std::runtime_error("input_ids size (" + std::to_string(input_ids.size()) + ") + current sequence length (" + std::to_string(search_->GetSequenceLength()) + ") exceeds max length (" + std::to_string(state_->params_->search.max_length) + ")");
   if (model_->config_->model.type == "whisper" || model_->config_->model.type == "phi3v")
     throw std::runtime_error("Please use params.SetInputs for " + model_->config_->model.type + ". AppendTokens is not supported for this model type.");

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -237,6 +237,10 @@ void GeneratorParams::SetInputs(const NamedTensors& named_tensors) {
     if (name == Config::Defaults::InputIdsName) {
       aux_input_ids = cpu_span<int32_t>(tensor->ort_tensor_->GetTensorMutableData<int32_t>(),
                                         tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetElementCount());
+      if (aux_input_ids.size() > search.max_length)
+        throw std::runtime_error("input_ids size (" + std::to_string(aux_input_ids.size()) + ") exceeds max length (" + std::to_string(search.max_length) + ")");
+      else if (aux_input_ids.size() == 0)
+        throw std::runtime_error("input_ids is empty");
     } else {
       // If the nominal name is found in the map, use the graph name.
       // Else, use the nominal name as the graph name.
@@ -309,6 +313,8 @@ void Generator::AppendTokens(cpu_span<const int32_t> input_ids) {
   ThrowErrorIfSessionTerminated(state_->session_terminated_);
   if (input_ids.size() == 0)
     throw std::runtime_error("input_ids is empty");
+  if (input_ids.size() + search_->GetSequenceLength() > state_->params_->search.max_length)
+    throw std::runtime_error("input_ids size (" + std::to_string(input_ids.size()) + ") + current sequence length (" + std::to_string(search_->GetSequenceLength()) + ") exceeds max length (" + std::to_string(state_->params_->search.max_length) + ")");
   if (model_->config_->model.type == "whisper" || model_->config_->model.type == "phi3v")
     throw std::runtime_error("Please use params.SetInputs for " + model_->config_->model.type + ". AppendTokens is not supported for this model type.");
   if (search_->GetSequenceLength() != 0 && state_->params_->search.batch_size > 1)

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -146,13 +146,7 @@ TEST(CAPITests, MaxLength) {
 
   auto generator = OgaGenerator::Create(*model, *params);
   generator->AppendTokens(input_ids_0.data(), input_ids_0.size());
-
-  try {
-    generator->AppendTokens(input_ids_1.data(), input_ids_1.size());
-    ASSERT_TRUE(false); // Should not reach here
-  } catch (const std::runtime_error& e) {
-    std::cout << "Caught expected exception: " << e.what() << std::endl;
-  }
+  EXPECT_THROW(generator->AppendTokens(input_ids_1.data(), input_ids_1.size()));
 
   // Batch size 3 case
   std::vector<int32_t> input_ids_2{1, 2, 3, 5, 8,
@@ -168,13 +162,7 @@ TEST(CAPITests, MaxLength) {
 
   generator = OgaGenerator::Create(*model, *params);
   generator->AppendTokens(input_ids_2.data(), input_ids_2.size());
-
-  try {
-    generator->AppendTokens(input_ids_3.data(), input_ids_3.size());
-    ASSERT_TRUE(false); // Should not reach here
-  } catch (const std::runtime_error& e) {
-    std::cout << "Caught expected exception: " << e.what() << std::endl;
-  }
+  EXPECT_THROW(generator->AppendTokens(input_ids_3.data(), input_ids_3.size()));
 }
 
 TEST(CAPITests, EndToEndPhiBatch) {

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -128,6 +128,30 @@ TEST(CAPITests, AppendTokensToSequence) {
 #endif
 }
 
+TEST(CAPITests, MaxLength) {
+  auto model = OgaModel::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto tokenizer = OgaTokenizer::Create(*model);
+
+  const char* input_string = "This is a test.";
+
+  auto input_sequence = OgaSequences::Create();
+  for (auto& string : input_strings)
+    tokenizer->Encode(string, *input_sequence);
+  std::cout << "Input sequence count:" << input_sequence->SequenceCount(0) << std::endl;
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 8);
+
+  auto generator = OgaGenerator::Create(*model, *params);
+  generator->AppendTokenSequences(*input_sequences);
+
+  try {
+    generator->AppendTokenSequences(*input_sequences);
+    ASSERT_TRUE(false); // Should not reach here
+  } catch (const std::runtime_error& e) {
+    std::cout << "Caught expected exception: " << e.what() << std::endl;
+  }
+}
+
 TEST(CAPITests, EndToEndPhiBatch) {
 #if TEST_PHI2
   auto model = OgaModel::Create(PHI2_PATH);

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -129,6 +129,7 @@ TEST(CAPITests, AppendTokensToSequence) {
 }
 
 TEST(CAPITests, MaxLength) {
+  // Batch size 1 case
   std::vector<int32_t> input_ids_0{1, 2, 3, 5, 8};
   std::vector<int32_t> input_ids_1{13, 21, 34, 55, 89};
 
@@ -148,6 +149,28 @@ TEST(CAPITests, MaxLength) {
 
   try {
     generator->AppendTokens(input_ids_1.data(), input_ids_1.size());
+    ASSERT_TRUE(false); // Should not reach here
+  } catch (const std::runtime_error& e) {
+    std::cout << "Caught expected exception: " << e.what() << std::endl;
+  }
+
+  // Batch size 3 case
+  std::vector<int32_t> input_ids_2{1, 2, 3, 5, 8,
+                                   0, 0, 0, 52, 104,
+                                   0, 0, 195, 731, 731};
+  std::vector<int32_t> input_ids_3{13, 21, 34, 55, 89,
+                                   52, 53, 54, 55, 56,
+                                   195, 64, 45, 23, 12};
+
+  params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", max_length);
+  params->SetSearchOption("batch_size", 3);
+
+  generator = OgaGenerator::Create(*model, *params);
+  generator->AppendTokens(input_ids_2.data(), input_ids_2.size());
+
+  try {
+    generator->AppendTokens(input_ids_3.data(), input_ids_3.size());
     ASSERT_TRUE(false); // Should not reach here
   } catch (const std::runtime_error& e) {
     std::cout << "Caught expected exception: " << e.what() << std::endl;

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -146,7 +146,7 @@ TEST(CAPITests, MaxLength) {
 
   auto generator = OgaGenerator::Create(*model, *params);
   generator->AppendTokens(input_ids_0.data(), input_ids_0.size());
-  EXPECT_THROW(generator->AppendTokens(input_ids_1.data(), input_ids_1.size()));
+  EXPECT_THROW(generator->AppendTokens(input_ids_1.data(), input_ids_1.size()), std::runtime_error);
 
   // Batch size 3 case
   std::vector<int32_t> input_ids_2{1, 2, 3, 5, 8,
@@ -162,7 +162,7 @@ TEST(CAPITests, MaxLength) {
 
   generator = OgaGenerator::Create(*model, *params);
   generator->AppendTokens(input_ids_2.data(), input_ids_2.size());
-  EXPECT_THROW(generator->AppendTokens(input_ids_3.data(), input_ids_3.size()));
+  EXPECT_THROW(generator->AppendTokens(input_ids_3.data(), input_ids_3.size()), std::runtime_error);
 }
 
 TEST(CAPITests, EndToEndPhiBatch) {

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -142,10 +142,10 @@ TEST(CAPITests, MaxLength) {
   params->SetSearchOption("max_length", 8);
 
   auto generator = OgaGenerator::Create(*model, *params);
-  generator->AppendTokenSequences(*input_sequences);
+  generator->AppendTokenSequences(*input_sequence);
 
   try {
-    generator->AppendTokenSequences(*input_sequences);
+    generator->AppendTokenSequences(*input_sequence);
     ASSERT_TRUE(false); // Should not reach here
   } catch (const std::runtime_error& e) {
     std::cout << "Caught expected exception: " << e.what() << std::endl;

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -129,11 +129,9 @@ TEST(CAPITests, AppendTokensToSequence) {
 }
 
 TEST(CAPITests, MaxLength) {
-    std::vector<int64_t> input_ids_shape{1, 4};
   std::vector<int32_t> input_ids_0{1, 2, 3, 5, 8};
   std::vector<int32_t> input_ids_1{13, 21, 34, 55, 89};
 
-  int batch_size = static_cast<int>(input_ids_shape[0]);
   int max_length = 7;
 
   // To generate this file:
@@ -144,7 +142,6 @@ TEST(CAPITests, MaxLength) {
 
   auto params = OgaGeneratorParams::Create(*model);
   params->SetSearchOption("max_length", max_length);
-  params->SetSearchOption("batch_size", batch_size);
 
   auto generator = OgaGenerator::Create(*model, *params);
   generator->AppendTokens(input_ids_0.data(), input_ids_0.size());

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -149,20 +149,15 @@ TEST(CAPITests, MaxLength) {
   EXPECT_THROW(generator->AppendTokens(input_ids_1.data(), input_ids_1.size()), std::runtime_error);
 
   // Batch size 3 case
-  std::vector<int32_t> input_ids_2{1, 2, 3, 5, 8,
-                                   0, 0, 0, 52, 104,
-                                   0, 0, 195, 731, 731};
-  std::vector<int32_t> input_ids_3{13, 21, 34, 55, 89,
-                                   52, 53, 54, 55, 56,
-                                   195, 64, 45, 23, 12};
-
+  std::vector<int32_t> input_ids_2{1, 2, 3, 5, 8, 13, 21, 34, 55, 89,
+                                   0, 0, 0, 52, 104, 52, 53, 54, 55, 56,
+                                   0, 0, 195, 731, 731, 195, 64, 45, 23, 12};
   params = OgaGeneratorParams::Create(*model);
   params->SetSearchOption("max_length", max_length);
   params->SetSearchOption("batch_size", 3);
 
   generator = OgaGenerator::Create(*model, *params);
-  generator->AppendTokens(input_ids_2.data(), input_ids_2.size());
-  EXPECT_THROW(generator->AppendTokens(input_ids_3.data(), input_ids_3.size()), std::runtime_error);
+  EXPECT_THROW(generator->AppendTokens(input_ids_2.data(), input_ids_2.size()), std::runtime_error);
 }
 
 TEST(CAPITests, EndToEndPhiBatch) {


### PR DESCRIPTION
This adds an error check for when the prompt length + current sequence length exceeds the user-defined max length.