### PR TITLE
Avoid copying test model assets to gradle bin directory

### DIFF
--- a/src/java/build.gradle
+++ b/src/java/build.gradle
@@ -102,11 +102,6 @@ sourceSets.main.java {
 
 // expects
 sourceSets.test {
-	// add test resource files
-	resources.srcDirs += [
-		"../../test/test_models"
-	]
-
 	if (cmakeNativeLibDir != null) {
 		// add compiled native libs
 		resources.srcDirs += [cmakeNativeLibDir]

--- a/src/java/gradle/wrapper/gradle-wrapper.properties
+++ b/src/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=9631d53cf3e74bfa726893aee1f8994fee4e060c401335946dba2156f440f24c
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionSha256Sum=5b9c5eb3f9fc2c94abaea57d90bd78747ca117ddbbf96c859d3741181a12bf2a
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/java/gradle/wrapper/gradle-wrapper.properties
+++ b/src/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=5b9c5eb3f9fc2c94abaea57d90bd78747ca117ddbbf96c859d3741181a12bf2a
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionSha256Sum=9631d53cf3e74bfa726893aee1f8994fee4e060c401335946dba2156f440f24c
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/java/src/test/java/ai/onnxruntime/genai/GenerationTest.java
+++ b/src/java/src/test/java/ai/onnxruntime/genai/GenerationTest.java
@@ -24,7 +24,7 @@ public class GenerationTest {
   // phi-2 can be used in full end-to-end testing but needs to be manually downloaded.
   // it's also used this way in the C# unit tests.
   private static final String phi2ModelPath() {
-    return TestUtils.getFilePathFromResource("/phi-2/int4/cpu");
+    return TestUtils.getTestResourcePath("phi-2/int4/cpu");
   }
 
   @SuppressWarnings("unused") // Used in EnabledIf

--- a/src/java/src/test/java/ai/onnxruntime/genai/MultiModalProcessorTest.java
+++ b/src/java/src/test/java/ai/onnxruntime/genai/MultiModalProcessorTest.java
@@ -22,7 +22,10 @@ public class MultiModalProcessorTest {
       String inputs =
           new String(
               "<|user|>\n<|image_1|>\n Can you convert the table to markdown format?\n<|end|>\n<|assistant|>\n");
-      try (Images image = new Images(TestUtils.getFilePathFromResource("/images/sheet.png"));
+      try (Images image =
+              new Images(
+                  TestUtils.getFilePathFromDisk(
+                      TestUtils.getTestResourcePath("images/sheet.png")));
           NamedTensors processed = multiModalProcessor.processImages(inputs, image); ) {
         assertNotNull(processed);
       }

--- a/src/java/src/test/java/ai/onnxruntime/genai/TestUtils.java
+++ b/src/java/src/test/java/ai/onnxruntime/genai/TestUtils.java
@@ -12,19 +12,19 @@ public class TestUtils {
   private static final Logger logger = Logger.getLogger(TestUtils.class.getName());
 
   public static final String testAdapterTestModelPath() {
-    return getFilePathFromResource("/adapters");
+    return getFilePathFromResource(getRepoRoot() + "test/test_models/adapters");
   }
 
   public static final String testAdapterTestAdaptersPath() {
-    return getFilePathFromResource("/adapters/adapters.onnx_adapter");
+    return getFilePathFromResource(getRepoRoot() + "test/test_models/adapters/adapters.onnx_adapter");
   }
 
   public static final String tinyGpt2ModelPath() {
-    return getFilePathFromResource("/hf-internal-testing/tiny-random-gpt2-fp32");
+    return getFilePathFromResource(getRepoRoot() + "test/test_models/hf-internal-testing/tiny-random-gpt2-fp32");
   }
 
   public static final String testVisionModelPath() {
-    return getFilePathFromResource("/vision-preprocessing");
+    return getFilePathFromResource(getRepoRoot() + "test/test_models/vision-preprocessing");
   }
 
   public static final String getRepoRoot() {

--- a/src/java/src/test/java/ai/onnxruntime/genai/TestUtils.java
+++ b/src/java/src/test/java/ai/onnxruntime/genai/TestUtils.java
@@ -12,19 +12,23 @@ public class TestUtils {
   private static final Logger logger = Logger.getLogger(TestUtils.class.getName());
 
   public static final String testAdapterTestModelPath() {
-    return getFilePathFromResource(getRepoRoot() + "test/test_models/adapters");
+    return getFilePathFromDisk(getTestResourcePath("adapters"));
   }
 
   public static final String testAdapterTestAdaptersPath() {
-    return getFilePathFromResource(getRepoRoot() + "test/test_models/adapters/adapters.onnx_adapter");
+    return getFilePathFromDisk(getTestResourcePath("adapters/adapters.onnx_adapter"));
   }
 
   public static final String tinyGpt2ModelPath() {
-    return getFilePathFromResource(getRepoRoot() + "test/test_models/hf-internal-testing/tiny-random-gpt2-fp32");
+    return getFilePathFromDisk(getTestResourcePath("hf-internal-testing/tiny-random-gpt2-fp32"));
   }
 
   public static final String testVisionModelPath() {
-    return getFilePathFromResource(getRepoRoot() + "test/test_models/vision-preprocessing");
+    return getFilePathFromDisk(getTestResourcePath("vision-preprocessing"));
+  }
+
+  public static final String getTestResourcePath(String relativeResourcePath) {
+    return getFilePathFromDisk(getRepoRoot() + "test/test_models/" + relativeResourcePath);
   }
 
   public static final String getRepoRoot() {
@@ -57,6 +61,20 @@ public class TestUtils {
     }
 
     File f = new File(url.getFile());
+    return f.getPath();
+  }
+
+  public static final String getFilePathFromDisk(String path) {
+    if (path == null) {
+      logger.warning("Path provided is null");
+      return null;
+    }
+    File f = new File(path);
+    if (!f.exists()) {
+      logger.warning("Model not found at " + path);
+      return null;
+    }
+
     return f.getPath();
   }
 


### PR DESCRIPTION
We started seeing pipeline failures as a result of exceeding disk space.

The java test build was duplicating the test models inside the gradle bin directory. This PR avoids needing to copy the test models to the gradle bin folder by reading from disk instead of from resource.