### PR TITLE
Update the C++ clang-format lint workflow to use clang 20

### DIFF
--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -1,22 +1,34 @@
 name: Clang Format Lint
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+
 on:
-  pull_request: { }
+  push:
+    branches:
+      - main
+      - rel-*
+  pull_request:
+    branches:
+      - main
+      - rel-*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref
+    || github.sha }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  lint-cpp:
+    runs-on:
+      - self-hosted
+      - "1ES.Pool=onnxruntime-genai-Ubuntu2204-AMD-CPU"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v5
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          python-version: '3.11.x'
-          architecture: 'x64'
-      - uses: DoozyX/clang-format-lint-action@v0.17
+          submodules: 'false'
+
+      - name: Check format
+        uses: microsoft/onnxruntime-github-actions/format-lint-check@v0.0.6
         with:
-          source: './src'
-          extensions: 'h,cpp'
-          clangFormatVersion: 17
+          llvm-version: '20.1.0'
+          llvm-sha256-hash: '954ac51498519f6ed9540714fb04bc401f70039b296a8160dd1559be380788d7'

--- a/examples/c/src/common.h
+++ b/examples/c/src/common.h
@@ -35,7 +35,6 @@ class Timing {
   TimePoint end_timestamp_;
 };
 
-
 class TerminateSession {
  public:
   std::condition_variable cv;

--- a/examples/c/src/phi3.cpp
+++ b/examples/c/src/phi3.cpp
@@ -74,7 +74,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
       include_system_prompt = false;
     } else {
       tokenizer->Encode(prompt.c_str(), *sequences);
-   }
+    }
 
     std::cout << "Generating response..." << std::endl;
     generator->AppendTokenSequences(*sequences);
@@ -92,8 +92,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
         const auto new_token = generator->GetSequenceData(0)[num_tokens - 1];
         std::cout << tokenizer_stream->Decode(new_token) << std::flush;
       }
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
       std::cout << "Session Terminated: " << e.what() << std::endl;
     }
 

--- a/examples/c/src/phi3_qa.cpp
+++ b/examples/c/src/phi3_qa.cpp
@@ -81,8 +81,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
         const auto new_token = generator->GetSequenceData(0)[num_tokens - 1];
         std::cout << tokenizer_stream->Decode(new_token) << std::flush;
       }
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
       std::cout << "Session Terminated: " << e.what() << std::endl;
     }
 

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -353,24 +353,18 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       })
       .def("to_token_id", &OgaTokenizer::ToTokenId)
       .def("decode", [](const OgaTokenizer& t, pybind11::array_t<int32_t> tokens) -> std::string { return t.Decode(ToSpan(tokens)).p_; })
-      .def(
-          "apply_chat_template", [](const OgaTokenizer& t, const char* template_str, const char* messages, bool add_generation_prompt) -> std::string {
-            return t.ApplyChatTemplate(template_str, messages, add_generation_prompt).p_;
-          },
-          pybind11::arg("template_str") = nullptr, pybind11::arg("messages"), pybind11::arg("add_generation_prompt"))
+      .def("apply_chat_template", [](const OgaTokenizer& t, const char* template_str, const char* messages, bool add_generation_prompt) -> std::string { return t.ApplyChatTemplate(template_str, messages, add_generation_prompt).p_; }, pybind11::arg("template_str") = nullptr, pybind11::arg("messages"), pybind11::arg("add_generation_prompt"))
       .def("encode_batch", [](const OgaTokenizer& t, std::vector<std::string> strings) {
         std::vector<const char*> c_strings;
         for (const auto& s : strings)
           c_strings.push_back(s.c_str());
-        return t.EncodeBatch(c_strings.data(), c_strings.size());
-      })
+        return t.EncodeBatch(c_strings.data(), c_strings.size()); })
       .def("decode_batch", [](const OgaTokenizer& t, const OgaTensor& tokens) {
         std::vector<std::string> strings;
         auto decoded = t.DecodeBatch(tokens);
         for (size_t i = 0; i < decoded->Count(); i++)
           strings.push_back(decoded->Get(i));
-        return strings;
-      })
+        return strings; })
       .def("create_stream", [](const OgaTokenizer& t) { return OgaTokenizerStream::Create(t); });
 
   pybind11::class_<OgaConfig>(m, "Config")

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -117,11 +117,12 @@ TEST(CAPITests, ChatTemplate) {
       }
     ])";
   const char* chat_template = R"({% for message in messages %}{% if message['role'] == 'system' and 'tools' in message and message['tools'] is not none %}{{ '<|' + message['role'] + '|>' + message['content'] + '<|tool|>' + message['tools'] + '<|/tool|>' + '<|end|>' }}{% else %}{{ '<|' + message['role'] + '|>' + message['content'] + '<|end|>' }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>' }}{% else %}{{ eos_token }}{% endif %})";
-  
+
   // From HuggingFace Python output for 'microsoft/Phi-4-multimodal-instruct'
-  const char* expected_output = "<|system|>You are a helpful assistant.<|tool|>Calculator<|/tool|><|end|><|user|>"
-    "How do I add two numbers?<|end|><|assistant|>You can add numbers by using the '+' operator.<|end|><|assistant|>";
-  
+  const char* expected_output =
+      "<|system|>You are a helpful assistant.<|tool|>Calculator<|/tool|><|end|><|user|>"
+      "How do I add two numbers?<|end|><|assistant|>You can add numbers by using the '+' operator.<|end|><|assistant|>";
+
   auto out_string = tokenizer->ApplyChatTemplate(chat_template, messages_json, true);
   ASSERT_STREQ(expected_output, out_string);
 
@@ -242,7 +243,7 @@ TEST(CAPITests, EndToEndPhiBatch) {
       1212, 318, 257, 1332, 13, 50256, 50256, 50256, 50256, 50256, 198, 50280, 2, 16926, 1330, 1635, 10412, 6617, 278, 6335, 32994, 21857, 13849, 38665, 82, 21815, 1108, 9557, 40755, 27446, 2417, 6381, 6, 7131, 6, 14870, 31314, 21411, 46009, 3974,
       49, 1381, 389, 7427, 17252, 0, 50256, 50256, 50256, 50256, 198, 50284, 37811, 628, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256,
       464, 2068, 7586, 21831, 18045, 625, 262, 16931, 3290, 13, 198, 50284, 37811, 628, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256, 50256};
-  
+
   for (size_t i = 0; i < 3; i++) {
     const auto sequence_length = generator->GetSequenceCount(i);
     const auto* sequence_data = generator->GetSequenceData(i);
@@ -280,8 +281,8 @@ TEST(CAPITests, EndToEndPhi) {
 
   // Verify outputs match expected outputs
   std::vector<int32_t> expected_output{
-      1212, 318, 257, 1332, 13, 198, 50280, 2, 16926, 1330, 1635, 10412, 6617, 278, 
-      6335, 32994, 21857, 13849, 38665, 82, 21815, 1108, 9557, 40755, 27446, 2417, 
+      1212, 318, 257, 1332, 13, 198, 50280, 2, 16926, 1330, 1635, 10412, 6617, 278,
+      6335, 32994, 21857, 13849, 38665, 82, 21815, 1108, 9557, 40755, 27446, 2417,
       6381, 6, 7131, 6, 14870, 31314, 21411, 46009, 3974, 82, 1039, 889, 263, 3684};
 
   const auto sequence_length = generator->GetSequenceCount(0);
@@ -508,8 +509,7 @@ TEST(CAPITests, SetTerminate) {
     EXPECT_THROW({
       while (!generator->IsDone()) {
         generator->GenerateNextToken();
-      }
-    }, std::runtime_error);
+      } }, std::runtime_error);
   };
 
   auto model = OgaModel::Create(PHI2_PATH);

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -34,7 +34,7 @@ static const std::pair<const char*, const char*> c_tiny_gpt2_model_paths[] = {
 
 #if USE_DML
 TEST(ModelTests, DMLAdapterSelection) {
-#if 0 // TEST_PHI2 TODO: Remove this? Can't access the device directly anymore.
+#if 0  // TEST_PHI2 TODO: Remove this? Can't access the device directly anymore.
   auto model = Generators::CreateModel(Generators::GetOrtEnv(), PHI2_PATH);
   auto d3d12Device = model->GetD3D12Device();
 
@@ -179,7 +179,7 @@ void Test_GreedySearch_Gpt_Cuda(const char* model_path, const char* model_label)
   while (!generator->IsDone()) {
     generator->GenerateNextToken();
   }
-  
+
   // Verify outputs match expected outputs
   auto sequence = generator->GetSequence(0);
   auto* expected_output_start = &expected_output_continuous[0];

--- a/test/sampling_benchmark.cpp
+++ b/test/sampling_benchmark.cpp
@@ -47,7 +47,7 @@ struct SamplingBenchmark {
     switch (benchmark_function_) {
       case BenchmarkFunction::TopP:
         params->SetSearchOption("top_p", 0.95f);
-        break;  
+        break;
       case BenchmarkFunction::TopK:
         params->SetSearchOption("top_k", 5);
         break;
@@ -68,7 +68,7 @@ struct SamplingBenchmark {
     double total_time = 0.0;
     int num_iter = 1000;
 
-    auto logits = OgaTensor::Create<float>(nullptr, std::array<int64_t, 1>{vocab_size*batch_size_});
+    auto logits = OgaTensor::Create<float>(nullptr, std::array<int64_t, 1>{vocab_size * batch_size_});
     auto test_start = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < num_iter; i++) {
@@ -78,7 +78,7 @@ struct SamplingBenchmark {
       generator->SetLogits(*logits);
       auto start = std::chrono::high_resolution_clock::now();
       generator->GenerateNextToken();
-      auto result=generator->GetNextTokens();
+      auto result = generator->GetNextTokens();
       auto stop = std::chrono::high_resolution_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
       total_time += duration.count();

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -72,7 +72,7 @@ TEST(SamplingTests, BatchedSamplingTopKCpu) {
   auto next_tokens = generator->GetNextTokens();
   for (int b = 0; b < batch_size; b++) {
     auto next_token = next_tokens[b];
-    auto next_token_score = logits_cpu[next_token + 5 /*vocab_size*/* b];
+    auto next_token_score = logits_cpu[next_token + 5 /*vocab_size*/ * b];
     EXPECT_GT(next_token_score, 1.25f);
   }
 }
@@ -205,7 +205,7 @@ TEST(SamplingTests, RandomizedSamplingTopKCpu) {
   std::vector<float> logits_cpu(vocab_size * batch_size);
   const int num_iter = 100;
   std::map<float, int> logit_to_count;
-  
+
   // Run test
   for (int i = 0; i < num_iter; i++) {
     logits_cpu = std::vector<float>(vocab_size * batch_size, 0.0f);


### PR DESCRIPTION
Update the C++ clang-format lint workflow to use clang 20, and format code with the new clang version.