### PR TITLE
Fixed the MacOS build and updated the test script.

### DIFF
--- a/examples/slm_engine/src/CMakeLists.txt
+++ b/examples/slm_engine/src/CMakeLists.txt
@@ -77,14 +77,14 @@ set_target_properties(
     IMPORTED_IMPLIB 
     ${ARTIFACTS}/${SYS_TARGET_ID}/lib/${LIBNAME_PREFIX}onnxruntime${LIB_VERSION_ORT}.${LIB_EXT})
 
-file(GLOB_RECURSE ORT_LIBS
+file(GLOB ORT_LIB_FILES 
     "${ARTIFACTS}/${SYS_TARGET_ID}/lib/${LIBNAME_PREFIX}onnxruntime*")
 
-list(APPEND IMPORTED_LIB_LIST ${ORT_LIBS})
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    list(APPEND IMPORTED_LIB_LIST 
-        ${ARTIFACTS}/${SYS_TARGET_ID}/lib/${LIBNAME_PREFIX}onnxruntime${LIB_VERSION_ORT}.${LIB_EXT})
-endif() 
+file(GLOB ORT_LIB_DIRS "${ARTIFACTS}/${SYS_TARGET_ID}/lib"
+    "${ARTIFACTS}/${SYS_TARGET_ID}/lib/${LIBNAME_PREFIX}onnxruntime*/")
+
+list(APPEND IMPORTED_LIB_LIST ${ORT_LIB_FILES})
+list(APPEND IMPORTED_LIB_LIST ${ORT_LIB_DIRS})
 
 # Import ONNXRT-GenAI stuff
 add_library(ort-genai SHARED IMPORTED)
@@ -98,7 +98,14 @@ list(APPEND IMPORTED_LIB_LIST
 ${ARTIFACTS}/${SYS_TARGET_ID}/lib/${LIBNAME_PREFIX}onnxruntime-genai.${LIB_EXT})
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install/")
-install(FILES ${IMPORTED_LIB_LIST} DESTINATION bin)
+
+# In a loop copy all the files and directories in the list
+# We cannot use "install(FILES" because the list contains both files and directories"
+foreach (lib ${IMPORTED_LIB_LIST})
+    get_filename_component(lib_name ${lib} NAME)
+    message(STATUS "Copying ${lib_name} to install directory")
+    file(COPY ${lib} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+endforeach()
 
 # Include directories
 message(STATUS "Adding include directories: ${ARTIFACTS}/${SYS_TARGET_ID}/include")

--- a/examples/slm_engine/test/test_slm_server.py
+++ b/examples/slm_engine/test/test_slm_server.py
@@ -57,16 +57,13 @@ def run_test(url: str):
     # Test the API
     print("Testing the API with a test message")
     test_message = """
-    {
-        "messages": 
-        [
-            {"role": "system", "content": "You are a helpful assistant. Be very brief and precise"}, 
-            {"role": "user", "content": "How to make pizza?"}
-        ],
-        "temperature":0, 
-        "max_tokens": 1200, 
-        "stop":["\\n\\n\\n"]
-    }
+        {"messages":
+            [
+                {"role": "system", "content": "You are a helpful assistant. Be very brief and precise"}, 
+                {"role": "user", "content": "How to make pizza in five steps?"}
+            ], 
+                "max_tokens": 1200
+        }
     """
     json_message = json.loads(test_message)
     response = requests.post(url + "/completions", json=json_message)
@@ -81,7 +78,7 @@ def run_test(url: str):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Test OpenAI API Interface")
+    parser = argparse.ArgumentParser(description="Test SLM Engine Using HTTP API")
 
     # Adding arguments
     parser.add_argument(


### PR DESCRIPTION
**This PR addresses the following:**

1. Fixed the macOS build from pre-built ORT. 
   This was failing due to a bug in the CMakeLists.txt in which the libonnruntime.<VERSION>.dylib.dSYM directory was not being copied to the install/bin directory. As a result the build would complete but executables won't run. 
1. Added a new build option `--ort_home_dir` that can be specified to a pre-built ORT library
1. Updated the test_slm_server.py with proper input formatting.