### PR TITLE
Fix array eos_token_id handling

### DIFF
--- a/src/beam_search_scorer.cpp
+++ b/src/beam_search_scorer.cpp
@@ -122,7 +122,7 @@ void BeamSearchScorer::Process(Sequences& sequences,
 
       int const batch_beam_idx = static_cast<int>(batch * num_beams_) + next_index;
       // Add to generated hypotheses if end of sentence.
-      if ((eos_token_id_ >= 0) && (next_token == eos_token_id_)) {
+      if (contains(eos_token_id_, next_token)) {
         bool const is_beam_token_worse_than_top_num_beams = (j >= num_beams_);
         if (is_beam_token_worse_than_top_num_beams) {
           continue;

--- a/src/beam_search_scorer.h
+++ b/src/beam_search_scorer.h
@@ -53,7 +53,7 @@ struct BeamSearchScorer {
   int num_beams_;
   int max_length_;
   int pad_token_id_;
-  int eos_token_id_;
+  std::vector<int> eos_token_id_;
   bool early_stopping_;
   int not_done_count_;  // When zero, every batch entry is done (starts at batch_size_)
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -31,6 +31,18 @@ struct NamedStrings_Element : JSON::Element {
   std::vector<Config::NamedString>& v_;
 };
 
+struct Int_Array_Element : JSON::Element {
+  explicit Int_Array_Element(std::vector<int>& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    v_.emplace_back(static_cast<int>(JSON::Get<double>(value)));
+  }
+
+ private:
+  std::vector<int>& v_;
+};
+
+
 struct ProviderOptionsObject_Element : JSON::Element {
   explicit ProviderOptionsObject_Element(std::vector<Config::ProviderOptions>& v) : v_{v} {}
 
@@ -509,29 +521,6 @@ struct Speech_Element : JSON::Element {
   SpeechOutputs_Element outputs_{v_.outputs};
 };
 
-struct Eos_Array_Element : JSON::Element {
-  explicit Eos_Array_Element(Config::Model& v) : v_{v} {}
-
-  void OnValue(std::string_view name, JSON::Value value) override {
-    v_.eos_token_ids.push_back(static_cast<int>(JSON::Get<double>(value)));
-  }
-
-  void OnComplete(bool empty) override {
-    if (v_.eos_token_ids.empty())
-      return;  // Empty array, nothign to do
-
-    // Copy the first eos_token_id into the eos_token_id value, it will be our primary eos token
-    v_.eos_token_id = v_.eos_token_ids.front();
-
-    // If the array is just one value, clear the array and just act like a single value was set
-    if (v_.eos_token_ids.size() == 1)
-      v_.eos_token_ids.clear();
-  }
-
- private:
-  Config::Model& v_;
-};
-
 struct EmbeddingInputs_Element : JSON::Element {
   explicit EmbeddingInputs_Element(Config::Model::Embedding::Inputs& v) : v_{v} {}
 
@@ -634,7 +623,7 @@ struct Model_Element : JSON::Element {
     } else if (name == "pad_token_id") {
       v_.pad_token_id = static_cast<int>(JSON::Get<double>(value));
     } else if (name == "eos_token_id") {
-      v_.eos_token_id = static_cast<int>(JSON::Get<double>(value));
+      v_.eos_token_id.assign(1, static_cast<int>(JSON::Get<double>(value)));
     } else if (name == "bos_token_id") {
       v_.bos_token_id = static_cast<int>(JSON::Get<double>(value));
     } else if (name == "decoder_start_token_id") {
@@ -647,7 +636,7 @@ struct Model_Element : JSON::Element {
 
   Element& OnArray(std::string_view name) override {
     if (name == "eos_token_id")
-      return eos_token_ids_;
+      return eos_token_id_;
     throw JSON::unknown_value_error{};
   }
 
@@ -677,7 +666,7 @@ struct Model_Element : JSON::Element {
   Config::Model& v_;
   EncoderDecoderInit_Element encoder_decoder_init_{v_.encoder_decoder_init};
   Decoder_Element decoder_{v_.decoder};
-  Eos_Array_Element eos_token_ids_{v_};
+  Int_Array_Element eos_token_id_{v_.eos_token_id};
   Vision_Element vision_{v_.vision};
   Embedding_Element embedding_{v_.embedding};
   PromptTemplates_Element prompt_templates_{v_.prompt_templates};
@@ -858,6 +847,10 @@ Config::Config(const fs::path& path, std::string_view json_overlay) : config_pat
 
   if (search.max_length == 0)
     search.max_length = model.context_length;
+
+  // If no eos_token_id was set, set it to the pad token id
+  if (model.eos_token_id.empty())
+    model.eos_token_id.push_back(model.pad_token_id);
 }
 
 void Config::AddMapping(const std::string& nominal_name, const std::string& graph_name) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -42,7 +42,6 @@ struct Int_Array_Element : JSON::Element {
   std::vector<int>& v_;
 };
 
-
 struct ProviderOptionsObject_Element : JSON::Element {
   explicit ProviderOptionsObject_Element(std::vector<Config::ProviderOptions>& v) : v_{v} {}
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -703,11 +703,8 @@ void ClearProviders(Config& config) {
 }
 
 void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value) {
-  if (std::find(config.model.decoder.session_options.providers.begin(),
-                config.model.decoder.session_options.providers.end(), provider_name) ==
-      config.model.decoder.session_options.providers.end()) {
+  if (!contains(config.model.decoder.session_options.providers, provider_name))
     config.model.decoder.session_options.providers.push_back(std::string(provider_name));
-  }
 
   std::ostringstream json;
   json << R"({")" << provider_name << R"(":{)";

--- a/src/config.h
+++ b/src/config.h
@@ -81,11 +81,11 @@ struct Config {
   struct Model {
     std::string type;
 
-    int pad_token_id{};              // The id of the padding token.
-    std::vector<int> eos_token_id;   // The end-of-stream tokens (when set as a single value it is converted to a vector with one value).
-    int bos_token_id{};              // The id of the beginning-of-stream token.
-    int sep_token_id{};              // The id of the separation token.
-    int decoder_start_token_id{};    // If an encoder-decoder model starts decoding with a different token than bos, the id of that token.
+    int pad_token_id{};             // The id of the padding token.
+    std::vector<int> eos_token_id;  // The end-of-stream tokens (when set as a single value it is converted to a vector with one value).
+    int bos_token_id{};             // The id of the beginning-of-stream token.
+    int sep_token_id{};             // The id of the separation token.
+    int decoder_start_token_id{};   // If an encoder-decoder model starts decoding with a different token than bos, the id of that token.
     int vocab_size{};
     int context_length{};
 

--- a/src/config.h
+++ b/src/config.h
@@ -82,8 +82,7 @@ struct Config {
     std::string type;
 
     int pad_token_id{};              // The id of the padding token.
-    int eos_token_id{};              // The id of the end-of-stream token.
-    std::vector<int> eos_token_ids;  // If eos_token_id is passed as an array, this is where the values go (eos_token_id gets set to the first entry in the array)
+    std::vector<int> eos_token_id;   // The end-of-stream tokens (when set as a single value it is converted to a vector with one value).
     int bos_token_id{};              // The id of the beginning-of-stream token.
     int sep_token_id{};              // The id of the separation token.
     int decoder_start_token_id{};    // If an encoder-decoder model starts decoding with a different token than bos, the id of that token.

--- a/src/cuda/beam_search_scorer_cuda.cuh
+++ b/src/cuda/beam_search_scorer_cuda.cuh
@@ -32,7 +32,6 @@ struct BeamScorerState {
   int num_beams_;
   int max_length_;
   int pad_token_id_;
-  int eos_token_id_;
   bool early_stopping_;
   int not_done_count_;  // When zero, every batch entry is done (starts at batch_size_)
 
@@ -43,6 +42,7 @@ void LaunchInitializeBeamHypotheses(std::span<BeamHypotheses> beam_hyps, float l
 
 void LaunchBeamSearchScorer_Process(BeamScorerState& state_cpu,
                                     BeamScorerState& state,
+                                    std::span<const int32_t> eos_token_ids,
                                     std::span<const int32_t> sequences,
                                     int sequence_length,
                                     std::span<BeamHypotheses> beam_hyps_,

--- a/src/cuda/beam_search_scorer_cuda.h
+++ b/src/cuda/beam_search_scorer_cuda.h
@@ -4,7 +4,7 @@
 namespace Generators {
 
 struct BeamSearchScorer_Cuda {
-  BeamSearchScorer_Cuda(const GeneratorParams& parameters);
+  BeamSearchScorer_Cuda(const GeneratorParams& parameters, std::span<int32_t> cuda_eos_tokens);
 
   void Process(Sequences& sequences,
                std::span<const float> next_scores,
@@ -26,7 +26,9 @@ struct BeamSearchScorer_Cuda {
   mutable cuda_event_holder event_process_complete_;
   cuda_host_unique_ptr<cuda::BeamScorerState> state_cpu_;
   cuda_unique_ptr<cuda::BeamScorerState> state_gpu_;
+
   cudaStream_t stream_;
+  std::span<int32_t> eos_tokens_;
 
   DeviceSpan<float> next_beam_scores_;
   DeviceSpan<int32_t> next_beam_tokens_;

--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -143,10 +143,6 @@ struct CudaInterfaceImpl final : DeviceInterface {
     return true;
   }
 
-  void LaunchHandleEOSArray(float* batch_logits, int batch_beam_size, int vocab_size, const int32_t* eos_token_ids, int eos_token_ids_count) override {
-    cuda::LaunchHandleEOSArray(batch_logits, batch_beam_size, vocab_size, eos_token_ids, eos_token_ids_count, GetStream());
-  }
-
   void UpdateCacheIndirectionKernelLauncher(int32_t* tgt_indir_cache, const int32_t* src_indir_cache, const int32_t* beam_ids, int batch_size, int beam_width, int input_seq_length, int max_seq_length, int current_length) override {
     cuda::UpdateCacheIndirectionKernelLauncher(tgt_indir_cache, src_indir_cache, beam_ids, batch_size, beam_width, input_seq_length, max_seq_length, current_length, GetStream());
   }

--- a/src/cuda/kernels.h
+++ b/src/cuda/kernels.h
@@ -11,8 +11,6 @@ void Launch_UpdatePositionIds(T* positions, int batch_beam_size, int total_lengt
 template <typename T>
 void Launch_UpdateAttentionMask(T* mask_data, T* old_data, int batch_beam_size, int new_kv_length, int total_length, int max_length, bool update_only, cudaStream_t stream);
 
-void LaunchHandleEOSArray(float* batch_logits, int batch_beam_size, int vocab_size, const int32_t* eos_token_ids, int eos_token_ids_count, cudaStream_t stream);
-
 void LaunchFp16ToFp32(const uint16_t* fp16, float* fp32, int count, cudaStream_t stream);
 void LaunchFp32ToFp16(const float* fp32, uint16_t* fp16, int count, cudaStream_t stream);
 void LaunchInt32ToInt64(const int32_t* src, int64_t* dst, int count, cudaStream_t stream);

--- a/src/cuda/model_kernels.cu
+++ b/src/cuda/model_kernels.cu
@@ -82,25 +82,6 @@ void Launch_UpdateAttentionMask(T* next_mask_data, T* mask_data, int batch_beam_
 template void Launch_UpdateAttentionMask(int32_t* next_mask_data, int32_t* mask_data, int batch_beam_size, int new_kv_length, int total_length, int max_length, bool update_only, cudaStream_t stream);
 template void Launch_UpdateAttentionMask(int64_t* next_mask_data, int64_t* mask_data, int batch_beam_size, int new_kv_length, int total_length, int max_length, bool update_only, cudaStream_t stream);
 
-__global__ void HandleEOSArray(float* batch_logits, int batch_beam_size, int vocab_size, const int32_t* eos_token_ids, int eos_token_ids_count) {
-  int index = blockIdx.x * blockDim.x + threadIdx.x;
-  if (index >= batch_beam_size)
-    return;
-
-  float* logits = batch_logits + index * vocab_size;
-  float max = std::numeric_limits<float>::lowest();
-  for (int i = 0; i < eos_token_ids_count; i++) {
-    max = std::max(max, logits[eos_token_ids[i]]);
-    logits[eos_token_ids[i]] = std::numeric_limits<float>::lowest();  // Set all EOS token options to never happen (the first will get the max of all)
-  }
-
-  logits[eos_token_ids[0]] = max;  // Set the score of the primary EOS token to the highest of any of the EOS tokens
-}
-
-void LaunchHandleEOSArray(float* batch_logits, int batch_beam_size, int vocab_size, const int32_t* eos_token_ids, int eos_token_ids_count, cudaStream_t stream) {
-  HandleEOSArray<<<(batch_beam_size + 255) / 256, 256, 0, stream>>>(batch_logits, batch_beam_size, vocab_size, eos_token_ids, eos_token_ids_count);
-}
-
 __global__ void ConvertFp16ToFp32(const half* src, float* dst, int count) {
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
   if (idx < count)

--- a/src/cuda/search_cuda.cu
+++ b/src/cuda/search_cuda.cu
@@ -74,20 +74,20 @@ struct ArgMaxDataImpl : ArgMaxData {
   cuda_unique_ptr<cub::KeyValuePair<int, float>> argmaxen_owner_;
 };
 
-__global__ void CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, bool* eos_meet, const int* eos_token_ids, int eos_token_count, int pad_token_id, bool* done_cpu) {
-  // Look for EOS tokens, if seen set EOS flag and replace with pad token
+__global__ void CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, bool* eos_seen, const int* eos_token_ids, int eos_token_count, int pad_token_id, bool* done_cpu) {
   for (int batch_id = 0; batch_id < next_tokens_count; ++batch_id) {
-    bool eos_found = false;
-    for (int eos_id = 0; eos_id < eos_token_count; ++eos_id) {
-      if (next_tokens[batch_id] == eos_token_ids[eos_id]) {
-        eos_found = true;
-        break;
-      }
+    // If EOS already met, pad
+    if (eos_seen[batch_id]) {
+      next_tokens[batch_id] = pad_token_id;
+      continue;
     }
 
-    if (eos_found || eos_meet[batch_id] == true) {
-      eos_meet[batch_id] = true;
-      next_tokens[batch_id] = pad_token_id;
+    // Look for EOS
+    for (int eos_id = 0; eos_id < eos_token_count; ++eos_id) {
+      if (next_tokens[batch_id] == eos_token_ids[eos_id]) {
+        eos_seen[batch_id] = true;
+        break;
+      }
     }
   }
 
@@ -96,7 +96,7 @@ __global__ void CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, b
   {
     int batch_id = 0;
     while (batch_id < next_tokens_count) {
-      if (eos_meet[batch_id] == false) {
+      if (eos_seen[batch_id] == false) {
         break;
       }
       ++batch_id;
@@ -108,8 +108,8 @@ __global__ void CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, b
   }
 }
 
-void Launch_CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, bool* eos_meet, const int *eos_token_ids, int eos_token_count, int pad_token_id, bool* done_cpu, cudaStream_t stream) {
-  CheckForEOSAndPad<<<1, 1, 0, stream>>>(next_tokens, next_tokens_count, eos_meet, eos_token_ids, eos_token_count, pad_token_id, done_cpu);
+void Launch_CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, bool* eos_seen, const int *eos_token_ids, int eos_token_count, int pad_token_id, bool* done_cpu, cudaStream_t stream) {
+  CheckForEOSAndPad<<<1, 1, 0, stream>>>(next_tokens, next_tokens_count, eos_seen, eos_token_ids, eos_token_count, pad_token_id, done_cpu);
 }
 
 __global__ void AddProbsKernel(float* log_probs,

--- a/src/cuda/search_cuda.cuh
+++ b/src/cuda/search_cuda.cuh
@@ -9,7 +9,8 @@ struct ArgMaxData {
   virtual ~ArgMaxData() = default;
 };
 
-void Launch_CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, bool* eos_meet, const int32_t* eos_token_ids, int eos_token_count, int pad_token_id, bool* done_cpu, cudaStream_t stream);
+void Launch_CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, bool* eos_seen, const int32_t* eos_token_ids, int eos_token_count, bool* done_cpu, cudaStream_t stream);
+void Launch_CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, bool* eos_seen, const int32_t* eos_token_ids, int eos_token_count, int pad_token_id, bool* done_cpu, cudaStream_t stream);
 void Launch_ExpandInputSequences(const std::span<int32_t> input_sequences, std::span<int32_t> sequences, int batch_size, int beam_size, int max_length, cudaStream_t stream);
 void Launch_AppendNextTokensToSequences(std::span<const int32_t> next_tokens, std::span<int32_t> sequences, int batch_beam_size, int past_length, int max_length, cudaStream_t stream);
 void Launch_GetLastTokens(int32_t* next_tokens, const int32_t* sequences, int batch_beam_size, int sequence_length, int max_length, cudaStream_t stream);

--- a/src/cuda/search_cuda.cuh
+++ b/src/cuda/search_cuda.cuh
@@ -9,7 +9,7 @@ struct ArgMaxData {
   virtual ~ArgMaxData() = default;
 };
 
-void Launch_CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, bool* eos_meet, int eos_token_id, int pad_token_id, bool* done_cpu, cudaStream_t stream);
+void Launch_CheckForEOSAndPad(int32_t* next_tokens, int next_tokens_count, bool* eos_meet, const int32_t* eos_token_ids, int eos_token_count, int pad_token_id, bool* done_cpu, cudaStream_t stream);
 void Launch_ExpandInputSequences(const std::span<int32_t> input_sequences, std::span<int32_t> sequences, int batch_size, int beam_size, int max_length, cudaStream_t stream);
 void Launch_AppendNextTokensToSequences(std::span<const int32_t> next_tokens, std::span<int32_t> sequences, int batch_beam_size, int past_length, int max_length, cudaStream_t stream);
 void Launch_GetLastTokens(int32_t* next_tokens, const int32_t* sequences, int batch_beam_size, int sequence_length, int max_length, cudaStream_t stream);

--- a/src/cuda/search_cuda.h
+++ b/src/cuda/search_cuda.h
@@ -33,6 +33,7 @@ struct Search_Cuda : Search {
 
   gpu_span<bool> eos_meet_;  // shape (beam_size*batch_size)
   cuda_unique_ptr<bool> eos_meet_buffer_;
+  DeviceSpan<int32_t> eos_token_ids_;
 
   gpu_span<int32_t> next_tokens_;        // shape (beam_size*batch_size)
   DeviceSpan<float> next_token_scores_;  // shape (beam_size*batch_size, vocab_size)

--- a/src/cuda/search_cuda.h
+++ b/src/cuda/search_cuda.h
@@ -31,8 +31,8 @@ struct Search_Cuda : Search {
 
   DeviceSpan<int32_t> sequence_lengths_;  // shape (beam_size*batch_size)
 
-  gpu_span<bool> eos_meet_;  // shape (beam_size*batch_size)
-  cuda_unique_ptr<bool> eos_meet_buffer_;
+  gpu_span<bool> eos_seen_;  // shape (beam_size*batch_size)
+  cuda_unique_ptr<bool> eos_seen_buffer_;
   DeviceSpan<int32_t> eos_token_ids_;
 
   gpu_span<int32_t> next_tokens_;        // shape (beam_size*batch_size)

--- a/src/generators.h
+++ b/src/generators.h
@@ -42,6 +42,11 @@ struct State;
 struct Search;
 struct Tokenizer;
 
+template <typename T, typename V>
+bool contains(const T& t, V v) {
+  return std::find(t.begin(), t.end(), v) != t.end();
+}
+
 template <typename T>
 DeviceSpan<T> WrapTensor(DeviceInterface& device, OrtValue& value) {
   auto info = value.GetTensorTypeAndShapeInfo();

--- a/src/generators.h
+++ b/src/generators.h
@@ -43,7 +43,7 @@ struct Search;
 struct Tokenizer;
 
 template <typename T, typename V>
-bool contains(const T& t, V v) {
+bool contains(const T& t, V&& v) {
   return std::find(t.begin(), t.end(), v) != t.end();
 }
 

--- a/src/models/logits.h
+++ b/src/models/logits.h
@@ -16,8 +16,6 @@ struct Logits {
   void Update(const DeviceSpan<int32_t>& next_tokens, size_t new_kv_length);
 
  private:
-  void HandleEOSArray(std::span<float> logits);
-
   State& state_;
   const Model& model_{state_.model_};
   size_t output_index_{~0U};
@@ -36,8 +34,6 @@ struct Logits {
   std::vector<int> input_sequence_lengths;
   // OrtValue wrapped in a DeviceMemory object to make it universal
   DeviceSpan<float> logits_;
-
-  DeviceSpan<int32_t> cuda_eos_token_ids_;  // eos_token_ids from params, but in cuda accessible memory
 
   // Set to true when prefill will generate the already 'trimmed' logits required for sampling.
   bool trimmed_prefill_logits_ = false;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -53,6 +53,7 @@ DeviceSpan<float> Search_Cpu::GetLogits() const {
 
 void Search_Cpu::SetLogits(DeviceSpan<float> logits) {
   next_token_scores_ = logits;
+  next_token_scores_.CopyDeviceToCpu();  // To the device->cpu copy once here as all later calls use CpuSpan()
 }
 
 DeviceSpan<int32_t> GreedySearch_Cpu::GetNextTokens() {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -246,7 +246,7 @@ bool GreedySearch_Cpu::PadIfAlreadyEOS(size_t batch_id) {
 
 void GreedySearch_Cpu::SetNextToken(size_t batch_id, int32_t token) {
   next_tokens_[batch_id] = token;
-  if (token == params_->config.model.eos_token_id) {
+  if (contains(params_->config.model.eos_token_id, token)) {
     eos_seen_[batch_id] = true;
     if (g_log.enabled && g_log.hit_eos)
       Log("hit_eos", "EOS seen on batch " + std::to_string(batch_id));
@@ -396,7 +396,8 @@ void Search_Cpu::ApplyMinLength(int min_length) {
   const int batch_beam_size = params_->BatchBeamSize();
   for (int i = 0; i < batch_beam_size; i++) {
     std::span<float> const beam_token_scores = GetScores(i);
-    beam_token_scores[params_->config.model.eos_token_id] = std::numeric_limits<float>::lowest();
+    for (auto token_id : params_->config.model.eos_token_id)
+      beam_token_scores[token_id] = std::numeric_limits<float>::lowest();
   }
 }
 

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -120,7 +120,6 @@ struct DeviceInterface {
   virtual bool UpdatePositionIds(void* /*position_ids*/, int /*batch_beam_size*/, int /*total_length*/, int /*new_kv_length*/, ONNXTensorElementDataType /*type*/) { return false; }
   virtual bool UpdateAttentionMask(void* /*next_mask_data*/, void* /*mask_data*/, int /*batch_beam_size*/, int /*new_kv_length*/, int /*total_length*/, int /*max_length*/, bool /*update_only*/, ONNXTensorElementDataType /*type*/) { return false; }
 
-  virtual void LaunchHandleEOSArray(float* /*batch_logits*/, int /*batch_beam_size*/, int /*vocab_size*/, const int32_t* /*eos_token_ids*/, int /*eos_token_ids_count*/) { assert(false); }
   virtual void UpdateCacheIndirectionKernelLauncher(int32_t* /*tgt_indir_cache*/, const int32_t* /*src_indir_cache*/, const int32_t* /*beam_ids*/, int /*batch_size*/, int /*beam_width*/, int /*input_seq_length*/, int /*max_seq_length*/, int /*current_length*/) { assert(false); }
   virtual void ReorderPastStatesKernelLauncher(void* /*out_buffer*/, const void* /*in_buffer*/, int /*batch_size*/, int /*num_heads*/, int /*max_length*/, int /*head_size*/, int /*chunk_size*/) { assert(false); }
   virtual void LaunchCopyCrossQKSingleDecodeStep(float* /*cross_qk_buffer_data*/, float** /*qk_layer_pointers*/, int /*token_index*/, int /*batch_beam_size*/, int /*num_layers*/, int /*num_heads*/, int /*num_alignment_heads*/, const int* /*alignment_heads*/, int /*frames*/, int /*max_length*/) { assert(false); }


### PR DESCRIPTION
The previous approach to tweak the logit values would change the behavior of continuous decoding models by modifying which eos token id was chosen.

This change turns the EOS token id into an array in all places and preserves which EOS token was chosen in the output.

Fixes Issue #1412 