### PR TITLE
Added cancellation to the streaming method of OnnxRuntimeGenAIChatClient.

### DIFF
--- a/src/csharp/OnnxRuntimeGenAIChatClient.cs
+++ b/src/csharp/OnnxRuntimeGenAIChatClient.cs
@@ -154,6 +154,7 @@ public sealed class OnnxRuntimeGenAIChatClient : IChatClient
                 }
 
                 // Avoid blocking calling thread with expensive compute
+                cancellationToken.ThrowIfCancellationRequested();
                 await YieldAwaiter.Instance;
 
                 // Generate the next token.


### PR DESCRIPTION
The current version doesn't support cancellation. It did at some point but after some refactoring, this got lost. This just adds it back.