### PR TITLE
Release Pipeline - Add support for dev and stable nuget package artifacts.

### DIFF
--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -85,6 +85,14 @@ parameters:
   - 'relwithdebinfo'
   - 'debug'
 
+- name: 'nuget_version_type'
+  displayName: 'Nuget version - stable uses VERSION_INFO, dev appends date, build_id and commit-ish, e.g. 1.21.0-dev-20250205-1932-8f6ddf3bd5'
+  type: string
+  default: dev
+  values:
+  - dev
+  - stable
+
 resources:
   repositories:
   - repository: manylinux
@@ -128,6 +136,7 @@ stages:
     ort_dml_version: ${{ parameters.ort_dml_version }}
     build_config: ${{ parameters.build_config }}
     enable_win_qnn: ${{ parameters.enable_win_qnn }}
+    nuget_version_type: ${{ parameters.nuget_version_type }}
 
 - ${{ if eq(parameters.enable_post_packaging_validation, true) }}:
   - template: stages/nuget-validation-stage.yml

--- a/.pipelines/stages/jobs/nuget-packaging-job.yml
+++ b/.pipelines/stages/jobs/nuget-packaging-job.yml
@@ -59,6 +59,9 @@ parameters:
   type: string
   default: 'release'
 
+- name: nuget_version_type
+  type: string
+
 jobs:
 - job: nuget_${{ parameters.ep }}_packaging_dep_qnn_${{ parameters.enable_win_qnn }}
   pool: 'onnxruntime-Win-CPU-2022'
@@ -187,6 +190,8 @@ jobs:
     submodules: recursive
 
   - template: steps/utils/set-genai-version.yml
+    parameters:
+      nuget_version_type: ${{ parameters.nuget_version_type }}
 
   - task: NuGetAuthenticate@1
 

--- a/.pipelines/stages/jobs/steps/utils/set-genai-version.yml
+++ b/.pipelines/stages/jobs/steps/utils/set-genai-version.yml
@@ -1,3 +1,7 @@
+parameters:
+- name: nuget_version_type
+  type: string
+
 steps:
 - task: PowerShell@2
   displayName: 'Set genai_version variable from VERSION_INFO'
@@ -5,6 +9,27 @@ steps:
     workingDirectory: $(Build.SourcesDirectory)
     targetType: inline
     script: |
-      $version = (Get-Content -Path .\VERSION_INFO).Trim()
+      $build_id = $env:BUILD_BUILDID
+      Write-Host "build_id: ${build_id}"
+
+      $nuget_version_type = "${{parameters.nuget_version_type}}"
+      Write-Host "nuget_version_type: $nuget_version_type"
+
+      $commit = git rev-parse --short HEAD
+      Write-Host "commit: $commit"
+
+      $version_info = (Get-Content -Path .\VERSION_INFO).Trim()
+      Write-Host "version: $version_info"
+
+      $date = (Get-Date).ToString("yyyyMMdd")
+      Write-Host "date: $date"
+
+      $version = switch ($nuget_version_type)
+      {
+        'dev' { "$version_info-$build_id-$date-$commit" }
+        'stable' { "$version_info" }
+        default { 'unknown' }
+      }
+
       Write-Host "Setting variable: genai_version = ${version}"
       Write-Host "##vso[task.setvariable variable=genai_version]${version}"

--- a/.pipelines/stages/jobs/steps/utils/set-genai-version.yml
+++ b/.pipelines/stages/jobs/steps/utils/set-genai-version.yml
@@ -26,7 +26,7 @@ steps:
 
       $version = switch ($nuget_version_type)
       {
-        'dev' { "$version_info-$build_id-$date-$commit" }
+        'dev' { "$version_info-$date-$build_id-$commit" }
         'stable' { "$version_info" }
         default { 'unknown' }
       }

--- a/.pipelines/stages/nuget-packaging-stage.yml
+++ b/.pipelines/stages/nuget-packaging-stage.yml
@@ -59,6 +59,9 @@ parameters:
   type: string
   default: 'release'
 
+- name: nuget_version_type
+  type: string
+
 stages:
 - stage: nuget_packaging
   jobs:
@@ -74,6 +77,7 @@ stages:
           enable_macos_cpu: ${{ parameters.enable_macos_cpu }}
           enable_android: ${{ parameters.enable_android }}
           enable_apple_framework: ${{ parameters.enable_apple_framework }}
+          nuget_version_type: ${{ parameters.nuget_version_type }}
     - ${{ if or(eq(parameters.enable_linux_cuda, true), eq(parameters.enable_win_cuda, true)) }}:
       - template: jobs/nuget-packaging-job.yml
         parameters:
@@ -82,6 +86,7 @@ stages:
           build_config: ${{ parameters.build_config }}
           enable_linux_cuda: ${{ parameters.enable_linux_cuda }}
           enable_win_cuda: ${{ parameters.enable_win_cuda }}
+          nuget_version_type: ${{ parameters.nuget_version_type }}
     - ${{ if eq(parameters.enable_win_dml, true) }}:
       - template: jobs/nuget-packaging-job.yml
         parameters:
@@ -94,7 +99,6 @@ stages:
       - template: jobs/nuget-packaging-job.yml
         parameters:
           ep: 'cpu'
-          ort_version: ${{ parameters.ort_version }}
           build_config: ${{ parameters.build_config }}
           enable_linux_cpu: false
           enable_win_cpu: false
@@ -103,3 +107,4 @@ stages:
           enable_android: false
           enable_apple_framework: false
           enable_win_qnn: true
+          nuget_version_type: ${{ parameters.nuget_version_type }}


### PR DESCRIPTION
Add `nuget_version_type` pipeline parameter, which allows the user to choose if the NuGet artifacts should have a stable or floating 'developer' version.

Example:
- dev  - `$version_info-$date-$build_id-$commit`
- stable - `$version_info`
