### PR TITLE
Add ability to load audio from bytes, to match images API

### DIFF
--- a/src/models/processor.h
+++ b/src/models/processor.h
@@ -36,6 +36,7 @@ struct Audios {
 };
 
 std::unique_ptr<Audios> LoadAudios(const std::span<const char* const>& audio_paths);
+std::unique_ptr<Audios> LoadAudiosFromBuffers(std::span<const void*> audio_data, std::span<const size_t> audio_data_sizes);
 
 struct Payload {
   const std::string& prompt;

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -542,6 +542,12 @@ struct OgaAudios : OgaAbstract {
   }
 #endif
 
+  static std::unique_ptr<OgaAudios> Load(const void** audio_data, const size_t* audio_data_sizes, size_t count) {
+    OgaAudios* p;
+    OgaCheckResult(OgaLoadAudiosFromBuffers(audio_data, audio_data_sizes, count, &p));
+    return std::unique_ptr<OgaAudios>(p);
+  }
+
   static void operator delete(void* p) { OgaDestroyAudios(reinterpret_cast<OgaAudios*>(p)); }
 };
 

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -151,6 +151,13 @@ OgaResult* OGA_API_CALL OgaLoadAudios(const OgaStringArray* audio_paths, OgaAudi
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaLoadAudiosFromBuffers(const void** audio_data, const size_t* audio_data_sizes, size_t count, OgaAudios** audios) {
+  OGA_TRY
+  *audios = reinterpret_cast<OgaAudios*>(Generators::LoadAudiosFromBuffers(std::span<const void*>(audio_data, count), std::span<const size_t>(audio_data_sizes, count)).release());
+  return nullptr;
+  OGA_CATCH
+}
+
 OgaResult* OGA_API_CALL OgaCreateRuntimeSettings(OgaRuntimeSettings** out) {
   OGA_TRY
   *out = reinterpret_cast<OgaRuntimeSettings*>(Generators::CreateRuntimeSettings().release());

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -174,6 +174,16 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaLoadAudio(const char* audio_path, OgaAudio
 
 OGA_EXPORT OgaResult* OGA_API_CALL OgaLoadAudios(const OgaStringArray* audio_paths, OgaAudios** audios);
 
+/**
+ * \brief Load multiple audios from an array of byte buffers
+ * \param[in] audio_data Array of byte buffers containing the audio data.
+ * \param[in] audio_data_sizes Array of sizes of the byte buffers.
+ * \param[in] count Number of audios to load.
+ * \param[out] audios The loaded audios.
+ * \return OgaResult containing the error message if the loading of the audios failed.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaLoadAudiosFromBuffers(const void** audio_data, const size_t* audio_data_sizes, size_t count, OgaAudios** audios);
+
 OGA_EXPORT void OGA_API_CALL OgaDestroyAudios(OgaAudios* audios);
 
 /**

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -436,6 +436,20 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
         }
 
         return OgaAudios::Load(audio_paths_vector);
+      })
+      .def_static("open_bytes", [](pybind11::args audio_datas) {
+        std::vector<const void*> audio_raw_data(audio_datas.size());
+        std::vector<size_t> audio_sizes(audio_datas.size());
+        for (size_t i = 0; i < audio_datas.size(); ++i) {
+          if (!pybind11::isinstance<pybind11::bytes>(audio_datas[i]))
+            throw std::runtime_error("Audio data must be bytes.");
+          auto bytes = audio_datas[i].cast<pybind11::bytes>();
+          pybind11::buffer_info info(pybind11::buffer(bytes).request());
+          audio_raw_data[i] = reinterpret_cast<void*>(info.ptr);
+          audio_sizes[i] = info.size;
+        }
+
+        return OgaAudios::Load(audio_raw_data.data(), audio_sizes.data(), audio_raw_data.size());
       });
 
   pybind11::class_<OgaMultiModalProcessor>(m, "MultiModalProcessor")


### PR DESCRIPTION
Adds OgaLoadAudiosFromBuffers to the C API and everything else follows from that to other APIs. It resolves this issue: https://github.com/microsoft/onnxruntime-genai/issues/1292.