### PR TITLE
Missed an all lowercase "webgpu" string

### DIFF
--- a/src/runtime_settings.cpp
+++ b/src/runtime_settings.cpp
@@ -13,7 +13,7 @@ std::string RuntimeSettings::GenerateConfigOverlay() const {
       "session_options": {
         "provider_options": [
           {
-            "webgpu": {
+            "WebGPU": {
               "dawnProcTable": ")";
   constexpr std::string_view webgpu_overlay_post = R"("
             }


### PR DESCRIPTION
This is in code we should deprecate going forward but it's breaking an existing case and this is the quickest fix.