### PR TITLE
Fix package version errors when creating Phi-4 multimodal

### DIFF
--- a/examples/python/phi-4-multi-modal.md
+++ b/examples/python/phi-4-multi-modal.md
@@ -71,8 +71,35 @@ Please ensure you have the following Python packages installed to create the ONN
 - `scipy`
 - `soundfile`
 - `torch`
-    - Please install the latest nightly version. You can install torch by following the [instructions](https://pytorch.org/get-started/locally/). For getting ONNX models that can run on CUDA or DirectML, please install torch with CUDA and ensure the CUDA version you choose in the instructions is the one you have installed.
-- `torchvision`
+    - Please install the Jan 25, 2025 nightly version. You can install torch by following the [instructions](https://pytorch.org/get-started/locally/). For getting ONNX models that can run on CUDA or DirectML, please install torch with CUDA and ensure the CUDA version you choose in the instructions is the one you have installed.
+    - For CPU:
+    ```bash
+    pip install torch==2.7.0.dev20250125
+    ```
+    - For CUDA:
+    ```bash
+    pip install torch==2.7.0.dev20250125+cu124 --index-url https://download.pytorch.org/whl/nightly/cu124
+    ```
+- `torchaudio`
+    - Please install the Jan 25, 2025 nightly version. You can install torchaudio by following the [instructions](https://pytorch.org/get-started/locally/). For getting ONNX models that can run on CUDA or DirectML, please install torchaudio with CUDA and ensure the CUDA version you choose in the instructions is the one you have installed.
+    - For CPU:
+    ```bash
+    pip install torchaudio==2.6.0.dev20250125+cu124
+    ```
+    - For CUDA:
+    ```bash
+    pip install torchaudio==2.6.0.dev20250125+cu124 --index-url https://download.pytorch.org/whl/nightly/cu124
+    ```
+- `torchvision` 
+    - Please install the Jan 25, 2025 nightly version. You can install torchvision by following the [instructions](https://pytorch.org/get-started/locally/). For getting ONNX models that can run on CUDA or DirectML, please install torchaudio with CUDA and ensure the CUDA version you choose in the instructions is the one you have installed.
+    - For CPU:
+    ```bash
+    pip install torchvision==0.22.0.dev20250125+cu124
+    ```
+    - For CUDA:
+    ```bash
+    pip install torchvision==0.22.0.dev20250125+cu124 --index-url https://download.pytorch.org/whl/nightly/cu124
+    ```
 - `transformers`
 
 ## 1. Prepare Local Workspace

--- a/examples/python/phi-4-multi-modal.md
+++ b/examples/python/phi-4-multi-modal.md
@@ -91,7 +91,7 @@ Please ensure you have the following Python packages installed to create the ONN
     pip install torchaudio==2.6.0.dev20250125+cu124 --index-url https://download.pytorch.org/whl/nightly/cu124
     ```
 - `torchvision` 
-    - Please install the Jan 25, 2025 nightly version. You can install torchvision by following the [instructions](https://pytorch.org/get-started/locally/). For getting ONNX models that can run on CUDA or DirectML, please install torchaudio with CUDA and ensure the CUDA version you choose in the instructions is the one you have installed.
+    - Please install the Jan 25, 2025 nightly version. You can install torchvision by following the [instructions](https://pytorch.org/get-started/locally/). For getting ONNX models that can run on CUDA or DirectML, please install torchvision with CUDA and ensure the CUDA version you choose in the instructions is the one you have installed.
     - For CPU:
     ```bash
     pip install torchvision==0.22.0.dev20250125+cu124

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -3119,7 +3119,7 @@ class GraniteModel(MistralModel):
             self.layernorm_attrs["last_layernorm"] = True
 
 
-class PhiOModel(Phi3VModel):
+class Phi4MMModel(Phi3VModel):
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
         super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
         self.matmul_attrs["use_lora"] = True
@@ -3262,10 +3262,10 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
             print("WARNING: This is only generating the text component of the model. Setting `--extra_options exclude_embeds=true` by default.")
             extra_options["exclude_embeds"] = True
             onnx_model = Phi3VModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
-        elif config.architectures[0] == "PhiOForCausalLM":
+        elif config.architectures[0] == "Phi4MMForCausalLM":
             print("WARNING: This is only generating the text component of the model. Setting `--extra_options exclude_embeds=true` by default.")
             extra_options["exclude_embeds"] = True
-            onnx_model = PhiOModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
+            onnx_model = Phi4MMModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Qwen2ForCausalLM":
             onnx_model = QwenModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         else:


### PR DESCRIPTION
### Description

This PR specifies the exact package versions to use when creating the Phi-4 multimodal model.

### Motivation and Context

The latest nightly packages from PyTorch break the export process.