### PR TITLE
Fix model chat example for rewind

### DIFF
--- a/examples/python/model-chat.py
+++ b/examples/python/model-chat.py
@@ -140,6 +140,7 @@ def main(args):
     # Ignoring the last end of text token as it is messes up the generation when grammar is enabled
     if guidance_type:
         input_tokens = input_tokens[:-1]
+    system_prompt_length = len(input_tokens)
     generator.append_tokens(input_tokens)
 
     # Keep asking for input prompts in a loop


### PR DESCRIPTION
Fix model chat example for rewind as system_prompt_length is needed for rewind.