### PR TITLE
Clamp KV Cache Size to Sliding Window for NvTensorRtRtx EP

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -425,6 +425,8 @@ struct Decoder_Element : JSON::Element {
       v_.num_hidden_layers = static_cast<int>(JSON::Get<double>(value));
     } else if (name == "head_size") {
       v_.head_size = static_cast<int>(JSON::Get<double>(value));
+    } else if (name == "sliding_window_size") {
+      v_.sliding_window_size = static_cast<int>(JSON::Get<double>(value));
     } else
       throw JSON::unknown_value_error{};
   }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -367,6 +367,8 @@ struct SlidingWindow_Element : JSON::Element {
       v_->alignment = JSON::Get<std::string_view>(value);
     } else if (name == "slide_key_value_cache") {
       v_->slide_key_value_cache = JSON::Get<bool>(value);
+    } else if (name == "slide_inputs") {
+      v_->slide_inputs = JSON::Get<bool>(value);
     } else
       throw JSON::unknown_value_error{};
   }
@@ -425,8 +427,6 @@ struct Decoder_Element : JSON::Element {
       v_.num_hidden_layers = static_cast<int>(JSON::Get<double>(value));
     } else if (name == "head_size") {
       v_.head_size = static_cast<int>(JSON::Get<double>(value));
-    } else if (name == "sliding_window_size") {
-      v_.sliding_window_size = static_cast<int>(JSON::Get<double>(value));
     } else
       throw JSON::unknown_value_error{};
   }

--- a/src/config.h
+++ b/src/config.h
@@ -174,13 +174,13 @@ struct Config {
       int num_key_value_heads{};
       int num_hidden_layers{};
       int head_size{};
-      int sliding_window_size{-1};
 
       struct SlidingWindow {               // Sliding window parameters for models that process input prompt in chunks
         int window_size{};                 // The size of the window to slide over the input prompt
         int pad_value{};                   // The key-value cache padding value to use for the sliding window for inactive tokens
         std::string alignment{"right"};    // The alignment of the window, either "left" or "right"
         bool slide_key_value_cache{true};  // Whether to slide the key-value cache along with the input prompt
+        bool slide_inputs{true};           // Whether to slide the input prompt along with the key-value cache
       };
       std::optional<SlidingWindow> sliding_window;
 

--- a/src/config.h
+++ b/src/config.h
@@ -174,6 +174,7 @@ struct Config {
       int num_key_value_heads{};
       int num_hidden_layers{};
       int head_size{};
+      int sliding_window_size{-1};
 
       struct SlidingWindow {               // Sliding window parameters for models that process input prompt in chunks
         int window_size{};                 // The size of the window to slide over the input prompt

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -321,7 +321,10 @@ DeviceSpan<int32_t> Generator::AllocateInputIdsOnDevice(cpu_span<const int32_t> 
     // If the model has a sliding window, pad the input_ids to the next multiple of the window size
     // so that the input_ids can be divided into window size chunks.
     const auto window_size = model_->config_->model.decoder.sliding_window->window_size;
-    padded_input_ids_size = ((input_ids.size() + window_size - 1) / window_size) * window_size;
+
+    if (model_->config_->model.decoder.sliding_window->slide_inputs) {
+      padded_input_ids_size = ((input_ids.size() + window_size - 1) / window_size) * window_size;
+    }
   }
 
   auto input_ids_device = state_->params_->p_device->Allocate<int32_t>(padded_input_ids_size);

--- a/src/models/input_ids.cpp
+++ b/src/models/input_ids.cpp
@@ -226,7 +226,7 @@ void WindowedInputIDs::Update(DeviceSpan<int32_t> new_tokens) {
 }
 
 std::unique_ptr<InputIDs> CreateInputIDs(State& state) {
-  if (state.model_.config_->model.decoder.sliding_window.has_value()) {
+  if (state.model_.config_->model.decoder.sliding_window.has_value() && state.model_.config_->model.decoder.sliding_window->slide_inputs) {
     return std::make_unique<WindowedInputIDs>(state);
   } else {
     return std::make_unique<DefaultInputIDs>(state);

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -175,7 +175,7 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
   }
 
   // Set the size after empty_past_ has been created with 0 for this field
-  if (past_present_share_buffer_ && model_.config_->model.decoder.sliding_window_size > 0)
+  if (state.model_.p_device_->GetType() == DeviceType::NvTensorRtRtx && model_.config_->model.decoder.sliding_window_size > 0)
     shape_[2] = std::min(state_.params_->search.max_length, model_.config_->model.decoder.sliding_window_size);
   else if (past_present_share_buffer_)
     shape_[2] = state_.params_->search.max_length;

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -175,8 +175,10 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
   }
 
   // Set the size after empty_past_ has been created with 0 for this field
-  if (state.model_.p_device_->GetType() == DeviceType::NvTensorRtRtx && model_.config_->model.decoder.sliding_window_size > 0)
-    shape_[2] = std::min(state_.params_->search.max_length, model_.config_->model.decoder.sliding_window_size);
+  if (state.model_.p_device_->GetType() == DeviceType::NvTensorRtRtx &&
+      model_.config_->model.decoder.sliding_window.has_value() &&
+      model_.config_->model.decoder.sliding_window->window_size > 0)
+    shape_[2] = std::min(state_.params_->search.max_length, model_.config_->model.decoder.sliding_window->window_size);
   else if (past_present_share_buffer_)
     shape_[2] = state_.params_->search.max_length;
 
@@ -424,7 +426,8 @@ std::unique_ptr<KeyValueCache> CreateKeyValueCache(State& state) {
     return nullptr;
   }
 
-  if (state.model_.config_->model.decoder.sliding_window &&
+  if (state.model_.p_device_->GetType() != DeviceType::NvTensorRtRtx && 
+      state.model_.config_->model.decoder.sliding_window && 
       state.model_.config_->model.decoder.sliding_window->slide_key_value_cache) {
     return std::make_unique<WindowedKeyValueCache>(state);
   }

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -177,10 +177,12 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
   // Set the size after empty_past_ has been created with 0 for this field
   if (state.model_.p_device_->GetType() == DeviceType::NvTensorRtRtx &&
       model_.config_->model.decoder.sliding_window.has_value() &&
-      model_.config_->model.decoder.sliding_window->window_size > 0)
-    shape_[2] = std::min(state_.params_->search.max_length, model_.config_->model.decoder.sliding_window->window_size);
-  else if (past_present_share_buffer_)
+      model_.config_->model.decoder.sliding_window->window_size > 0) {
+    shape_[2] = std::min(state_.params_->search.max_length,
+                         model_.config_->model.decoder.sliding_window->window_size);
+  } else if (past_present_share_buffer_) {
     shape_[2] = state_.params_->search.max_length;
+  }
 
   try {
     for (int i = 0; i < layer_count_ * 2; ++i) {
@@ -426,8 +428,8 @@ std::unique_ptr<KeyValueCache> CreateKeyValueCache(State& state) {
     return nullptr;
   }
 
-  if (state.model_.p_device_->GetType() != DeviceType::NvTensorRtRtx && 
-      state.model_.config_->model.decoder.sliding_window && 
+  if (state.model_.p_device_->GetType() != DeviceType::NvTensorRtRtx &&
+      state.model_.config_->model.decoder.sliding_window &&
       state.model_.config_->model.decoder.sliding_window->slide_key_value_cache) {
     return std::make_unique<WindowedKeyValueCache>(state);
   }

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -175,7 +175,9 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
   }
 
   // Set the size after empty_past_ has been created with 0 for this field
-  if (past_present_share_buffer_)
+  if (past_present_share_buffer_ && model_.config_->model.decoder.sliding_window_size > 0)
+    shape_[2] = std::min(state_.params_->search.max_length, model_.config_->model.decoder.sliding_window_size);
+  else if (past_present_share_buffer_)
     shape_[2] = state_.params_->search.max_length;
 
   try {

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -438,7 +438,7 @@ void WindowedPositionInputs::Update(DeviceSpan<int32_t> next_tokens, int total_l
 }
 
 std::unique_ptr<PositionInputs> CreatePositionInputs(State& state, DeviceSpan<int32_t> sequence_lengths, const std::string& attention_mask_name_) {
-  if (state.model_.config_->model.decoder.sliding_window.has_value()) {
+  if (state.model_.config_->model.decoder.sliding_window.has_value() && state.model_.config_->model.decoder.sliding_window->slide_inputs) {
     return std::make_unique<WindowedPositionInputs>(state);
   } else {
     return std::make_unique<DefaultPositionInputs>(state.model_, state, sequence_lengths, attention_mask_name_);

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -433,6 +433,9 @@ class Model:
             },
         }
 
+        if self.window_size > 0:
+            genai_config["model"]["decoder"]["sliding_window_size"] = self.window_size
+
         if self.ep != "cpu":
             ep_options = { self.ep : self.ep_attrs[self.ep] }
             genai_config["model"]["decoder"]["session_options"]["provider_options"].append(ep_options)

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -433,7 +433,7 @@ class Model:
             },
         }
 
-        if self.window_size > 0:
+        if self.window_size is not None and self.window_size > 0:
             genai_config["model"]["decoder"]["sliding_window_size"] = self.window_size
 
         if self.ep != "cpu":

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -434,7 +434,7 @@ class Model:
         }
 
         if self.window_size is not None and self.window_size > 0:
-            genai_config["model"]["decoder"]["sliding_window_size"] = self.window_size
+            genai_config["model"]["decoder"]["sliding_window"] = {"window_size": self.window_size, "slide_key_value_cache": False, "slide_inputs": False}
 
         if self.ep != "cpu":
             ep_options = { self.ep : self.ep_attrs[self.ep] }


### PR DESCRIPTION
# Overview
This pull request modifies the ORT GenAI to ensure that the key-value (KV) cache size used by the NvTensorRtRtx Execution Provider (EP) is clamped to the configured sliding window size. 

# Changes
1. Updated GenAI Model Builder to write 'sliding windowed size' config in genai_config.json.
2. Updated GenAI kv cache to limit the kv allocation size when 'sliding windowed size' is set for NvTensorRtRtx EP. 

# Benefits
This leads to required memory footprint reduction for the models that uses sliding window.

# Tests
[x] Locally verified DeepSeek-R1-Distill-Qwen-1.5B and few others for NvTensorRtRtx EP.

@kunal-vaishnavi @baijumeswani 


