### PR TITLE
fix bug in python benchmark script

### DIFF
--- a/benchmark/python/benchmark_e2e.py
+++ b/benchmark/python/benchmark_e2e.py
@@ -77,16 +77,10 @@ def generate_prompt(model, tokenizer, prompt_length, use_graph_capture) -> str:
     if use_graph_capture:
         params.try_graph_capture_with_max_batch_size(1)
 
-    print("inside generate_prompt")
     generator=og.Generator(model, params)
     generator.append_tokens(tokens)
-    print("appended tokens")
     while not generator.is_done():
         generator.generate_next_token()
-    output_tokens = generator.get_sequence(0)
-    print("generated tokens")
-    output_prompt = tokenizer.decode(output_tokens)
-    print("generated prompt")
     return tokenizer.decode(generator.get_sequence(0))
 
 # Use prompt length to get pre-defined prompt
@@ -271,7 +265,7 @@ def run_benchmark(args, batch_size, prompt_length, generation_length, max_length
 
     params = og.GeneratorParams(model)
     do_sample = args.top_k > 1 or (args.top_p != 1.0 and args.top_p > 0.0)
-    params.set_search_options(do_sample=do_sample, top_k=args.top_k, top_p=args.top_p, temperature=temperature, max_length=max_length, min_length=max_length)
+    params.set_search_options(do_sample=do_sample, top_k=args.top_k, top_p=args.top_p, temperature=temperature, max_length=max_length, min_length=max_length, batch_size=batch_size)
 
     if args.use_graph_capture:
         params.try_graph_capture_with_max_batch_size(batch_size)


### PR DESCRIPTION
Bug: if we use random token ids (with flag `--use_random_token`), decoding and encoding generates a different set of tokens which is not equal to the original set. This changes the number of prompt tokens and generates incorrect result during benchmarking. e.g. 

```py
original_tokens = np.random.randint(100, size=(1, 50))
prompt = tokenizer.decode(original_tokens )
new_tokens = tokenizer.encode(prompt)
```

Earlier the number of tokens was 50 but in `new_tokens` it may not be 50. Updated code to prevent change of prompt length.