### PR TITLE
Update triggers

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -3,11 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
@@ -22,7 +22,7 @@ jobs:
     #       it doesn't work on macos-14.
     #         HVF error: HV_UNSUPPORTED
     #       it works on macos-13 but with macos-15 being released soon that isn't a long term solution.
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-AMD-CPU" ]
+    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-AMD-CPU"]
     steps:
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,14 +6,14 @@
 #
 name: "CodeQL"
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '41 13 * * 0'
 
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: ['python']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -3,11 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 jobs:
   iphonesimulator-arm64-build:
@@ -29,7 +29,7 @@ jobs:
           python3 -m pip install requests
 
       - name: Run iOS Build
-        run: |
+        run: |-
           set -e -x
           source genai-macos-venv/bin/activate
           python3 build.py --ios \

--- a/.github/workflows/linux-cpu-arm64-build.yml
+++ b/.github/workflows/linux-cpu-arm64-build.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
@@ -18,7 +18,7 @@ env:
 
 jobs:
   linux-cpu-arm64-build:
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2004-ARM-CPU" ]
+    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2004-ARM-CPU"]
     steps:
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v4

--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -3,11 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
@@ -16,7 +16,7 @@ env:
   DOTNET_INSTALL_DIR: "${{ github.workspace }}/dotnet"
 jobs:
   linux_cpu_x64:
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-AMD-CPU" ]
+    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-AMD-CPU"]
     steps:
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
           rustup override set 1.86.0
           rustup component add rust-src
           rustup show active-toolchain
-      
+
       - name: Get the Latest OnnxRuntime Nightly Version
         shell: pwsh
         run: |

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -19,9 +19,9 @@ env:
 
 jobs:
   linux-cuda-x64-build:
-    env :
+    env:
       PYTHON_EXECUTABLE: "/opt/python/cp310-cp310/bin/python3.10"
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-A10" ]
+    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Ubuntu2204-A10"]
     steps:
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
           rustup override set 1.86.0
           rustup component add rust-src
           rustup show active-toolchain
-      
+
       - name: Get the Latest OnnxRuntime Nightly Version
         shell: pwsh
         run: |

--- a/.github/workflows/mac-cpu-arm64-build.yml
+++ b/.github/workflows/mac-cpu-arm64-build.yml
@@ -3,11 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
   binaryDir: 'build/cpu/win-arm64'
@@ -17,104 +17,104 @@ env:
 
 jobs:
   windows-cpu-arm64-build:
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-win11-arm64-cpu" ]
+    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-win11-arm64-cpu"]
     steps:
-    - name: Checkout OnnxRuntime GenAI repo
-      uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Checkout OnnxRuntime GenAI repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - name: Setup Visual Studio 2022
-      uses: microsoft/setup-msbuild@v1.1
-      with:
-        vs-version: '17.4'
-        msbuild-architecture: arm64
+      - name: Setup Visual Studio 2022
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-version: '17.4'
+          msbuild-architecture: arm64
 
-    - uses: nuget/setup-nuget@v2
-      with:
-        nuget-version: '5.x'
+      - uses: nuget/setup-nuget@v2
+        with:
+          nuget-version: '5.x'
 
-    - name: Setup Java 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: 'gradle'
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        gradle-version: '8.6'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: '8.6'
 
-    - name: Download OnnxRuntime Nightly
-      shell: powershell
-      run: |
-        $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
-        $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
-        Write-Host "$ORT_NIGHTLY_VERSION"
-        "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
-        nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -x -NonInteractive
+      - name: Download OnnxRuntime Nightly
+        shell: powershell
+        run: |
+          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
+          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
+          Write-Host "$ORT_NIGHTLY_VERSION"
+          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
+          nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -x -NonInteractive
 
-    - run: Get-ChildItem  ${{ env.ORT_PACKAGE_NAME }} -Recurse
-      continue-on-error: true
+      - run: Get-ChildItem  ${{ env.ORT_PACKAGE_NAME }} -Recurse
+        continue-on-error: true
 
-    - name: Extract OnnxRuntime library and header files
-      run: |
-        mkdir ort/lib
-        move ${{ env.ORT_PACKAGE_NAME }}/build/native/include ort/
-        move ${{ env.ORT_PACKAGE_NAME }}/runtimes/win-arm64/native/* ort/lib/
+      - name: Extract OnnxRuntime library and header files
+        run: |
+          mkdir ort/lib
+          move ${{ env.ORT_PACKAGE_NAME }}/build/native/include ort/
+          move ${{ env.ORT_PACKAGE_NAME }}/runtimes/win-arm64/native/* ort/lib/
 
-    - name: Install Rust Toolchain
-      run: |
-        $exePath = "$env:TEMP\rustup-init.exe"
-        (New-Object Net.WebClient).DownloadFile('https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe', $exePath)
-        & $exePath -y --default-toolchain=1.86.0
-        Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
+      - name: Install Rust Toolchain
+        run: |
+          $exePath = "$env:TEMP\rustup-init.exe"
+          (New-Object Net.WebClient).DownloadFile('https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe', $exePath)
+          & $exePath -y --default-toolchain=1.86.0
+          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
 
-    - name: Install LLVM
-      run: |
-        choco install llvm --yes
-        Add-Content $env:GITHUB_PATH "C:\Program Files\LLVM\bin"
+      - name: Install LLVM
+        run: |
+          choco install llvm --yes
+          Add-Content $env:GITHUB_PATH "C:\Program Files\LLVM\bin"
 
-    - name: Configure CMake
-      run: |
-        python -m pip install wheel requests
+      - name: Configure CMake
+        run: |
+          python -m pip install wheel requests
 
-        cmake --preset windows_arm64_cpu_release -DUSE_GUIDANCE=ON
+          cmake --preset windows_arm64_cpu_release -DUSE_GUIDANCE=ON
 
-    - name: Build with CMake
-      run: |
-        cmake --build --preset windows_arm64_cpu_release --parallel -DUSE_GUIDANCE=ON
+      - name: Build with CMake
+        run: |
+          cmake --build --preset windows_arm64_cpu_release --parallel -DUSE_GUIDANCE=ON
 
-    - name: Install the Python Wheel and Test Dependencies
-      run: |
-        # Uninstalling LLVM/Clang as it is no longer required and causes issues with numpy installation
-        choco uninstall llvm --yes
-        python -m pip install "numpy<2" coloredlogs flatbuffers packaging protobuf sympy pytest
-        python -m pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ ort-nightly-qnn
-        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
+      - name: Install the Python Wheel and Test Dependencies
+        run: |
+          # Uninstalling LLVM/Clang as it is no longer required and causes issues with numpy installation
+          choco uninstall llvm --yes
+          python -m pip install "numpy<2" coloredlogs flatbuffers packaging protobuf sympy pytest
+          python -m pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ ort-nightly-qnn
+          python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
-    - name: Run the Python Tests
-      run: |
-        python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
+      - name: Run the Python Tests
+        run: |
+          python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
 
-    - name: Build the C# API and Run the C# Tests
-      run: |
-        cd test\csharp
-        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib"
+      - name: Build the C# API and Run the C# Tests
+        run: |
+          cd test\csharp
+          dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib"
 
-    - name: Build the Java API and Run the Java Tests
-      run: |
-        python build.py --config=Release --build_dir $env:binaryDir --build_java --parallel
+      - name: Build the Java API and Run the Java Tests
+        run: |
+          python build.py --config=Release --build_dir $env:binaryDir --build_java --parallel
 
-    - name: Verify Build Artifacts
-      if: always()
-      continue-on-error: true
-      run: |
-        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir -Recurse
-        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir\test -Recurse
+      - name: Verify Build Artifacts
+        if: always()
+        continue-on-error: true
+        run: |
+          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir -Recurse
+          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir\test -Recurse
 
-    - name: Run tests
-      run: |
-        copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
-        & .\$env:binaryDir\Release\unit_tests.exe
+      - name: Run tests
+        run: |-
+          copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
+          & .\$env:binaryDir\Release\unit_tests.exe

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
   binaryDir: 'build/cpu/win-x64'
@@ -17,122 +17,122 @@ env:
 
 jobs:
   windows-cpu-x64-build:
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-CPU" ]
+    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-CPU"]
     permissions:
       security-events: write
       actions: read
     steps:
-    - name: Checkout OnnxRuntime GenAI repo
-      uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Checkout OnnxRuntime GenAI repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11.x'
-        architecture: 'x64'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.x'
+          architecture: 'x64'
 
-    - name: Setup VCPKG
-      uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
-      with:
-        vcpkg-version: '2025.03.19'
-        vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
-        cmake-version: '3.31.6'
-        cmake-hash: '0f1584e8666cf4a65ec514bd02afe281caabf1d45d2c963f3151c41484f457386aa03273ab25776a670be02725354ce0b46f3a5121857416da37366342a833a0'
-        add-cmake-to-path: 'true'
-        disable-terrapin: 'false'
+      - name: Setup VCPKG
+        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        with:
+          vcpkg-version: '2025.03.19'
+          vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+          cmake-version: '3.31.6'
+          cmake-hash: '0f1584e8666cf4a65ec514bd02afe281caabf1d45d2c963f3151c41484f457386aa03273ab25776a670be02725354ce0b46f3a5121857416da37366342a833a0'
+          add-cmake-to-path: 'true'
+          disable-terrapin: 'false'
 
-    - name: Setup Visual Studio 2022
-      uses: microsoft/setup-msbuild@v1.1
-      with:
-        vs-version: '17.5'
+      - name: Setup Visual Studio 2022
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-version: '17.5'
 
-    - uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '8.0.x'
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
-    - name: Setup Java 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'gradle'
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        gradle-version: '8.6'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: '8.6'
 
-    - name: Install Rust Toolchain
-      run: |
-        $exePath = "$env:TEMP\rustup-init.exe"
-        (New-Object Net.WebClient).DownloadFile('https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe', $exePath)
-        & $exePath -y --default-toolchain=1.86.0
-        Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
+      - name: Install Rust Toolchain
+        run: |
+          $exePath = "$env:TEMP\rustup-init.exe"
+          (New-Object Net.WebClient).DownloadFile('https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe', $exePath)
+          & $exePath -y --default-toolchain=1.86.0
+          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
 
-    - name: Download OnnxRuntime Nightly
-      shell: pwsh
-      run: |
-        $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
-        $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
-        Write-Host "$ORT_NIGHTLY_VERSION"
-        "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
-        nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -x -NonInteractive
+      - name: Download OnnxRuntime Nightly
+        shell: pwsh
+        run: |
+          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
+          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
+          Write-Host "$ORT_NIGHTLY_VERSION"
+          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
+          nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -x -NonInteractive
 
-    - run: Get-ChildItem  ${{ env.ORT_PACKAGE_NAME }} -Recurse
-      continue-on-error: true
+      - run: Get-ChildItem  ${{ env.ORT_PACKAGE_NAME }} -Recurse
+        continue-on-error: true
 
-    - name: Extract OnnxRuntime library and header files
-      run: |
-        mkdir ort/lib
-        move ${{ env.ORT_PACKAGE_NAME }}/build/native/include ort/
-        move ${{ env.ORT_PACKAGE_NAME }}/runtimes/win-x64/native/* ort/lib/
+      - name: Extract OnnxRuntime library and header files
+        run: |
+          mkdir ort/lib
+          move ${{ env.ORT_PACKAGE_NAME }}/build/native/include ort/
+          move ${{ env.ORT_PACKAGE_NAME }}/runtimes/win-x64/native/* ort/lib/
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: 'cpp'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: 'cpp'
 
-    - name: Configure CMake
-      run: |
-        cmake --preset windows_x64_cpu_release -DUSE_GUIDANCE=ON
+      - name: Configure CMake
+        run: |
+          cmake --preset windows_x64_cpu_release -DUSE_GUIDANCE=ON
 
-    - name: Build with CMake
-      run: |
-        cmake --build --preset windows_x64_cpu_release --parallel -DUSE_GUIDANCE=ON
+      - name: Build with CMake
+        run: |
+          cmake --build --preset windows_x64_cpu_release --parallel -DUSE_GUIDANCE=ON
 
-    - name: Install the python wheel and test dependencies
-      run: |
-        python3 -m pip install -r test\python\requirements.txt --user
-        python3 -m pip install -r test\python\cpu\torch\requirements.txt --user
-        python3 -m pip install -r test\python\cpu\ort\requirements.txt --user
-        python3 -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
+      - name: Install the python wheel and test dependencies
+        run: |
+          python3 -m pip install -r test\python\requirements.txt --user
+          python3 -m pip install -r test\python\cpu\torch\requirements.txt --user
+          python3 -m pip install -r test\python\cpu\ort\requirements.txt --user
+          python3 -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
-    - name: Run the Python Tests
-      run: |
-        python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
+      - name: Run the Python Tests
+        run: |
+          python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models"
 
-    - name: Build the C# API and Run the C# Tests
-      run: |
-        cd test\csharp
-        dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib" --verbosity normal
+      - name: Build the C# API and Run the C# Tests
+        run: |
+          cd test\csharp
+          dotnet test /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib" --verbosity normal
 
-    - name: Build the Java API and Run the Java Tests
-      run: |
-        python3 build.py --config=Release --build_dir $env:binaryDir --build_java --parallel
+      - name: Build the Java API and Run the Java Tests
+        run: |
+          python3 build.py --config=Release --build_dir $env:binaryDir --build_java --parallel
 
-    - name: Verify Build Artifacts
-      if: always()
-      continue-on-error: true
-      run: |
-        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir -Recurse
-        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir\test -Recurse
+      - name: Verify Build Artifacts
+        if: always()
+        continue-on-error: true
+        run: |
+          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir -Recurse
+          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir\test -Recurse
 
-    - name: Run tests
-      run: |
-        copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
-        & .\$env:binaryDir\Release\unit_tests.exe
+      - name: Run tests
+        run: |
+          copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
+          & .\$env:binaryDir\Release\unit_tests.exe
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
 

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -23,100 +23,100 @@ env:
 
 jobs:
   windows-cuda-x64-build:
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-GPU-A10" ]
+    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-GPU-A10"]
     steps:
-    - name: Checkout OnnxRuntime GenAI repo
-      uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Checkout OnnxRuntime GenAI repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11.x'
-        architecture: 'x64'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.x'
+          architecture: 'x64'
 
-    - name: Setup VCPKG
-      uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
-      with:
-        vcpkg-version: '2025.03.19'
-        vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
-        cmake-version: '3.31.6'
-        cmake-hash: '0f1584e8666cf4a65ec514bd02afe281caabf1d45d2c963f3151c41484f457386aa03273ab25776a670be02725354ce0b46f3a5121857416da37366342a833a0'
-        add-cmake-to-path: 'true'
-        disable-terrapin: 'false'
+      - name: Setup VCPKG
+        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        with:
+          vcpkg-version: '2025.03.19'
+          vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+          cmake-version: '3.31.6'
+          cmake-hash: '0f1584e8666cf4a65ec514bd02afe281caabf1d45d2c963f3151c41484f457386aa03273ab25776a670be02725354ce0b46f3a5121857416da37366342a833a0'
+          add-cmake-to-path: 'true'
+          disable-terrapin: 'false'
 
-    - name: Download cuda
-      run: |
-        azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ env.cuda_version }}" ${{ env.cuda_dir}}
+      - name: Download cuda
+        run: |
+          azcopy.exe cp --recursive "https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ env.cuda_version }}" ${{ env.cuda_dir}}
 
-    - uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '8.0.x'
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
-    - name: Download OnnxRuntime Nightly
-      shell: pwsh
-      run: |
-        $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
-        $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
-        Write-Host "$ORT_NIGHTLY_VERSION"
-        "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
-        nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -ExcludeVersion -NonInteractive
+      - name: Download OnnxRuntime Nightly
+        shell: pwsh
+        run: |
+          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
+          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
+          Write-Host "$ORT_NIGHTLY_VERSION"
+          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
+          nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -ExcludeVersion -NonInteractive
 
-    - run: Get-ChildItem  ${{ env.ORT_PACKAGE_NAME }} -Recurse
-      continue-on-error: true
+      - run: Get-ChildItem  ${{ env.ORT_PACKAGE_NAME }} -Recurse
+        continue-on-error: true
 
-    - name: Extract OnnxRuntime library and header files
-      run: |
-        mkdir ort/lib
-        move ${{ env.ORT_PACKAGE_NAME }}/buildTransitive/native/include ort/
-        move ${{ env.ORT_PACKAGE_NAME }}/runtimes/win-x64/native/* ort/lib/
+      - name: Extract OnnxRuntime library and header files
+        run: |
+          mkdir ort/lib
+          move ${{ env.ORT_PACKAGE_NAME }}/buildTransitive/native/include ort/
+          move ${{ env.ORT_PACKAGE_NAME }}/runtimes/win-x64/native/* ort/lib/
 
-    - name: Install Rust Toolchain
-      run: |
-        $exePath = "$env:TEMP\rustup-init.exe"
-        (New-Object Net.WebClient).DownloadFile('https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe', $exePath)
-        & $exePath -y --default-toolchain=1.86.0
-        Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
+      - name: Install Rust Toolchain
+        run: |
+          $exePath = "$env:TEMP\rustup-init.exe"
+          (New-Object Net.WebClient).DownloadFile('https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe', $exePath)
+          & $exePath -y --default-toolchain=1.86.0
+          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
 
-    - name: Configure CMake
-      run: |
-        cmake --preset windows_x64_cuda_release -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }} -DUSE_GUIDANCE=ON
+      - name: Configure CMake
+        run: |
+          cmake --preset windows_x64_cuda_release -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }} -DUSE_GUIDANCE=ON
 
-    - name: Build with CMake
-      run: |
-        cmake --build --preset windows_x64_cuda_release --parallel -DUSE_GUIDANCE=ON
+      - name: Build with CMake
+        run: |
+          cmake --build --preset windows_x64_cuda_release --parallel -DUSE_GUIDANCE=ON
 
-    - name: Add CUDA to PATH
-      run: |
-        echo "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Add CUDA to PATH
+        run: |
+          echo "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-    - name: Install the Python Wheel and Test Dependencies
-      run: |
-        python -m pip install -r test\python\requirements.txt
-        python -m pip install -r test\python\cuda\torch\requirements.txt
-        python -m pip install -r test\python\cuda\ort\requirements.txt
-        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
+      - name: Install the Python Wheel and Test Dependencies
+        run: |
+          python -m pip install -r test\python\requirements.txt
+          python -m pip install -r test\python\cuda\torch\requirements.txt
+          python -m pip install -r test\python\cuda\ort\requirements.txt
+          python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
-    - name: Run the Python Tests
-      run: |
-        python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models" --e2e
+      - name: Run the Python Tests
+        run: |
+          python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models" --e2e
 
-    - name: Verify Build Artifacts
-      if: always()
-      continue-on-error: true
-      run: |
-        
-        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir -Recurse
+      - name: Verify Build Artifacts
+        if: always()
+        continue-on-error: true
+        run: |2
 
-    - name: Build the C# API and Run the C# Tests
-      run: |
-        $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH
-        cd test\csharp
-        dotnet test /p:Configuration=release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib"
+          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir -Recurse
 
-    - name: Prepend CUDA to PATH and Run tests
-      run: |
-        $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
-        echo "Current PATH variable is: $env:PATH" 
-        copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
-        & .\$env:binaryDir\Release\unit_tests.exe
+      - name: Build the C# API and Run the C# Tests
+        run: |
+          $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH
+          cd test\csharp
+          dotnet test /p:Configuration=release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib"
+
+      - name: Prepend CUDA to PATH and Run tests
+        run: |-
+          $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
+          echo "Current PATH variable is: $env:PATH" 
+          copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
+          & .\$env:binaryDir\Release\unit_tests.exe

--- a/.github/workflows/win-directml-x64-build.yml
+++ b/.github/workflows/win-directml-x64-build.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
-    - rel-*
+      - main
+      - rel-*
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -28,100 +28,100 @@ env:
 
 jobs:
   windows-directml-x64-build:
-    runs-on: [ "self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-GPU-A10" ]
+    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-genai-Win2022-GPU-A10"]
     steps:
-    - name: Checkout OnnxRuntime GenAI repo
-      uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Checkout OnnxRuntime GenAI repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11.x'
-        architecture: 'x64'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.x'
+          architecture: 'x64'
 
-    - name: Setup VCPKG
-      uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
-      with:
-        vcpkg-version: '2025.03.19'
-        vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
-        cmake-version: '3.31.6'
-        cmake-hash: '0f1584e8666cf4a65ec514bd02afe281caabf1d45d2c963f3151c41484f457386aa03273ab25776a670be02725354ce0b46f3a5121857416da37366342a833a0'
-        add-cmake-to-path: 'true'
-        disable-terrapin: 'false'
+      - name: Setup VCPKG
+        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        with:
+          vcpkg-version: '2025.03.19'
+          vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
+          cmake-version: '3.31.6'
+          cmake-hash: '0f1584e8666cf4a65ec514bd02afe281caabf1d45d2c963f3151c41484f457386aa03273ab25776a670be02725354ce0b46f3a5121857416da37366342a833a0'
+          add-cmake-to-path: 'true'
+          disable-terrapin: 'false'
 
-    - name: Download OnnxRuntime Nightly
-      shell: pwsh
-      run: |
-        $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
-        $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
-        Write-Host "$ORT_NIGHTLY_VERSION"
-        "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
-        nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -x -NonInteractive
+      - name: Download OnnxRuntime Nightly
+        shell: pwsh
+        run: |
+          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
+          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
+          Write-Host "$ORT_NIGHTLY_VERSION"
+          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
+          nuget install ${{ env.ORT_PACKAGE_NAME }} -version $ORT_NIGHTLY_VERSION -x -NonInteractive
 
-    - name: Download DirectML
-      run: |
-        Invoke-WebRequest -Uri $env:dml_url -OutFile $env:dml_zip
+      - name: Download DirectML
+        run: |
+          Invoke-WebRequest -Uri $env:dml_url -OutFile $env:dml_zip
 
-    - name: Download the D3D12 Agility SDK
-      run: |
-        Invoke-WebRequest -Uri $env:d3d12_url -OutFile $env:d3d12_zip
+      - name: Download the D3D12 Agility SDK
+        run: |
+          Invoke-WebRequest -Uri $env:d3d12_url -OutFile $env:d3d12_zip
 
-    - name: Extract OnnxRuntime library and header files
-      run: |
-        mkdir ort/lib
-        move ${{ env.ORT_PACKAGE_NAME }}/build/native/include ort/
-        move ${{ env.ORT_PACKAGE_NAME }}/runtimes/win-x64/native/* ort/lib/
+      - name: Extract OnnxRuntime library and header files
+        run: |
+          mkdir ort/lib
+          move ${{ env.ORT_PACKAGE_NAME }}/build/native/include ort/
+          move ${{ env.ORT_PACKAGE_NAME }}/runtimes/win-x64/native/* ort/lib/
 
-    - name: Unzip DirectML
-      run: |
-        Expand-Archive $env:dml_zip -DestinationPath $env:dml_dir
-        Remove-Item -Path $env:dml_zip
+      - name: Unzip DirectML
+        run: |
+          Expand-Archive $env:dml_zip -DestinationPath $env:dml_dir
+          Remove-Item -Path $env:dml_zip
 
-    - name: Unzip the D3D12 Agility SDK
-      run: |
-        Expand-Archive $env:d3d12_zip -DestinationPath $env:d3d12_dir
-        Remove-Item -Path $env:d3d12_zip
+      - name: Unzip the D3D12 Agility SDK
+        run: |
+          Expand-Archive $env:d3d12_zip -DestinationPath $env:d3d12_dir
+          Remove-Item -Path $env:d3d12_zip
 
-    - name: Move the files to the ort directory
-      run: |
-        mv $env:dml_dir\bin\x64-win\DirectML.dll ort\lib
-        mv $env:d3d12_dir\build\native\bin\x64\D3D12Core.dll ort\lib
-        mv $env:dml_dir\include\DirectML.h ort\include
+      - name: Move the files to the ort directory
+        run: |
+          mv $env:dml_dir\bin\x64-win\DirectML.dll ort\lib
+          mv $env:d3d12_dir\build\native\bin\x64\D3D12Core.dll ort\lib
+          mv $env:dml_dir\include\DirectML.h ort\include
 
-    - name: Install Rust Toolchain
-      run: |
-        $exePath = "$env:TEMP\rustup-init.exe"
-        (New-Object Net.WebClient).DownloadFile('https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe', $exePath)
-        & $exePath -y --default-toolchain=1.86.0
-        Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
+      - name: Install Rust Toolchain
+        run: |
+          $exePath = "$env:TEMP\rustup-init.exe"
+          (New-Object Net.WebClient).DownloadFile('https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe', $exePath)
+          & $exePath -y --default-toolchain=1.86.0
+          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
 
-    - name: Configure CMake
-      run: |
-        cmake --preset windows_x64_directml_release -DTEST_PHI2=True -DUSE_GUIDANCE=ON
+      - name: Configure CMake
+        run: |
+          cmake --preset windows_x64_directml_release -DTEST_PHI2=True -DUSE_GUIDANCE=ON
 
-    - name: Build with CMake
-      run: |
-        cmake --build --preset windows_x64_directml_release --parallel -DUSE_GUIDANCE=ON
+      - name: Build with CMake
+        run: |
+          cmake --build --preset windows_x64_directml_release --parallel -DUSE_GUIDANCE=ON
 
-    - name: Install the Python Wheel and Test Dependencies
-      run: |
-        python -m pip install -r test\python\requirements.txt
-        python -m pip install -r test\python\directml\torch\requirements.txt
-        python -m pip install -r test\python\directml\ort\requirements.txt
-        python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
+      - name: Install the Python Wheel and Test Dependencies
+        run: |
+          python -m pip install -r test\python\requirements.txt
+          python -m pip install -r test\python\directml\torch\requirements.txt
+          python -m pip install -r test\python\directml\ort\requirements.txt
+          python -m pip install (Get-ChildItem ("$env:binaryDir\wheel\*.whl")) --no-deps
 
-    - name: Run the Python Tests
-      run: |
-        python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models" --e2e
+      - name: Run the Python Tests
+        run: |
+          python test/python/test_onnxruntime_genai.py --cwd "test\python" --test_models "test\test_models" --e2e
 
-    - name: Verify Build Artifacts
-      if: always()
-      continue-on-error: true
-      run: |
-        Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir -Recurse
+      - name: Verify Build Artifacts
+        if: always()
+        continue-on-error: true
+        run: |
+          Get-ChildItem -Path $env:GITHUB_WORKSPACE\$env:binaryDir -Recurse
 
-    - name: Run tests
-      run: |
-        copy $env:GITHUB_WORKSPACE\ort\lib\* $env:GITHUB_WORKSPACE\$env:binaryDir\Release
-        & .\$env:binaryDir\Release\unit_tests.exe
+      - name: Run tests
+        run: |-
+          copy $env:GITHUB_WORKSPACE\ort\lib\* $env:GITHUB_WORKSPACE\$env:binaryDir\Release
+          & .\$env:binaryDir\Release\unit_tests.exe


### PR DESCRIPTION
### Description
1. Update Github Actions pipelines' triggers. Make all of them to be the same(The same as the ORT main repo's setting)
2. Format yaml files.

Before this change, the pipelines' triggers were set as following:

```
on:
  push:
    branches: [ main, 'rel-*']
  pull_request:
    branches: [ main, 'rel-*']
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

I set "cancel-in-progress: true" because for pipeline runs triggered by pull requests if the pull request was updated(a new commit was added there), the old pipeline runs can be cancelled. However, this setting doesn't work well for the runs triggered by "push" events for the main branch. Let's say, we merged a PR , then it triggered this pipeline. Then before the pipeline is finished, we merged another PR. Then the old pipeline run will be cancelled. But we do want it to be cancelled. Each commit in the main branch should be verified.

### Motivation and Context
See: https://github.com/microsoft/onnxruntime/pull/24547
