### PR TITLE
Fix broken link in package description

### DIFF
--- a/nuget/PACKAGE.md
+++ b/nuget/PACKAGE.md
@@ -124,6 +124,6 @@ ONNX Runtime is an open source project. See:
 
 ## Documentation
 
-See [ONNX Runtime GenAI Documentation](https://onxxruntime.ai/docs/genai)
+See [ONNX Runtime GenAI Documentation](https://onnxruntime.ai/docs/genai)
 
 


### PR DESCRIPTION
Small fix for a broken link in Nuget.Org package descriptions.