### PR TITLE
Make model type backwards compatible

### DIFF
--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -10,6 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime"
   ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
@@ -83,10 +84,6 @@ jobs:
           python3 -m pip install -r test/python/cpu/torch/requirements.txt --user
           python3 -m pip install -r test/python/cpu/ort/requirements.txt --user
           python3 -m pip install --user --no-index --no-deps --find-links build/cpu/wheel onnxruntime_genai
-
-      - name: Use Dummy HuggingFace Token
-        run: |
-          echo "HF_TOKEN=12345" >> $GITHUB_ENV
 
       - name: Verify Build Artifacts
         if: always()

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -12,6 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   ort_dir: "onnxruntime-linux-x64-1.18.0"
   ort_zip: "onnxruntime-linux-x64-1.18.0.tgz"
   ort_url: "https://github.com/microsoft/onnxruntime/releases/download/v1.18.0/onnxruntime-linux-x64-1.18.0.tgz"
@@ -54,10 +55,6 @@ jobs:
           python3 -m pip install -r test/python/cpu/torch/requirements.txt --user
           python3 -m pip install -r test/python/cpu/ort/requirements.txt --user
           python3 -m pip install build/cpu/wheel/onnxruntime_genai*.whl --no-deps
-
-      - name: Use Dummy HuggingFace Token
-        run: |
-          echo "HF_TOKEN=12345" >> $GITHUB_ENV
 
       - name: Run the python tests
         run: |

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Linux&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: Microsoft.ML.OnnxRuntime.Gpu.Linux
   ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
@@ -108,10 +109,6 @@ jobs:
             -w /ort_genai_src onnxruntimecudabuildx64 \
             bash -c " \
               /usr/bin/cmake --build --preset linux_gcc_cuda_release"
-
-      - name: Use Dummy HuggingFace Token
-        run: |
-          echo "HF_TOKEN=12345" >> $GITHUB_ENV
 
       - name: Install the onnxruntime-genai Python wheel and run python test
         run: |

--- a/.github/workflows/mac-cpu-arm64-build.yml
+++ b/.github/workflows/mac-cpu-arm64-build.yml
@@ -10,6 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime"
 jobs:
@@ -86,7 +87,6 @@ jobs:
       - name: Run the python tests
         run: |
           source genai-macos-venv/bin/activate
-          export HF_TOKEN="12345"
           export ORTGENAI_LOG_ORT_LIB=1
           python3 -m pip install requests
           python3 test/python/test_onnxruntime_genai.py --cwd test/python --test_models test/test_models

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -11,6 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   binaryDir: 'build/cpu/win-x64'
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime"
@@ -90,10 +91,6 @@ jobs:
         python3 -m pip install -r test\python\cpu\torch\requirements.txt --user
         python3 -m pip install -r test\python\cpu\ort\requirements.txt --user
         python3 -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
-
-    - name: Use Dummy HuggingFace Token
-      run: |
-        Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=12345"
 
     - name: Run the Python Tests
       run: |

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   AZCOPY_AUTO_LOGIN_TYPE: MSI
   AZCOPY_MSI_CLIENT_ID: 63b63039-6328-442f-954b-5a64d124e5b4
   cuda_dir: "${{ github.workspace }}\\cuda_sdk"
@@ -79,10 +80,6 @@ jobs:
         python -m pip install -r test\python\cuda\torch\requirements.txt
         python -m pip install -r test\python\cuda\ort\requirements.txt
         python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
-
-    - name: Use Dummy HuggingFace Token
-      run: |
-        Add-Content -Path $env:GITHUB_ENV -Value "HF_TOKEN=12345"
 
     - name: Run the Python Tests
       run: |

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -99,11 +99,7 @@ def main(args):
 
         if args.timings: started_timestamp = time.time()
 
-        # If there is a chat template, use it
-        prompt = text
-        if args.chat_template:
-            prompt = f'{args.chat_template.format(input=text)}'
-
+        prompt = f'{args.chat_template.format(input=text)}'
         input_tokens = tokenizer.encode(prompt)
         
         generator.append_tokens(input_tokens)

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -59,7 +59,7 @@ def main(args):
             elif model_type.startswith("llama2"):
                 args.chat_template = '<s>{input}'
             elif model_type.startswith("qwen2"):
-                args.chat_template = '<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n'
+                args.chat_template = '<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n'
             else:
                 raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
 

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -35,7 +35,7 @@ def main(args):
     if hasattr(model, "type"):
         model_type = model.type
     else:
-        import json
+        import json, os
 
         genai_config = json.load(os.path.join(args.model_path, "genai_config.json"))
         model_type = genai_config["model"]["type"]

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -37,8 +37,9 @@ def main(args):
     else:
         import json, os
 
-        genai_config = json.load(os.path.join(args.model_path, "genai_config.json"))
-        model_type = genai_config["model"]["type"]
+        with open(os.path.join(args.model_path, "genai_config.json"), "r") as f:
+            genai_config = json.load(f)
+            model_type = genai_config["model"]["type"]
     
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -42,10 +42,11 @@ def main(args):
             model_type = genai_config["model"]["type"]
     
     # Set chat template
+    default_chat_template = ""
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:
             raise ValueError("Chat template must have exactly one pair of curly braces with input word in it, e.g. '<|user|>\n{input} <|end|>\n<|assistant|>'")
-    else:
+    elif args.chat_template == default_chat_template:
         if model_type.startswith("phi2") or model_type.startswith("phi3"):
             args.chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
         elif model_type.startswith("phi4"):
@@ -69,19 +70,21 @@ def main(args):
     if args.verbose: print("Generator created")
 
     # Set system prompt
-    if model_type.startswith('phi2') or model_type.startswith('phi3'):
-        system_prompt = f"<|system|>\n{args.system_prompt}<|end|>"
-    elif model_type.startswith('phi4'):
-        system_prompt = f"<|im_start|>system<|im_sep|>\n{args.system_prompt}<|im_end|>"
-    elif model_type.startswith("llama3"):
-        system_prompt = f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n{args.system_prompt}<|eot_id|>"
-    elif model_type.startswith("llama2"):
-        system_prompt = f"<s>[INST] <<SYS>>\n{args.system_prompt}\n<</SYS>>"
-    elif model_type.startswith("qwen2"):
-        qwen_system_prompt = "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
-        system_prompt = f"<|im_start|>system\n{qwen_system_prompt}<|im_end|>\n"
-    else:
-        system_prompt = args.system_prompt
+    default_system_prompt = "You are a helpful assistant."
+    if args.system_prompt == default_system_prompt:
+        if model_type.startswith('phi2') or model_type.startswith('phi3'):
+            system_prompt = f"<|system|>\n{args.system_prompt}<|end|>"
+        elif model_type.startswith('phi4'):
+            system_prompt = f"<|im_start|>system<|im_sep|>\n{args.system_prompt}<|im_end|>"
+        elif model_type.startswith("llama3"):
+            system_prompt = f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n{args.system_prompt}<|eot_id|>"
+        elif model_type.startswith("llama2"):
+            system_prompt = f"<s>[INST] <<SYS>>\n{args.system_prompt}\n<</SYS>>"
+        elif model_type.startswith("qwen2"):
+            qwen_system_prompt = "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+            system_prompt = f"<|im_start|>system\n{qwen_system_prompt}<|im_end|>\n"
+        else:
+            system_prompt = args.system_prompt
 
     system_tokens = tokenizer.encode(system_prompt)
     generator.append_tokens(system_tokens)

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -69,7 +69,7 @@ def main(args):
     if args.verbose: print("Generator created")
 
     # Set system prompt
-    if "<|" in args.system_prompt and "|>" in args.chat_template:
+    if "<|" in args.system_prompt and "|>" in args.system_prompt:
         # User-provided system template already has tags
         system_prompt = args.system_prompt
     else:

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -42,23 +42,26 @@ def main(args):
             model_type = genai_config["model"]["type"]
     
     # Set chat template
-    default_chat_template = ""
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:
             raise ValueError("Chat template must have exactly one pair of curly braces with input word in it, e.g. '<|user|>\n{input} <|end|>\n<|assistant|>'")
-    elif args.chat_template == default_chat_template:
-        if model_type.startswith("phi2") or model_type.startswith("phi3"):
-            args.chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
-        elif model_type.startswith("phi4"):
-            args.chat_template = '<|im_start|>user<|im_sep|>\n{input}<|im_end|>\n<|im_start|>assistant<|im_sep|>'
-        elif model_type.startswith("llama3"):
-            args.chat_template = '<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>'
-        elif model_type.startswith("llama2"):
-            args.chat_template = '<s>{input}'
-        elif model_type.startswith("qwen2"):
-            args.chat_template = '<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n'
+    
+        if "<|" in args.chat_template and "|>" in args.chat_template:
+            # User-provided chat template already has tags
+            pass
         else:
-            raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
+            if model_type.startswith("phi2") or model_type.startswith("phi3"):
+                args.chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
+            elif model_type.startswith("phi4"):
+                args.chat_template = '<|im_start|>user<|im_sep|>\n{input}<|im_end|>\n<|im_start|>assistant<|im_sep|>'
+            elif model_type.startswith("llama3"):
+                args.chat_template = '<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>'
+            elif model_type.startswith("llama2"):
+                args.chat_template = '<s>{input}'
+            elif model_type.startswith("qwen2"):
+                args.chat_template = '<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n'
+            else:
+                raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
 
     if args.verbose:
         print("Model type is:", model_type)
@@ -70,8 +73,10 @@ def main(args):
     if args.verbose: print("Generator created")
 
     # Set system prompt
-    default_system_prompt = "You are a helpful assistant."
-    if args.system_prompt == default_system_prompt:
+    if "<|" in args.system_prompt and "|>" in args.chat_template:
+        # User-provided system template already has tags
+        system_prompt = args.system_prompt
+    else:
         if model_type.startswith('phi2') or model_type.startswith('phi3'):
             system_prompt = f"<|system|>\n{args.system_prompt}<|end|>"
         elif model_type.startswith('phi4'):
@@ -81,8 +86,7 @@ def main(args):
         elif model_type.startswith("llama2"):
             system_prompt = f"<s>[INST] <<SYS>>\n{args.system_prompt}\n<</SYS>>"
         elif model_type.startswith("qwen2"):
-            qwen_system_prompt = "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
-            system_prompt = f"<|im_start|>system\n{qwen_system_prompt}<|im_end|>\n"
+            system_prompt = f"<|im_start|>system\n{args.system_prompt}<|im_end|>\n"
         else:
             system_prompt = args.system_prompt
 

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -45,23 +45,19 @@ def main(args):
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:
             raise ValueError("Chat template must have exactly one pair of curly braces with input word in it, e.g. '<|user|>\n{input} <|end|>\n<|assistant|>'")
-    
-        if "<|" in args.chat_template and "|>" in args.chat_template:
-            # User-provided chat template already has tags
-            pass
+    else:
+        if model_type.startswith("phi2") or model_type.startswith("phi3"):
+            args.chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
+        elif model_type.startswith("phi4"):
+            args.chat_template = '<|im_start|>user<|im_sep|>\n{input}<|im_end|>\n<|im_start|>assistant<|im_sep|>'
+        elif model_type.startswith("llama3"):
+            args.chat_template = '<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>'
+        elif model_type.startswith("llama2"):
+            args.chat_template = '<s>{input}'
+        elif model_type.startswith("qwen2"):
+            args.chat_template = '<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n'
         else:
-            if model_type.startswith("phi2") or model_type.startswith("phi3"):
-                args.chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
-            elif model_type.startswith("phi4"):
-                args.chat_template = '<|im_start|>user<|im_sep|>\n{input}<|im_end|>\n<|im_start|>assistant<|im_sep|>'
-            elif model_type.startswith("llama3"):
-                args.chat_template = '<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>'
-            elif model_type.startswith("llama2"):
-                args.chat_template = '<s>{input}'
-            elif model_type.startswith("qwen2"):
-                args.chat_template = '<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n'
-            else:
-                raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
+            raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
 
     if args.verbose:
         print("Model type is:", model_type)

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -29,24 +29,34 @@ def main(args):
     search_options['batch_size'] = 1
 
     if args.verbose: print(search_options)
+
+    # Get model type
+    model_type = None
+    if hasattr(model, "type"):
+        model_type = model.type
+    else:
+        import json
+
+        genai_config = json.load(os.path.join(args.model_path, "genai_config.json"))
+        model_type = genai_config["model"]["type"]
     
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:
             raise ValueError("Chat template must have exactly one pair of curly braces with input word in it, e.g. '<|user|>\n{input} <|end|>\n<|assistant|>'")
     else:
-        if model.type.startswith("phi2") or model.type.startswith("phi3"):
+        if model_type.startswith("phi2") or model_type.startswith("phi3"):
             args.chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
-        elif model.type.startswith("phi4"):
+        elif model_type.startswith("phi4"):
             args.chat_template = '<|im_start|>user<|im_sep|>\n{input}<|im_end|>\n<|im_start|>assistant<|im_sep|>'
-        elif model.type.startswith("llama3"):
+        elif model_type.startswith("llama3"):
             args.chat_template = '<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>'
-        elif model.type.startswith("llama2"):
+        elif model_type.startswith("llama2"):
             args.chat_template = '<s>{input}'
         else:
-            raise ValueError(f"Chat Template for model type {model.type} is not known. Please provide chat template using --chat_template")
+            raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
 
     if args.verbose:
-        print("Model type is:", model.type)
+        print("Model type is:", model_type)
         print("Chat Template is:", args.chat_template)
 
     params = og.GeneratorParams(model)
@@ -55,13 +65,13 @@ def main(args):
     if args.verbose: print("Generator created")
 
     # Set system prompt
-    if model.type.startswith('phi2') or model.type.startswith('phi3'):
+    if model_type.startswith('phi2') or model_type.startswith('phi3'):
         system_prompt = f"<|system|>\n{args.system_prompt}<|end|>"
-    elif model.type.startswith('phi4'):
+    elif model_type.startswith('phi4'):
         system_prompt = f"<|im_start|>system<|im_sep|>\n{args.system_prompt}<|im_end|>"
-    elif model.type.startswith("llama3"):
+    elif model_type.startswith("llama3"):
         system_prompt = f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n{args.system_prompt}<|eot_id|>"
-    elif model.type.startswith("llama2"):
+    elif model_type.startswith("llama2"):
         system_prompt = f"<s>[INST] <<SYS>>\n{args.system_prompt}\n<</SYS>>"
     else:
         system_prompt = args.system_prompt

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -41,6 +41,7 @@ def main(args):
             genai_config = json.load(f)
             model_type = genai_config["model"]["type"]
     
+    # Set chat template
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:
             raise ValueError("Chat template must have exactly one pair of curly braces with input word in it, e.g. '<|user|>\n{input} <|end|>\n<|assistant|>'")
@@ -53,6 +54,8 @@ def main(args):
             args.chat_template = '<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>'
         elif model_type.startswith("llama2"):
             args.chat_template = '<s>{input}'
+        elif model_type.startswith("qwen2"):
+            args.chat_template = '<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n'
         else:
             raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
 
@@ -74,6 +77,9 @@ def main(args):
         system_prompt = f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n{args.system_prompt}<|eot_id|>"
     elif model_type.startswith("llama2"):
         system_prompt = f"<s>[INST] <<SYS>>\n{args.system_prompt}\n<</SYS>>"
+    elif model_type.startswith("qwen2"):
+        qwen_system_prompt = "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+        system_prompt = f"<|im_start|>system\n{qwen_system_prompt}<|im_end|>\n"
     else:
         system_prompt = args.system_prompt
 

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -91,11 +91,7 @@ def main(args):
 
         if args.timings: started_timestamp = time.time()
 
-        # If there is a chat template, use it
-        prompt = text
-        if args.chat_template:
-            prompt = f'{args.chat_template.format(input=text)}'
-
+        prompt = f'{args.chat_template.format(input=text)}'
         input_tokens = tokenizer.encode(prompt)
         
         generator.append_tokens(input_tokens)

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -38,6 +38,7 @@ def main(args):
             genai_config = json.load(f)
             model_type = genai_config["model"]["type"]
     
+    # Set chat template
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:
             raise ValueError("Chat template must have exactly one pair of curly braces with input word in it, e.g. '<|user|>\n{input} <|end|>\n<|assistant|>'")
@@ -50,6 +51,8 @@ def main(args):
             args.chat_template = '<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>'
         elif model_type.startswith("llama2"):
             args.chat_template = '<s>{input}'
+        elif model_type.startswith("qwen2"):
+            args.chat_template = '<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n'
         else:
             raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
 
@@ -66,6 +69,9 @@ def main(args):
         system_prompt = f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n{args.system_prompt}<|eot_id|>"
     elif model_type.startswith("llama2"):
         system_prompt = f"<s>[INST] <<SYS>>\n{args.system_prompt}\n<</SYS>>"
+    elif model_type.startswith("qwen2"):
+        qwen_system_prompt = "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+        system_prompt = f"<|im_start|>system\n{qwen_system_prompt}<|im_end|>\n"
     else:
         system_prompt = args.system_prompt
 

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -32,7 +32,7 @@ def main(args):
     if hasattr(model, "type"):
         model_type = model.type
     else:
-        import json
+        import json, os
 
         genai_config = json.load(os.path.join(args.model_path, "genai_config.json"))
         model_type = genai_config["model"]["type"]

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -42,23 +42,19 @@ def main(args):
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:
             raise ValueError("Chat template must have exactly one pair of curly braces with input word in it, e.g. '<|user|>\n{input} <|end|>\n<|assistant|>'")
-    
-        if "<|" in args.chat_template and "|>" in args.chat_template:
-            # User-provided chat template already has tags
-            pass
+    else:
+        if model_type.startswith("phi2") or model_type.startswith("phi3"):
+            args.chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
+        elif model_type.startswith("phi4"):
+            args.chat_template = '<|im_start|>user<|im_sep|>\n{input}<|im_end|>\n<|im_start|>assistant<|im_sep|>'
+        elif model_type.startswith("llama3"):
+            args.chat_template = '<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>'
+        elif model_type.startswith("llama2"):
+            args.chat_template = '<s>{input}'
+        elif model_type.startswith("qwen2"):
+            args.chat_template = '<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n'
         else:
-            if model_type.startswith("phi2") or model_type.startswith("phi3"):
-                args.chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
-            elif model_type.startswith("phi4"):
-                args.chat_template = '<|im_start|>user<|im_sep|>\n{input}<|im_end|>\n<|im_start|>assistant<|im_sep|>'
-            elif model_type.startswith("llama3"):
-                args.chat_template = '<|start_header_id|>user<|end_header_id|>\n{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>'
-            elif model_type.startswith("llama2"):
-                args.chat_template = '<s>{input}'
-            elif model_type.startswith("qwen2"):
-                args.chat_template = '<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n'
-            else:
-                raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
+            raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
 
     params = og.GeneratorParams(model)
     params.set_search_options(**search_options)

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -56,7 +56,7 @@ def main(args):
             elif model_type.startswith("llama2"):
                 args.chat_template = '<s>{input}'
             elif model_type.startswith("qwen2"):
-                args.chat_template = '<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n'
+                args.chat_template = '<|im_start|>user\n{input}<|im_end|>\n<|im_start|>assistant\n'
             else:
                 raise ValueError(f"Chat Template for model type {model_type} is not known. Please provide chat template using --chat_template")
 

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -61,7 +61,7 @@ def main(args):
     generator = og.Generator(model, params)
 
     # Set system prompt
-    if "<|" in args.system_prompt and "|>" in args.chat_template:
+    if "<|" in args.system_prompt and "|>" in args.system_prompt:
         # User-provided system template already has tags
         system_prompt = args.system_prompt
     else:

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -34,8 +34,9 @@ def main(args):
     else:
         import json, os
 
-        genai_config = json.load(os.path.join(args.model_path, "genai_config.json"))
-        model_type = genai_config["model"]["type"]
+        with open(os.path.join(args.model_path, "genai_config.json"), "r") as f:
+            genai_config = json.load(f)
+            model_type = genai_config["model"]["type"]
     
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -39,10 +39,11 @@ def main(args):
             model_type = genai_config["model"]["type"]
     
     # Set chat template
+    default_chat_template = ""
     if args.chat_template:
         if args.chat_template.count('{') != 1 or args.chat_template.count('}') != 1:
             raise ValueError("Chat template must have exactly one pair of curly braces with input word in it, e.g. '<|user|>\n{input} <|end|>\n<|assistant|>'")
-    else:
+    elif args.chat_template == default_chat_template:
         if model_type.startswith("phi2") or model_type.startswith("phi3"):
             args.chat_template = '<|user|>\n{input} <|end|>\n<|assistant|>'
         elif model_type.startswith("phi4"):
@@ -61,19 +62,21 @@ def main(args):
     generator = og.Generator(model, params)
 
     # Set system prompt
-    if model_type.startswith('phi2') or model_type.startswith('phi3'):
-        system_prompt = f"<|system|>\n{args.system_prompt}<|end|>"
-    elif model_type.startswith('phi4'):
-        system_prompt = f"<|im_start|>system<|im_sep|>\n{args.system_prompt}<|im_end|>"
-    elif model_type.startswith("llama3"):
-        system_prompt = f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n{args.system_prompt}<|eot_id|>"
-    elif model_type.startswith("llama2"):
-        system_prompt = f"<s>[INST] <<SYS>>\n{args.system_prompt}\n<</SYS>>"
-    elif model_type.startswith("qwen2"):
-        qwen_system_prompt = "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
-        system_prompt = f"<|im_start|>system\n{qwen_system_prompt}<|im_end|>\n"
-    else:
-        system_prompt = args.system_prompt
+    default_system_prompt = "You are a helpful assistant."
+    if args.system_prompt == default_system_prompt:
+        if model_type.startswith('phi2') or model_type.startswith('phi3'):
+            system_prompt = f"<|system|>\n{args.system_prompt}<|end|>"
+        elif model_type.startswith('phi4'):
+            system_prompt = f"<|im_start|>system<|im_sep|>\n{args.system_prompt}<|im_end|>"
+        elif model_type.startswith("llama3"):
+            system_prompt = f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n{args.system_prompt}<|eot_id|>"
+        elif model_type.startswith("llama2"):
+            system_prompt = f"<s>[INST] <<SYS>>\n{args.system_prompt}\n<</SYS>>"
+        elif model_type.startswith("qwen2"):
+            qwen_system_prompt = "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+            system_prompt = f"<|im_start|>system\n{qwen_system_prompt}<|im_end|>\n"
+        else:
+            system_prompt = args.system_prompt
 
     system_tokens = tokenizer.encode(system_prompt)
     generator.append_tokens(system_tokens)

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -6,5 +6,5 @@ protobuf==5.27
 sympy
 pytest
 onnx
-transformers<4.48.2
-huggingface_hub[cli]
+transformers
+huggingface_hub[cli]<0.28.1

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -7,4 +7,4 @@ sympy
 pytest
 onnx
 transformers
-huggingface_hub[cli]<0.28.1
+huggingface_hub[cli]

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -6,5 +6,5 @@ protobuf==5.27
 sympy
 pytest
 onnx
-transformers
+transformers<4.48.2
 huggingface_hub[cli]


### PR DESCRIPTION
### Description

This PR makes accessing the model type possible by reading from the GenAI config if the model object does not contain the type attribute. It also adds the chat and system templates for Qwen models.

### Motivation and Context

This PR allows the examples to be backwards compatible with the published RCs for v0.6.0.

The Qwen chat template and Qwen system template were obtained from the following information.

```
>>> from transformers import AutoTokenizer
>>> tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct", cache_dir="./cache_dir")
tokenizer_config.json: 100%|█████████████████████████████████████████████████████████████████████████████| 7.30k/7.30k [00:00<00:00, 9.64MB/s]
vocab.json: 100%|████████████████████████████████████████████████████████████████████████████████████████| 2.78M/2.78M [00:00<00:00, 16.5MB/s]
merges.txt: 100%|████████████████████████████████████████████████████████████████████████████████████████| 1.67M/1.67M [00:00<00:00, 15.6MB/s]
tokenizer.json: 100%|████████████████████████████████████████████████████████████████████████████████████| 7.03M/7.03M [00:00<00:00, 21.5MB/s]
>>> prompt = "Give me a short introduction to large language model."
>>> messages = [ {"role": "system", "content": "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."}, {"role": "user", "content": prompt} ]
>>> text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
>>> text
'<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nGive me a short introduction to large language model.<|im_end|>\n<|im_start|>assistant\n'
```