### PR TITLE
Add missing 'value_stats' to logging API, and fix wrong default

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -38,6 +38,8 @@ void SetLogBool(std::string_view name, bool value) {
     g_log.model_logits = value;
   else if (name == "ort_lib")
     g_log.ort_lib = value;
+  else if (name == "value_stats")
+    g_log.value_stats = value;
   else
     throw JSON::unknown_value_error{};
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -41,7 +41,7 @@ struct LogItems {
   bool model_input_values{};   // Dump the input tensor shapes & values before the model runs
   bool model_output_shapes{};  // Before the model runs there are only the output shapes, no values in them. Useful for pre Session::Run debugging
   bool model_output_values{};  // After the model runs the output tensor values can be displayed
-  bool model_logits{true};     // Same as model_output_values but only for the logits
+  bool model_logits{};         // Same as model_output_values but only for the logits
   bool ort_lib{};              // Log the onnxruntime library loading and api calls.
   bool value_stats{true};      // When logging float values, also dump some basic stats about the values (min, max, mean, std dev, and if there are any NaN or Inf values)
 };

--- a/src/models/debugging.cpp
+++ b/src/models/debugging.cpp
@@ -11,7 +11,9 @@ static constexpr size_t c_value_count = 10;  // Dump this many values at the sta
 // Tensor value statistics to help easily eyeball if the values in a tensor are reasonable.
 struct Stats {
   float min = std::numeric_limits<float>::max();
+  size_t min_index{};
   float max = std::numeric_limits<float>::lowest();
+  size_t max_index{};
   float sum{};
   float sum_of_squares{};
   size_t count{};
@@ -22,15 +24,24 @@ struct Stats {
   size_t non_finite_count{};
 
   void Dump(std::ostream& stream) const {
-    stream << SGR::Fg_Cyan << " Min: " << SGR::Reset << min << SGR::Fg_Cyan << " Max: " << SGR::Reset << max << SGR::Fg_Cyan << " Mean: " << SGR::Reset << Mean() << SGR::Fg_Cyan << " StdDev: " << SGR::Reset << StdDev();
+    stream << SGR::Fg_Cyan << " Min: " << SGR::Reset << min << " at index[" << min_index << "]"
+           << SGR::Fg_Cyan << " Max: " << SGR::Reset << max << " at index[" << max_index << "]"
+           << SGR::Fg_Cyan << " Mean: " << SGR::Reset << Mean()
+           << SGR::Fg_Cyan << " StdDev: " << SGR::Reset << StdDev();
     if (found_non_finite)
       stream << " " << SGR::Bg_Red << "First non-finite value at index " << first_non_finite_index << ": " << non_finite_value << " Count of non-finite values: " << non_finite_count << SGR::Reset;
     stream << std::endl;
   }
 
   Stats& operator<<(float value) {
-    min = std::min(min, value);
-    max = std::max(max, value);
+    if (min > value) {
+      min = value;
+      min_index = count;
+    }
+    if (max < value) {
+      max = value;
+      max_index = count;
+    }
     sum += value;
     sum_of_squares += value * value;
     count++;


### PR DESCRIPTION
Default logging for model_logits was left as true in previous API. Returning back to false.
Note: Default value for 'value_stats' is meant to be 'true' as it piggybacks on other logging options and is shown with them by default.

`value_stats    Min: -0.349669 at index[1706] Max: 0.479325 at index[204] Mean: 0.0044581 StdDev: 0.114219`

![image](https://github.com/user-attachments/assets/8eaf44dd-e2bc-4d2f-b221-eef09917acc8)
