### PR TITLE
Persist provider options across ClearProviders, AppendProvider where possible

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -74,6 +74,7 @@ struct Config {
     std::vector<NamedString> config_entries;  // Entries go into OrtSessionOptions::AddConfigEntry
 
     std::vector<ProviderOptions> provider_options;
+    std::vector<ProviderOptions> provider_options_backup;
     std::optional<GraphOptimizationLevel> graph_optimization_level;
   };
 


### PR DESCRIPTION
Currently, most applications will ClearProviders and AppendProvider to change the execution provider at runtime to the desired EP. While doing this, the provider options listed in the genai config.json are lost.

Some models, require a provider options to run correctly. So, doing `ClearProviders` and then doing `AppendProvider` does not work since the options are lost in the process.

This pull-request will enable persisting the provider options through a backup in case user tries to add a provider already mentioned in the genai_config.json.