### PR TITLE
Add enable_skip_layer_norm_strict_mode flag

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -67,6 +67,7 @@ class Model:
             "cpu": {},
             "cuda": {
                 "enable_cuda_graph": "1" if extra_options.get("enable_cuda_graph", False) else "0",              # "1" if the model is able to enable cuda graph, "0" otherwise
+                "enable_skip_layer_norm_strict_mode": "1"
             },
             "rocm": {
                 "tunable_op_enable": "1",


### PR DESCRIPTION
Model quality for various models suffers due to layer norms being calculated in a lower precision. This fixes the problem.