### PR TITLE
Update C examples downloads

### DIFF
--- a/examples/c/README.md
+++ b/examples/c/README.md
@@ -45,13 +45,10 @@ Change into the `onnxruntime-genai\examples\c` folder.
 2. Install onnxruntime-genai
 
    ```cmd
-   curl -L https://github.com/microsoft/onnxruntime-genai/releases/download/v0.6.0/onnxruntime-genai-win-cpu-x64-capi.zip -o onnxruntime-genai-win-cpu-x64-capi.zip
-   tar -xvf onnxruntime-genai-win-cpu-x64-capi.zip
-   cd onnxruntime-genai-win-cpu-x64-capi
+   curl -L https://github.com/microsoft/onnxruntime-genai/releases/download/v0.6.0/onnxruntime-genai-0.6.0-win-x64.zip -o onnxruntime-genai-0.6.0-win-x64.zip
    tar -xvf onnxruntime-genai-0.6.0-win-x64.zip
-   copy onnxruntime-genai-0.6.0-win-x64\include\* ..\include
-   copy onnxruntime-genai-0.6.0-win-x64\lib\* ..\lib
-   cd ..
+   copy onnxruntime-genai-0.6.0-win-x64\include\* include
+   copy onnxruntime-genai-0.6.0-win-x64\lib\* lib
    ```
 
 #### Build this sample
@@ -80,8 +77,8 @@ Change into the `onnxruntime-genai\examples\c` folder.
    ```cmd
    mkdir onnxruntime-win-x64-directml
    cd onnxruntime-win-x64-directml
-   curl -L https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/Microsoft.ML.OnnxRuntime.DirectML.1.20.1.nupkg -o Microsoft.ML.OnnxRuntime.DirectML.1.20.1.nupkg
-   tar -xvf Microsoft.ML.OnnxRuntime.DirectML.1.20.1.nupkg
+   curl -L https://github.com/microsoft/onnxruntime/releases/download/v1.20.0/Microsoft.ML.OnnxRuntime.DirectML.1.20.0.nupkg -o Microsoft.ML.OnnxRuntime.DirectML.1.20.0.nupkg
+   tar -xvf Microsoft.ML.OnnxRuntime.DirectML.1.20.0.nupkg
    copy build\native\include\* ..\include
    copy runtimes\win-x64\native\* ..\lib
    cd ..
@@ -90,9 +87,7 @@ Change into the `onnxruntime-genai\examples\c` folder.
 2. Install onnxruntime-genai
 
    ```cmd
-   curl -L https://github.com/microsoft/onnxruntime-genai/releases/download/v0.6.0/onnxruntime-genai-win-directml-x64-capi.zip -o onnxruntime-genai-win-directml-x64-capi.zip
-   tar -xvf onnxruntime-genai-win-directml-x64-capi.zip
-   cd onnxruntime-genai-win-directml-x64-capi
+   curl -L https://github.com/microsoft/onnxruntime-genai/releases/download/v0.6.0/onnxruntime-genai-0.6.0-win-x64-dml.zip -o onnxruntime-genai-0.6.0-win-x64-dml.zip
    tar -xvf onnxruntime-genai-0.6.0-win-x64-dml.zip
    copy onnxruntime-genai-0.6.0-win-x64-dml\include\* ..\include
    copy onnxruntime-genai-0.6.0-win-x64-dml\lib\* ..\lib
@@ -132,9 +127,7 @@ Change into the `onnxruntime-genai\examples\c` folder.
 2. Install onnxruntime-genai
 
    ```cmd
-   curl -L https://github.com/microsoft/onnxruntime-genai/releases/download/v0.6.0/onnxruntime-genai-win-cpu-arm64-capi.zip -o onnxruntime-genai-win-cpu-arm64-capi.zip
-   tar -xvf onnxruntime-genai-win-cpu-arm64-capi.zip
-   cd onnxruntime-genai-win-cpu-arm64-capi
+   curl -L https://github.com/microsoft/onnxruntime-genai/releases/download/v0.6.0/onnxruntime-genai-0.6.0-win-arm64.zip -o onnxruntime-genai-0.6.0-win-arm64.zip
    tar -xvf onnxruntime-genai-0.6.0-win-arm64.zip
    copy onnxruntime-genai-0.6.0-win-arm64\include\* ..\include
    copy onnxruntime-genai-0.6.0-win-arm64\lib\* ..\lib
@@ -177,9 +170,7 @@ Change into the `onnxruntime-genai\examples\c` folder.
 2. Install onnxruntime-genai
 
    ```cmd
-   curl -L https://github.com/microsoft/onnxruntime-genai/releases/download/v0.6.0/onnxruntime-genai-win-directml-arm64-capi.zip -o onnxruntime-genai-win-directml-arm64-capi.zip
-   tar -xvf onnxruntime-genai-win-directml-arm64-capi.zip
-   cd onnxruntime-genai-win-directml-arm64-capi
+   curl -L https://github.com/microsoft/onnxruntime-genai/releases/download/v0.6.0/onnxruntime-genai-0.6.0-win-arm64-dml.zip -o onnxruntime-genai-0.6.0-win-arm64-dml.zip
    tar -xvf onnxruntime-genai-0.6.0-win-arm64-dml.zip
    copy onnxruntime-genai-0.6.0-win-arm64-dml\include\* ..\include
    copy onnxruntime-genai-0.6.0-win-arm64-dml\lib\* ..\lib

--- a/examples/c/README.md
+++ b/examples/c/README.md
@@ -160,8 +160,8 @@ Change into the `onnxruntime-genai\examples\c` folder.
    ```cmd
    mkdir onnxruntime-win-arm64-directml
    cd onnxruntime-win-arm64-directml
-   curl -L https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/Microsoft.ML.OnnxRuntime.DirectML.1.20.1.nupkg -o Microsoft.ML.OnnxRuntime.DirectML.1.20.1.nupkg
-   tar -xvf Microsoft.ML.OnnxRuntime.DirectML.1.20.1.nupkg
+   curl -L https://github.com/microsoft/onnxruntime/releases/download/v1.20.0/Microsoft.ML.OnnxRuntime.DirectML.1.20.0.nupkg -o Microsoft.ML.OnnxRuntime.DirectML.1.20.0.nupkg
+   tar -xvf Microsoft.ML.OnnxRuntime.DirectML.1.20.0.nupkg
    copy build\native\include\* ..\include
    copy runtimes\win-arm64\native\* ..\lib
    cd ..


### PR DESCRIPTION
Update C examples download paths:
1. Correct all GenAI paths and correct the steps
2. Fix the Nuget packages for OnnxRuntime 