### PR TITLE
Add value_stats logging option to show statistical information about …

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -368,7 +368,7 @@ void Generator::ComputeLogits(DeviceSpan<int32_t> next_tokens) {
   auto logits = state_->Run(search_->GetSequenceLength(), next_tokens, search_->GetNextIndices());
   if (g_log.enabled && g_log.model_logits) {
     auto& stream = Log("model_logits");
-    DumpSpan(stream, logits.CopyDeviceToCpu());
+    DumpValues(stream, Ort::TypeToTensorType<float>, logits.CopyDeviceToCpu().data(), logits.size());
     stream << std::endl;
   }
   SetLogits(logits);

--- a/src/logging.h
+++ b/src/logging.h
@@ -29,7 +29,7 @@ void SetLogString(std::string_view name, std::string_view value);
 
 struct LogItems {
   // Special log related entries
-  bool enabled{};        // Global on/off for all logging
+  bool enabled{true};        // Global on/off for all logging
   bool ansi_tags{true};  // Use ansi SGR color & style tags to make console output easier to read
   bool warning{true};    // warning messages, like options that were set but don't apply
 
@@ -41,8 +41,9 @@ struct LogItems {
   bool model_input_values{};   // Dump the input tensor shapes & values before the model runs
   bool model_output_shapes{};  // Before the model runs there are only the output shapes, no values in them. Useful for pre Session::Run debugging
   bool model_output_values{};  // After the model runs the output tensor values can be displayed
-  bool model_logits{};         // Same as model_output_values but only for the logits
+  bool model_logits{true};     // Same as model_output_values but only for the logits
   bool ort_lib{};              // Log the onnxruntime library loading and api calls.
+  bool value_stats{true};      // When logging float values, also dump some basic stats about the values (min, max, mean, std dev, and if there are any NaN or Inf values)
 };
 
 extern LogItems g_log;

--- a/src/logging.h
+++ b/src/logging.h
@@ -29,7 +29,7 @@ void SetLogString(std::string_view name, std::string_view value);
 
 struct LogItems {
   // Special log related entries
-  bool enabled{true};        // Global on/off for all logging
+  bool enabled{};        // Global on/off for all logging
   bool ansi_tags{true};  // Use ansi SGR color & style tags to make console output easier to read
   bool warning{true};    // warning messages, like options that were set but don't apply
 

--- a/src/models/debugging.cpp
+++ b/src/models/debugging.cpp
@@ -6,7 +6,59 @@
 #include "model.h"
 
 namespace Generators {
-static constexpr size_t c_value_count = 10;  // Dump this many values from the start of a tensor
+static constexpr size_t c_value_count = 10;  // Dump this many values at the start & end of a tensor (with '...' in between)
+
+// Tensor value statistics to help easily eyeball if the values in a tensor are reasonable.
+struct Stats {
+  float min = std::numeric_limits<float>::max();
+  float max = std::numeric_limits<float>::lowest();
+  float sum{};
+  float sum_of_squares{};
+  size_t count{};
+
+  bool found_non_finite {};
+  size_t first_non_finite_index{};
+  float non_finite_value{};
+  size_t non_finite_count{};
+
+  void Dump(std::ostream& stream) const {
+    stream << SGR::Fg_Cyan << " Min: " << SGR::Reset << min << SGR::Fg_Cyan << " Max: " << SGR::Reset << max << SGR::Fg_Cyan << " Mean: " << SGR::Reset << Mean() << SGR::Fg_Cyan << " StdDev: " << SGR::Reset << StdDev();
+    if (found_non_finite)
+      stream << " " << SGR::Bg_Red << "First non-finite value at index " << first_non_finite_index << ": " << non_finite_value << " Count of non-finite values: " << non_finite_count << SGR::Reset;
+    stream << std::endl;
+  }
+
+  Stats &operator<<(float value) {
+    min = std::min(min, value);
+    max = std::max(max, value);
+    sum += value;
+    sum_of_squares += value * value;
+    count++;
+
+    // Check if a value is a NaN or Inf and update
+    if (!std::isfinite(value)) {
+      non_finite_count++;
+      if (!found_non_finite) {
+        found_non_finite = true;
+        first_non_finite_index = count;
+        non_finite_value = value;
+      }
+    }
+    return *this;
+  }
+
+  float Mean() const {
+    return sum / count;
+  }
+
+  float Variance() const {
+    return (sum_of_squares - sum * sum / count) / count;
+  }
+
+  float StdDev() const {
+    return std::sqrt(Variance());
+  }
+};
 
 template <typename... Types>
 const char* TypeToString(ONNXTensorElementDataType type, Ort::TypeList<Types...>) {
@@ -25,7 +77,7 @@ std::ostream& operator<<(std::ostream& stream, Ort::Float16_t v) {
 }
 
 std::ostream& operator<<(std::ostream& stream, Ort::BFloat16_t v) {
-  stream << "BF16:" << v.value;  // TODO: implement conversion when useful
+  stream << BFloat16ToFloat32(v);
   return stream;
 }
 
@@ -61,6 +113,30 @@ void DumpValues(std::ostream& stream, ONNXTensorElementDataType type, const void
     stream << SGR::Fg_Red << "Unhandled data type" << SGR::Reset;
 
   stream << SGR::Fg_Green << "]" << SGR::Reset << std::endl;
+
+  if (g_log.value_stats) {
+    Stats stats;
+    if (type == Ort::TypeToTensorType<float>) {
+      auto p_values = reinterpret_cast<const float*>(p_values_raw);
+      for (size_t i = 0; i < count; i++)
+        stats << p_values[i];
+    } else if (type == Ort::TypeToTensorType<double>) {
+      auto p_values = reinterpret_cast<const double*>(p_values_raw);
+      for (size_t i = 0; i < count; i++)
+        stats << static_cast<float>(p_values[i]);
+    } else if (type == Ort::TypeToTensorType<Ort::Float16_t>) {
+      auto p_values = reinterpret_cast<const Ort::Float16_t*>(p_values_raw);
+      for (size_t i = 0; i < count; i++)
+        stats << ToFloat32(p_values[i]);
+    } else if (type == Ort::TypeToTensorType<Ort::BFloat16_t>) {
+      auto p_values = reinterpret_cast<const Ort::BFloat16_t*>(p_values_raw);
+      for (size_t i = 0; i < count; i++)
+        stats << ToFloat32(p_values[i]);
+    }
+
+    if (stats.count)
+      stats.Dump(Log("value_stats"));
+  }
 }
 
 void DumpTensor(const Model& model, std::ostream& stream, OrtValue* value, bool dump_value) {

--- a/src/models/debugging.cpp
+++ b/src/models/debugging.cpp
@@ -16,7 +16,7 @@ struct Stats {
   float sum_of_squares{};
   size_t count{};
 
-  bool found_non_finite {};
+  bool found_non_finite{};
   size_t first_non_finite_index{};
   float non_finite_value{};
   size_t non_finite_count{};
@@ -28,7 +28,7 @@ struct Stats {
     stream << std::endl;
   }
 
-  Stats &operator<<(float value) {
+  Stats& operator<<(float value) {
     min = std::min(min, value);
     max = std::max(max, value);
     sum += value;

--- a/src/models/debugging.h
+++ b/src/models/debugging.h
@@ -5,6 +5,10 @@ namespace Generators {
 void DumpTensor(const Model& model, std::ostream& stream, OrtValue* value, bool dump_value);
 void DumpTensors(const Model& model, std::ostream& stream, OrtValue** values, const char** names, size_t count, bool dump_values);
 
+// Outputs the values and (if enabled) the statistics of the values in the given values
+void DumpValues(std::ostream& stream, ONNXTensorElementDataType type, const void* values, size_t count);
+
+// Only outputs the values given
 template <typename T>
 void DumpSpan(std::ostream& stream, std::span<const T> values);
 template <typename T>

--- a/src/models/utils.cpp
+++ b/src/models/utils.cpp
@@ -47,31 +47,42 @@ int64_t ElementCountFromShape(std::span<const int64_t> shape) {
   return std::accumulate(shape.begin(), shape.end(), int64_t{1}, std::multiplies<int64_t>());
 }
 
-// IEEE 752-2008 binary16 format, 1 sign bit, 5 bit exponent, 10 bit fraction
-float Float16ToFloat32(uint16_t v) {
-  // Extract sign, exponent, and fraction from numpy.float16
-  int const sign = (v & 0x8000) >> 15;
-  int const exponent = (v & 0x7C00) >> 10;
-  int const fraction = v & 0x03FF;
+template <int exponent_bits, int fraction_bits>
+float TFloatToFloat32(uint16_t v) {
+  constexpr int exponent_bias = (1 << (exponent_bits - 1)) - 1;
+  constexpr int fraction_mask = (1 << fraction_bits) - 1;
+  constexpr int exponent_mask = ((1 << exponent_bits) - 1) << fraction_bits;
+
+  int sign = v >> (exponent_bits + fraction_bits);
+  int exponent = (v & exponent_mask) >> fraction_bits;
+  int fraction = v & fraction_mask;
 
   // Handle special cases
   if (exponent == 0) {
-    if (fraction == 0) {
-      // Zero
+    if (fraction == 0) // Zero
       return sign != 0 ? -0.0f : 0.0f;
-    }  // Subnormal number
-    return std::ldexp((sign != 0 ? -1.0f : 1.0f) * static_cast<float>(fraction) / 1024.0f, -14);
+    // Subnormal number
+    return std::ldexp((sign != 0 ? -1.0f : 1.0f) * static_cast<float>(fraction) / (1 << fraction_bits), 1 - exponent_bias);
   }
-  if (exponent == 31) {
-    if (fraction == 0) {
-      // Infinity
+  if (exponent == (1 << exponent_bits) - 1) {
+    if (fraction == 0) // Infinity
       return sign != 0 ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity();
-    }  // NaN
+    // NaN
     return std::numeric_limits<float>::quiet_NaN();
   }
 
   // Normalized number
-  return std::ldexp((sign != 0 ? -1.0f : 1.0f) * (1.0f + static_cast<float>(fraction) / 1024.0f), exponent - 15);
+  return std::ldexp((sign != 0 ? -1.0f : 1.0f) * (1.0f + static_cast<float>(fraction) / (1 << fraction_bits)), exponent - exponent_bias);
+}
+
+// IEEE 752-2008 binary16 format, 1 sign bit, 5 bit exponent, 10 bit fraction
+float Float16ToFloat32(uint16_t v) {
+  return TFloatToFloat32<5, 10>(v);
+}
+
+// BFloat16 binary16 format, 1 sign bit, 8 bit exponent, 7 bit fraction
+float BFloat16ToFloat32(uint16_t v) {
+  return TFloatToFloat32<8, 7>(v);
 }
 
 // C++17 compatible version of bit_cast for the code below

--- a/src/models/utils.cpp
+++ b/src/models/utils.cpp
@@ -59,13 +59,13 @@ float TFloatToFloat32(uint16_t v) {
 
   // Handle special cases
   if (exponent == 0) {
-    if (fraction == 0) // Zero
+    if (fraction == 0)  // Zero
       return sign != 0 ? -0.0f : 0.0f;
     // Subnormal number
     return std::ldexp((sign != 0 ? -1.0f : 1.0f) * static_cast<float>(fraction) / (1 << fraction_bits), 1 - exponent_bias);
   }
   if (exponent == (1 << exponent_bits) - 1) {
-    if (fraction == 0) // Infinity
+    if (fraction == 0)  // Infinity
       return sign != 0 ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity();
     // NaN
     return std::numeric_limits<float>::quiet_NaN();

--- a/src/models/utils.h
+++ b/src/models/utils.h
@@ -24,8 +24,14 @@ size_t SizeOf(ONNXTensorElementDataType type);
 
 int64_t ElementCountFromShape(std::span<const int64_t> shape);
 
+// NOTE: Until all compilers fully support C++23 and give us float16_t and bfloat16_t, we have to do it ourselves:
+
 // Slower fp16 to fp32 conversion that handles NaN and Inf (useful for debugging vs runtime conversion)
 float Float16ToFloat32(uint16_t v);
+float BFloat16ToFloat32(uint16_t v);
+
+inline float ToFloat32(Ort::Float16_t v) { return Float16ToFloat32(v); }
+inline float ToFloat32(Ort::BFloat16_t v) { return BFloat16ToFloat32(v); }
 
 // Fast fp16<->fp32 conversions that do not handle NaN and Inf but are fast (as these are not typical values)
 float FastFloat16ToFloat32(const uint16_t x);


### PR DESCRIPTION
Adds a new logging option "value_stats" that is on by default. This will show 'value_stats' after any array of values is also logged.

So when tensor inputs/output data is shown, the 'value_stats' will be shown after them. Also for things like 'model_logits' as below:

```
  model_logits   Values[ 2.51172 4.83594 6.32422 1.30469 1.97949 ... -1.28418 -1.28418 -1.28711 -1.28516 -1.28223 ]
  value_stats    Min: -5.35156 Max: 8.35156 Mean: 0.933448 StdDev: 1.1297
```

![image](https://github.com/user-attachments/assets/c5e0ae84-8602-4001-9560-53fc10ae759e)

This will also detect non-finite values and say the index of the first value similar to this image: (was renamed to just 'value_stats' but the rest is accurate)

![image](https://github.com/user-attachments/assets/ebb06b0c-1402-4cd1-b2d4-2e1bbd67b1e0)


This also generalizes the Float16ToFloat32 code to be templatized on the number of bits per field. This makes the implementation easier to read (no more magic numbers) and also adds bfloat16 support trivially.
