### PR TITLE
Avoid adding providers if not requested

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -831,7 +831,7 @@ Config::Config(const fs::path& path, std::string_view json_overlay) : config_pat
     search.max_length = model.context_length;
 
   for (const auto& provider_option : model.decoder.session_options.provider_options) {
-    providers.push_back(provider_option.name);
+    model.decoder.session_options.providers.push_back(provider_option.name);
   }
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -141,12 +141,6 @@ struct SessionOptions_Element : JSON::Element {
     throw JSON::unknown_value_error{};
   }
 
-  void OnComplete(bool) override {
-    for (const auto& provider_option : v_.provider_options) {
-      v_.providers.push_back(provider_option.name);
-    }
-  }
-
  private:
   Config::SessionOptions& v_;
   ProviderOptionsArray_Element provider_options_{v_.provider_options};
@@ -835,6 +829,10 @@ Config::Config(const fs::path& path, std::string_view json_overlay) : config_pat
 
   if (search.max_length == 0)
     search.max_length = model.context_length;
+
+  for (const auto& provider_option : model.decoder.session_options.provider_options) {
+    providers.push_back(provider_option.name);
+  }
 }
 
 void Config::AddMapping(const std::string& nominal_name, const std::string& graph_name) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -54,8 +54,7 @@ struct ProviderOptionsObject_Element : JSON::Element {
 };
 
 struct ProviderOptionsArray_Element : JSON::Element {
-  explicit ProviderOptionsArray_Element(std::vector<Config::ProviderOptions>& v, std::vector<std::string>& providers)
-      : v_{v}, providers_{providers} {}
+  explicit ProviderOptionsArray_Element(std::vector<Config::ProviderOptions>& v) : v_{v} {}
 
   JSON::Element& OnObject(std::string_view name) override { return object_; }
 
@@ -69,18 +68,11 @@ struct ProviderOptionsArray_Element : JSON::Element {
       } else if (v.name == "dml") {
         v.name = "DML";
       }
-
-      if (std::find(providers_.begin(), providers_.end(), v.name) == providers_.end()) {
-        // The providers array determines the which execution provider is picked for the session..
-        // It also determines the order of the providers.
-        providers_.push_back(v.name);
-      }
     }
   }
 
  private:
   std::vector<Config::ProviderOptions>& v_;
-  std::vector<std::string>& providers_;
   ProviderOptionsObject_Element object_{v_};
 };
 
@@ -149,9 +141,15 @@ struct SessionOptions_Element : JSON::Element {
     throw JSON::unknown_value_error{};
   }
 
+  void OnComplete(bool) override {
+    for (const auto& provider_option : v_.provider_options) {
+      v_.providers.push_back(provider_option.name);
+    }
+  }
+
  private:
   Config::SessionOptions& v_;
-  ProviderOptionsArray_Element provider_options_{v_.provider_options, v_.providers};
+  ProviderOptionsArray_Element provider_options_{v_.provider_options};
   NamedStrings_Element config_entries_{v_.config_entries};
 };
 
@@ -723,13 +721,20 @@ void ClearProviders(Config& config) {
 }
 
 void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value) {
+  if (std::find(config.model.decoder.session_options.providers.begin(),
+                config.model.decoder.session_options.providers.end(), provider_name) ==
+      config.model.decoder.session_options.providers.end()) {
+    config.model.decoder.session_options.providers.push_back(std::string(provider_name));
+  }
+
   std::ostringstream json;
   json << R"({")" << provider_name << R"(":{)";
   if (!option_name.empty()) {
     json << R"(")" << option_name << R"(":")" << option_value << R"(")";
   }
   json << R"(}})";
-  ProviderOptionsArray_Element element{config.model.decoder.session_options.provider_options, config.model.decoder.session_options.providers};
+
+  ProviderOptionsArray_Element element{config.model.decoder.session_options.provider_options};
   JSON::Parse(element, json.str());
 }
 


### PR DESCRIPTION
In a previous PR: #1454 I added support for the providers to persist the provider options across clearprovider->appendprovider. A bug was introduced where the providers always got built to include every provider in the provider options.

This PR fixes it. So, if the user clears the providers , and then appends a provider, only the new provider should be present in the providers list (not all the ones in the provider options).