### PR TITLE
Update SimpleGenAI.java docs

### DIFF
--- a/src/java/src/main/java/ai/onnxruntime/genai/SimpleGenAI.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/SimpleGenAI.java
@@ -22,8 +22,7 @@ import java.util.function.Consumer;
  * </ul>
  *
  * <p>The listener is used as a callback mechanism so that tokens can be used as they are generated.
- * Create a class that implements the TokenUpdateListener interface and provide an instance of that
- * class as the `listener` argument.
+ * It should be an instance of a type that implements the Consumer<String> interface.
  */
 public class SimpleGenAI implements AutoCloseable {
   private Model model;
@@ -59,8 +58,10 @@ public class SimpleGenAI implements AutoCloseable {
    *
    * @param generatorParams The prompt and settings to run the model with.
    * @param prompt The prompt text to encode.
-   * @param listener Optional callback for tokens to be provided as they are generated. NOTE: Token
-   *     generation will be blocked until the listener's `accept` method returns.
+   * @param listener Optional callback for tokens to be provided as they are generated.
+   *     NOTE: Token generation will be blocked until the listener's `accept` method returns.
+   *     `listener` will be called within the token generation loop and calls to `listener` will be
+   *     made sequentially, not concurrently.
    * @return The generated text.
    * @throws GenAIException on failure
    */


### PR DESCRIPTION
- Remove reference to `TokenUpdateListener` which seems outdated.
- Specify that `listener` callback will not get called concurrently. This additional guarantee can simplify the implementation of `listener`. E.g., by not requiring `listener` to synchronize access to state shared between calls to it.