### PR TITLE
Update android min sdk version to 24

### DIFF
--- a/tools/ci_build/github/android/default_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_aar_build_settings.json
@@ -3,7 +3,7 @@
         "arm64-v8a",
         "x86_64"
     ],
-    "android_min_sdk_version": 21,
+    "android_min_sdk_version": 27,
     "android_target_sdk_version": 33,
     "build_params": [
         "--android",

--- a/tools/ci_build/github/android/default_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_aar_build_settings.json
@@ -3,7 +3,7 @@
         "arm64-v8a",
         "x86_64"
     ],
-    "android_min_sdk_version": 27,
+    "android_min_sdk_version": 24,
     "android_target_sdk_version": 33,
     "build_params": [
         "--android",


### PR DESCRIPTION
Packaging pipeline has been failing since ort 1.21.0 release updated the min version requirements. This PR updates the min sdk version to 24 to fix the pipeline.