### PR TITLE
Update Chat Template Examples for Tools API change

### DIFF
--- a/examples/c/src/phi3.cpp
+++ b/examples/c/src/phi3.cpp
@@ -55,7 +55,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
       break;  // Exit the loop
     }
 
-    const std::string prompt = tokenizer->ApplyChatTemplate("", text.c_str(), true);
+    const std::string prompt = tokenizer->ApplyChatTemplate("", text.c_str(), "", true);
 
     bool is_first_token = true;
     Timing timing;

--- a/examples/c/src/phi3_qa.cpp
+++ b/examples/c/src/phi3_qa.cpp
@@ -45,7 +45,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
       break;  // Exit the loop
     }
 
-    const std::string prompt = tokenizer->ApplyChatTemplate("", text.c_str(), true);
+    const std::string prompt = tokenizer->ApplyChatTemplate("", text.c_str(), "", true);
 
     bool is_first_token = true;
     Timing timing;

--- a/examples/csharp/HelloPhi/Program.cs
+++ b/examples/csharp/HelloPhi/Program.cs
@@ -116,7 +116,7 @@ if (option == 1 || option == 2)
         {
             break;
         }
-        var sequences = tokenizer.Encode(tokenizer.ApplyChatTemplate("", prompt, true));
+        var sequences = tokenizer.Encode(tokenizer.ApplyChatTemplate("", prompt, "", true));
 
         if (option == 1) // Complete Output
         {
@@ -183,7 +183,7 @@ if (option == 3) // Streaming Chat
         {
             break;
         }
-        var sequences = tokenizer.Encode(tokenizer.ApplyChatTemplate("", prompt, true));
+        var sequences = tokenizer.Encode(tokenizer.ApplyChatTemplate("", prompt, "", true));
         var watch = System.Diagnostics.Stopwatch.StartNew();
         generator.AppendTokenSequences(sequences);
         while (!generator.IsDone())


### PR DESCRIPTION
Updates examples broken by https://github.com/microsoft/onnxruntime-genai/pull/1472.

Note: only C and C# examples are updated. Python examples need no updating as `tools` is an optional input with a default value in the Python API.