### PR TITLE
Add possibility to change graph optimization level

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -62,6 +62,19 @@ struct ProviderOptionsArray_Element : JSON::Element {
   ProviderOptionsObject_Element object_{v_};
 };
 
+GraphOptimizationLevel getGraphOptimizationLevel(std::string_view name) {
+  if (name =="ORT_DISABLE_ALL") {
+      return ORT_DISABLE_ALL;
+  } else if (name == "ORT_ENABLE_BASIC") {
+      return ORT_ENABLE_BASIC;
+  } else if (name == "ORT_ENABLE_EXTENDED") {
+      return ORT_ENABLE_EXTENDED;
+  } else if (name == "ORT_ENABLE_ALL") {
+      return ORT_ENABLE_ALL;
+  } else
+    throw JSON::unknown_value_error{};
+}
+
 struct SessionOptions_Element : JSON::Element {
   explicit SessionOptions_Element(Config::SessionOptions& v) : v_{v} {}
 
@@ -94,6 +107,8 @@ struct SessionOptions_Element : JSON::Element {
       v_.ep_context_enable = JSON::Get<bool>(value);
     else if (name == "use_env_allocators")
       v_.use_env_allocators = JSON::Get<bool>(value);
+    else if (name == "graph_optimization_level")
+      v_.graph_optimization_level = getGraphOptimizationLevel(JSON::Get<std::string_view>(value));
     else
       throw JSON::unknown_value_error{};
   }

--- a/src/config.h
+++ b/src/config.h
@@ -48,6 +48,7 @@ struct Config {
     bool use_env_allocators{};
 
     std::vector<ProviderOptions> provider_options;
+    std::optional<GraphOptimizationLevel> graph_optimization_level;
   };
 
   struct Model {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -407,6 +407,10 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
     session_options.AddConfigEntry("session.use_env_allocators", "1");
   }
 
+  if (config_session_options.graph_optimization_level.has_value()) {
+    session_options.SetGraphOptimizationLevel(config_session_options.graph_optimization_level.value());
+  }
+
   for (auto& provider_options : config_session_options.provider_options) {
     if (provider_options.name == "cuda") {
       auto ort_provider_options = OrtCUDAProviderOptionsV2::Create();


### PR DESCRIPTION
This PR adds the option to set the graph optimization level when running a model.

See discussion in https://github.com/microsoft/onnxruntime-genai/discussions/1260#discussioncomment-12247562

(Disclaimer: I am not very familiar with cpp, so any hints for improving my changes are very very welcome)