### PR TITLE
Extensible AppendExecutionProvider and expose OrtSessionOptions::AddConfigEntry directly

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -57,6 +57,17 @@ struct ProviderOptionsArray_Element : JSON::Element {
 
   JSON::Element& OnObject(std::string_view name) override { return object_; }
 
+  void OnComplete(bool /*empty*/) override {
+    // For backwards compatibility turn our old names like 'qnn' into 'QNN', and 'webgpu' to 'WebGPU'
+    for (auto& v : v_) {
+      if (v.name == "qnn") {
+        v.name = "QNN";
+      } else if (v.name == "webgpu") {
+        v.name = "WebGPU";
+      }
+    }
+  }
+
  private:
   std::vector<Config::ProviderOptions>& v_;
   ProviderOptionsObject_Element object_{v_};

--- a/src/config.h
+++ b/src/config.h
@@ -46,10 +46,10 @@ struct Config {
 
   fs::path config_path;  // Path of the config directory
 
-  using ProviderOption = std::pair<std::string, std::string>;
+  using NamedString = std::pair<std::string, std::string>;
   struct ProviderOptions {
     std::string name;
-    std::vector<ProviderOption> options;
+    std::vector<NamedString> options;
   };
 
   struct SessionOptions {
@@ -69,6 +69,7 @@ struct Config {
     // TODO(baijumeswani): Sharing env allocators across sessions leads to crashes on windows and iOS.
     //                     Identify the reason for the crash to enable allocator sharing by default.
     bool use_env_allocators{};
+    std::vector<NamedString> config_entries;  // Entries go into OrtSessionOptions::AddConfigEntry
 
     std::vector<ProviderOptions> provider_options;
     std::optional<GraphOptimizationLevel> graph_optimization_level;

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -440,7 +440,7 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
   }
 
   // Turn this into a lambda:
-  auto AppendExecutionProvider=[&](const std::string& name, const Config::ProviderOptions& options) {
+  auto AppendExecutionProvider = [&](const std::string& name, const Config::ProviderOptions& options) {
     std::vector<const char*> keys, values;
     for (auto& option : options.options) {
       keys.emplace_back(option.first.c_str());

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -595,8 +595,7 @@ struct OrtSessionOptions {
   ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_CANN
   OrtSessionOptions& AppendExecutionProvider_CANN(const OrtCANNProviderOptions& provider_options);
   /// Wraps OrtApi::SessionOptionsAppendExecutionProvider. Currently supports SNPE and XNNPACK.
-  OrtSessionOptions& AppendExecutionProvider(const std::string& provider_name,
-                                             const std::unordered_map<std::string, std::string>& provider_options = {});
+  OrtSessionOptions& AppendExecutionProvider(const std::string& provider_name, const char* const* keys, const char* const* values, size_t num_keys);
 
   OrtSessionOptions& SetCustomCreateThreadFn(OrtCustomCreateThreadFn ort_custom_create_thread_fn);  ///< Wraps OrtApi::SessionOptionsSetCustomCreateThreadFn
   OrtSessionOptions& SetCustomThreadCreationOptions(void* ort_custom_thread_creation_options);      ///< Wraps OrtApi::SessionOptionsSetCustomThreadCreationOptions

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -675,24 +675,8 @@ inline OrtSessionOptions& OrtSessionOptions::AppendExecutionProvider_CANN(const 
   return *this;
 }
 
-inline OrtSessionOptions& OrtSessionOptions::AppendExecutionProvider(
-    const std::string& provider_name,
-    const std::unordered_map<std::string, std::string>& provider_options) {
-  auto num_entries = provider_options.size();
-  std::vector<const char*> keys, values;
-  if (num_entries > 0) {
-    keys.reserve(num_entries);
-    values.reserve(num_entries);
-
-    for (const auto& entry : provider_options) {
-      keys.push_back(entry.first.c_str());
-      values.push_back(entry.second.c_str());
-    }
-  }
-
-  Ort::ThrowOnError(Ort::api->SessionOptionsAppendExecutionProvider(this, provider_name.c_str(),
-                                                                    keys.data(), values.data(), num_entries));
-
+inline OrtSessionOptions& OrtSessionOptions::AppendExecutionProvider(const std::string& provider_name, const char* const* keys, const char* const* values, size_t num_keys) {
+  Ort::ThrowOnError(Ort::api->SessionOptionsAppendExecutionProvider(this, provider_name.c_str(), keys, values, num_keys));
   return *this;
 }
 


### PR DESCRIPTION
Also simplify our AppendExecutionProvider usage. I removed the unnecessary extra step of copying into an unordered_map then back into a std::vector.

This also unifies all AppendExecutionProviders together and is now extensible to future unknown providers.

Now for unknown providers, Onnxruntime will report an error with a list of the valid providers. In testing, the list in onnxruntime was found to be incomplete, this PR addresses this: https://github.com/microsoft/onnxruntime/pull/24352