### PR TITLE
Fix mismatch in Java bindings

### DIFF
--- a/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
+++ b/src/java/src/main/native/ai_onnxruntime_genai_Config.cpp
@@ -42,7 +42,7 @@ Java_ai_onnxruntime_genai_Config_appendProvider(JNIEnv* env, jobject thiz, jlong
 }
 
 JNIEXPORT void JNICALL
-Java_ai_onnxruntime_genai_Config_setProvider(JNIEnv* env, jobject thiz, jlong native_handle, jstring provider_name, jstring option_key, jstring option_value) {
+Java_ai_onnxruntime_genai_Config_setProviderOption(JNIEnv* env, jobject thiz, jlong native_handle, jstring provider_name, jstring option_key, jstring option_value) {
   CString c_provider_name{env, provider_name};
   CString c_option_key{env, option_key};
   CString c_option_value{env, option_value};


### PR DESCRIPTION
Changes the JNI code to match the correct Java method.

The Java method is:
https://github.com/microsoft/onnxruntime-genai/blob/3158f551364b17e9843dd6ccd61c1af7cde07ff4/src/java/src/main/java/ai/onnxruntime/genai/Config.java#L51