### PR TITLE
Pin NDK version

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -52,7 +52,7 @@ jobs:
           echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
           "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --install "ndk;${{ env.ANDROID_NDK_VERSION }}"
 
-          echo "ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/${{ env.ANDROID_NDK_VERSION }}"
+          echo "ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/${{ env.ANDROID_NDK_VERSION }}" >> $GITHUB_ENV
           echo "ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME"
           ls -l $ANDROID_HOME/ndk
 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -15,6 +15,7 @@ env:
   ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
   # ANDROID_ABI: "arm64-v8a"
   ANDROID_ABI: "x86_64"
+  ANDROID_NDK_VERSION: "27.2.12479018"  # LTS version
 jobs:
   android_x64:
     # Note: linux is the only good option for the Android emulator currently.
@@ -49,8 +50,9 @@ jobs:
           ls -l $ANDROID_HOME
 
           echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+          "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --install "ndk;${{ env.ANDROID_NDK_VERSION }}"
 
-          echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME"
+          echo "ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/${{ env.ANDROID_NDK_VERSION }}"
           echo "ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME"
           ls -l $ANDROID_HOME/ndk
 
@@ -76,12 +78,12 @@ jobs:
         run: |
           set -e -x
           rm -rf build
-          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_LATEST_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --update
+          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --update
 
       - name: Run Android build
         run: |
           set -e -x
-          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_LATEST_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --build
+          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --build
 
       - name: Enable KVM group perms so Android emulator can run
         run: |
@@ -92,4 +94,4 @@ jobs:
       - name: Run Android tests
         run: |
           set -e -x
-          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_LATEST_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --android_run_emulator --test
+          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --android_run_emulator --test

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -16,7 +16,7 @@ env:
   # ANDROID_ABI: "arm64-v8a"
   ANDROID_ABI: "x86_64"
   ANDROID_NDK_VERSION: "27.2.12479018"  # LTS version
-  ANDROID_AVD_HOME: ${{ runner.temp }}
+  ANDROID_AVD_HOME: "${RUNNER_TEMP}"
 jobs:
   android_x64:
     # Note: linux is the only good option for the Android emulator currently.

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -16,7 +16,6 @@ env:
   # ANDROID_ABI: "arm64-v8a"
   ANDROID_ABI: "x86_64"
   ANDROID_NDK_VERSION: "27.2.12479018"  # LTS version
-  ANDROID_AVD_HOME: "${RUNNER_TEMP}"
 jobs:
   android_x64:
     # Note: linux is the only good option for the Android emulator currently.
@@ -54,6 +53,8 @@ jobs:
           "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --install "ndk;${{ env.ANDROID_NDK_VERSION }}"
 
           echo "ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/${{ env.ANDROID_NDK_VERSION }}" >> $GITHUB_ENV
+          echo "ANDROID_AVD_HOME=${{ runner.temp }}" >> $GITHUB_ENV
+
           echo "ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME"
           ls -l $ANDROID_HOME/ndk
 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -16,6 +16,7 @@ env:
   # ANDROID_ABI: "arm64-v8a"
   ANDROID_ABI: "x86_64"
   ANDROID_NDK_VERSION: "27.2.12479018"  # LTS version
+  ANDROID_AVD_HOME: ${{ runner.temp }}
 jobs:
   android_x64:
     # Note: linux is the only good option for the Android emulator currently.


### PR DESCRIPTION
Android NDK version 28.x uses LLVM 19+ which is not compatible with dlib. dlib is an ort-extensions dependency that gets built when building ort-genai.

As a workaround, pinning ndk version to 27.x.

More details here: https://github.com/davisking/dlib/issues/3045