### PR TITLE
Default `add_generation_prompt` for Chat Templates to true in Python API

### DIFF
--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -358,21 +358,7 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       })
       .def("to_token_id", &OgaTokenizer::ToTokenId)
       .def("decode", [](const OgaTokenizer& t, pybind11::array_t<int32_t> tokens) -> std::string { return t.Decode(ToSpan(tokens)).p_; })
-      .def(
-    "apply_chat_template",
-    [](const OgaTokenizer& t,
-       const char* messages,
-       const char* template_str,
-       const char* tools,
-       bool add_generation_prompt) -> std::string {
-        return t.ApplyChatTemplate(template_str, messages, tools, add_generation_prompt).p_;
-    },
-    pybind11::arg("messages"),
-    pybind11::kw_only(),
-    pybind11::arg("template_str") = nullptr,
-    pybind11::arg("tools") = nullptr,
-    pybind11::arg("add_generation_prompt") = true
-)
+      .def("apply_chat_template", [](const OgaTokenizer& t, const char* messages, const char* template_str, const char* tools, bool add_generation_prompt) -> std::string { return t.ApplyChatTemplate(template_str, messages, tools, add_generation_prompt).p_; }, pybind11::arg("messages"), pybind11::kw_only(), pybind11::arg("template_str") = nullptr, pybind11::arg("tools") = nullptr, pybind11::arg("add_generation_prompt") = true)
       .def("encode_batch", [](const OgaTokenizer& t, std::vector<std::string> strings) {
         std::vector<const char*> c_strings;
         for (const auto& s : strings)

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -358,7 +358,21 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       })
       .def("to_token_id", &OgaTokenizer::ToTokenId)
       .def("decode", [](const OgaTokenizer& t, pybind11::array_t<int32_t> tokens) -> std::string { return t.Decode(ToSpan(tokens)).p_; })
-      .def("apply_chat_template", [](const OgaTokenizer& t, const char* template_str, const char* messages, const char* tools, bool add_generation_prompt) -> std::string { return t.ApplyChatTemplate(template_str, messages, tools, add_generation_prompt).p_; }, pybind11::arg("template_str") = nullptr, pybind11::arg("messages"), pybind11::arg("tools") = nullptr, pybind11::arg("add_generation_prompt") = true)
+      .def(
+    "apply_chat_template",
+    [](const OgaTokenizer& t,
+       const char* messages,
+       const char* template_str,
+       const char* tools,
+       bool add_generation_prompt) -> std::string {
+        return t.ApplyChatTemplate(template_str, messages, tools, add_generation_prompt).p_;
+    },
+    pybind11::arg("messages"),
+    pybind11::kw_only(),
+    pybind11::arg("template_str") = nullptr,
+    pybind11::arg("tools") = nullptr,
+    pybind11::arg("add_generation_prompt") = true
+)
       .def("encode_batch", [](const OgaTokenizer& t, std::vector<std::string> strings) {
         std::vector<const char*> c_strings;
         for (const auto& s : strings)

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -358,7 +358,7 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       })
       .def("to_token_id", &OgaTokenizer::ToTokenId)
       .def("decode", [](const OgaTokenizer& t, pybind11::array_t<int32_t> tokens) -> std::string { return t.Decode(ToSpan(tokens)).p_; })
-      .def("apply_chat_template", [](const OgaTokenizer& t, const char* template_str, const char* messages, const char* tools, bool add_generation_prompt) -> std::string { return t.ApplyChatTemplate(template_str, messages, tools, add_generation_prompt).p_; }, pybind11::arg("template_str") = nullptr, pybind11::arg("messages"), pybind11::arg("tools") = nullptr, pybind11::arg("add_generation_prompt"))
+      .def("apply_chat_template", [](const OgaTokenizer& t, const char* template_str, const char* messages, const char* tools, bool add_generation_prompt) -> std::string { return t.ApplyChatTemplate(template_str, messages, tools, add_generation_prompt).p_; }, pybind11::arg("template_str") = nullptr, pybind11::arg("messages"), pybind11::arg("tools") = nullptr, pybind11::arg("add_generation_prompt") = true)
       .def("encode_batch", [](const OgaTokenizer& t, std::vector<std::string> strings) {
         std::vector<const char*> c_strings;
         for (const auto& s : strings)


### PR DESCRIPTION
Adds default to make `add_generation_prompt` optional in the Python API (note: because of lack of support for optionals in the C API we can only do this for Python).