### PR TITLE
Remove DirectML.dll dependency

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -102,8 +102,6 @@ def generate_dependencies(xml_text, package_version, ort_package_name, ort_packa
         xml_text.append(f'<group targetFramework="{framework}">')
         xml_text.append(f'<dependency id="Microsoft.ML.OnnxRuntimeGenAI.Managed" version="{package_version}" />')
         xml_text.append(f'<dependency id="{ort_package_name}" version="{ort_package_version}" />')
-        if ort_package_name.endswith("DirectML"):
-            xml_text.append(f'<dependency id="Microsoft.AI.DirectML" version="1.15.2" />')
         xml_text.append("</group>")
 
     xml_text.append("</dependencies>")


### PR DESCRIPTION
Microsoft.ML.OnnxRuntimeGenAI.DirectML depends on Microsoft.ML.OnnxRnutime.DirectML which depends on Microsoft.AI.DirectML.

To avoid versioning conflicts, this pull-request removes the direct dependency on Microsoft.AI.DirectML.