### PR TITLE
Use lazy tensor

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -538,16 +538,6 @@ class Model:
             size_threshold_bytes=0,
         )
 
-        # TODO(justinchuby): This makes the model not savable again when the weight
-        # files are deleted.
-        # Delete external data files on disk before re-saving
-        for path in os.listdir(self.cache_dir):
-            if path.endswith(".bin"):
-                try:
-                    os.remove(os.path.join(self.cache_dir, path))
-                except OSError:
-                    logger.debug("Error deleting file", stack_info=True)
-
         # Delete temporary cache dir if empty
         if not os.listdir(self.cache_dir):
             os.rmdir(self.cache_dir)
@@ -2325,7 +2315,7 @@ class Model:
                 cache_dir=self.cache_dir,
                 token=self.hf_token,
                 trust_remote_code=True,
-                torch_dtype="auto",
+                torch_dtype=torch.bfloat16,
                 **extra_kwargs,
             )
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -2315,7 +2315,7 @@ class Model:
                 cache_dir=self.cache_dir,
                 token=self.hf_token,
                 trust_remote_code=True,
-                torch_dtype=torch.bfloat16,
+                torch_dtype="auto",
                 **extra_kwargs,
             )
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -481,6 +481,8 @@ class Model:
             os.rmdir(self.cache_dir)
 
         model = self.as_ir_model()
+        # Make sure all nodes are topologically sorted
+        model.graph.sort()
 
         # Save ONNX model with only one external data file and delete any existing duplicate copies
         out_path = os.path.join(out_dir, self.filename)

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -2875,7 +2875,6 @@ class Gemma2Model(GemmaModel):
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
         super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
         self.attention_attrs["scale"] = config.query_pre_attn_scalar ** -0.5
-        self.lm_head_attrs["scale"] = config.final_logit_softcapping if config.final_logit_softcapping is not None else 1.0
         self.is_local = lambda layer_id: layer_id % 2 == 1
 
     def make_layer(self, layer_id, layer):

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -362,14 +362,14 @@ class Model:
             self.quant_attrs["use_g_idx"] = config.quantization_config["desc_act"] if "desc_act" in config.quantization_config else False
 
     def make_attention_init(self):
-        valid_gqa_configurations = [
+        valid_gqa_configurations = {
             ("cpu", ir.DataType.FLOAT),
             ("cuda", ir.DataType.FLOAT16),
             ("rocm", ir.DataType.FLOAT16),
             ("dml", ir.DataType.FLOAT16),
             ("webgpu", ir.DataType.FLOAT16),
             ("webgpu", ir.DataType.FLOAT),
-        ]
+        }
         if (self.ep, self.io_dtype) in valid_gqa_configurations:
             # Change model settings for GroupQueryAttention
             self.attention_attrs["op_type"] = "GroupQueryAttention"

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -13,15 +13,20 @@ import argparse
 import ast
 import gc
 import json
-import os
 import logging
+import os
 import textwrap
 from typing import Literal, Sequence
 
 import numpy as np
 import torch
 from onnxscript import ir
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    GenerationConfig,
+)
 
 try:
     # For users who runs this script from source

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -8,20 +8,20 @@
 Run this script to create the desired ONNX model.
 """
 from __future__ import annotations
-from typing import Sequence
-import ast
-
-from onnxruntime.quantization.matmul_4bits_quantizer import MatMul4BitsQuantizer, QuantFormat
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig
-import numpy as np
-import torch
-from onnxscript import ir
 
 import argparse
+import ast
 import gc
 import json
 import os
 import textwrap
+from typing import Sequence
+
+import numpy as np
+import torch
+from onnxruntime.quantization.matmul_4bits_quantizer import MatMul4BitsQuantizer, QuantFormat
+from onnxscript import ir
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig
 
 # NOTE: Avoid importing from onnx helper and numpy_helper. Instead, leverage
 # ONNX IR methods like ir.tensor, ir.DataType.numpy() and other methods for constructing

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -379,7 +379,7 @@ class Model:
 
         genai_config = {
             "model": {
-                "bos_token_id": config.bos_token_id if hasattr(config, "bos_token_id") and config.bos_token_id != None else 1,  # config.bos_token_id not present in ChatGLM model configs.
+                "bos_token_id": config.bos_token_id if hasattr(config, "bos_token_id") and config.bos_token_id is not None else 1,  # config.bos_token_id not present in ChatGLM model configs.
                 "context_length": self.context_length,
                 "decoder": {
                     "session_options" : {

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -652,18 +652,16 @@ class Model:
         # Add model-specific inputs to list of model inputs
         inputs = self._model.graph.inputs
         for name in self.input_names:
-            value = self._get_or_create_value(
-                name, dtype=self.input_types[name], shape=self.input_shapes[name]
-            )
-            inputs.append(value)
+            dtype = self.input_types[name]
+            shape = self.input_shapes[name]
+            inputs.append(self._get_or_create_value(name, dtype=dtype, shape=shape))
 
         # Add model-specific outputs to list of model outputs
         outputs = self._model.graph.outputs
         for name in self.output_names:
-            value = self._get_or_create_value(
-                name, dtype=self.output_types[name], shape=self.output_shapes[name]
-            )
-            outputs.append(value)
+            dtype = self.output_types[name]
+            shape = self.output_shapes[name]
+            outputs.append(self._get_or_create_value(name, dtype=dtype, shape=shape))
 
         # Add KV cache to inputs and outputs
         for i in range(self.num_layers):

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -3417,6 +3417,7 @@ def parse_hf_token(hf_token):
 def create_model(model_name, input_path, output_dir, precision, execution_provider, cache_dir, **extra_options):
     # Create cache and output directories
     os.makedirs(output_dir, exist_ok=True)
+    os.makedirs(cache_dir, exist_ok=True)
 
     # Load model config
     extra_kwargs = {} if os.path.isdir(input_path) else {"cache_dir": cache_dir}

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -102,8 +102,8 @@ class Model:
     def __init__(
         self,
         config,
-        io_dtype: Literal[ir.DataType.FLOAT, ir.DataType.FLOAT16],
-        onnx_dtype: Literal[ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.UINT4],
+        io_dtype: Literal[ir.DataType.FLOAT, ir.DataType.FLOAT16] | int,
+        onnx_dtype: Literal[ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.UINT4] | int,
         ep: str,
         cache_dir,
         extra_options,
@@ -122,8 +122,8 @@ class Model:
 
         self.model_name_or_path = config._name_or_path
         self.model_type = config.architectures[0]
-        self.io_dtype: ir.DataType = ir.DataType(io_dtype)  # {"fp16", "fp32"}
-        self.onnx_dtype: ir.DataType = ir.DataType(onnx_dtype)  # {"int4", "fp16", "fp32"}
+        self.io_dtype: ir.DataType = ir.DataType(io_dtype)
+        self.onnx_dtype: ir.DataType = ir.DataType(onnx_dtype)
         self.quant_type = config.quantization_config["quant_method"] if hasattr(config, "quantization_config") else None
         self.adapter_path = extra_options.get("adapter_path", None)
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -1693,14 +1693,14 @@ class Model:
         # Make MatMul node (output projection weight node)
         o_proj = 'o_proj' if hasattr(attention, 'o_proj') else 'dense'
         o_matmul_basename = f"/model/layers.{layer_id}/attn/o_proj/MatMul"
-        o_weight = eval(f"attention.{o_proj}")
+        o_weight = getattr(attention, o_proj)
         o_matmul_name = self.make_matmul(o_weight, o_matmul_basename, f"{attn_name}/output_0")
 
         # Make Add node (output projection bias node if bias exists)
-        o_bias_exists = eval(f"attention.{o_proj}.bias") is not None
+        o_bias_exists = getattr(attention, o_proj).bias is not None
         if o_bias_exists:
             o_add_name = f"/model/layers.{layer_id}/attn/o_proj/Add"
-            o_bias = eval(f"attention.{o_proj}.bias.numpy(force=True)")
+            o_bias = getattr(attention, o_proj).bias.numpy(force=True)
             self.make_add_bias(o_bias, o_add_name, root_input=f"{o_matmul_name}/output_0")
 
         # Assign output 0 of previous output node as skip input to next SkipLayerNorm

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -615,7 +615,7 @@ class Model:
         # status in the graph. The above checks can then decide whether the proposed node actually
         # needs to be added into the graph or not.
 
-    def make_value_info(self, name, dtype: int, shape: Sequence[int | str]) -> None:
+    def make_value_info(self, name, dtype: ir.DataType | int| None, shape: Sequence[int | str] | None) -> None:
         if name not in self._values:
             raise KeyError(f"Value {name} not found in model values. You must create the node before creating the value info.")
         if dtype is not None:

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -529,22 +529,26 @@ class Model:
     ) -> ir.Value | None:
         """Obtain an IR value by value name. If the value does not exist a new one is created.
 
+        If dtype and shape are provided, they will be set on the value.
+
         Args:
             name: The name of the value.
             output: Whether the value is an output value.
+            dtype: The data type of the value.
+            shape: The shape of the value.
         """
         if name == "":
             if not output:
                 return None
             else:
                 return ir.Value(name="")
-        value = ir.Value(name=name)
+
+        value = self._values.setdefault(name, ir.Value(name=name))
         if shape is not None:
             value.shape = ir.Shape(shape)
         if dtype is not None:
             value.dtype = ir.DataType(dtype)
-
-        return self._values.setdefault(name, value)
+        return value
 
     def as_ir_model(self) -> ir.Model:
         """Return the IR model."""
@@ -656,8 +660,6 @@ class Model:
             self._values[name].shape = ir.Shape(shape)
 
     def make_inputs_and_outputs(self):
-
-
         # Add model-specific inputs to list of model inputs
         inputs = self._model.graph.inputs
         for name in self.input_names:

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -565,7 +565,7 @@ class Model:
         initializer.const_value = ir_tensor
         initializer.dtype = ir.DataType(ir_tensor.dtype)
         initializer.shape = ir_tensor.shape
-        self._model.graph.initializers[name] = initializer
+        self._model.graph.register_initializer(initializer)
 
     def make_node(self, op_type, inputs: Sequence[str], outputs: Sequence[str], *, name, domain="", **kwargs):
         # Save any constants as nodes

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -576,6 +576,7 @@ class Model:
 
     def to_int4(self, model: ir.Model) -> ir.Model:
         # TODO(justinchuby): This function doesn't use self and should not be a method. Lift out
+        ir.external_data.load_to_model(model)
         quant = MatMul4BitsQuantizer(
             model=ir.to_proto(model),
             block_size=self.quant_attrs["int4"]["block_size"],

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -848,7 +848,7 @@ class Model:
         if hasattr(matmul, "g_idx") and matmul.g_idx is not None:
             g_idx = name[1:].replace("/", ".") + ".g_idx"
             self.make_external_tensor(
-                lambda: matmul.g_idx.numpy(force=True).astype(np.int32), g_idx
+                lambda: matmul.g_idx.numpy(force=True).astype(np.int32), g_idx,
                 dtype=ir.DataType.INT32, shape=matmul.g_idx.shape
             )
             inputs.append(g_idx)

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -10,7 +10,7 @@ Run this script to create the desired ONNX model.
 from __future__ import annotations
 from typing import Sequence
 
-from onnx import helper, numpy_helper, TensorProto
+from onnx import TensorProto
 from onnxruntime.quantization.matmul_4bits_quantizer import MatMul4BitsQuantizer, QuantFormat
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig
 import numpy as np
@@ -1404,7 +1404,7 @@ class Model:
         shape_2_name = f"{basename}/Shape_2"
         self.make_shape(shape_2_name, f"{reshape_2_name}/output_0", shape=[1])
         constant_shape_name = f"{basename}/ConstantOfShape"
-        constant_shape_value = numpy_helper.from_array(np.array([1], dtype="int64"))
+        constant_shape_value = ir.tensor([1], dtype=ir.DataType.INT64))
         self.make_constant_of_shape(constant_shape_name, f"{shape_2_name}/output_0", value=constant_shape_value, dtype=TensorProto.INT64, shape=[5])
         mul_2_name = f"{basename}/Mul"
         mul_2_inputs = [f"{constant_shape_name}/output_0", "/model/constants/TensorProto.INT64/0D/-1"]
@@ -2382,7 +2382,7 @@ class Model:
         self.make_concat(concat_2_name, concat_inputs, dtype=TensorProto.INT64, shape=[2], axis=0)
         constant_shape_name = f"{basename}/ConstantOfShape_2"
         constant_shape_numpy_dtype = self.io_dtype.numpy()
-        constant_shape_value = numpy_helper.from_array(np.array([np.finfo(constant_shape_numpy_dtype).min], dtype=constant_shape_numpy_dtype))
+        constant_shape_value = ir.tensor(np.array([np.finfo(constant_shape_numpy_dtype).min], dtype=constant_shape_numpy_dtype))
         self.make_constant_of_shape(constant_shape_name, f"{concat_2_name}/output_0", value=constant_shape_value, dtype=self.io_dtype, shape=['unk', 'unk'])
 
         # Top path
@@ -2533,7 +2533,7 @@ class Model:
         shape_3_name = f"{basename}/Shape_3"
         self.make_shape(shape_3_name, f"{concat_name}/output_0", shape=[1])
         constant_shape_name = f"{basename}/ConstantOfShape" if not input_ids_subgraph else f"{basename}/ConstantOfShape_1"
-        constant_shape_value = numpy_helper.from_array(np.array([1], dtype="int64"))
+        constant_shape_value = ir.tensor([1], dtype=ir.DataType.INT64)
         self.make_constant_of_shape(constant_shape_name, f"{shape_3_name}/output_0", value=constant_shape_value, dtype=TensorProto.INT64, shape=["unk"])
         mul_name = f"{basename}/Mul"
         mul_inputs = [f"{constant_shape_name}/output_0", "/model/constants/TensorProto.INT64/0D/-1"]

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -499,7 +499,9 @@ class Model:
         # status in the graph. The above checks can then decide whether the proposed node actually
         # needs to be added into the graph or not.
 
-    def make_value_info(self, name, dtype: int, shape: Sequence[int]):
+    def make_value_info(self, name, dtype: int, shape: Sequence[int | str]) -> None:
+        if name not in self._values:
+            raise KeyError(f"Value {name} not found in model values. You must create the node before creating the value info.")
         self._values[name].dtype = ir.DataType(dtype)
         self._values[name].shape = ir.Shape(shape)
 
@@ -538,6 +540,7 @@ class Model:
     def make_constant(self, name):
         # Make constant ops for 0, 1, 2, 3, etc.
         # Format of name is "/model/constants/{dtype}/{shape}/{num}"
+        # TODO(justinchuby): I am here
         path = name.split("/")
         onnx_dtype, dims, num = eval(path[-3]), path[-2], eval(path[-1])
         np_dtype = self.to_numpy_dtype[onnx_dtype]

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -808,7 +808,7 @@ class Model:
     def make_matmul_fp16_or_fp32(self, matmul, name, root_input, **kwargs):
         weight = name[1:].replace("/", ".") + ".weight"
         self.make_external_tensor(
-            lambda: matmul.weight.t().to(dtype=self.io_torch_dtype),
+            lambda: matmul.weight.detach().t().contiguous().to(dtype=self.io_torch_dtype),
             weight,
             dtype=self.io_dtype,
             shape=transpose_shape(matmul.weight.shape),
@@ -3654,4 +3654,9 @@ def get_args():
 if __name__ == '__main__':
     args = get_args()
     extra_options = parse_extra_options(args.extra_options)
+    # import pyinstrument
+    # profiler = pyinstrument.Profiler()
+    # profiler.start()
     create_model(args.model_name, args.input, args.output, args.precision, args.execution_provider, args.cache_dir, **extra_options)
+    # profiler.stop()
+    # profiler.print()

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -135,13 +135,6 @@ class Model:
         self.hf_token = parse_hf_token(extra_options.get("hf_token", "true"))
         self.extra_options = extra_options
 
-        # States for building the model
-        graph = ir.Graph([], [], nodes=[], name="main_graph")
-        # A tracer for recording the nodes added
-        # TODO(justinchuby): Bump IR version to 10
-        self._model = ir.Model(graph, ir_version=7, producer_name="onnxruntime-genai")
-        self._values: dict[str, ir.Value] = {}
-
         # EP-specific variables
         self.ep = ep
         self.ep_attrs = {
@@ -371,6 +364,22 @@ class Model:
             # Create quantized attributes from quantization config
             self.quant_attrs["config"] = config.quantization_config
             self.quant_attrs["use_g_idx"] = config.quantization_config["desc_act"] if "desc_act" in config.quantization_config else False
+
+        # States for building the model
+        graph = ir.Graph(
+            inputs=(),
+            outputs=(),
+            nodes=(),
+            opset_imports={
+                "": 21 if self.quant_attrs["use_qdq"] else 14,
+                "com.microsoft": 1,
+            },
+            name="main_graph",
+        )
+        # A tracer for recording the nodes added
+        # TODO(justinchuby): Bump IR version to 10
+        self._model = ir.Model(graph, ir_version=7, producer_name="onnxruntime-genai")
+        self._values: dict[str, ir.Value] = {}
 
     def make_attention_init(self):
         valid_gqa_configurations = {

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -3594,5 +3594,6 @@ def get_args():
 if __name__ == '__main__':
     args = get_args()
     extra_options = parse_extra_options(args.extra_options)
+    # Use tempfile.TemporaryDirectory to automatically clean up the cache directory
     with tempfile.TemporaryDirectory(dir=args.cache_dir, ignore_cleanup_errors=True) as temp_dir:
         create_model(args.model_name, args.input, args.output, args.precision, args.execution_provider, temp_dir, **extra_options)

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -475,7 +475,14 @@ class Model:
         # TODO: Replace by quantizing the MatMuls as they are created
         already_quantized_in_qdq_format = self.quant_type is not None and self.quant_attrs["use_qdq"]  # Skip quantizing `MatMul` in `DequantizeLinear --> Transpose --> MatMul` path
         if self.onnx_dtype == ir.DataType.UINT4 and not already_quantized_in_qdq_format:
-            model = builder_utils.to_int4(self._model)
+            model = builder_utils.to_int4(
+                self._model,
+                block_size=self.quant_attrs["int4"]["block_size"],
+                is_symmetric=self.quant_attrs["int4"]["is_symmetric"],
+                accuracy_level=self.quant_attrs["int4"]["accuracy_level"],
+                use_qdq=self.quant_attrs["use_qdq"],
+                op_types_to_quantize=self.quant_attrs["int4"]["op_types_to_quantize"],
+            )
         else:
             model = self._model
         return model

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -618,8 +618,10 @@ class Model:
     def make_value_info(self, name, dtype: int, shape: Sequence[int | str]) -> None:
         if name not in self._values:
             raise KeyError(f"Value {name} not found in model values. You must create the node before creating the value info.")
-        self._values[name].dtype = ir.DataType(dtype)
-        self._values[name].shape = ir.Shape(shape)
+        if dtype is not None:
+            self._values[name].dtype = ir.DataType(dtype)
+        if shape is not None:
+            self._values[name].shape = ir.Shape(shape)
 
     def make_inputs_and_outputs(self):
         inputs = self._model.graph.inputs

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -23,7 +23,11 @@ import torch
 from onnxscript import ir
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig
 
-import builder_utils
+try:
+    # For users who runs this script from source
+    import builder_utils
+except ImportError:
+    from onnxruntime_genai.models import builder_utils
 
 # NOTE: Avoid importing from onnx helper and numpy_helper. Instead, leverage
 # ONNX IR methods like ir.tensor, ir.DataType.numpy() and other methods for constructing

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -1442,7 +1442,7 @@ class Model:
         shape_2_name = f"{basename}/Shape_2"
         self.make_shape(shape_2_name, f"{reshape_2_name}/output_0", shape=[1])
         constant_shape_name = f"{basename}/ConstantOfShape"
-        constant_shape_value = ir.tensor([1], dtype=ir.DataType.INT64))
+        constant_shape_value = ir.tensor([1], dtype=ir.DataType.INT64)
         self.make_constant_of_shape(constant_shape_name, f"{shape_2_name}/output_0", value=constant_shape_value, dtype=ir.DataType.INT64, shape=[5])
         mul_2_name = f"{basename}/Mul"
         mul_2_inputs = [f"{constant_shape_name}/output_0", "/model/constants/TensorProto.INT64/0D/-1"]

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -702,7 +702,7 @@ class Model:
 
     def make_matmul_fp16_or_fp32(self, matmul, name, root_input, **kwargs):
         weight = name[1:].replace("/", ".") + ".weight"
-        self.make_external_tensor(matmul.weight.transpose().astype(self.to_numpy_dtype[self.io_dtype]), weight)
+        self.make_external_tensor(matmul.weight.detach().numpy().transpose().astype(self.to_numpy_dtype[self.io_dtype]), weight)
 
         last_dim = matmul.weight.shape[0]
         output = "logits" if kwargs.get("logits", False) else f"{name}/output_0"
@@ -722,20 +722,20 @@ class Model:
 
         # Input weights are quantized, save quantized MatMul numpy weights for onnx model
         weight = name[1:].replace("/", ".") + ".qweight"
-        self.make_external_tensor(matmul.qweight, weight)
+        self.make_external_tensor(matmul.qweight.detach().numpy(), weight)
         scales = name[1:].replace("/", ".") + ".scales"
-        self.make_external_tensor(matmul.scales.astype(self.to_numpy_dtype[self.io_dtype]), scales)
+        self.make_external_tensor(matmul.scales.detach().numpy().astype(self.to_numpy_dtype[self.io_dtype]), scales)
 
         inputs = [root_input, weight, scales]
 
         if hasattr(matmul, "qzeros") and matmul.qzeros is not None:
             zeros = name[1:].replace("/", ".") + ".qzeros"
-            self.make_external_tensor(matmul.qzeros, zeros)
+            self.make_external_tensor(matmul.qzeros.detach().numpy(), zeros)
             inputs.append(zeros)
 
         if hasattr(matmul, "g_idx") and matmul.g_idx is not None:
             g_idx = name[1:].replace("/", ".") + ".g_idx"
-            self.make_external_tensor(matmul.g_idx.astype(np.int32), g_idx)
+            self.make_external_tensor(matmul.g_idx.detach().numpy().astype(np.int32), g_idx)
             inputs.append(g_idx)
 
         output = "logits" if kwargs.get("logits", False) else f"{name}/output_0"
@@ -751,12 +751,12 @@ class Model:
     def make_dequantize_linear(self, dequantize_name, quantized_op):
         # Input weights are quantized, save quantized MatMul numpy weights for onnx model
         qweight = dequantize_name[1:].replace("/", ".") + ".qweight"
-        qweight_npy = quantized_op.qweight
+        qweight_npy = quantized_op.qweight.detach().numpy()
         qweight_npy = qweight_npy.reshape(*qweight_npy.shape[:-2], qweight_npy.shape[-2] * qweight_npy.shape[-1])
         self.make_external_tensor(qweight_npy, qweight, True)
 
         scales = dequantize_name[1:].replace("/", ".") + ".scales"
-        scales_npy = quantized_op.scales.astype(self.to_numpy_dtype[self.io_dtype])
+        scales_npy = quantized_op.scales.detach().numpy().astype(self.to_numpy_dtype[self.io_dtype])
         scales_npy = scales_npy.reshape(*qweight_npy.shape[:-1], qweight_npy.shape[-1] * 2 // quantized_op.group_size)
         self.make_external_tensor(scales_npy, scales)
 
@@ -764,7 +764,7 @@ class Model:
 
         if hasattr(quantized_op, "qzeros") and quantized_op.qzeros is not None:
             zeros = dequantize_name[1:].replace("/", ".") + ".qzeros"
-            zeros_npy = quantized_op.qzeros
+            zeros_npy = quantized_op.qzeros.detach().numpy()
             zeros_npy = zeros_npy.reshape(*qweight_npy.shape[:-1], qweight_npy.shape[-1] // quantized_op.group_size)
             self.make_external_tensor(zeros_npy, zeros, True)
             dequantize_inputs.append(zeros)
@@ -788,7 +788,7 @@ class Model:
         # compute quantized matmul when the weights are transposed. In most implementations, the transpose should usually be converted to a "transposeB"
         # attribute on the MatMul itself. A more natural way to represent this would have been to use Gemm since it already supports a transB attribute,
         # but unfortunately Gemm doesn't support batches.
-        qweight_shape = matmul.qweight.shape
+        qweight_shape = matmul.qweight.detach().numpy().shape
         transposed_shape = [qweight_shape[1] * qweight_shape[2] * 2, qweight_shape[0]]
         transpose_name = f"{matmul_name}/Transpose"
         self.make_transpose(transpose_name, dequantize_output, self.io_dtype, transposed_shape, [1, 0])
@@ -889,20 +889,20 @@ class Model:
 
         # Input weights are quantized, save quantized MatMul numpy weights for onnx model
         weight = name[1:].replace("/", ".") + ".qweight"
-        self.make_external_tensor(matmul.qweight, weight)
+        self.make_external_tensor(matmul.qweight.detach().numpy(), weight)
         scales = name[1:].replace("/", ".") + ".scales"
-        self.make_external_tensor(matmul.scales.astype(self.to_numpy_dtype[self.io_dtype]), scales)
+        self.make_external_tensor(matmul.scales.detach().numpy().astype(self.to_numpy_dtype[self.io_dtype]), scales)
 
         inputs = [root_input, weight, scales]
 
         if hasattr(matmul, "qzeros") and matmul.qzeros is not None:
             zeros = name[1:].replace("/", ".") + ".qzeros"
-            self.make_external_tensor(matmul.qzeros, zeros)
+            self.make_external_tensor(matmul.qzeros.detach().numpy(), zeros)
             inputs.append(zeros)
 
         if hasattr(matmul, "g_idx") and matmul.g_idx is not None:
             g_idx = name[1:].replace("/", ".") + ".g_idx"
-            self.make_external_tensor(matmul.g_idx.astype(np.int32), g_idx)
+            self.make_external_tensor(matmul.g_idx.detach().numpy().astype(np.int32), g_idx)
             inputs.append(g_idx)
 
         output = "logits" if kwargs.get("logits", False) else f"{name}/output_0"
@@ -964,10 +964,10 @@ class Model:
         skip_input = self.layernorm_attrs["skip_input"]
 
         weight = f"model.layers.{layer_id}.{location}_layernorm.weight"
-        self.make_external_tensor(layernorm.weight.astype(self.to_numpy_dtype[self.io_dtype]) + self.layernorm_attrs["add_offset"], weight)
+        self.make_external_tensor(layernorm.weight.detach().numpy().astype(self.to_numpy_dtype[self.io_dtype]) + self.layernorm_attrs["add_offset"], weight)
         bias = f"model.layers.{layer_id}.{location}_layernorm.bias"
         if not simple:
-            self.make_external_tensor(layernorm.bias.astype(self.to_numpy_dtype[self.io_dtype]), bias)
+            self.make_external_tensor(layernorm.bias.detach().numpy().astype(self.to_numpy_dtype[self.io_dtype]), bias)
 
         inputs = [root_input, skip_input, weight] if skip else [root_input, weight]
         if not simple:
@@ -1061,9 +1061,9 @@ class Model:
 
             # Slice cos/sin caches from (M, H) to (M, H/2)
             hidden_dim = cos_cache.shape[-1]
-            cos_cache = cos_cache.squeeze()[:, : (hidden_dim // 2)]
+            cos_cache = cos_cache.squeeze()[:, : (hidden_dim // 2)].detach().numpy()
             cos_cache = cos_cache.astype(self.to_numpy_dtype[self.io_dtype])
-            sin_cache = sin_cache.squeeze()[:, : (hidden_dim // 2)]
+            sin_cache = sin_cache.squeeze()[:, : (hidden_dim // 2)].detach().numpy()
             sin_cache = sin_cache.astype(self.to_numpy_dtype[self.io_dtype])
 
             # Slice cos/sin caches from (M, H/2) to (M, R/2) if partial rotary embeddings are used
@@ -1200,7 +1200,7 @@ class Model:
         q_layernorm_name = f"/model/layers.{layer_id}/attn/q_norm/SimplifiedLayerNormalization"
         q_weight_name = f"model.layers.{layer_id}.attn.q_norm.layernorm.weight"
         q_layernorm_output = f"{q_layernorm_name}/output_0"
-        self.make_external_tensor(attention.q_norm.weight.astype(self.to_numpy_dtype[self.io_dtype]) + self.layernorm_attrs["add_offset"], q_weight_name)
+        self.make_external_tensor(attention.q_norm.weight.detach().numpy().astype(self.to_numpy_dtype[self.io_dtype]) + self.layernorm_attrs["add_offset"], q_weight_name)
         self.make_node("SimplifiedLayerNormalization", inputs=[q_reshape_1_output, q_weight_name], outputs=[q_layernorm_output], name=q_layernorm_name, **layernorm_kwargs)
         self.make_value_info(q_layernorm_output, dtype=self.io_dtype, shape=['batch_size', 'sequence_length * num_attention_heads', self.head_size])
 
@@ -1219,7 +1219,7 @@ class Model:
         k_layernorm_name = f"/model/layers.{layer_id}/attn/k_norm/SimplifiedLayerNormalization"
         k_weight_name = f"model.layers.{layer_id}.attn.k_norm.layernorm.weight"
         k_layernorm_output = f"{k_layernorm_name}/output_0"
-        self.make_external_tensor(attention.k_norm.weight.astype(self.to_numpy_dtype[self.io_dtype]) + self.layernorm_attrs["add_offset"], k_weight_name)
+        self.make_external_tensor(attention.k_norm.weight.detach().numpy().astype(self.to_numpy_dtype[self.io_dtype]) + self.layernorm_attrs["add_offset"], k_weight_name)
         self.make_node("SimplifiedLayerNormalization", inputs=[k_reshape_1_output, k_weight_name], outputs=[k_layernorm_output], name=k_layernorm_name, **layernorm_kwargs)
         self.make_value_info(k_layernorm_output, dtype=self.io_dtype, shape=['batch_size', 'sequence_length * num_key_value_heads', self.head_size])
 
@@ -1532,20 +1532,20 @@ class Model:
         if all_bias_exists and self.attention_attrs["use_packed_matmul"]:
             # Combine 3 Adds into 1 packed Add
             qkv_add_name = f"/model/layers.{layer_id}/attn/qkv_proj/Add"
-            self.make_packed_add(attention.q_proj.bias, attention.k_proj.bias, attention.v_proj.bias, qkv_add_name, root_input=self.attention_attrs["q_path"])
+            self.make_packed_add(attention.q_proj.bias.detach().numpy(), attention.k_proj.bias.detach().numpy(), attention.v_proj.bias.detach().numpy(), qkv_add_name, root_input=self.attention_attrs["q_path"])
             self.attention_attrs["q_path"] = f"{qkv_add_name}/output_0"
         else:
             if q_bias_exists:
                 q_add_name = f"/model/layers.{layer_id}/attn/q_proj/Add"
-                self.make_add_bias(attention.q_proj.bias, q_add_name, root_input=self.attention_attrs["q_path"])
+                self.make_add_bias(attention.q_proj.bias.detach().numpy(), q_add_name, root_input=self.attention_attrs["q_path"])
                 self.attention_attrs["q_path"] = f"{q_add_name}/output_0"
             if k_bias_exists:
                 k_add_name = f"/model/layers.{layer_id}/attn/k_proj/Add"
-                self.make_add_bias(attention.k_proj.bias, k_add_name, root_input=self.attention_attrs["k_path"])
+                self.make_add_bias(attention.k_proj.bias.detach().numpy(), k_add_name, root_input=self.attention_attrs["k_path"])
                 self.attention_attrs["k_path"] = f"{k_add_name}/output_0"
             if v_bias_exists:
                 v_add_name = f"/model/layers.{layer_id}/attn/v_proj/Add"
-                self.make_add_bias(attention.v_proj.bias, v_add_name, root_input=self.attention_attrs["v_path"])
+                self.make_add_bias(attention.v_proj.bias.detach().numpy(), v_add_name, root_input=self.attention_attrs["v_path"])
                 self.attention_attrs["v_path"] = f"{v_add_name}/output_0"
 
         # Make Q/K SimplifiedLayerNorm nodes
@@ -1592,7 +1592,7 @@ class Model:
         o_bias_exists = eval(f"attention.{o_proj}.bias") is not None
         if o_bias_exists:
             o_add_name = f"/model/layers.{layer_id}/attn/o_proj/Add"
-            o_bias = eval(f"attention.{o_proj}.bias")
+            o_bias = eval(f"attention.{o_proj}.bias.detach().numpy()")
             self.make_add_bias(o_bias, o_add_name, root_input=f"{o_matmul_name}/output_0")
 
         # Assign output 0 of previous output node as skip input to next SkipLayerNorm
@@ -1781,7 +1781,7 @@ class Model:
         gate_name = gate_matmul_name
         if gate_bias_exists:
             gate_add_name = f"/model/layers.{layer_id}/mlp/gate_proj/Add"
-            self.make_add_bias(mlp.gate_proj.bias, gate_add_name, root_input=f"{gate_name}/output_0")
+            self.make_add_bias(mlp.gate_proj.bias.detach().numpy(), gate_add_name, root_input=f"{gate_name}/output_0")
             gate_name = gate_add_name
 
         # Make Up proj nodes
@@ -1790,7 +1790,7 @@ class Model:
         up_name = up_matmul_name
         if up_bias_exists:
             up_add_name = f"/model/layers.{layer_id}/mlp/up_proj/Add"
-            self.make_add_bias(mlp.up_proj.bias, up_add_name, root_input=f"{up_name}/output_0")
+            self.make_add_bias(mlp.up_proj.bias.detach().numpy(), up_add_name, root_input=f"{up_name}/output_0")
             up_name = up_add_name
 
         # Make activation node(s)
@@ -1807,7 +1807,7 @@ class Model:
         down_name = down_matmul_name
         if down_bias_exists:
             down_add_name = f"/model/layers.{layer_id}/mlp/down_proj/Add"
-            self.make_add_bias(mlp.down_proj.bias, down_add_name, root_input=f"{down_name}/output_0")
+            self.make_add_bias(mlp.down_proj.bias.detach().numpy(), down_add_name, root_input=f"{down_name}/output_0")
             down_name = down_add_name
 
         # Assign output 0 of previous MatMul as skip input to next SkipLayerNorm
@@ -1838,7 +1838,7 @@ class Model:
         fc1_name = fc1_matmul_name
         if fc1_bias_exists:
             fc1_add_name = f"/model/layers.{layer_id}/mlp/fc1/Add"
-            self.make_add_bias(mlp.fc1.bias, fc1_add_name, root_input=f"{fc1_name}/output_0")
+            self.make_add_bias(mlp.fc1.bias.detach().numpy(), fc1_add_name, root_input=f"{fc1_name}/output_0")
             fc1_name = fc1_add_name
 
         # Make activation function
@@ -1850,7 +1850,7 @@ class Model:
         fc2_name = fc2_matmul_name
         if fc2_bias_exists:
             fc2_add_name = f"/model/layers.{layer_id}/mlp/fc2/Add"
-            self.make_add_bias(mlp.fc2.bias, fc2_add_name, root_input=f"{fc2_name}/output_0")
+            self.make_add_bias(mlp.fc2.bias.detach().numpy(), fc2_add_name, root_input=f"{fc2_name}/output_0")
             fc2_name = fc2_add_name
 
         # Assign output 0 of MLP layer as output of last layer
@@ -1950,7 +1950,7 @@ class Model:
         moe_expert_scales_3_name = f"model.layers.{layer_id}.moe.scales_3"
 
         def make_moe_external_tensor(w_list, moe_expert_name, numpy_type):
-            moe_experts_weight = torch.stack(w_list, dim=0)
+            moe_experts_weight = torch.stack(w_list, dim=0).detach().numpy()
             self.make_external_tensor(moe_experts_weight.astype(numpy_type), moe_expert_name)
 
         make_moe_external_tensor(w1_list, moe_expert_weight_1_name, np.uint8)
@@ -2058,7 +2058,7 @@ class Model:
 
         if bias_exists:
             add_name = "/lm_head/Add"
-            self.make_add_bias(lm_head.bias, add_name, root_input=f"{lm_name}/output_0", logits=not(scale_exists or mask_exists or softcap_exists))
+            self.make_add_bias(lm_head.bias.detach().numpy(), add_name, root_input=f"{lm_name}/output_0", logits=not(scale_exists or mask_exists or softcap_exists))
             lm_name = add_name
 
         if scale_exists:
@@ -2072,7 +2072,7 @@ class Model:
         if mask_exists:
             # Save logits mask as initializer
             logits_mask_name = "logits_mask"
-            self.make_external_tensor(self.lm_head_attrs["mask"], logits_mask_name)
+            self.make_external_tensor(self.lm_head_attrs["mask"].detach().numpy(), logits_mask_name)
 
             where_name = "/lm_head/Where"
             where_inputs = [logits_mask_name, f"/model/constants/{self.to_str_dtype[self.io_dtype]}/0D/{np.finfo(self.to_numpy_dtype[self.io_dtype]).min}", f"{lm_name}/output_0"]
@@ -2160,7 +2160,7 @@ class Model:
                 if not self.exclude_embeds:
                     # Embedding layer
                     print("Reading embedding layer")
-                    self.make_embedding(module.weight)
+                    self.make_embedding(module.weight.detach().numpy())
                 else:
                     # Exclude embedding layer from model
                     self.layernorm_attrs["root_input"] = "inputs_embeds"
@@ -2792,9 +2792,9 @@ class Phi3MiniLongRoPEModel(Phi3MiniModel):
 
             # Slice cos/sin caches from (M, H) to (M, H/2)
             hidden_dim = cos_cache.shape[-1]
-            cos_cache = cos_cache.squeeze()[:, : (hidden_dim // 2)]
+            cos_cache = cos_cache.squeeze()[:, : (hidden_dim // 2)].detach().numpy()
             cos_cache = cos_cache.astype(self.to_numpy_dtype[self.io_dtype])
-            sin_cache = sin_cache.squeeze()[:, : (hidden_dim // 2)]
+            sin_cache = sin_cache.squeeze()[:, : (hidden_dim // 2)].detach().numpy()
             sin_cache = sin_cache.astype(self.to_numpy_dtype[self.io_dtype])
 
             # Slice cos/sin caches from (M, H/2) to (M, R/2) if partial rotary embeddings are used
@@ -2885,11 +2885,11 @@ class Phi3SmallModel(Model):
 
         # Create tensors for row indices and col indices
         crows_name = "block_row_indices"
-        self.make_external_tensor(crows.astype(np.int32), crows_name)
+        self.make_external_tensor(crows.detach().numpy().astype(np.int32), crows_name)
         self.mask_attrs["block_row_indices"] = crows_name
 
         cols_name = "block_col_indices"
-        self.make_external_tensor(cols.astype(np.int32), cols_name)
+        self.make_external_tensor(cols.detach().numpy().astype(np.int32), cols_name)
         self.mask_attrs["block_col_indices"] = cols_name
 
     def make_attention(self, layer_id, attention, root_input, **kwargs):
@@ -2962,7 +2962,7 @@ class Phi3SmallModel(Model):
         up_matmul_name = f"/model/layers.{layer_id}/mlp/up_proj/MatMul"
         self.make_matmul(mlp.up_proj, up_matmul_name, root_input)
         up_add_name = f"/model/layers.{layer_id}/mlp/up_proj/Add"
-        self.make_add_bias(mlp.up_proj.bias, up_add_name, f"{up_matmul_name}/output_0")
+        self.make_add_bias(mlp.up_proj.bias.detach().numpy(), up_add_name, f"{up_matmul_name}/output_0")
 
         # Left path
         slice_1_name = f"/model/layers.{layer_id}/mlp/gelu/Slice"
@@ -3008,7 +3008,7 @@ class Phi3SmallModel(Model):
         down_matmul_name = f"/model/layers.{layer_id}/mlp/down_proj/MatMul"
         self.make_matmul(mlp.down_proj, down_matmul_name, f"{mul_name}/output_0")
         down_add_name = f"/model/layers.{layer_id}/mlp/down_proj/Add"
-        self.make_add_bias(mlp.down_proj.bias, down_add_name, f"{down_matmul_name}/output_0")
+        self.make_add_bias(mlp.down_proj.bias.detach().numpy(), down_add_name, f"{down_matmul_name}/output_0")
 
         # Assign output 0 of previous MatMul as skip input to next SkipLayerNorm
         self.layernorm_attrs["skip_input"] = f"{down_add_name}/output_0"

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -530,7 +530,7 @@ class Model:
         # Quantize ONNX model to desired precision
         # TODO: Replace by quantizing the MatMuls as they are created
         already_quantized_in_qdq_format = self.quant_type is not None and self.quant_attrs["use_qdq"]  # Skip quantizing `MatMul` in `DequantizeLinear --> Transpose --> MatMul` path
-        if self.onnx_dtype == ir.DataType.INT4 and not already_quantized_in_qdq_format:
+        if self.onnx_dtype == ir.DataType.UINT4 and not already_quantized_in_qdq_format:
             model = self.to_int4(self._model)
         else:
             model = self._model

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -3594,5 +3594,5 @@ def get_args():
 if __name__ == '__main__':
     args = get_args()
     extra_options = parse_extra_options(args.extra_options)
-    with tempfile.TemporaryDirectory(dir=args.cache_dir) as temp_dir:
+    with tempfile.TemporaryDirectory(dir=args.cache_dir, ignore_cleanup_errors=True) as temp_dir:
         create_model(args.model_name, args.input, args.output, args.precision, args.execution_provider, temp_dir, **extra_options)

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -2262,14 +2262,14 @@ class Model:
 
         if softcap_exists:
             # Add final logit softcapping (Div --> Tanh --> Mul)
-            div_name = "/lm_head/Div"
+            div_name = "/lm_head/softcap/Div"
             div_inputs = [f"{lm_name}/output_0", f"/model/constants/{self.to_str_dtype[self.io_dtype]}/0D/{self.lm_head_attrs['softcap']}"]
             self.make_div(div_name, div_inputs, dtype=self.io_dtype, shape=['batch_size', 'sequence_length', self.vocab_size])
 
-            tanh_name = "/lm_head/Tanh"
+            tanh_name = "/lm_head/softcap/Tanh"
             self.make_tanh(tanh_name, f"{div_name}/output_0", dtype=self.io_dtype, shape=['batch_size', 'sequence_length', self.vocab_size])
 
-            mul_name = "/lm_head/Mul"
+            mul_name = "/lm_head/softcap/Mul"
             mul_inputs = [f"{tanh_name}/output_0", f"/model/constants/{self.to_str_dtype[self.io_dtype]}/0D/{self.lm_head_attrs['softcap']}"]
             mul_output = "logits"
             self.make_node('Mul', inputs=mul_inputs, outputs=[mul_output], name=mul_name)

--- a/src/python/py/models/builder_utils.py
+++ b/src/python/py/models/builder_utils.py
@@ -94,21 +94,29 @@ def unpack_uint4(data: np.ndarray, dims: Sequence[int]) -> np.ndarray:
     return _unpack_uint4_as_uint8(data, dims).view(ml_dtypes.uint4)
 
 
-def to_int4(model: ir.Model) -> ir.Model:
+def to_int4(
+    model: ir.Model,
+    *,
+    block_size: int,
+    is_symmetric: bool,
+    accuracy_level: int,
+    use_qdq: bool,
+    op_types_to_quantize: tuple[str, ...],
+) -> ir.Model:
     """Quantize the model to int4."""
     ir.external_data.load_to_model(model)
     quant = matmul_4bits_quantizer.MatMul4BitsQuantizer(
         model=ir.to_proto(model),
-        block_size=self.quant_attrs["int4"]["block_size"],
-        is_symmetric=self.quant_attrs["int4"]["is_symmetric"],
-        accuracy_level=self.quant_attrs["int4"]["accuracy_level"],
+        block_size=block_size,
+        is_symmetric=is_symmetric,
+        accuracy_level=accuracy_level,
         nodes_to_exclude=[],
         quant_format=(
             matmul_4bits_quantizer.QuantFormat.QDQ
-            if self.quant_attrs["use_qdq"]
+            if use_qdq
             else matmul_4bits_quantizer.QuantFormat.QOperator
         ),
-        op_types_to_quantize=self.quant_attrs["int4"]["op_types_to_quantize"],
+        op_types_to_quantize=op_types_to_quantize,
     )
     quant.process()
     return ir.from_proto(quant.model.model)

--- a/src/python/py/models/builder_utils.py
+++ b/src/python/py/models/builder_utils.py
@@ -1,0 +1,114 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from __future__ import annotations
+
+__all__ = ["tensor_proto_string_to_dtype", "unpack_uint4", "to_int4"]
+
+from typing import Sequence
+
+import ml_dtypes
+import numpy as np
+from onnxscript import ir
+from onnxruntime.quantization import matmul_4bits_quantizer
+
+
+_TENSOR_PROTO_STRING_TO_DTYPE = {
+    "TensorProto.UNDEFINED": ir.DataType.UNDEFINED,
+    "TensorProto.FLOAT": ir.DataType.FLOAT,
+    "TensorProto.UINT8": ir.DataType.UINT8,
+    "TensorProto.INT8": ir.DataType.INT8,
+    "TensorProto.UINT16": ir.DataType.UINT16,
+    "TensorProto.INT16": ir.DataType.INT16,
+    "TensorProto.INT32": ir.DataType.INT32,
+    "TensorProto.INT64": ir.DataType.INT64,
+    "TensorProto.STRING": ir.DataType.STRING,
+    "TensorProto.BOOL": ir.DataType.BOOL,
+    "TensorProto.FLOAT16": ir.DataType.FLOAT16,
+    "TensorProto.DOUBLE": ir.DataType.DOUBLE,
+    "TensorProto.UINT32": ir.DataType.UINT32,
+    "TensorProto.UINT64": ir.DataType.UINT64,
+    "TensorProto.COMPLEX64": ir.DataType.COMPLEX64,
+    "TensorProto.COMPLEX128": ir.DataType.COMPLEX128,
+    "TensorProto.BFLOAT16": ir.DataType.BFLOAT16,
+    "TensorProto.FLOAT8E4M3FN": ir.DataType.FLOAT8E4M3FN,
+    "TensorProto.FLOAT8E4M3FNUZ": ir.DataType.FLOAT8E4M3FNUZ,
+    "TensorProto.FLOAT8E5M2": ir.DataType.FLOAT8E5M2,
+    "TensorProto.FLOAT8E5M2FNUZ": ir.DataType.FLOAT8E5M2FNUZ,
+    "TensorProto.UINT4": ir.DataType.UINT4,
+    "TensorProto.INT4": ir.DataType.INT4,
+    "TensorProto.FLOAT4E2M1": ir.DataType.FLOAT4E2M1,
+}
+
+
+def tensor_proto_string_to_dtype(tensor_proto_string: str) -> ir.DataType:
+    """Convert a TensorProto string to an ir.DataType.
+
+    Args:
+        tensor_proto_string: A string representing the TensorProto type.
+
+    Returns:
+        The corresponding ir.DataType.
+    """
+    if tensor_proto_string not in _TENSOR_PROTO_STRING_TO_DTYPE:
+        raise ValueError(f"Unsupported TensorProto string: {tensor_proto_string}")
+    return _TENSOR_PROTO_STRING_TO_DTYPE[tensor_proto_string]
+
+
+def _unpack_uint4_as_uint8(data: np.ndarray, dims: Sequence[int]) -> np.ndarray:
+    """Convert a packed uint4 array to unpacked uint4 array represented as uint8.
+
+    Args:
+        data: A numpy array.
+        dims: The dimensions are used to reshape the unpacked buffer.
+
+    Returns:
+        A numpy array of int8/uint8 reshaped to dims.
+    """
+    result = np.empty([data.size * 2], dtype=data.dtype)
+    array_low = data & np.uint8(0x0F)
+    array_high = data & np.uint8(0xF0)
+    array_high >>= np.uint8(4)
+    result[0::2] = array_low
+    result[1::2] = array_high
+    if result.size == np.prod(dims) + 1:
+        # handle single-element padding due to odd number of elements
+        result = result[:-1]
+    result.resize(dims, refcheck=False)
+    return result
+
+
+def unpack_uint4(data: np.ndarray, dims: Sequence[int]) -> np.ndarray:
+    """Convert a packed uint4 array to unpacked uint4 array represented as uint8.
+
+    Args:
+        data: A numpy array.
+        dims: The dimensions are used to reshape the unpacked buffer.
+
+    Returns:
+        A numpy array of int8/uint8 reshaped to dims.
+    """
+    data = data.view(np.uint8).flatten()
+    return _unpack_uint4_as_uint8(data, dims).view(ml_dtypes.uint4)
+
+
+def to_int4(model: ir.Model) -> ir.Model:
+    """Quantize the model to int4."""
+    ir.external_data.load_to_model(model)
+    quant = matmul_4bits_quantizer.MatMul4BitsQuantizer(
+        model=ir.to_proto(model),
+        block_size=self.quant_attrs["int4"]["block_size"],
+        is_symmetric=self.quant_attrs["int4"]["is_symmetric"],
+        accuracy_level=self.quant_attrs["int4"]["accuracy_level"],
+        nodes_to_exclude=[],
+        quant_format=(
+            matmul_4bits_quantizer.QuantFormat.QDQ
+            if self.quant_attrs["use_qdq"]
+            else matmul_4bits_quantizer.QuantFormat.QOperator
+        ),
+        op_types_to_quantize=self.quant_attrs["int4"]["op_types_to_quantize"],
+    )
+    quant.process()
+    return ir.from_proto(quant.model.model)

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -6,5 +6,6 @@ protobuf==5.27
 sympy
 pytest
 onnx
+onnxscript>=0.2.5
 transformers
 huggingface_hub[cli]


### PR DESCRIPTION
- Use LazyTensor to avoid having the store to disk.
- Load model in native dtype with `torch_dtype="auto"` to avoid the cast overhead when loading the model.
- The end result is 6.7 GB of peak memory usage (75% reduction) w/o needing temp disk space & 28% reduction in export time
- Memory needed for a model is (size of the weights + max(size of individual weight) * 3)

![image](https://github.com/user-attachments/assets/6d263d6f-b8f4-44ca-b0de-597d78d1f7c3)

## With a bigger model (google/gemma-3-12b-it) (model size 22.7 GB):

Time: 0:14:38 -> 0:01:57 (87% reduction) Memory: 190.5 -> 35.3 (81% reduction)

(left: current main, right: with IR and lazy tensor)


![image](https://github.com/user-attachments/assets/2d19820d-1e87-405f-a75d-4e2f5c71475e)

![image](https://github.com/user-attachments/assets/a46aaafa-af68-4c93-bd98-af5edf451b98)

### Compare with gguf conversion tool

![image](https://github.com/user-attachments/assets/51d6373d-879f-4f50-b9b6-71a191991bd4)
