### PR TITLE
Fix iOS packaging pipeline after static library removal

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -122,6 +122,14 @@ if(BUILD_APPLE_FRAMEWORK)
     set(STATIC_FRAMEWORK_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}-${CMAKE_OSX_SYSROOT})
   endif()
 
+  # Setup the various directories required. Remove any existing ones so we start with a clean directory.
+  set(STATIC_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/static_libraries)
+
+  # Copy the onnxruntime-genai shared library to the framework directory
+  add_custom_command(TARGET onnxruntime-genai POST_BUILD
+                     COMMAND ${CMAKE_COMMAND} -E
+                     copy $<TARGET_FILE:onnxruntime-genai> ${STATIC_FRAMEWORK_DIR}/onnxruntime-genai)
+
     # Assemble the other pieces of the static framework
   add_custom_command(TARGET onnxruntime-genai POST_BUILD
                      COMMAND ${CMAKE_COMMAND} -E

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -134,7 +134,7 @@ if(BUILD_APPLE_FRAMEWORK)
   add_custom_command(TARGET onnxruntime-genai PRE_BUILD COMMAND ${CMAKE_COMMAND} -E make_directory ${STATIC_FRAMEWORK_DIR})
 
   set(INTERNAL_LIBRARIES)
-  list(APPEND INTERNAL_LIBRARIES onnxruntime-genai-static)
+  list(APPEND INTERNAL_LIBRARIES onnxruntime-genai)
 
   # If it's an onnxruntime library, extract .o files from the original cmake build path to a separate directory for
   # each library to avoid any clashes with filenames (e.g. utils.o)

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -162,9 +162,9 @@ if(BUILD_APPLE_FRAMEWORK)
   endforeach()
 
   # do the pre-link with `ld -r` to create a single relocatable object with correct symbol visibility
-  add_custom_command(TARGET onnxruntime-genai POST_BUILD
-                     COMMAND ld ARGS -r -o ${STATIC_LIB_DIR}/prelinked_objects.o */*.o ../*.a
-                     WORKING_DIRECTORY ${STATIC_LIB_TEMP_DIR})
+  # add_custom_command(TARGET onnxruntime-genai POST_BUILD
+  #                    COMMAND ld ARGS -r -o ${STATIC_LIB_DIR}/prelinked_objects.o */*.o ../*.a
+  #                    WORKING_DIRECTORY ${STATIC_LIB_TEMP_DIR})
 
   # create the static library
   add_custom_command(TARGET onnxruntime-genai POST_BUILD

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -123,7 +123,7 @@ if(BUILD_APPLE_FRAMEWORK)
   endif()
 
   # Setup the various directories required. Remove any existing ones so we start with a clean directory.
-  set(STATIC_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/static_libraries)
+  set(STATIC_FRAMEWORK_DIR ${STATIC_FRAMEWORK_OUTPUT_DIR}/static_framework/onnxruntime-genai.framework)
 
   # Copy the onnxruntime-genai shared library to the framework directory
   add_custom_command(TARGET onnxruntime-genai POST_BUILD

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -167,9 +167,9 @@ if(BUILD_APPLE_FRAMEWORK)
   #                    WORKING_DIRECTORY ${STATIC_LIB_TEMP_DIR})
 
   # create the static library
-  add_custom_command(TARGET onnxruntime-genai POST_BUILD
-                     COMMAND libtool -static -o ${STATIC_FRAMEWORK_DIR}/onnxruntime-genai prelinked_objects.o
-                     WORKING_DIRECTORY ${STATIC_LIB_DIR})
+  # add_custom_command(TARGET onnxruntime-genai POST_BUILD
+  #                    COMMAND libtool -static -o ${STATIC_FRAMEWORK_DIR}/onnxruntime-genai prelinked_objects.o
+  #                    WORKING_DIRECTORY ${STATIC_LIB_DIR})
 
     # Assemble the other pieces of the static framework
   add_custom_command(TARGET onnxruntime-genai POST_BUILD

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -122,37 +122,6 @@ if(BUILD_APPLE_FRAMEWORK)
     set(STATIC_FRAMEWORK_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}-${CMAKE_OSX_SYSROOT})
   endif()
 
-  # Setup the various directories required. Remove any existing ones so we start with a clean directory.
-  set(STATIC_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/static_libraries)
-  set(STATIC_LIB_TEMP_DIR ${STATIC_LIB_DIR}/temp)
-  add_custom_command(TARGET onnxruntime-genai PRE_BUILD COMMAND ${CMAKE_COMMAND} -E rm -rf ${STATIC_LIB_DIR})
-  add_custom_command(TARGET onnxruntime-genai PRE_BUILD COMMAND ${CMAKE_COMMAND} -E make_directory ${STATIC_LIB_DIR})
-  add_custom_command(TARGET onnxruntime-genai PRE_BUILD COMMAND ${CMAKE_COMMAND} -E make_directory ${STATIC_LIB_TEMP_DIR})
-
-  set(STATIC_FRAMEWORK_DIR ${STATIC_FRAMEWORK_OUTPUT_DIR}/static_framework/onnxruntime-genai.framework)
-  add_custom_command(TARGET onnxruntime-genai PRE_BUILD COMMAND ${CMAKE_COMMAND} -E rm -rf ${STATIC_FRAMEWORK_DIR})
-  add_custom_command(TARGET onnxruntime-genai PRE_BUILD COMMAND ${CMAKE_COMMAND} -E make_directory ${STATIC_FRAMEWORK_DIR})
-
-    # for external libraries we create a symlink to the .a file
-  foreach(_LIB ${EXTERNAL_LIBRARIES})
-    GET_TARGET_PROPERTY(_LIB_TYPE ${_LIB} TYPE)
-    if(_LIB_TYPE STREQUAL "STATIC_LIBRARY")
-      add_custom_command(TARGET onnxruntime-genai POST_BUILD
-                         COMMAND ${CMAKE_COMMAND} -E create_symlink
-                           $<TARGET_FILE:${_LIB}> ${STATIC_LIB_DIR}/$<TARGET_LINKER_FILE_NAME:${_LIB}>)
-    endif()
-  endforeach()
-
-  # do the pre-link with `ld -r` to create a single relocatable object with correct symbol visibility
-  add_custom_command(TARGET onnxruntime-genai POST_BUILD
-                     COMMAND ld ARGS -r -o ${STATIC_LIB_DIR}/prelinked_objects.o */*.o ../*.a
-                     WORKING_DIRECTORY ${STATIC_LIB_TEMP_DIR})
-
-  # create the static library
-  add_custom_command(TARGET onnxruntime-genai POST_BUILD
-                     COMMAND libtool -static -o ${STATIC_FRAMEWORK_DIR}/onnxruntime-genai prelinked_objects.o
-                     WORKING_DIRECTORY ${STATIC_LIB_DIR})
-
     # Assemble the other pieces of the static framework
   add_custom_command(TARGET onnxruntime-genai POST_BUILD
                      COMMAND ${CMAKE_COMMAND} -E


### PR DESCRIPTION
After discussing with a few teammates who worked on the iOS packaging, switching to a shared library is fine but the steps below were removed as we no longer need to hide the symbols as it's no longer a static library. So now it's just a simple step of copying the shared library into the package.
