### PR TITLE
QuantizedModel: support group_size -1 (per-channel)

### DIFF
--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -31,7 +31,11 @@ class QuantizedTensorModule:
         self.in_features = 0
         self.out_features = 0
         self.bits = bits
-        self.group_size = group_size
+        self._group_size = group_size
+
+    @property
+    def group_size(self):
+        return self._group_size if self._group_size != -1 else self.in_features
 
     def __str__(self):
         qweight = f"qweight = {self.qweight.shape}, {self.qweight}\n"


### PR DESCRIPTION
Both gptq and awq support per channel quantization. This is represented using `group_size = -1`. But the builder is not able to handle this case. 

This PR makes `group_size` into a property that returns `in_features` if `_group_size == -1`. The group size cannot be set during init since `in_features` is set after init.

Note: The resultant MatMulNBits node might be invalid if the group_size is not supported by the operator kernel, but it can be converted into a valid DQ -> MatMul. This can be done either in the builder or subsequently using an olive pass https://github.com/microsoft/Olive/blob/50f360aeacfb949abc0d845e4070922555f7c58a/olive/passes/onnx/mnb_to_qdq.py#L27.

This PR also fixes [this issue](https://github.com/microsoft/onnxruntime-genai/issues/775).