### PR TITLE
Our C# tests weren't creating and destroying an OgaHandle

### DIFF
--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -86,10 +86,14 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
         });
 
         private static string _adaptersPath => _lazyAdaptersPath.Value;
-
+        private static OgaHandle ogaHandle;
 
         public OnnxRuntimeGenAITests(ITestOutputHelper o)
         {
+            // Initialize GenAI and register a handler to dispose it on process exit
+            ogaHandle = new OgaHandle();
+            AppDomain.CurrentDomain.ProcessExit += (sender, e) => ogaHandle.Dispose();
+
             this.output = o;
         }
 


### PR DESCRIPTION
When I ran the tests locally I would get an abort() exception on exit due to not calling OgaShutdown()

The C# OgaHandle type will initialize and shutdown Oga safely but we have to use it for it to work.