### PR TITLE
Trim genai version for dev runs in Nuget packaging

### DIFF
--- a/.pipelines/stages/jobs/nuget-packaging-job.yml
+++ b/.pipelines/stages/jobs/nuget-packaging-job.yml
@@ -232,25 +232,17 @@ jobs:
       $outputDir = '$(Build.Repository.LocalPath)/$(buildDir)'
       Write-Host "List extracted artifacts"
       Get-ChildItem -Path $nativeBuildOutputDir -Recurse
-      # For non-stable versions, we don't need the complete version, just the first two parts
-      # e.g. "0.9.0-dev-rest" → "0.9.0-dev"
-      $version_parts = "$(genai_version)" -split '-', 3
-      if ($version_parts.Count -ge 2) {
-        $req_genai_version = "$($version_parts[0])-$($version_parts[1])"
-      } else {
-        $req_genai_version = "$(genai_version)"
-      }
 
       mkdir -Force $outputDir
       foreach ($file in $artifacts) {
         $a = $file.Name
         Write-Host "Extracting " $a
-        $rid_match = $a -match "onnxruntime-genai-$req_genai_version-(.+?)-?(?:cuda|dml)?(\.zip|\.tar\.gz)"
+        $rid_match = $a -match "onnxruntime-genai-$(genai_version_raw)-(.+?)-?(?:cuda|dml)?(\.zip|\.tar\.gz)"
         if ($rid_match) {
           $rid = $Matches.1
         }
         else {
-          $rid_match = $a -match "onnxruntime-genai-(android|ios)-$req_genai_version(.+?)?(\.zip|\.aar)"
+          $rid_match = $a -match "onnxruntime-genai-(android|ios)-$(genai_version_raw)(.+?)?(\.zip|\.aar)"
           if ($rid_match) {
             $rid = $Matches.1
           }

--- a/.pipelines/stages/jobs/nuget-packaging-job.yml
+++ b/.pipelines/stages/jobs/nuget-packaging-job.yml
@@ -232,17 +232,25 @@ jobs:
       $outputDir = '$(Build.Repository.LocalPath)/$(buildDir)'
       Write-Host "List extracted artifacts"
       Get-ChildItem -Path $nativeBuildOutputDir -Recurse
+      # For non-stable versions, we don't need the complete version, just the first two parts
+      # e.g. "0.9.0-dev-rest" → "0.9.0-dev"
+      $version_parts = $(genai_version) -split '-', 3
+      if ($version_parts.Count -ge 2) {
+        $req_genai_version = "$($version_parts[0])-$($version_parts[1])"
+      } else {
+        $req_genai_version = $(genai_version)
+      }
 
       mkdir -Force $outputDir
       foreach ($file in $artifacts) {
         $a = $file.Name
         Write-Host "Extracting " $a
-        $rid_match = $a -match "onnxruntime-genai-$(genai_version)-(.+?)-?(?:cuda|dml)?(\.zip|\.tar\.gz)"
+        $rid_match = $a -match "onnxruntime-genai-$req_genai_version-(.+?)-?(?:cuda|dml)?(\.zip|\.tar\.gz)"
         if ($rid_match) {
           $rid = $Matches.1
         }
         else {
-          $rid_match = $a -match "onnxruntime-genai-(android|ios)-$(genai_version)(.+?)?(\.zip|\.aar)"
+          $rid_match = $a -match "onnxruntime-genai-(android|ios)-$req_genai_version(.+?)?(\.zip|\.aar)"
           if ($rid_match) {
             $rid = $Matches.1
           }

--- a/.pipelines/stages/jobs/nuget-packaging-job.yml
+++ b/.pipelines/stages/jobs/nuget-packaging-job.yml
@@ -234,11 +234,11 @@ jobs:
       Get-ChildItem -Path $nativeBuildOutputDir -Recurse
       # For non-stable versions, we don't need the complete version, just the first two parts
       # e.g. "0.9.0-dev-rest" → "0.9.0-dev"
-      $version_parts = $(genai_version) -split '-', 3
+      $version_parts = "$(genai_version)" -split '-', 3
       if ($version_parts.Count -ge 2) {
         $req_genai_version = "$($version_parts[0])-$($version_parts[1])"
       } else {
-        $req_genai_version = $(genai_version)
+        $req_genai_version = "$(genai_version)"
       }
 
       mkdir -Force $outputDir

--- a/.pipelines/stages/jobs/steps/utils/set-genai-version.yml
+++ b/.pipelines/stages/jobs/steps/utils/set-genai-version.yml
@@ -34,3 +34,5 @@ steps:
 
       Write-Host "Setting variable: genai_version = ${version}"
       Write-Host "##vso[task.setvariable variable=genai_version]${version}"
+      Write-Host "Setting variable: genai_version_raw = ${version_info}"
+      Write-Host "##vso[task.setvariable variable=genai_version_raw]${version_info}"


### PR DESCRIPTION
Trim genai version for dev runs in Nuget packaging step and fixes the issue for Nuget packaging output for dev runs.

Currently the genai version for dev runs is something like this "0.9.0-dev-423423-da43-d34*" and because of that it doesn't match the file names. We just need to extract the first two parts in the genai version and this PR does the same. Have started test runs to ensure it works properly.