### PR TITLE
Update upload Artifact version

### DIFF
--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -65,7 +65,7 @@ jobs:
           ls -l ${{ github.workspace }}/build
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onnxruntime-genai-linux-cpu-x64
           path: ${{ github.workspace }}/build/**/*.a


### PR DESCRIPTION
Update upload Artifact version as the nightly pipelines are not even starting because of this:

example: https://github.com/microsoft/onnxruntime-genai/actions/runs/13450446168

more details: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/