### PR TITLE
Add device index support to DML provider option

### DIFF
--- a/src/dml/dml_helpers.cpp
+++ b/src/dml/dml_helpers.cpp
@@ -22,7 +22,7 @@ static bool IsSoftwareAdapter(IDXGIAdapter1* adapter) {
 };
 
 static std::vector<ComPtr<IDXGIAdapter1>> EnumerateAdapters(PLUID device_luid = nullptr,
-                                                            UINT* deviceIndex = nullptr) {
+                                                            uint32_t* deviceIndex = nullptr) {
   ComPtr<IDXGIFactory4> dxgi_factory;
   THROW_IF_FAILED(CreateDXGIFactory(IID_PPV_ARGS(&dxgi_factory)));
 
@@ -112,7 +112,7 @@ static std::vector<ComPtr<IDXGIAdapter1>> EnumerateAdapters(PLUID device_luid = 
   return adapter_infos;
 }
 
-static ComPtr<IDXGIAdapter1> CreateAdapter(PLUID device_luid = nullptr, UINT* deviceIndex = nullptr) {
+static ComPtr<IDXGIAdapter1> CreateAdapter(PLUID device_luid = nullptr, uint32_t* deviceIndex = nullptr) {
   auto filtered_adapters = EnumerateAdapters(device_luid, deviceIndex);
   if (filtered_adapters.empty()) {
     throw std::runtime_error("No adapter is available for DML.");
@@ -120,7 +120,7 @@ static ComPtr<IDXGIAdapter1> CreateAdapter(PLUID device_luid = nullptr, UINT* de
   return filtered_adapters.front();
 }
 
-DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device_luid, UINT* deviceIndex) {
+DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device_luid, uint32_t* deviceIndex) {
   D3D12_COMMAND_QUEUE_DESC command_queue_description = {
       D3D12_COMMAND_LIST_TYPE_COMPUTE,
       0,

--- a/src/dml/dml_helpers.cpp
+++ b/src/dml/dml_helpers.cpp
@@ -78,35 +78,34 @@ static std::vector<ComPtr<IDXGIAdapter1>> EnumerateAdapters(PLUID device_luid = 
         }
       }
     }
-  }
-  else {
-      // Enumerate adapters without ordering.
-      ComPtr<IDXGIAdapter1> adapter;
-      uint32_t hwAdapterIndex = 0;
-      for (uint32_t adapter_index = 0; dxgi_factory->EnumAdapters1(adapter_index, &adapter) != DXGI_ERROR_NOT_FOUND; adapter_index++) {
-          // We can't assume the ordering of hardware and software adapters, so keep looping. This path should only execute on Windows 10
-          // version 1709 or earlier; IDD (e.g. remote desktop) adapters do not exist when taking this code path.
-          if (IsSoftwareAdapter(adapter.Get())) {
-              continue;
-          }
-
-          // Make sure that we are able to create the device
-          ComPtr<ID3D12Device> d3d12_device;
-          THROW_IF_FAILED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&d3d12_device)));
-
-          if (d3d12_device && deviceIndex) {
-              // get device specified by the deviceIndex
-              if (*deviceIndex == hwAdapterIndex) {
-                  adapter_infos.emplace_back(std::move(adapter));
-                  break;
-              }
-          }
-          else if (d3d12_device) {
-              adapter_infos.emplace_back(std::move(adapter));
-          }
-
-          hwAdapterIndex++;
+  } else {
+    // Enumerate adapters without ordering.
+    ComPtr<IDXGIAdapter1> adapter;
+    uint32_t hwAdapterIndex = 0;
+    for (uint32_t adapter_index = 0; dxgi_factory->EnumAdapters1(adapter_index, &adapter) != DXGI_ERROR_NOT_FOUND; adapter_index++) {
+      // We can't assume the ordering of hardware and software adapters, so keep looping. This path should only execute on Windows 10
+      // version 1709 or earlier; IDD (e.g. remote desktop) adapters do not exist when taking this code path.
+      if (IsSoftwareAdapter(adapter.Get())) {
+        continue;
       }
+
+      // Make sure that we are able to create the device
+      ComPtr<ID3D12Device> d3d12_device;
+      THROW_IF_FAILED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&d3d12_device)));
+
+      if (d3d12_device && deviceIndex) {
+        // get device specified by the deviceIndex
+        if (*deviceIndex == hwAdapterIndex) {
+          adapter_infos.emplace_back(std::move(adapter));
+          break;
+        }
+      }
+      else if (d3d12_device) {
+        adapter_infos.emplace_back(std::move(adapter));
+      }
+
+      hwAdapterIndex++;
+    }
   }
 
   return adapter_infos;

--- a/src/dml/dml_helpers.cpp
+++ b/src/dml/dml_helpers.cpp
@@ -21,14 +21,15 @@ static bool IsSoftwareAdapter(IDXGIAdapter1* adapter) {
   return desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE || (is_basic_render_driver_vendor_id && is_basic_render_driver_device_id);
 };
 
-static std::vector<ComPtr<IDXGIAdapter1>> EnumerateAdapters(PLUID device_luid = nullptr) {
+static std::vector<ComPtr<IDXGIAdapter1>> EnumerateAdapters(PLUID device_luid = nullptr,
+                                                            UINT* deviceIndex = nullptr) {
   ComPtr<IDXGIFactory4> dxgi_factory;
   THROW_IF_FAILED(CreateDXGIFactory(IID_PPV_ARGS(&dxgi_factory)));
 
   std::vector<ComPtr<IDXGIAdapter1>> adapter_infos;
 
   ComPtr<IDXGIFactory6> dxgi_factory6;
-  if (SUCCEEDED(dxgi_factory.As(&dxgi_factory6)) && !device_luid) {
+  if (SUCCEEDED(dxgi_factory.As(&dxgi_factory6)) && !device_luid && !deviceIndex) {
     // Enumerate adapters by performance. This only works in Windows 10 Version 1803 and later.
     ComPtr<IDXGIAdapter1> adapter;
     for (uint32_t adapter_index = 0;
@@ -52,7 +53,7 @@ static std::vector<ComPtr<IDXGIAdapter1>> EnumerateAdapters(PLUID device_luid = 
         adapter_infos.emplace_back(std::move(adapter));
       }
     }
-  } else {
+  } else if (device_luid) {
     // Enumerate adapters without ordering.
     ComPtr<IDXGIAdapter1> adapter;
     for (uint32_t adapter_index = 0; dxgi_factory->EnumAdapters1(adapter_index, &adapter) != DXGI_ERROR_NOT_FOUND; adapter_index++) {
@@ -66,7 +67,7 @@ static std::vector<ComPtr<IDXGIAdapter1>> EnumerateAdapters(PLUID device_luid = 
       ComPtr<ID3D12Device> d3d12_device;
       THROW_IF_FAILED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&d3d12_device)));
 
-      if (d3d12_device && device_luid) {
+      if (d3d12_device) {
         DXGI_ADAPTER_DESC1 description = {};
         THROW_IF_FAILED(adapter->GetDesc1(&description));
 
@@ -75,24 +76,51 @@ static std::vector<ComPtr<IDXGIAdapter1>> EnumerateAdapters(PLUID device_luid = 
           adapter_infos.emplace_back(std::move(adapter));
           break;
         }
-      } else if (d3d12_device) {
-        adapter_infos.emplace_back(std::move(adapter));
       }
     }
+  }
+  else {
+      // Enumerate adapters without ordering.
+      ComPtr<IDXGIAdapter1> adapter;
+      uint32_t hwAdapterIndex = 0;
+      for (uint32_t adapter_index = 0; dxgi_factory->EnumAdapters1(adapter_index, &adapter) != DXGI_ERROR_NOT_FOUND; adapter_index++) {
+          // We can't assume the ordering of hardware and software adapters, so keep looping. This path should only execute on Windows 10
+          // version 1709 or earlier; IDD (e.g. remote desktop) adapters do not exist when taking this code path.
+          if (IsSoftwareAdapter(adapter.Get())) {
+              continue;
+          }
+
+          // Make sure that we are able to create the device
+          ComPtr<ID3D12Device> d3d12_device;
+          THROW_IF_FAILED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&d3d12_device)));
+
+          if (d3d12_device && deviceIndex) {
+              // get device specified by the deviceIndex
+              if (*deviceIndex == hwAdapterIndex) {
+                  adapter_infos.emplace_back(std::move(adapter));
+                  break;
+              }
+          }
+          else if (d3d12_device) {
+              adapter_infos.emplace_back(std::move(adapter));
+          }
+
+          hwAdapterIndex++;
+      }
   }
 
   return adapter_infos;
 }
 
-static ComPtr<IDXGIAdapter1> CreateAdapter(PLUID device_luid = nullptr) {
-  auto filtered_adapters = EnumerateAdapters(device_luid);
+static ComPtr<IDXGIAdapter1> CreateAdapter(PLUID device_luid = nullptr, UINT* deviceIndex = nullptr) {
+  auto filtered_adapters = EnumerateAdapters(device_luid, deviceIndex);
   if (filtered_adapters.empty()) {
     throw std::runtime_error("No adapter is available for DML.");
   }
   return filtered_adapters.front();
 }
 
-DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device_luid) {
+DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device_luid, UINT* deviceIndex) {
   D3D12_COMMAND_QUEUE_DESC command_queue_description = {
       D3D12_COMMAND_LIST_TYPE_COMPUTE,
       0,
@@ -102,7 +130,7 @@ DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device
 
   DmlObjects dml_objects;
 
-  auto adapter = CreateAdapter(device_luid);
+  auto adapter = CreateAdapter(device_luid, deviceIndex);
   ComPtr<ID3D12SDKConfiguration1> d3d12_sdk_config;
   ComPtr<ID3D12DeviceFactory> d3d12_factory;
 

--- a/src/dml/dml_helpers.cpp
+++ b/src/dml/dml_helpers.cpp
@@ -99,8 +99,7 @@ static std::vector<ComPtr<IDXGIAdapter1>> EnumerateAdapters(PLUID device_luid = 
           adapter_infos.emplace_back(std::move(adapter));
           break;
         }
-      }
-      else if (d3d12_device) {
+      } else if (d3d12_device) {
         adapter_infos.emplace_back(std::move(adapter));
       }
 

--- a/src/dml/dml_helpers.h
+++ b/src/dml/dml_helpers.h
@@ -31,7 +31,7 @@ struct DmlObjects {
 };
 
 namespace DmlHelpers {
-DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device_luid = nullptr);
+DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device_luid = nullptr, UINT* p_device_index = nullptr);
 
 DmlReusedCommandListState BuildReusableCommandList(
     IDMLDevice* dml_device,

--- a/src/dml/dml_helpers.h
+++ b/src/dml/dml_helpers.h
@@ -31,7 +31,7 @@ struct DmlObjects {
 };
 
 namespace DmlHelpers {
-DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device_luid = nullptr, UINT* p_device_index = nullptr);
+DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device_luid = nullptr, uint32_t* p_device_index = nullptr);
 
 DmlReusedCommandListState BuildReusableCommandList(
     IDMLDevice* dml_device,

--- a/src/dml/interface.cpp
+++ b/src/dml/interface.cpp
@@ -96,7 +96,7 @@ struct GpuMemory final : DeviceBuffer {
 };
 
 struct InterfaceImpl : DeviceInterface {
-  InterfaceImpl(LUID* p_device_luid, UINT* p_device_index) {
+  InterfaceImpl(LUID* p_device_luid, uint32_t* p_device_index) {
     Ort::ThrowOnError(Ort::api->GetExecutionProviderApi("DML", ORT_API_VERSION, reinterpret_cast<const void**>(&dml_api_)));
     if (!dml_api_) {
       throw std::runtime_error("Unexpected nullptr getting OrtDmlApi");
@@ -213,7 +213,7 @@ struct InterfaceImpl : DeviceInterface {
 
 std::unique_ptr<Dml::InterfaceImpl> g_dml_device;
 
-void InitDmlInterface(LUID* p_device_luid, UINT* p_device_index) {
+void InitDmlInterface(LUID* p_device_luid, uint32_t* p_device_index) {
   if (!g_dml_device)
     g_dml_device = std::make_unique<Dml::InterfaceImpl>(p_device_luid, p_device_index);
 }

--- a/src/dml/interface.cpp
+++ b/src/dml/interface.cpp
@@ -96,13 +96,13 @@ struct GpuMemory final : DeviceBuffer {
 };
 
 struct InterfaceImpl : DeviceInterface {
-  InterfaceImpl(LUID* p_device_luid) {
+  InterfaceImpl(LUID* p_device_luid, UINT* p_device_index) {
     Ort::ThrowOnError(Ort::api->GetExecutionProviderApi("DML", ORT_API_VERSION, reinterpret_cast<const void**>(&dml_api_)));
     if (!dml_api_) {
       throw std::runtime_error("Unexpected nullptr getting OrtDmlApi");
     }
 
-    dml_objects_ = DmlHelpers::CreateDmlObjects(CurrentModulePath(), p_device_luid);
+    dml_objects_ = DmlHelpers::CreateDmlObjects(CurrentModulePath(), p_device_luid, p_device_index);
 
     constexpr auto directml_dll = "DirectML.dll";
     smart_directml_dll_ = wil::unique_hmodule{LoadLibraryEx(directml_dll, nullptr, 0)};
@@ -213,9 +213,9 @@ struct InterfaceImpl : DeviceInterface {
 
 std::unique_ptr<Dml::InterfaceImpl> g_dml_device;
 
-void InitDmlInterface(LUID* p_device_luid) {
+void InitDmlInterface(LUID* p_device_luid, UINT* p_device_index) {
   if (!g_dml_device)
-    g_dml_device = std::make_unique<Dml::InterfaceImpl>(p_device_luid);
+    g_dml_device = std::make_unique<Dml::InterfaceImpl>(p_device_luid, p_device_index);
 }
 
 void SetDmlProvider(OrtSessionOptions& session_options) {

--- a/src/dml/interface.h
+++ b/src/dml/interface.h
@@ -10,7 +10,7 @@ typedef struct _LUID {
 
 namespace Generators {
 
-void InitDmlInterface(LUID* p_device_luid);
+void InitDmlInterface(LUID* p_device_luid, UINT* p_device_index);
 void SetDmlProvider(OrtSessionOptions& options);
 
 DeviceInterface* GetDmlInterface();

--- a/src/dml/interface.h
+++ b/src/dml/interface.h
@@ -10,7 +10,7 @@ typedef struct _LUID {
 
 namespace Generators {
 
-void InitDmlInterface(LUID* p_device_luid, UINT* p_device_index);
+void InitDmlInterface(LUID* p_device_luid, uint32_t* p_device_index);
 void SetDmlProvider(OrtSessionOptions& options);
 
 DeviceInterface* GetDmlInterface();

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -333,8 +333,8 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
       if (!GetDmlInterface()) {
         LUID device_luid{};
         LUID* p_device_luid{};
-        UINT device_index{};
-        UINT* p_device_index{};
+        uint32_t device_index{};
+        uint32_t* p_device_index{};
         for (const auto& [name, value] : provider_options.options) {
           if (name == "luid") {
             if (auto separator_position = value.find(":"); separator_position != std::string::npos) {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -333,6 +333,8 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
       if (!GetDmlInterface()) {
         LUID device_luid{};
         LUID* p_device_luid{};
+        UINT device_index{};
+        UINT* p_device_index{};
         for (const auto& [name, value] : provider_options.options) {
           if (name == "luid") {
             if (auto separator_position = value.find(":"); separator_position != std::string::npos) {
@@ -340,10 +342,13 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
               device_luid.LowPart = std::stol(value.substr(separator_position + 1));
               p_device_luid = &device_luid;
             }
+          } else if (name == "device_index") {
+            device_index = std::stoi(value);
+            p_device_index = &device_index;
           }
         }
 
-        InitDmlInterface(p_device_luid);
+        InitDmlInterface(p_device_luid, p_device_index);
       }
 
       if (!disable_graph_capture) {


### PR DESCRIPTION
Add device index support to DML provider option. Its useful feature to force a particular device on a multi GPU systems. genAI is missing the device index support