### PR TITLE
Support load/unload of models to avoid QNN errors on deepseek r1 1.5B

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -230,6 +230,8 @@ struct PipelineModel_Element : JSON::Element {
       v_.run_on_prompt = JSON::Get<bool>(value);
     } else if (name == "run_on_token_gen") {
       v_.run_on_token_gen = JSON::Get<bool>(value);
+    } else if (name == "reset_session_idx") {
+      v_.reset_session_idx = static_cast<int>(JSON::Get<double>(value));
     } else
       throw JSON::unknown_value_error{};
   }

--- a/src/config.h
+++ b/src/config.h
@@ -192,6 +192,7 @@ struct Config {
         std::unordered_map<std::string, std::string> output_names_forwarder;
         bool run_on_prompt{true};
         bool run_on_token_gen{true};
+        int32_t reset_session_idx{-1};
       };
 
       std::vector<PipelineModel> pipeline;

--- a/src/config.h
+++ b/src/config.h
@@ -192,8 +192,10 @@ struct Config {
         std::unordered_map<std::string, std::string> output_names_forwarder;
         bool run_on_prompt{true};
         bool run_on_token_gen{true};
-        int reset_session_idx{-1};  // Some models cannot keeo all the ort sessions in memory at once due to memory constraints.
+        int reset_session_idx{-1};  // Some models cannot keep all the ort sessions in memory at once due to memory constraints.
                                     // This is the index of the session that needs to be reset during the execution of the current session.
+                                    // This is a temporary solution until the QNN driver updates are available.
+                                    // Once the driver updates are available, this option will be deprecated.
       };
 
       std::vector<PipelineModel> pipeline;

--- a/src/config.h
+++ b/src/config.h
@@ -192,7 +192,8 @@ struct Config {
         std::unordered_map<std::string, std::string> output_names_forwarder;
         bool run_on_prompt{true};
         bool run_on_token_gen{true};
-        int32_t reset_session_idx{-1};
+        int reset_session_idx{-1};  // Some models cannot keeo all the ort sessions in memory at once due to memory constraints.
+                                    // This is the index of the session that needs to be reset during the execution of the current session.
       };
 
       std::vector<PipelineModel> pipeline;

--- a/src/models/decoder_only_pipeline.cpp
+++ b/src/models/decoder_only_pipeline.cpp
@@ -181,7 +181,13 @@ void DecoderOnlyPipelineState::RunPipeline(int total_length, DeviceSpan<int32_t>
       continue;
     }
 
-    if (model_.config_->model.decoder.pipeline[pipeline_state->id_].reset_session_idx != -1) {
+    if (model_.config_->model.decoder.pipeline[pipeline_state->id_].reset_session_idx > -1) {
+      if (model_.config_->model.decoder.pipeline[pipeline_state->id_].reset_session_idx >=
+          static_cast<int>(model_.sessions_.size())) {
+        throw std::runtime_error(
+            MakeString("Invalid reset_session_idx ", model_.config_->model.decoder.pipeline[pipeline_state->id_].reset_session_idx,
+                       " for pipeline model ", model_.config_->model.decoder.pipeline[pipeline_state->id_].model_id));
+      }
       (const_cast<DecoderOnlyPipelineModel*>(&model_))->sessions_[model_.config_->model.decoder.pipeline[pipeline_state->id_].reset_session_idx].reset();
     }
 

--- a/src/models/decoder_only_pipeline.cpp
+++ b/src/models/decoder_only_pipeline.cpp
@@ -9,7 +9,7 @@
 namespace Generators {
 
 DecoderOnlyPipelineModel::DecoderOnlyPipelineModel(std::unique_ptr<Config> config, OrtEnv& ort_env)
-    : Model{std::move(config)} {
+    : Model{std::move(config)}, ort_env_{ort_env} {
   for (const auto& model : config_->model.decoder.pipeline) {
     sessions_.emplace_back(OrtSession::Create(ort_env, (config_->config_path / fs::path(model.filename)).c_str(),
                                               GetSessionOptions(model.model_id)));
@@ -83,6 +83,11 @@ bool IntermediatePipelineState::SupportsPrimaryDevice() const {
 
 DeviceSpan<float> IntermediatePipelineState::Run(int total_length, DeviceSpan<int32_t>& next_tokens,
                                                  DeviceSpan<int32_t> next_indices) {
+  if (!model_.sessions_[id_]) {
+    const_cast<DecoderOnlyPipelineModel*>(&model_)->sessions_[id_] =
+        OrtSession::Create(model_.ort_env_, (model_.config_->config_path / fs::path(model_.config_->model.decoder.pipeline[id_].filename)).c_str(),
+                           model_.GetSessionOptions(model_.config_->model.decoder.pipeline[id_].model_id));
+  }
   State::Run(*model_.sessions_[id_]);
   return {};
 }
@@ -174,6 +179,10 @@ void DecoderOnlyPipelineState::RunPipeline(int total_length, DeviceSpan<int32_t>
       continue;
     } else if (!first_run_ && !model_.config_->model.decoder.pipeline[pipeline_state->id_].run_on_token_gen) {
       continue;
+    }
+
+    if (model_.config_->model.decoder.pipeline[pipeline_state->id_].reset_session_idx != -1) {
+      (const_cast<DecoderOnlyPipelineModel*>(&model_))->sessions_[model_.config_->model.decoder.pipeline[pipeline_state->id_].reset_session_idx].reset();
     }
 
     // Clear the intermediate pipeline state outputs from the previous runs.

--- a/src/models/decoder_only_pipeline.h
+++ b/src/models/decoder_only_pipeline.h
@@ -27,6 +27,7 @@ struct DecoderOnlyPipelineModel : Model {
                                      const GeneratorParams& params) const override;
 
   std::vector<std::unique_ptr<OrtSession>> sessions_;
+  OrtEnv& ort_env_;
 };
 
 struct IntermediatePipelineState : State {


### PR DESCRIPTION
The deepseek r1 1.5B model will fail to run on NPU due to memory issues. This PR adds support for loading and unloading models to avoid QNN errors if the genai config requests it.

The alternative is to have the driver update for the QNN NPU but I am not sure when that will be rolled out.