### PR TITLE
Fix type mismatch in Java bindings

### DIFF
--- a/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
@@ -100,7 +100,7 @@ public final class Generator implements AutoCloseable, Iterable<Integer> {
    * @param newLength The desired length in tokens after rewinding.
    * @throws GenAIException If the call to the GenAI native API fails.
    */
-  public void rewindTo(int newLength) throws GenAIException {
+  public void rewindTo(long newLength) throws GenAIException {
     if (nativeHandle == 0) {
       throw new IllegalStateException("Instance has been freed and is invalid");
     }
@@ -226,7 +226,7 @@ public final class Generator implements AutoCloseable, Iterable<Integer> {
   private native void appendTokenSequences(long nativeHandle, long sequencesHandle)
       throws GenAIException;
 
-  private native void rewindTo(long nativeHandle, int newLength) throws GenAIException;
+  private native void rewindTo(long nativeHandle, long newLength) throws GenAIException;
 
   private native void generateNextTokenNative(long nativeHandle) throws GenAIException;
 


### PR DESCRIPTION
Changes the Java method signature of `Generator::rewindTo` to be the same as the JNI function.

This resolves the following error when invoking the `rewindTo` method from Java.
```
java.lang.UnsatisfiedLinkError: No implementation found for void ai.onnxruntime.genai.Generator.rewindTo(long, int) (tried Java_ai_onnxruntime_genai_Generator_rewindTo and Java_ai_onnxruntime_genai_Generator_rewindTo__JI)
```

The corresponding JNI function is (the parameter `length` is `jlong`):
https://github.com/microsoft/onnxruntime-genai/blob/2b741723abb2814e899d3d6272022f4c2fa66a5d/src/java/src/main/native/ai_onnxruntime_genai_Generator.cpp#L57