### PR TITLE
C++ and python samples: follow_config support

### DIFF
--- a/benchmark/python/benchmark_e2e.py
+++ b/benchmark/python/benchmark_e2e.py
@@ -212,11 +212,12 @@ def run_benchmark(args, batch_size, prompt_length, generation_length, max_length
     # Get tokenizer, and model
     if args.verbose: print("Getting config")
     config = og.Config(f'{args.input_folder}')
-    config.clear_providers()
+    if args.execution_provider != "follow_config":
+        config.clear_providers()
+        if args.execution_provider != "cpu":
+            if args.verbose: print(f"Setting model to {args.execution_provider}")
+            config.append_provider(args.execution_provider)
     if args.verbose: print("Loading model... ")
-    if args.execution_provider != "cpu":
-        if args.verbose: print(f"Setting model to {args.execution_provider}")
-        config.append_provider(args.execution_provider)
     model = og.Model(config)
     if args.verbose: print("Model loaded")
     tokenizer = og.Tokenizer(model)
@@ -446,7 +447,7 @@ if __name__ == "__main__":
     parser.add_argument('--use_random_tokens', action='store_true', help='Use random tokens instead of generating a prompt')
     parser.add_argument('--use_prompt_set', action='store_true', help='Use pre-generated prompt set instead of generating a prompt')
     parser.add_argument('--chat_template', type=str, default='', help='Chat template to use for the prompt. User input will be injected into {input}')
-    parser.add_argument('-e', '--execution_provider', type=str, required=True, choices=["cpu", "cuda", "dml"], help='Execution provider to run ONNX model with')
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
     args = parser.parse_args()
 
     # check max_lengths

--- a/benchmark/python/benchmark_e2e.py
+++ b/benchmark/python/benchmark_e2e.py
@@ -447,7 +447,7 @@ if __name__ == "__main__":
     parser.add_argument('--use_random_tokens', action='store_true', help='Use random tokens instead of generating a prompt')
     parser.add_argument('--use_prompt_set', action='store_true', help='Use pre-generated prompt set instead of generating a prompt')
     parser.add_argument('--chat_template', type=str, default='', help='Chat template to use for the prompt. User input will be injected into {input}')
-    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run the ONNX Runtime session with. Defaults to follow_config that uses the execution provider listed in the genai_config.json instead.")
     args = parser.parse_args()
 
     # check max_lengths

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -76,7 +76,7 @@ if(PHI3V)
 endif()
 
 if(PHI4-MM)
-  add_executable(phi4-mm ${CMAKE_SOURCE_DIR}/src/phi4-mm.cpp)
+  add_executable(phi4-mm ${CMAKE_SOURCE_DIR}/src/phi4-mm.cpp ${EXAMPLES_SOURCE_DIR}/common.cpp)
   prepare_executable(phi4-mm)
 endif()
 

--- a/examples/c/src/common.cpp
+++ b/examples/c/src/common.cpp
@@ -87,6 +87,23 @@ std::string trim(const std::string& str) {
   return str.substr(first, (last - first + 1));
 }
 
-void print_usage(int /*argc*/, char** argv) {
+static void print_usage(int /*argc*/, char** argv) {
   std::cerr << "usage: " << argv[0] << " <model_path> <execution_provider>" << std::endl;
+  std::cerr << "  model_path: [required] Path to the folder containing onnx models, genai_config.json, etc." << std::endl;
+  std::cerr << "  execution_provider: [optional] Force use of a particular execution provider (e.g. \"cpu\")" << std::endl;
+  std::cerr << "                      If not specified, EP / provider options specified in genai_config.json will be used." << std::endl;
+}
+
+bool parse_args(int argc, char** argv, std::string& model_path, std::string& ep) {
+  if (argc < 2) {
+    print_usage(argc, argv);
+    return false;
+  }
+  model_path = argv[1];
+  if (argc > 2) {
+    ep = argv[2];
+  } else {
+    ep = "follow_config";
+  }
+  return true;
 }

--- a/examples/c/src/common.cpp
+++ b/examples/c/src/common.cpp
@@ -108,7 +108,7 @@ bool parse_args(int argc, char** argv, std::string& model_path, std::string& ep)
   return true;
 }
 
-void append_provider(OgaConfig& config, const std::string &provider) {
+void append_provider(OgaConfig& config, const std::string& provider) {
   if (provider.compare("follow_config") != 0) {
     config.ClearProviders();
     if (provider.compare("cpu") != 0) {

--- a/examples/c/src/common.cpp
+++ b/examples/c/src/common.cpp
@@ -88,7 +88,5 @@ std::string trim(const std::string& str) {
 }
 
 void print_usage(int /*argc*/, char** argv) {
-  std::cerr << "usage: " << argv[0] << std::endl;
-  std::cerr << "model_path = " << argv[1] << std::endl;
-  std::cerr << "execution_provider = " << argv[2] << std::endl;
+  std::cerr << "usage: " << argv[0] << " <model_path> <execution_provider>" << std::endl;
 }

--- a/examples/c/src/common.cpp
+++ b/examples/c/src/common.cpp
@@ -107,3 +107,15 @@ bool parse_args(int argc, char** argv, std::string& model_path, std::string& ep)
   }
   return true;
 }
+
+void append_provider(OgaConfig& config, const std::string &provider) {
+  if (provider.compare("follow_config") != 0) {
+    config.ClearProviders();
+    if (provider.compare("cpu") != 0) {
+      config.AppendProvider(provider.c_str());
+      if (provider.compare("cuda") == 0) {
+        config.SetProviderOption(provider.c_str(), "enable_cuda_graph", "0");
+      }
+    }
+  }
+}

--- a/examples/c/src/common.h
+++ b/examples/c/src/common.h
@@ -55,3 +55,7 @@ std::string trim(const std::string& str);
 // Returns false if insufficient cmd-line arguments were passed.
 // Note: ep will be set to "follow_config" if user only gives model_path
 bool parse_args(int /*argc*/, char** argv, std::string& model_path, std::string& ep);
+
+// Append provider / options to config.
+// This is a no-op if provider=="follow_config"
+void append_provider(OgaConfig& config, const std::string &provider);

--- a/examples/c/src/common.h
+++ b/examples/c/src/common.h
@@ -51,4 +51,7 @@ bool FileExists(const char* path);
 
 std::string trim(const std::string& str);
 
-void print_usage(int /*argc*/, char** argv);
+// Returns true if model_path & ep were able to be set from user cmd-line args.
+// Returns false if insufficient cmd-line arguments were passed.
+// Note: ep will be set to "follow_config" if user only gives model_path
+bool parse_args(int /*argc*/, char** argv, std::string& model_path, std::string& ep);

--- a/examples/c/src/common.h
+++ b/examples/c/src/common.h
@@ -58,4 +58,4 @@ bool parse_args(int /*argc*/, char** argv, std::string& model_path, std::string&
 
 // Append provider / options to config.
 // This is a no-op if provider=="follow_config"
-void append_provider(OgaConfig& config, const std::string &provider);
+void append_provider(OgaConfig& config, const std::string& provider);

--- a/examples/c/src/phi3.cpp
+++ b/examples/c/src/phi3.cpp
@@ -114,14 +114,9 @@ void CXX_API(const char* model_path, const char* execution_provider) {
 }
 
 int main(int argc, char** argv) {
-  std::string ep = "follow_config";
-  if (argc < 2) {
-    print_usage(argc, argv);
+  std::string model_path, ep;
+  if (!parse_args(argc, argv, model_path, ep)) {
     return -1;
-  }
-
-  if (argc > 2) {
-    ep = argv[2];
   }
 
   // Responsible for cleaning up the library during shutdown
@@ -132,7 +127,7 @@ int main(int argc, char** argv) {
   std::cout << "-------------" << std::endl;
 
   std::cout << "C++ API" << std::endl;
-  CXX_API(argv[1], ep.c_str());
+  CXX_API(model_path.c_str(), ep.c_str());
 
   return 0;
 }

--- a/examples/c/src/phi3.cpp
+++ b/examples/c/src/phi3.cpp
@@ -23,12 +23,14 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   std::cout << "Creating config..." << std::endl;
   auto config = OgaConfig::Create(model_path);
 
-  config->ClearProviders();
   std::string provider(execution_provider);
-  if (provider.compare("cpu") != 0) {
-    config->AppendProvider(execution_provider);
-    if (provider.compare("cuda") == 0) {
-      config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
+  if (provider.compare("follow_config") != 0) {
+    config->ClearProviders();
+    if (provider.compare("cpu") != 0) {
+      config->AppendProvider(execution_provider);
+      if (provider.compare("cuda") == 0) {
+        config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
+      }
     }
   }
 
@@ -112,9 +114,14 @@ void CXX_API(const char* model_path, const char* execution_provider) {
 }
 
 int main(int argc, char** argv) {
-  if (argc != 3) {
+  std::string ep = "follow_config";
+  if (argc < 2) {
     print_usage(argc, argv);
     return -1;
+  }
+
+  if (argc > 2) {
+    ep = argv[2];
   }
 
   // Responsible for cleaning up the library during shutdown
@@ -125,7 +132,7 @@ int main(int argc, char** argv) {
   std::cout << "-------------" << std::endl;
 
   std::cout << "C++ API" << std::endl;
-  CXX_API(argv[1], argv[2]);
+  CXX_API(argv[1], ep.c_str());
 
   return 0;
 }

--- a/examples/c/src/phi3.cpp
+++ b/examples/c/src/phi3.cpp
@@ -24,15 +24,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   auto config = OgaConfig::Create(model_path);
 
   std::string provider(execution_provider);
-  if (provider.compare("follow_config") != 0) {
-    config->ClearProviders();
-    if (provider.compare("cpu") != 0) {
-      config->AppendProvider(execution_provider);
-      if (provider.compare("cuda") == 0) {
-        config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
-      }
-    }
-  }
+  append_provider(*config, provider);
 
   std::cout << "Creating model..." << std::endl;
   auto model = OgaModel::Create(*config);

--- a/examples/c/src/phi3_qa.cpp
+++ b/examples/c/src/phi3_qa.cpp
@@ -23,12 +23,14 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   std::cout << "Creating config..." << std::endl;
   auto config = OgaConfig::Create(model_path);
 
-  config->ClearProviders();
   std::string provider(execution_provider);
-  if (provider.compare("cpu") != 0) {
-    config->AppendProvider(execution_provider);
-    if (provider.compare("cuda") == 0) {
-      config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
+  if (provider.compare("follow_config") != 0) {
+    config->ClearProviders();
+    if (provider.compare("cpu") != 0) {
+      config->AppendProvider(execution_provider);
+      if (provider.compare("cuda") == 0) {
+        config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
+      }
     }
   }
 
@@ -101,9 +103,14 @@ void CXX_API(const char* model_path, const char* execution_provider) {
 }
 
 int main(int argc, char** argv) {
-  if (argc != 3) {
+  std::string ep = "follow_config";
+  if (argc < 2) {
     print_usage(argc, argv);
     return -1;
+  }
+
+  if (argc > 2) {
+    ep = argv[2];
   }
 
   // Responsible for cleaning up the library during shutdown
@@ -114,7 +121,7 @@ int main(int argc, char** argv) {
   std::cout << "-------------" << std::endl;
 
   std::cout << "C++ API" << std::endl;
-  CXX_API(argv[1], argv[2]);
+  CXX_API(argv[1], ep.c_str());
 
   return 0;
 }

--- a/examples/c/src/phi3_qa.cpp
+++ b/examples/c/src/phi3_qa.cpp
@@ -24,15 +24,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   auto config = OgaConfig::Create(model_path);
 
   std::string provider(execution_provider);
-  if (provider.compare("follow_config") != 0) {
-    config->ClearProviders();
-    if (provider.compare("cpu") != 0) {
-      config->AppendProvider(execution_provider);
-      if (provider.compare("cuda") == 0) {
-        config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
-      }
-    }
-  }
+  append_provider(*config, provider);
 
   std::cout << "Creating model..." << std::endl;
   auto model = OgaModel::Create(*config);

--- a/examples/c/src/phi3_qa.cpp
+++ b/examples/c/src/phi3_qa.cpp
@@ -100,10 +100,6 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  if (argc > 2) {
-    ep = argv[2];
-  }
-
   // Responsible for cleaning up the library during shutdown
   OgaHandle handle;
 

--- a/examples/c/src/phi3_qa.cpp
+++ b/examples/c/src/phi3_qa.cpp
@@ -103,9 +103,8 @@ void CXX_API(const char* model_path, const char* execution_provider) {
 }
 
 int main(int argc, char** argv) {
-  std::string ep = "follow_config";
-  if (argc < 2) {
-    print_usage(argc, argv);
+  std::string model_path, ep;
+  if (!parse_args(argc, argv, model_path, ep)) {
     return -1;
   }
 
@@ -121,7 +120,7 @@ int main(int argc, char** argv) {
   std::cout << "-------------" << std::endl;
 
   std::cout << "C++ API" << std::endl;
-  CXX_API(argv[1], ep.c_str());
+  CXX_API(model_path.c_str(), ep.c_str());
 
   return 0;
 }

--- a/examples/c/src/phi3v.cpp
+++ b/examples/c/src/phi3v.cpp
@@ -12,12 +12,14 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   std::cout << "Creating config..." << std::endl;
   auto config = OgaConfig::Create(model_path);
 
-  config->ClearProviders();
   std::string provider(execution_provider);
-  if (provider.compare("cpu") != 0) {
-    config->AppendProvider(execution_provider);
-    if (provider.compare("cuda") == 0) {
-      config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
+  if (provider.compare("follow_config") != 0) {
+    config->ClearProviders();
+    if (provider.compare("cpu") != 0) {
+      config->AppendProvider(execution_provider);
+      if (provider.compare("cuda") == 0) {
+        config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
+      }
     }
   }
 
@@ -87,9 +89,14 @@ void CXX_API(const char* model_path, const char* execution_provider) {
 }
 
 int main(int argc, char** argv) {
-  if (argc != 3) {
+  std::string ep = "follow_config";
+  if (argc < 2) {
     print_usage(argc, argv);
     return -1;
+  }
+
+  if (argc > 2) {
+    ep = argv[2];
   }
 
   std::cout << "--------------------" << std::endl;
@@ -97,7 +104,7 @@ int main(int argc, char** argv) {
   std::cout << "--------------------" << std::endl;
 
   std::cout << "C++ API" << std::endl;
-  CXX_API(argv[1], argv[2]);
+  CXX_API(argv[1], ep.c_str());
 
   return 0;
 }

--- a/examples/c/src/phi3v.cpp
+++ b/examples/c/src/phi3v.cpp
@@ -89,14 +89,9 @@ void CXX_API(const char* model_path, const char* execution_provider) {
 }
 
 int main(int argc, char** argv) {
-  std::string ep = "follow_config";
-  if (argc < 2) {
-    print_usage(argc, argv);
+  std::string model_path, ep;
+  if (!parse_args(argc, argv, model_path, ep)) {
     return -1;
-  }
-
-  if (argc > 2) {
-    ep = argv[2];
   }
 
   std::cout << "--------------------" << std::endl;
@@ -104,7 +99,7 @@ int main(int argc, char** argv) {
   std::cout << "--------------------" << std::endl;
 
   std::cout << "C++ API" << std::endl;
-  CXX_API(argv[1], ep.c_str());
+  CXX_API(model_path.c_str(), ep.c_str());
 
   return 0;
 }

--- a/examples/c/src/phi3v.cpp
+++ b/examples/c/src/phi3v.cpp
@@ -13,15 +13,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   auto config = OgaConfig::Create(model_path);
 
   std::string provider(execution_provider);
-  if (provider.compare("follow_config") != 0) {
-    config->ClearProviders();
-    if (provider.compare("cpu") != 0) {
-      config->AppendProvider(execution_provider);
-      if (provider.compare("cuda") == 0) {
-        config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
-      }
-    }
-  }
+  append_provider(*config, provider);
 
   std::cout << "Creating model..." << std::endl;
   auto model = OgaModel::Create(*config);

--- a/examples/c/src/phi4-mm.cpp
+++ b/examples/c/src/phi4-mm.cpp
@@ -27,12 +27,14 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   std::cout << "Creating config..." << std::endl;
   auto config = OgaConfig::Create(model_path);
 
-  config->ClearProviders();
   std::string provider(execution_provider);
-  if (provider.compare("cpu") != 0) {
-    config->AppendProvider(execution_provider);
-    if (provider.compare("cuda") == 0) {
-      config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
+  if (provider.compare("follow_config") != 0) {
+    config->ClearProviders();
+    if (provider.compare("cpu") != 0) {
+      config->AppendProvider(execution_provider);
+      if (provider.compare("cuda") == 0) {
+        config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
+      }
     }
   }
 
@@ -137,15 +139,20 @@ static void print_usage(int /*argc*/, char** argv) {
 }
 
 int main(int argc, char** argv) {
-  if (argc != 3) {
+  std::string ep = "follow_config";
+  if (argc < 2) {
     print_usage(argc, argv);
     return -1;
+  }
+
+  if (argc > 2) {
+    ep = argv[2];
   }
 
   std::cout << "--------------------" << std::endl;
   std::cout << "Hello, Phi-4-Multimodal!" << std::endl;
   std::cout << "--------------------" << std::endl;
-  CXX_API(argv[1], argv[2]);
+  CXX_API(argv[1], ep.c_str());
 
   return 0;
 }

--- a/examples/c/src/phi4-mm.cpp
+++ b/examples/c/src/phi4-mm.cpp
@@ -15,15 +15,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   auto config = OgaConfig::Create(model_path);
 
   std::string provider(execution_provider);
-  if (provider.compare("follow_config") != 0) {
-    config->ClearProviders();
-    if (provider.compare("cpu") != 0) {
-      config->AppendProvider(execution_provider);
-      if (provider.compare("cuda") == 0) {
-        config->SetProviderOption(execution_provider, "enable_cuda_graph", "0");
-      }
-    }
-  }
+  append_provider(*config, provider);
 
   std::cout << "Creating model..." << std::endl;
   auto model = OgaModel::Create(*config);

--- a/examples/c/src/phi4-mm.cpp
+++ b/examples/c/src/phi4-mm.cpp
@@ -5,21 +5,8 @@
 #include <string>
 #include <fstream>
 #include <memory>
-
+#include "common.h"
 #include "ort_genai.h"
-
-bool FileExists(const char* path) {
-  return static_cast<bool>(std::ifstream(path));
-}
-
-std::string trim(const std::string& str) {
-  const size_t first = str.find_first_not_of(' ');
-  if (std::string::npos == first) {
-    return str;
-  }
-  const size_t last = str.find_last_not_of(' ');
-  return str.substr(first, (last - first + 1));
-}
 
 // C++ API Example
 
@@ -132,27 +119,16 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   }
 }
 
-static void print_usage(int /*argc*/, char** argv) {
-  std::cerr << "usage: " << argv[0] << std::endl;
-  std::cerr << "model_path = " << argv[1] << std::endl;
-  std::cerr << "execution_provider = " << argv[2] << std::endl;
-}
-
 int main(int argc, char** argv) {
-  std::string ep = "follow_config";
-  if (argc < 2) {
-    print_usage(argc, argv);
+  std::string model_path, ep;
+  if (!parse_args(argc, argv, model_path, ep)) {
     return -1;
-  }
-
-  if (argc > 2) {
-    ep = argv[2];
   }
 
   std::cout << "--------------------" << std::endl;
   std::cout << "Hello, Phi-4-Multimodal!" << std::endl;
   std::cout << "--------------------" << std::endl;
-  CXX_API(argv[1], ep.c_str());
+  CXX_API(model_path.c_str(), ep.c_str());
 
   return 0;
 }

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -142,7 +142,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description="End-to-end AI Question/Answer example for gen-ai")
     parser.add_argument('-m', '--model_path', type=str, required=True, help='Onnx model folder path (must contain genai_config.json and model.onnx)')
-    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run the ONNX Runtime session with. Defaults to follow_config that uses the execution provider listed in the genai_config.json instead.")
     parser.add_argument('-i', '--min_length', type=int, help='Min number of tokens to generate including the prompt')
     parser.add_argument('-l', '--max_length', type=int, help='Max number of tokens to generate including the prompt')
     parser.add_argument('-ds', '--do_sample', action='store_true', help='Do random sampling. When false, greedy or beam search are used to generate the output. Defaults to false')

--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -12,10 +12,11 @@ def main(args):
         first_token_timestamp = 0
 
     config = og.Config(args.model_path)
-    config.clear_providers()
-    if args.execution_provider != "cpu":
-        if args.verbose: print(f"Setting model to {args.execution_provider}")
-        config.append_provider(args.execution_provider)
+    if args.execution_provider != "follow_config":
+        config.clear_providers()
+        if args.execution_provider != "cpu":
+            if args.verbose: print(f"Setting model to {args.execution_provider}")
+            config.append_provider(args.execution_provider)
     model = og.Model(config)
 
     if args.verbose: print("Model loaded")
@@ -141,7 +142,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description="End-to-end AI Question/Answer example for gen-ai")
     parser.add_argument('-m', '--model_path', type=str, required=True, help='Onnx model folder path (must contain genai_config.json and model.onnx)')
-    parser.add_argument('-e', '--execution_provider', type=str, required=True, choices=["cpu", "cuda", "dml"], help="Execution provider to run ONNX model with")
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
     parser.add_argument('-i', '--min_length', type=int, help='Min number of tokens to generate including the prompt')
     parser.add_argument('-l', '--max_length', type=int, help='Max number of tokens to generate including the prompt')
     parser.add_argument('-ds', '--do_sample', action='store_true', help='Do random sampling. When false, greedy or beam search are used to generate the output. Defaults to false')

--- a/examples/python/model-generate.py
+++ b/examples/python/model-generate.py
@@ -75,7 +75,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description="End-to-end token generation loop example for gen-ai")
     parser.add_argument('-m', '--model_path', type=str, required=True, help='Onnx model folder path (must contain genai_config.json and model.onnx)')
-    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run the ONNX Runtime session with. Defaults to follow_config that uses the execution provider listed in the genai_config.json instead.")
     parser.add_argument('-pr', '--prompts', nargs='*', required=False, help='Input prompts to generate tokens from. Provide this parameter multiple times to batch multiple prompts')
     parser.add_argument('-i', '--min_length', type=int, default=25, help='Min number of tokens to generate including the prompt')
     parser.add_argument('-l', '--max_length', type=int, default=50, help='Max number of tokens to generate including the prompt')

--- a/examples/python/model-generate.py
+++ b/examples/python/model-generate.py
@@ -5,11 +5,12 @@ import time
 def main(args):
     if args.verbose: print("Loading model...")
     config = og.Config(args.model_path)
-    config.clear_providers()
-    if args.execution_provider != "cpu":
-        if args.verbose:
-            print(f"Setting model to {args.execution_provider}...")
-        config.append_provider(args.execution_provider)
+    if args.execution_provider != "follow_config":
+        config.clear_providers()
+        if args.execution_provider != "cpu":
+            if args.verbose:
+                print(f"Setting model to {args.execution_provider}...")
+            config.append_provider(args.execution_provider)
     model = og.Model(config)
 
     if args.verbose: print("Model loaded")
@@ -74,7 +75,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description="End-to-end token generation loop example for gen-ai")
     parser.add_argument('-m', '--model_path', type=str, required=True, help='Onnx model folder path (must contain genai_config.json and model.onnx)')
-    parser.add_argument("-e", "--execution_provider", type=str, required=True, choices=["cpu", "cuda", "dml"], help="Provider to run model")
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
     parser.add_argument('-pr', '--prompts', nargs='*', required=False, help='Input prompts to generate tokens from. Provide this parameter multiple times to batch multiple prompts')
     parser.add_argument('-i', '--min_length', type=int, default=25, help='Min number of tokens to generate including the prompt')
     parser.add_argument('-l', '--max_length', type=int, default=50, help='Max number of tokens to generate including the prompt')

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -12,10 +12,11 @@ def main(args):
         first_token_timestamp = 0
 
     config = og.Config(args.model_path)
-    config.clear_providers()
-    if args.execution_provider != "cpu":
-        if args.verbose: print(f"Setting model to {args.execution_provider}")
-        config.append_provider(args.execution_provider)
+    if args.execution_provider != "follow_config":
+        config.clear_providers()
+        if args.execution_provider != "cpu":
+            if args.verbose: print(f"Setting model to {args.execution_provider}")
+            config.append_provider(args.execution_provider)
     model = og.Model(config)
 
     if args.verbose: print("Model loaded")
@@ -144,7 +145,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description="End-to-end AI Question/Answer example for gen-ai")
     parser.add_argument('-m', '--model_path', type=str, required=True, help='Onnx model folder path (must contain genai_config.json and model.onnx)')
-    parser.add_argument('-e', '--execution_provider', type=str, required=True, choices=["cpu", "cuda", "dml"], help="Execution provider to run ONNX model with")
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
     parser.add_argument('-i', '--min_length', type=int, help='Min number of tokens to generate including the prompt')
     parser.add_argument('-l', '--max_length', type=int, help='Max number of tokens to generate including the prompt')
     parser.add_argument('-ds', '--do_sample', action='store_true', help='Do random sampling. When false, greedy or beam search are used to generate the output. Defaults to false')

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -145,7 +145,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description="End-to-end AI Question/Answer example for gen-ai")
     parser.add_argument('-m', '--model_path', type=str, required=True, help='Onnx model folder path (must contain genai_config.json and model.onnx)')
-    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run the ONNX Runtime session with. Defaults to follow_config that uses the execution provider listed in the genai_config.json instead.")
     parser.add_argument('-i', '--min_length', type=int, help='Min number of tokens to generate including the prompt')
     parser.add_argument('-l', '--max_length', type=int, help='Max number of tokens to generate including the prompt')
     parser.add_argument('-ds', '--do_sample', action='store_true', help='Do random sampling. When false, greedy or beam search are used to generate the output. Defaults to false')

--- a/examples/python/model-vision.py
+++ b/examples/python/model-vision.py
@@ -135,7 +135,7 @@ if __name__ == "__main__":
         "-m", "--model_path", type=str, required=True, help="Path to the folder containing the model"
     )
     parser.add_argument(
-        "-e", "--execution_provider", type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run model"
+        "-e", "--execution_provider", type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run the ONNX Runtime session with. Defaults to follow_config that uses the execution provider listed in the genai_config.json instead."
     )
     parser.add_argument(
         "--image_paths", nargs='*', type=str, required=False, help="Path to the images, mainly for CI usage"

--- a/examples/python/model-vision.py
+++ b/examples/python/model-vision.py
@@ -28,10 +28,11 @@ def _complete(text, state):
 def run(args: argparse.Namespace):
     print("Loading model...")
     config = og.Config(args.model_path)
-    config.clear_providers()
-    if args.execution_provider != "cpu":
-        print(f"Setting model to {args.execution_provider}...")
-        config.append_provider(args.execution_provider)
+    if args.execution_provider != "follow_config":
+        config.clear_providers()
+        if args.execution_provider != "cpu":
+            print(f"Setting model to {args.execution_provider}...")
+            config.append_provider(args.execution_provider)
     model = og.Model(config)
     print("Model loaded")
 
@@ -134,7 +135,7 @@ if __name__ == "__main__":
         "-m", "--model_path", type=str, required=True, help="Path to the folder containing the model"
     )
     parser.add_argument(
-        "-e", "--execution_provider", type=str, required=True, choices=["cpu", "cuda", "dml"], help="Execution provider to run model"
+        "-e", "--execution_provider", type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run model"
     )
     parser.add_argument(
         "--image_paths", nargs='*', type=str, required=False, help="Path to the images, mainly for CI usage"

--- a/examples/python/phi3-qa.py
+++ b/examples/python/phi3-qa.py
@@ -9,10 +9,11 @@ def main(args):
         first_token_timestamp = 0
 
     config = og.Config(args.model_path)
-    config.clear_providers()
-    if args.execution_provider != "cpu":
-        if args.verbose: print(f"Setting model to {args.execution_provider}")
-        config.append_provider(args.execution_provider)
+    if args.execution_provider != "follow_config":
+        config.clear_providers()
+        if args.execution_provider != "cpu":
+            if args.verbose: print(f"Setting model to {args.execution_provider}")
+            config.append_provider(args.execution_provider)
     model = og.Model(config)
 
     if args.verbose: print("Model loaded")
@@ -84,7 +85,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description="End-to-end AI Question/Answer example for gen-ai")
     parser.add_argument('-m', '--model_path', type=str, required=True, help='Onnx model folder path (must contain genai_config.json and model.onnx)')
-    parser.add_argument('-e', '--execution_provider', type=str, required=True, choices=["cpu", "cuda", "dml"], help="Execution provider to run ONNX model with")
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
     parser.add_argument('-i', '--min_length', type=int, help='Min number of tokens to generate including the prompt')
     parser.add_argument('-l', '--max_length', type=int, help='Max number of tokens to generate including the prompt')
     parser.add_argument('-ds', '--do_sample', action='store_true', default=False, help='Do random sampling. When false, greedy or beam search are used to generate the output. Defaults to false')

--- a/examples/python/phi3-qa.py
+++ b/examples/python/phi3-qa.py
@@ -85,7 +85,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description="End-to-end AI Question/Answer example for gen-ai")
     parser.add_argument('-m', '--model_path', type=str, required=True, help='Onnx model folder path (must contain genai_config.json and model.onnx)')
-    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run ONNX model with")
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run the ONNX Runtime session with. Defaults to follow_config that uses the execution provider listed in the genai_config.json instead.")
     parser.add_argument('-i', '--min_length', type=int, help='Min number of tokens to generate including the prompt')
     parser.add_argument('-l', '--max_length', type=int, help='Max number of tokens to generate including the prompt')
     parser.add_argument('-ds', '--do_sample', action='store_true', default=False, help='Do random sampling. When false, greedy or beam search are used to generate the output. Defaults to false')

--- a/examples/python/phi4-mm.py
+++ b/examples/python/phi4-mm.py
@@ -156,7 +156,7 @@ if __name__ == "__main__":
         "-m", "--model_path", type=str, required=True, help="Path to the folder containing the model"
     )
     parser.add_argument(
-        "-e", "--execution_provider", type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run model"
+        "-e", "--execution_provider", type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run the ONNX Runtime session with. Defaults to follow_config that uses the execution provider listed in the genai_config.json instead."
     )
     parser.add_argument(
         "--image_paths", nargs='*', type=str, required=False, help="Path to the images, mainly for CI usage"

--- a/examples/python/phi4-mm.py
+++ b/examples/python/phi4-mm.py
@@ -55,10 +55,11 @@ def get_paths(modality, user_provided_paths, default_paths, interactive):
 def run(args: argparse.Namespace):
     print("Loading model...")
     config = og.Config(args.model_path)
-    config.clear_providers()
-    if args.execution_provider != "cpu":
-        print(f"Setting model to {args.execution_provider}...")
-        config.append_provider(args.execution_provider)
+    if args.execution_provider != "follow_config":
+        config.clear_providers()
+        if args.execution_provider != "cpu":
+            print(f"Setting model to {args.execution_provider}...")
+            config.append_provider(args.execution_provider)
     model = og.Model(config)
     print("Model loaded")
 
@@ -155,7 +156,7 @@ if __name__ == "__main__":
         "-m", "--model_path", type=str, required=True, help="Path to the folder containing the model"
     )
     parser.add_argument(
-        "-e", "--execution_provider", type=str, required=True, choices=["cpu", "cuda", "dml"], help="Execution provider to run model"
+        "-e", "--execution_provider", type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run model"
     )
     parser.add_argument(
         "--image_paths", nargs='*', type=str, required=False, help="Path to the images, mainly for CI usage"


### PR DESCRIPTION
This PR adds the ability for `follow_config` to be given as the execution_provider option for C++ (Phi) example, (most) python samples, and benchmark_e2e.py tool.

When `follow_config` is set as the EP, the sample won't perform the `config.clear_providers()` operation, which was problematic in cases where important provider options, etc. are specified in `genai_config.json`