### PR TITLE
pin cmake version

### DIFF
--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -39,6 +39,15 @@ jobs:
         with:
           gradle-version: '8.6'
 
+      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        with:
+          vcpkg-version: '2025.03.19'
+          vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+          cmake-version: '3.31.6'
+          cmake-hash: '42395e20b10a8e9ef3e33014f9a4eed08d46ab952e02d2c1bbc8f6133eca0d7719fb75680f9bbff6552f20fcd1b73d86860f7f39388d631f98fb6f622b37cf04'
+          add-cmake-to-path: 'true'
+          disable-terrapin: 'true'
+
       - name: Get the Latest OnnxRuntime Nightly Version
         shell: pwsh
         run: |

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v2
 
+      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        with:
+          vcpkg-version: '2025.03.19'
+          vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+          cmake-version: '3.31.6'
+          cmake-hash: '42395e20b10a8e9ef3e33014f9a4eed08d46ab952e02d2c1bbc8f6133eca0d7719fb75680f9bbff6552f20fcd1b73d86860f7f39388d631f98fb6f622b37cf04'
+          add-cmake-to-path: 'true'
+          disable-terrapin: 'true'
+
       - name: Git Submodule Update
         run: |
           git submodule update --init --recursive

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -41,6 +41,15 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        with:
+          vcpkg-version: '2025.03.19'
+          vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+          cmake-version: '3.31.6'
+          cmake-hash: '42395e20b10a8e9ef3e33014f9a4eed08d46ab952e02d2c1bbc8f6133eca0d7719fb75680f9bbff6552f20fcd1b73d86860f7f39388d631f98fb6f622b37cf04'
+          add-cmake-to-path: 'true'
+          disable-terrapin: 'true'
+
       - name: Get the Latest OnnxRuntime Nightly Version
         shell: pwsh
         run: |

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -32,6 +32,16 @@ jobs:
         python-version: '3.11.x'
         architecture: 'x64'
 
+    - name: Setup VCPKG
+      uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+      with:
+        vcpkg-version: '2025.03.19'
+        vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+        cmake-version: '3.31.6'
+        cmake-hash: '0f1584e8666cf4a65ec514bd02afe281caabf1d45d2c963f3151c41484f457386aa03273ab25776a670be02725354ce0b46f3a5121857416da37366342a833a0'
+        add-cmake-to-path: 'true'
+        disable-terrapin: 'false'
+
     - name: Setup Visual Studio 2022
       uses: microsoft/setup-msbuild@v1.1
       with:

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -35,6 +35,16 @@ jobs:
         python-version: '3.11.x'
         architecture: 'x64'
 
+    - name: Setup VCPKG
+      uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+      with:
+        vcpkg-version: '2025.03.19'
+        vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+        cmake-version: '3.31.6'
+        cmake-hash: '0f1584e8666cf4a65ec514bd02afe281caabf1d45d2c963f3151c41484f457386aa03273ab25776a670be02725354ce0b46f3a5121857416da37366342a833a0'
+        add-cmake-to-path: 'true'
+        disable-terrapin: 'false'
+
     - name: Download cuda
       run: |
         azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ env.cuda_version }}" ${{ env.cuda_dir}}

--- a/.github/workflows/win-directml-x64-build.yml
+++ b/.github/workflows/win-directml-x64-build.yml
@@ -40,6 +40,16 @@ jobs:
         python-version: '3.11.x'
         architecture: 'x64'
 
+    - name: Setup VCPKG
+      uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+      with:
+        vcpkg-version: '2025.03.19'
+        vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+        cmake-version: '3.31.6'
+        cmake-hash: '0f1584e8666cf4a65ec514bd02afe281caabf1d45d2c963f3151c41484f457386aa03273ab25776a670be02725354ce0b46f3a5121857416da37366342a833a0'
+        add-cmake-to-path: 'true'
+        disable-terrapin: 'false'
+
     - name: Download OnnxRuntime Nightly
       shell: pwsh
       run: |


### PR DESCRIPTION
Pin cmake version(use the same github action as the main ort repo). To prevent sudden build breaks caused by updates of the  CI build machine images.