### PR TITLE
Always cast bf16 logits to fp32

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -322,6 +322,10 @@ class Model:
 
 
     def make_outputs_init(self):
+        # Always use float32 logits to improve accuracy in the case of bf16 models.
+        if self.onnx_dtype == "bf16":
+            self.output_types["logits"] = TensorProto.FLOAT
+
         self.exclude_lm_head = self.extra_options.get("exclude_lm_head", False)
         self.include_hidden_states = self.extra_options.get("include_hidden_states", False)
 
@@ -2921,11 +2925,6 @@ class Gemma2Model(GemmaModel):
         self.layernorm_attrs["cast"]["output_3"] = False
         self.attention_attrs["scale"] = config.query_pre_attn_scalar ** -0.5
         self.is_local = lambda layer_id: layer_id % 2 == 1
-
-    def make_outputs_init(self):
-        # Always use float32 logits to improve accuracy
-        self.output_types["logits"] = TensorProto.FLOAT
-        super().make_outputs_init()
 
     def make_layernorm(self, layer_id, layernorm, skip, simple, location):
         if "final_norm" in location:


### PR DESCRIPTION
To ensure better precision and consistency for our model chat during logits softmax and sampling, I'm always casting bf16 logits to fp32.