### PR TITLE
Fix last layer generation for text-only models

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -2616,7 +2616,7 @@ class Model:
             model = orig_model.language_model
         elif hasattr(orig_model, "base_model") and hasattr(orig_model.base_model, "model"):
             # Model is from PEFT
-            model = orig_model.base_model.model
+            model = orig_model.base_model
         else:
             model = orig_model
 
@@ -3766,7 +3766,9 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
             if precision == "fp16":
                 print("WARNING: This model loses accuracy with float16 precision. Setting `--precision bf16` by default.")
                 precision = "bf16"
+            print("Setting gemma3_text")
             onnx_model = Gemma3Model(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
+            onnx_model.model_type = "gemma3_text"
         elif config.architectures[0] == "GraniteForCausalLM":
             onnx_model = GraniteModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "LlamaForCausalLM":

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -3766,9 +3766,7 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
             if precision == "fp16":
                 print("WARNING: This model loses accuracy with float16 precision. Setting `--precision bf16` by default.")
                 precision = "bf16"
-            print("Setting gemma3_text")
             onnx_model = Gemma3Model(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
-            onnx_model.model_type = "gemma3_text"
         elif config.architectures[0] == "GraniteForCausalLM":
             onnx_model = GraniteModel(config, io_dtype, precision, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "LlamaForCausalLM":

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -2615,8 +2615,12 @@ class Model:
             # differ.
             model = orig_model.language_model
         elif hasattr(orig_model, "base_model") and hasattr(orig_model.base_model, "model"):
-            # Model is from PEFT
-            model = orig_model.base_model
+            if hasattr(orig_model.base_model.model, "model"):
+                # Model is from PEFT
+                model = orig_model.base_model.model
+            else:
+                # Model is text-based only.
+                model = orig_model.base_model
         else:
             model = orig_model
 


### PR DESCRIPTION
Models such as Gemma3 1B which is not a multimodal model will not generate correct last layer since it's immediately trying to fetch the model params which it should not. Instead it should only retrieve the base_model param.