### PR TITLE
Improve and Fix TopKTopP

### DIFF
--- a/src/softmax.h
+++ b/src/softmax.h
@@ -2,9 +2,7 @@
 
 namespace Generators {
 
-void SoftMax(std::span<float> scores, float temperature) {
-  float const max_score = *std::max_element(scores.begin(), scores.end());
-
+void SoftmaxWithMax(std::span<float> scores, float temperature, float max_score) {
   // Subtract max score and scale by temperature
   std::transform(scores.begin(), scores.end(), scores.begin(), [max_score, temperature](float score) { return std::exp((score - max_score) / temperature); });
 
@@ -13,6 +11,12 @@ void SoftMax(std::span<float> scores, float temperature) {
 
   // Divide each score by the sum of exponentials
   std::transform(scores.begin(), scores.end(), scores.begin(), [exp_sum](float score) { return score / exp_sum; });
+}
+
+void Softmax(std::span<float> scores, float temperature) {
+  const float max_score = *std::max_element(scores.begin(), scores.end());
+
+  SoftmaxWithMax(scores, temperature, max_score);
 }
 
 void LogSoftMax(std::span<float> scores, float temperature) {


### PR DESCRIPTION
This PR contains two changes:
(1) perf improvement: only SoftMax for top k tokens (currently it Softmax thus does exp for all 20k+ tokens, which is very expensive and no need)
(2) bug fix: if none of top k tokens are chosen, we should fall back to 0th token, not (k-1)th.
This bug is triggered when I tested onnx fp32 model for several prompts. At 6th prompt (top_k=40), 
Output: 
k=40, p=0.95, threshold_0=0.659818, batch_id=0, i_p=39, token=394, eos_token_score_1=-inf, eos_token_score_2=2552,(12, 21, 2876),(13, 14, 2837),(14, 9, 2793),(11, 4, 2704),(326, 3, 2674),(4441, 2, 2631),(200020, 1, 2552),(313, 1, 2537),(444, 1, 2528),(1986, 1, 2514),(220, 1, 2511),(3161, 1, 2505),(524, 0, 2501),(350, 0, 2499),(62, 0, 2494),(2469, 0, 2481),(577, 0, 2478),(551, 0, 2457),(503, 0, 2454),(1167, 0, 2454),(540, 0, 2452),(6189, 0, 2450),(1515, 0, 2445),(7863, 0, 2442),(6559, 0, 2438),(21214, 0, 2433),(2177, 0, 2431),(5, 0, 2430),(69472, 0, 2426),(1008, 0, 2422),(973, 0, 2418),(2887, 0, 2416),(310, 0, 2416),(8575, 0, 2413),(5518, 0, 2410),(384, 0, 2409),(379, 0, 2403),(427, 0, 2400),(2082, 0, 2399),(394, 0, 2398),
um
k=40, p=0.95, threshold_0=0.470863, batch_id=0, i_p=39, token=2177, eos_token_score_1=-inf, eos_token_score_2=2599,(13, 8, 2835),(4441, 5, 2788),(12, 5, 2780),(1167, 4, 2772),(524, 3, 2721),(11, 2, 2674),(1986, 1, 2642),(394, 1, 2635),(379, 1, 2632),(348, 1, 2622),(326, 1, 2609),(814, 1, 2605),(200020, 1, 2599),(3486, 1, 2591),(1207, 1, 2577),(488, 1, 2576),(21214, 1, 2574),(313, 1, 2570),(396, 1, 2568),(663, 1, 2562),(62, 1, 2561),(535, 1, 2560),(1785, 1, 2558),(629, 0, 2551),(973, 0, 2541),(594, 0, 2539),(3459, 0, 2531),(427, 0, 2525),(466, 0, 2522),(1904, 0, 2520),(8551, 0, 2519),(514, 0, 2519),(266, 0, 2518),(2082, 0, 2518),(28692, 0, 2514),(603, 0, 2511),(8171, 0, 2508),(1790, 0, 2507),(725, 0, 2506),(2177, 0, 2504),
umm
k=40, p=0.95, threshold_0=0.166951, batch_id=0, i_p=1, token=1167, eos_token_score_1=-inf, eos_token_score_2=2684,(4441, 15, 3009),(1167, 8, 2948),(12, 5, 2890),(524, 3, 2841),(396, 2, 2823),(403, 2, 2812),(313, 2, 2808),(394, 2, 2807),(64, 2, 2804),(348, 2, 2790),(1986, 1, 2775),(629, 1, 2768),(270, 1, 2746),(266, 1, 2743),(594, 1, 2741),(10202, 1, 2733),(488, 1, 2716),(427, 1, 2712),(466, 1, 2699),(535, 1, 2696),(644, 1, 2695),(72, 1, 2693),(1207, 1, 2690),(1785, 1, 2687),(200020, 1, 2684),(379, 1, 2673),(444, 0, 2667),(280, 0, 2667),(1904, 0, 2657),(603, 0, 2655),(1361, 0, 2653),(13, 0, 2646),(277, 0, 2640),(514, 0, 2639),(1515, 0, 2637),(296, 0, 2636),(384, 0, 2633),(273, 0, 2629),(3486, 0, 2622),(1956, 0, 2615),
ale

It picks the 39th token and then start to generate garbage.