### PR TITLE
[#1508] Automatically install java maven artifact in the local maven repository

### DIFF
--- a/build.py
+++ b/build.py
@@ -12,7 +12,6 @@ import shutil
 import sys
 import textwrap
 import subprocess
-import re
 
 from pathlib import Path
 

--- a/src/java/build.gradle
+++ b/src/java/build.gradle
@@ -122,8 +122,54 @@ if (cmakeNativeLibDir != null) {
 			from { generatePomFileForMavenPublication }
 			rename ".*", "pom.xml"
 		}
+
+		// Include compiled Java classes in their standard location
 		from sourceSets.main.output
-		from cmakeNativeLibDir
+
+		// Determine the OS and architecture string similar to GenAI.java
+		def osArch = ""
+		def os = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH)
+		def arch = System.getProperty("os.arch", "generic").toLowerCase(Locale.ENGLISH)
+
+		def detectedOS = ""
+		if (os.contains("mac") || os.contains("darwin")) {
+			detectedOS = "osx"
+		} else if (os.contains("win")) {
+			detectedOS = "win"
+		} else if (os.contains("nux")) {
+			detectedOS = "linux"
+		} else if (os == "android") { // Assuming "android" comes from System.getProperty
+			detectedOS = "android"
+		} else {
+			throw new IllegalStateException("Unsupported os:" + os)
+		}
+
+		def detectedArch = ""
+		if (arch.startsWith("amd64") || arch.startsWith("x86_64")) {
+			detectedArch = "x64"
+		} else if (arch.startsWith("x86")) {
+			detectedArch = "x86"
+		} else if (arch.startsWith("aarch64")) {
+			detectedArch = "aarch64"
+		} else if (arch.startsWith("ppc64")) {
+			detectedArch = "ppc64"
+		} else if (detectedOS == "android") {
+			detectedArch = arch // On Android, use the reported arch directly
+		} else {
+			throw new IllegalStateException("Unsupported arch:" + arch)
+		}
+
+		osArch = detectedOS + '-' + detectedArch
+
+		// Copy only native libraries to the platform-specific directory within the JAR
+		if (cmakeNativeLibDir != null) {
+			from(cmakeNativeLibDir) {
+				include "*.so"    // Linux shared libraries
+				include "*.dll"   // Windows shared libraries
+				include "*.dylib" // macOS shared libraries
+				into "ai/onnxruntime/genai/native/${osArch}"
+			}
+		}
 	}
 
 	task cmakeBuild(type: Copy) {


### PR DESCRIPTION
The best practice for Java Maven project is that project artifacts (jars, poms, etc.) are added to the local Maven repository as part of the build. This allows for easy consumption / integration /testing of such artifacts as dependencies in other Maven projects.
This PR automatically installs the generated onnxruntime-genai jar as a maven artifact in the local maven repository (if the "--build_java" flag is passed to the usual python build).

https://github.com/microsoft/onnxruntime-genai/issues/1508