### PR TITLE
Support loading models from memory

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -257,8 +257,8 @@ struct Config {
   // otherwise returns the nominal name and false
   std::pair<std::string, bool> GetGraphName(const std::string& nominal_name) const;
 
-  std::unordered_map<std::string, std::string> nominal_names_to_graph_names_;      // Mapping of nominal input/output names to graph input/output names
-  std::unordered_map<std::string, std::span<const std::byte>> model_datas_spans_;  // Model bytes to support loading a model from memory
+  std::unordered_map<std::string, std::string> nominal_names_to_graph_names_;     // Mapping of nominal input/output names to graph input/output names
+  std::unordered_map<std::string, std::span<const std::byte>> model_data_spans_;  // Model bytes to support loading a model from memory
 };
 
 void SetSearchNumber(Config::Search& search, std::string_view name, double value);

--- a/src/config.h
+++ b/src/config.h
@@ -258,6 +258,7 @@ struct Config {
   std::pair<std::string, bool> GetGraphName(const std::string& nominal_name) const;
 
   std::unordered_map<std::string, std::string> nominal_names_to_graph_names_;  // Mapping of nominal input/output names to graph input/output names
+  std::unordered_map<std::string, std::span<const uint8_t>> model_datas_;      // Model bytes to support loading a model from memory
 };
 
 void SetSearchNumber(Config::Search& search, std::string_view name, double value);

--- a/src/config.h
+++ b/src/config.h
@@ -257,8 +257,8 @@ struct Config {
   // otherwise returns the nominal name and false
   std::pair<std::string, bool> GetGraphName(const std::string& nominal_name) const;
 
-  std::unordered_map<std::string, std::string> nominal_names_to_graph_names_;  // Mapping of nominal input/output names to graph input/output names
-  std::unordered_map<std::string, std::span<const uint8_t>> model_datas_;      // Model bytes to support loading a model from memory
+  std::unordered_map<std::string, std::string> nominal_names_to_graph_names_;      // Mapping of nominal input/output names to graph input/output names
+  std::unordered_map<std::string, std::span<const std::byte>> model_datas_spans_;  // Model bytes to support loading a model from memory
 };
 
 void SetSearchNumber(Config::Search& search, std::string_view name, double value);

--- a/src/csharp/Config.cs
+++ b/src/csharp/Config.cs
@@ -30,6 +30,17 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             Result.VerifySuccess(NativeMethods.OgaConfigSetProviderOption(_configHandle, StringUtils.ToUtf8(provider), StringUtils.ToUtf8(option), StringUtils.ToUtf8(value)));
         }
 
+        public void RegisterModelData(string modelFilename, byte[] modelData)
+        {
+            unsafe
+            {
+                fixed (byte* modelDataBytes = modelData)
+                {
+                    Result.VerifySuccess(NativeMethods.OgaConfigRegisterModelData(_configHandle, StringUtils.ToUtf8(modelFilename), modelDataBytes, (UIntPtr)modelData.Length));
+                }
+            }
+        }
+
         ~Config()
         {
             Dispose(false);

--- a/src/csharp/Config.cs
+++ b/src/csharp/Config.cs
@@ -30,15 +30,20 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             Result.VerifySuccess(NativeMethods.OgaConfigSetProviderOption(_configHandle, StringUtils.ToUtf8(provider), StringUtils.ToUtf8(option), StringUtils.ToUtf8(value)));
         }
 
-        public void RegisterModelData(string modelFilename, byte[] modelData)
+        public void AddModelData(string modelFilename, byte[] modelData)
         {
             unsafe
             {
                 fixed (byte* modelDataBytes = modelData)
                 {
-                    Result.VerifySuccess(NativeMethods.OgaConfigRegisterModelData(_configHandle, StringUtils.ToUtf8(modelFilename), modelDataBytes, (UIntPtr)modelData.Length));
+                    Result.VerifySuccess(NativeMethods.OgaConfigAddModelData(_configHandle, StringUtils.ToUtf8(modelFilename), modelDataBytes, (UIntPtr)modelData.Length));
                 }
             }
+        }
+
+        public void RemoveModelData(string modelFilename)
+        {
+            Result.VerifySuccess(NativeMethods.OgaConfigRemoveModelData(_configHandle, StringUtils.ToUtf8(modelFilename)));
         }
 
         ~Config()

--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -55,6 +55,10 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
                                                                                 byte[] /* const char* */ option_name, byte[] /* const char* */ option_value);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern unsafe IntPtr /* OgaResult* */ OgaConfigRegisterModelData(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ model_filename,
+                                                                                       byte* /* const char* */ model_data, UIntPtr /* size_t */ model_data_length);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaCreateModel(byte[] /* const char* */ configPath,
                                                                     out IntPtr /* OgaModel** */ model);
 

--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern unsafe IntPtr /* OgaResult* */ OgaConfigRegisterModelData(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ model_filename,
-                                                                                       byte* /* const char* */ model_data, UIntPtr /* size_t */ model_data_length);
+                                                                                       byte* /* const void* */ model_data, UIntPtr /* size_t */ model_data_length);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaCreateModel(byte[] /* const char* */ configPath,

--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -55,8 +55,11 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
                                                                                 byte[] /* const char* */ option_name, byte[] /* const char* */ option_value);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
-        public static extern unsafe IntPtr /* OgaResult* */ OgaConfigRegisterModelData(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ model_filename,
-                                                                                       byte* /* const void* */ model_data, UIntPtr /* size_t */ model_data_length);
+        public static extern unsafe IntPtr /* OgaResult* */ OgaConfigAddModelData(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ model_filename,
+                                                                                  byte* /* const void* */ model_data, UIntPtr /* size_t */ model_data_length);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern IntPtr /* OgaResult* */ OgaConfigRemoveModelData(IntPtr /* OgaConfig* */ config, byte[] /* const char* */ model_filename);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaCreateModel(byte[] /* const char* */ configPath,

--- a/src/models/decoder_only.cpp
+++ b/src/models/decoder_only.cpp
@@ -4,7 +4,7 @@
 namespace Generators {
 DecoderOnly_Model::DecoderOnly_Model(std::unique_ptr<Config> config, OrtEnv& ort_env)
     : Model{std::move(config)} {
-  session_decoder_ = OrtSession::Create(ort_env, (config_->config_path / fs::path(config_->model.decoder.filename)).c_str(), session_options_.get());
+  session_decoder_ = CreateSession(ort_env, config_->model.decoder.filename, session_options_.get());
   session_info_.Add(*session_decoder_);
 }
 

--- a/src/models/decoder_only_pipeline.cpp
+++ b/src/models/decoder_only_pipeline.cpp
@@ -12,8 +12,7 @@ namespace Generators {
 DecoderOnlyPipelineModel::DecoderOnlyPipelineModel(std::unique_ptr<Config> config, OrtEnv& ort_env)
     : Model{std::move(config)}, ort_env_{ort_env} {
   for (const auto& model : config_->model.decoder.pipeline) {
-    sessions_.emplace_back(OrtSession::Create(ort_env, (config_->config_path / fs::path(model.filename)).c_str(),
-                                              GetSessionOptions(model.model_id)));
+    sessions_.emplace_back(CreateSession(ort_env, model.filename, GetSessionOptions(model.model_id)));
   }
 
   for (auto& session : sessions_) {

--- a/src/models/gpt.cpp
+++ b/src/models/gpt.cpp
@@ -5,7 +5,7 @@ namespace Generators {
 
 Gpt_Model::Gpt_Model(std::unique_ptr<Config> config, OrtEnv& ort_env)
     : Model{std::move(config)} {
-  session_decoder_ = OrtSession::Create(ort_env, (config_->config_path / fs::path(config_->model.decoder.filename)).c_str(), session_options_.get());
+  session_decoder_ = CreateSession(ort_env, config_->model.decoder.filename, session_options_.get());
   session_info_.Add(*session_decoder_);
 }
 

--- a/src/models/marian.cpp
+++ b/src/models/marian.cpp
@@ -7,8 +7,8 @@ namespace Generators {
 
 MarianModel::MarianModel(std::unique_ptr<Config> config, OrtEnv& ort_env)
     : Model{std::move(config)} {
-  session_encoder_ = OrtSession::Create(ort_env, (config_->config_path / fs::path(config_->model.encoder.filename)).c_str(), session_options_.get());
-  session_decoder_ = OrtSession::Create(ort_env, (config_->config_path / fs::path(config_->model.decoder.filename)).c_str(), session_options_.get());
+  session_encoder_ = CreateSession(ort_env, config_->model.encoder.filename, session_options_.get());
+  session_decoder_ = CreateSession(ort_env, config_->model.decoder.filename, session_options_.get());
 
   session_info_.Add(*session_decoder_);
   session_info_.Add(*session_encoder_);

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -854,10 +854,6 @@ std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::str
     dir_guard.ChangeTo(config_->config_path);
     auto session = OrtSession::Create(ort_env, model_data_it->second.data(), model_data_it->second.size(), session_options);
 
-    // Remove the model data from the map after creating the session
-    // The application must free up the memory used for the model data as it deems fit
-    config_->model_data_spans_.erase(model_data_it);
-
     return session;
   }
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -834,8 +834,8 @@ OrtSessionOptions* Model::GetSessionOptions(const std::string& model_id) const {
 }
 
 std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::string& model_filename, OrtSessionOptions* session_options) {
-  if (auto model_data_it = config_->model_datas_.find(model_filename);
-      model_data_it != config_->model_datas_.end()) {
+  if (auto model_data_it = config_->model_datas_spans_.find(model_filename);
+      model_data_it != config_->model_datas_spans_.end()) {
     // If model data was provided, load the model from memory
     if (model_data_it->second.empty()) {
       throw std::runtime_error("Failed to load model data from memory for " + model_filename);
@@ -846,7 +846,7 @@ std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::str
 
     // Remove the model data from the map after creating the session
     // The application must free up the memory used for the model data as it deems fit
-    config_->model_datas_.erase(model_data_it);
+    config_->model_datas_spans_.erase(model_data_it);
 
     return session;
   }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -24,7 +24,7 @@
 #if defined(_WIN32)
 #include <direct.h>
 #define GETCWD _getcwd
-#define CHDIR _chdir
+#define CHDIR _wchdir
 #include <windows.h>
 #else
 #include <unistd.h>

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -51,6 +51,10 @@ class DirGuard {
     }
   }
 
+  DirGuard(const DirGuard&) = delete;
+  DirGuard& operator=(const DirGuard&) = delete;
+  DirGuard(DirGuard&&) = delete;
+
   void ChangeTo(const fs::path& new_dir) {
     if (CHDIR(new_dir.c_str()) != 0) {
       throw std::runtime_error("Failed to change directory to: " + new_dir.string());

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -844,6 +844,10 @@ std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::str
     dir_guard.ChangeTo(config_->config_path);
     auto session = OrtSession::Create(ort_env, model_data_it->second.data(), model_data_it->second.size(), session_options);
 
+    // Remove the model data from the map after creating the session
+    // The application must free up the memory used for the model data as it deems fit
+    config_->model_datas_.erase(model_data_it);
+
     return session;
   }
 

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -142,6 +142,8 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model>, External
 
   OrtSessionOptions* GetSessionOptions(const std::string& model_id) const;
 
+  std::unique_ptr<OrtSession> CreateSession(OrtEnv& ort_env, const std::string& model_filename, OrtSessionOptions* session_options);
+
   std::unique_ptr<Config> config_;
   std::unique_ptr<OrtSessionOptions> session_options_;
 

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -65,24 +65,20 @@ MultiModalLanguageModel::MultiModalLanguageModel(std::unique_ptr<Config> config,
   if (vision) {
     auto vision_session_options = OrtSessionOptions::Create();
     CreateSessionOptionsFromConfig(config_->model.decoder.session_options, *vision_session_options, true, true);
-    vision_session_ = OrtSession::Create(
-        ort_env, (config_->config_path / fs::path(config_->model.vision.filename)).c_str(), vision_session_options.get());
+    vision_session_ = CreateSession(ort_env, config_->model.vision.filename, vision_session_options.get());
   }
 
   if (speech) {
     auto speech_session_options = OrtSessionOptions::Create();
     CreateSessionOptionsFromConfig(config_->model.decoder.session_options, *speech_session_options, true, true);
-    speech_session_ = OrtSession::Create(
-        ort_env, (config_->config_path / fs::path(config_->model.speech.filename)).c_str(), speech_session_options.get());
+    speech_session_ = CreateSession(ort_env, config_->model.speech.filename, speech_session_options.get());
   }
 
   auto embedding_session_options = OrtSessionOptions::Create();
   CreateSessionOptionsFromConfig(config_->model.decoder.session_options, *embedding_session_options, true, true);
 
-  embedding_session_ = OrtSession::Create(
-      ort_env, (config_->config_path / fs::path(config_->model.embedding.filename)).c_str(), embedding_session_options.get());
-  decoder_session_ = OrtSession::Create(
-      ort_env, (config_->config_path / fs::path(config_->model.decoder.filename)).c_str(), session_options_.get());
+  embedding_session_ = CreateSession(ort_env, config_->model.embedding.filename, embedding_session_options.get());
+  decoder_session_ = CreateSession(ort_env, config_->model.decoder.filename, session_options_.get());
 
   session_info_.Add(*decoder_session_);
   session_info_.Add(*embedding_session_);

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -4,10 +4,10 @@
 
 namespace Generators {
 
-DefaultPositionInputs::DefaultPositionInputs(const Model& model, State& state, DeviceSpan<int32_t> sequence_lengths_unk, const std::string& attention_mask_name_)
+DefaultPositionInputs::DefaultPositionInputs(const Model& model, State& state, DeviceSpan<int32_t> sequence_lengths_unk, const std::string& attention_mask_name)
     : model_{model},
       state_{state},
-      attention_mask_name_{attention_mask_name_} {
+      attention_mask_name_{attention_mask_name} {
   has_mask_input_ = model_.session_info_.HasInput(attention_mask_name_);
   has_posid_input_ = model_.session_info_.HasInput(model_.config_->model.decoder.inputs.position_ids);
 
@@ -437,11 +437,11 @@ void WindowedPositionInputs::Update(DeviceSpan<int32_t> next_tokens, int total_l
   window_index_++;
 }
 
-std::unique_ptr<PositionInputs> CreatePositionInputs(State& state, DeviceSpan<int32_t> sequence_lengths, const std::string& attention_mask_name_) {
+std::unique_ptr<PositionInputs> CreatePositionInputs(State& state, DeviceSpan<int32_t> sequence_lengths, const std::string& attention_mask_name) {
   if (state.model_.config_->model.decoder.sliding_window.has_value() && state.model_.config_->model.decoder.sliding_window->slide_inputs) {
     return std::make_unique<WindowedPositionInputs>(state);
   } else {
-    return std::make_unique<DefaultPositionInputs>(state.model_, state, sequence_lengths, attention_mask_name_);
+    return std::make_unique<DefaultPositionInputs>(state.model_, state, sequence_lengths, attention_mask_name);
   }
 }
 

--- a/src/models/position_inputs.h
+++ b/src/models/position_inputs.h
@@ -10,7 +10,7 @@ struct PositionInputs {
 };
 
 struct DefaultPositionInputs : PositionInputs {
-  DefaultPositionInputs(const Model& model, State& state, DeviceSpan<int32_t> sequence_lengths_unk, const std::string& attention_mask_name_);
+  DefaultPositionInputs(const Model& model, State& state, DeviceSpan<int32_t> sequence_lengths_unk, const std::string& attention_mask_name);
 
   void Add() override;
   void Update(DeviceSpan<int32_t> next_tokens, int total_length, int new_length) override;
@@ -103,6 +103,6 @@ struct WindowedPositionInputs : PositionInputs {
   size_t window_index_{};
 };
 
-std::unique_ptr<PositionInputs> CreatePositionInputs(State& state, DeviceSpan<int32_t> sequence_lengths, const std::string& attention_mask_name_);
+std::unique_ptr<PositionInputs> CreatePositionInputs(State& state, DeviceSpan<int32_t> sequence_lengths, const std::string& attention_mask_name);
 
 }  // namespace Generators

--- a/src/models/whisper.cpp
+++ b/src/models/whisper.cpp
@@ -8,8 +8,8 @@ namespace Generators {
 
 Whisper_Model::Whisper_Model(std::unique_ptr<Config> config, OrtEnv& ort_env)
     : Model{std::move(config)} {
-  session_encoder_ = OrtSession::Create(ort_env, (config_->config_path / fs::path(config_->model.encoder.filename)).c_str(), session_options_.get());
-  session_decoder_ = OrtSession::Create(ort_env, (config_->config_path / fs::path(config_->model.decoder.filename)).c_str(), session_options_.get());
+  session_encoder_ = CreateSession(ort_env, config_->model.encoder.filename, session_options_.get());
+  session_decoder_ = CreateSession(ort_env, config_->model.decoder.filename, session_options_.get());
 
   session_info_.Add(*session_decoder_);
   session_info_.Add(*session_encoder_);

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -179,6 +179,20 @@ struct OgaConfig : OgaAbstract {
     OgaCheckResult(OgaConfigOverlay(this, json));
   }
 
+  void RegisterModelData(const std::string& model_filename, const uint8_t* model_data, size_t model_data_length) {
+    OgaCheckResult(OgaConfigRegisterModelData(this, model_filename.c_str(), model_data, model_data_length));
+  }
+
+  void RegisterModelData(const std::string& model_filename, const std::vector<uint8_t>& model_data) {
+    OgaCheckResult(OgaConfigRegisterModelData(this, model_filename.c_str(), model_data.data(), model_data.size()));
+  }
+
+#if OGA_USE_SPAN
+  void RegisterModelData(const std::string& model_filename, std::span<const uint8_t> model_data) {
+    OgaCheckResult(OgaConfigRegisterModelData(this, model_filename.c_str(), model_data.data(), model_data.size()));
+  }
+#endif
+
   static void operator delete(void* p) { OgaDestroyConfig(reinterpret_cast<OgaConfig*>(p)); }
 };
 

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -179,19 +179,23 @@ struct OgaConfig : OgaAbstract {
     OgaCheckResult(OgaConfigOverlay(this, json));
   }
 
-  void RegisterModelData(const std::string& model_filename, const void* model_data, size_t model_data_length) {
-    OgaCheckResult(OgaConfigRegisterModelData(this, model_filename.c_str(), model_data, model_data_length));
+  void AddModelData(const std::string& model_filename, const void* model_data, size_t model_data_length) {
+    OgaCheckResult(OgaConfigAddModelData(this, model_filename.c_str(), model_data, model_data_length));
   }
 
-  void RegisterModelData(const std::string& model_filename, const std::vector<std::byte>& model_data) {
-    OgaCheckResult(OgaConfigRegisterModelData(this, model_filename.c_str(), model_data.data(), model_data.size()));
+  void AddModelData(const std::string& model_filename, const std::vector<std::byte>& model_data) {
+    OgaCheckResult(OgaConfigAddModelData(this, model_filename.c_str(), model_data.data(), model_data.size()));
   }
 
 #if OGA_USE_SPAN
-  void RegisterModelData(const std::string& model_filename, std::span<const std::byte> model_data) {
-    OgaCheckResult(OgaConfigRegisterModelData(this, model_filename.c_str(), model_data.data(), model_data.size()));
+  void AddModelData(const std::string& model_filename, std::span<const std::byte> model_data) {
+    OgaCheckResult(OgaConfigAddModelData(this, model_filename.c_str(), model_data.data(), model_data.size()));
   }
 #endif
+
+  void RemoveModelData(const std::string& model_filename) {
+    OgaCheckResult(OgaConfigRemoveModelData(this, model_filename.c_str()));
+  }
 
   static void operator delete(void* p) { OgaDestroyConfig(reinterpret_cast<OgaConfig*>(p)); }
 };

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -179,16 +179,16 @@ struct OgaConfig : OgaAbstract {
     OgaCheckResult(OgaConfigOverlay(this, json));
   }
 
-  void RegisterModelData(const std::string& model_filename, const uint8_t* model_data, size_t model_data_length) {
+  void RegisterModelData(const std::string& model_filename, const void* model_data, size_t model_data_length) {
     OgaCheckResult(OgaConfigRegisterModelData(this, model_filename.c_str(), model_data, model_data_length));
   }
 
-  void RegisterModelData(const std::string& model_filename, const std::vector<uint8_t>& model_data) {
+  void RegisterModelData(const std::string& model_filename, const std::vector<std::byte>& model_data) {
     OgaCheckResult(OgaConfigRegisterModelData(this, model_filename.c_str(), model_data.data(), model_data.size()));
   }
 
 #if OGA_USE_SPAN
-  void RegisterModelData(const std::string& model_filename, std::span<const uint8_t> model_data) {
+  void RegisterModelData(const std::string& model_filename, std::span<const std::byte> model_data) {
     OgaCheckResult(OgaConfigRegisterModelData(this, model_filename.c_str(), model_data.data(), model_data.size()));
   }
 #endif

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -259,13 +259,13 @@ OgaResult* OGA_API_CALL OgaConfigOverlay(OgaConfig* config, const char* json) {
   OGA_CATCH
 }
 
-OgaResult* OGA_API_CALL OgaConfigRegisterModelData(OgaConfig* config, const char* model_filename, const uint8_t* model_data, size_t model_data_length) {
+OgaResult* OGA_API_CALL OgaConfigRegisterModelData(OgaConfig* config, const char* model_filename, const void* model_data, size_t model_data_length) {
   OGA_TRY
   if (model_data == nullptr || model_data_length == 0) {
     throw std::runtime_error("Expected a valid model data pointer and length. Received nullptr or zero length.");
   }
 
-  config->model_datas_.emplace(model_filename, std::span<const uint8_t>(model_data, model_data_length));
+  config->model_datas_spans_.emplace(model_filename, std::span<const std::byte>(static_cast<const std::byte*>(model_data), model_data_length));
 
   return nullptr;
   OGA_CATCH

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -259,14 +259,30 @@ OgaResult* OGA_API_CALL OgaConfigOverlay(OgaConfig* config, const char* json) {
   OGA_CATCH
 }
 
-OgaResult* OGA_API_CALL OgaConfigRegisterModelData(OgaConfig* config, const char* model_filename, const void* model_data, size_t model_data_length) {
+OgaResult* OGA_API_CALL OgaConfigAddModelData(OgaConfig* config, const char* model_filename, const void* model_data, size_t model_data_length) {
   OGA_TRY
   if (model_data == nullptr || model_data_length == 0) {
     throw std::runtime_error("Expected a valid model data pointer and length. Received nullptr or zero length.");
   }
 
-  config->model_data_spans_.emplace(model_filename, std::span<const std::byte>(static_cast<const std::byte*>(model_data), model_data_length));
+  const auto emplaced = config->model_data_spans_.emplace(model_filename, std::span<const std::byte>(static_cast<const std::byte*>(model_data), model_data_length));
+  if (!emplaced.second) {
+    throw std::runtime_error("Model data for '" + std::string(model_filename) +
+                             "' was already added previously. "
+                             "If you want to replace it, please remove it first.");
+  }
 
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OGA_API_CALL OgaConfigRemoveModelData(OgaConfig* config, const char* model_filename) {
+  OGA_TRY
+  auto it = config->model_data_spans_.find(model_filename);
+  if (it == config->model_data_spans_.end()) {
+    throw std::runtime_error("Model data for '" + std::string(model_filename) + "' was not found.");
+  }
+  config->model_data_spans_.erase(it);
   return nullptr;
   OGA_CATCH
 }

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -259,6 +259,18 @@ OgaResult* OGA_API_CALL OgaConfigOverlay(OgaConfig* config, const char* json) {
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaConfigRegisterModelData(OgaConfig* config, const char* model_filename, const uint8_t* model_data, size_t model_data_length) {
+  OGA_TRY
+  if (model_data == nullptr || model_data_length == 0) {
+    throw std::runtime_error("Expected a valid model data pointer and length. Received nullptr or zero length.");
+  }
+
+  config->model_datas_.emplace(model_filename, std::span<const uint8_t>(model_data, model_data_length));
+
+  return nullptr;
+  OGA_CATCH
+}
+
 OgaResult* OGA_API_CALL OgaCreateModelFromConfig(const OgaConfig* config, OgaModel** out) {
   OGA_TRY
   auto config_copy = std::make_unique<Generators::Config>(*config);

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -265,7 +265,7 @@ OgaResult* OGA_API_CALL OgaConfigRegisterModelData(OgaConfig* config, const char
     throw std::runtime_error("Expected a valid model data pointer and length. Received nullptr or zero length.");
   }
 
-  config->model_datas_spans_.emplace(model_filename, std::span<const std::byte>(static_cast<const std::byte*>(model_data), model_data_length));
+  config->model_data_spans_.emplace(model_filename, std::span<const std::byte>(static_cast<const std::byte*>(model_data), model_data_length));
 
   return nullptr;
   OGA_CATCH

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -265,7 +265,7 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config,
  * \brief Register the model data to load the model from memory.
  * \param[in] config The config to register the model data on.
  * \param[in] model_filename The name of the model file as defined in the config.
- * \param[in] model_data The model data to register.
+ * \param[in] model_data The model data to register. The data is expected to be valid at least until the model is created.
  * \param[in] model_data_length The length of the model data.
  * \return OgaResult containing the error message if the registration of the model data failed.
  */

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -269,7 +269,7 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config,
  * \param[in] model_data_length The length of the model data.
  * \return OgaResult containing the error message if the registration of the model data failed.
  */
-OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigRegisterModelData(OgaConfig* config, const char* model_filename, const uint8_t* model_data, size_t model_data_length);
+OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigRegisterModelData(OgaConfig* config, const char* model_filename, const void* model_data, size_t model_data_length);
 
 /**
  * \brief Overlay JSON on top of config file

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -262,7 +262,7 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigAppendProvider(OgaConfig* config, co
 OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config, const char* provider, const char* key, const char* value);
 
 /**
- * \brief Add the model data to load the model from memory. Applications must call OgaConfigRemoveModelData to remove the model data
+ * \brief Add the model data to load the model from memory. Applications may call OgaConfigRemoveModelData to remove the model data
  *        when it is no longer needed.
  * \param[in] config The config to add the model data to.
  * \param[in] model_filename The name of the model file as defined in the config.
@@ -273,7 +273,7 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config,
 OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigAddModelData(OgaConfig* config, const char* model_filename, const void* model_data, size_t model_data_length);
 
 /**
- * \brief Cleanup model data previously added to the config.
+ * \brief Remove model data previously added to the config.
  * \param[in] config The config to remove the model data from.
  * \param[in] model_filename The name of the model file as defined in the config.
  * \return OgaResult containing the error message if the removal of the model data failed.

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -264,6 +264,12 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config,
 /**
  * \brief Add the model data to load the model from memory. Applications may call OgaConfigRemoveModelData to remove the model data
  *        when it is no longer needed.
+ *
+ * Note that the model data is expected to be valid at least until the model is created.
+ * If using session options such as `session.use_ort_model_bytes_directly`, the model data must remain valid
+ * until the OgaModel is destroyed, as the model data will be used directly by the Ort::Session.
+ * Please see the relevant ONNX Runtime documentation for more details on this option.
+ *
  * \param[in] config The config to add the model data to.
  * \param[in] model_filename The name of the model file as defined in the config.
  * \param[in] model_data The model data to add. The data is expected to be valid at least until the model is created.

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -262,6 +262,16 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigAppendProvider(OgaConfig* config, co
 OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config, const char* provider, const char* key, const char* value);
 
 /**
+ * \brief Register the model data to load the model from memory.
+ * \param[in] config The config to register the model data on.
+ * \param[in] model_filename The name of the model file as defined in the config.
+ * \param[in] model_data The model data to register.
+ * \param[in] model_data_length The length of the model data.
+ * \return OgaResult containing the error message if the registration of the model data failed.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigRegisterModelData(OgaConfig* config, const char* model_filename, const uint8_t* model_data, size_t model_data_length);
+
+/**
  * \brief Overlay JSON on top of config file
  * \param[in] config The config to overlay the JSON on.
  * \param[in] json The JSON to overlay on the config.

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -262,14 +262,23 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigAppendProvider(OgaConfig* config, co
 OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigSetProviderOption(OgaConfig* config, const char* provider, const char* key, const char* value);
 
 /**
- * \brief Register the model data to load the model from memory.
- * \param[in] config The config to register the model data on.
+ * \brief Add the model data to load the model from memory. Applications must call OgaConfigRemoveModelData to remove the model data
+ *        when it is no longer needed.
+ * \param[in] config The config to add the model data to.
  * \param[in] model_filename The name of the model file as defined in the config.
- * \param[in] model_data The model data to register. The data is expected to be valid at least until the model is created.
+ * \param[in] model_data The model data to add. The data is expected to be valid at least until the model is created.
  * \param[in] model_data_length The length of the model data.
- * \return OgaResult containing the error message if the registration of the model data failed.
+ * \return OgaResult containing the error message if the addition of the model data failed.
  */
-OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigRegisterModelData(OgaConfig* config, const char* model_filename, const void* model_data, size_t model_data_length);
+OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigAddModelData(OgaConfig* config, const char* model_filename, const void* model_data, size_t model_data_length);
+
+/**
+ * \brief Cleanup model data previously added to the config.
+ * \param[in] config The config to remove the model data from.
+ * \param[in] model_filename The name of the model file as defined in the config.
+ * \return OgaResult containing the error message if the removal of the model data failed.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaConfigRemoveModelData(OgaConfig* config, const char* model_filename);
 
 /**
  * \brief Overlay JSON on top of config file

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -390,7 +390,29 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def(pybind11::init([](const std::string& config_path) { return OgaConfig::Create(config_path.c_str()); }))
       .def("append_provider", &OgaConfig::AppendProvider)
       .def("set_provider_option", &OgaConfig::SetProviderOption)
-      .def("clear_providers", &OgaConfig::ClearProviders);
+      .def("clear_providers", &OgaConfig::ClearProviders)
+      .def("register_model_data", [](OgaConfig& config, const std::string& model_filename, pybind11::object obj) {
+        if (pybind11::isinstance<pybind11::bytes>(obj)) {
+          const auto model_bytes = obj.cast<pybind11::bytes>();
+          char* model_buffer;
+          ssize_t model_length;
+          if (PyBytes_AsStringAndSize(model_bytes.ptr(), &model_buffer, &model_length) != 0) {
+            throw std::runtime_error("Failed to extract bytes from the object");
+          }
+
+          const uint8_t* model_data = reinterpret_cast<const uint8_t*>(model_buffer);
+          config.RegisterModelData(model_filename, model_data, static_cast<size_t>(model_length));
+        } else if (pybind11::isinstance<pybind11::buffer>(obj)) {
+          pybind11::buffer_info info = obj.cast<pybind11::buffer>().request();
+          if (info.format != pybind11::format_descriptor<uint8_t>::format() || info.ndim != 1) {
+            throw std::runtime_error("Expected a 1D buffer of uint8_t");
+          }
+          const uint8_t* model_data = static_cast<uint8_t*>(info.ptr);
+          config.RegisterModelData(model_filename, model_data, info.size);
+        } else {
+          throw std::runtime_error("Unsupported input type. Expected bytes or buffer.");
+        }
+      });
 
   pybind11::class_<OgaModel>(m, "Model")
       .def(pybind11::init([](const OgaConfig& config) { return OgaModel::Create(config); }))

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -395,7 +395,7 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
         if (pybind11::isinstance<pybind11::bytes>(obj)) {
           const auto model_bytes = obj.cast<pybind11::bytes>();
           char* model_buffer;
-          ssize_t model_length;
+          Py_ssize_t model_length;
           if (PyBytes_AsStringAndSize(model_bytes.ptr(), &model_buffer, &model_length) != 0) {
             throw std::runtime_error("Failed to extract bytes from the object");
           }

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -394,20 +394,19 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def("register_model_data", [](OgaConfig& config, const std::string& model_filename, pybind11::object obj) {
         if (pybind11::isinstance<pybind11::bytes>(obj)) {
           const auto model_bytes = obj.cast<pybind11::bytes>();
-          char* model_buffer;
+          char* model_data;
           Py_ssize_t model_length;
-          if (PyBytes_AsStringAndSize(model_bytes.ptr(), &model_buffer, &model_length) != 0) {
+          if (PyBytes_AsStringAndSize(model_bytes.ptr(), &model_data, &model_length) != 0) {
             throw std::runtime_error("Failed to extract bytes from the object");
           }
 
-          const uint8_t* model_data = reinterpret_cast<const uint8_t*>(model_buffer);
           config.RegisterModelData(model_filename, model_data, static_cast<size_t>(model_length));
         } else if (pybind11::isinstance<pybind11::buffer>(obj)) {
           pybind11::buffer_info info = obj.cast<pybind11::buffer>().request();
           if (info.format != pybind11::format_descriptor<uint8_t>::format() || info.ndim != 1) {
             throw std::runtime_error("Expected a 1D buffer of uint8_t");
           }
-          const uint8_t* model_data = static_cast<uint8_t*>(info.ptr);
+          const std::byte* model_data = static_cast<std::byte*>(info.ptr);
           config.RegisterModelData(model_filename, model_data, info.size);
         } else {
           throw std::runtime_error("Unsupported input type. Expected bytes or buffer.");

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -391,7 +391,7 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def("append_provider", &OgaConfig::AppendProvider)
       .def("set_provider_option", &OgaConfig::SetProviderOption)
       .def("clear_providers", &OgaConfig::ClearProviders)
-      .def("register_model_data", [](OgaConfig& config, const std::string& model_filename, pybind11::object obj) {
+      .def("add_model_data", [](OgaConfig& config, const std::string& model_filename, pybind11::object obj) {
         if (pybind11::isinstance<pybind11::bytes>(obj)) {
           const auto model_bytes = obj.cast<pybind11::bytes>();
           char* model_data;
@@ -400,17 +400,20 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
             throw std::runtime_error("Failed to extract bytes from the object");
           }
 
-          config.RegisterModelData(model_filename, model_data, static_cast<size_t>(model_length));
+          config.AddModelData(model_filename, model_data, static_cast<size_t>(model_length));
         } else if (pybind11::isinstance<pybind11::buffer>(obj)) {
           pybind11::buffer_info info = obj.cast<pybind11::buffer>().request();
           if (info.format != pybind11::format_descriptor<uint8_t>::format() || info.ndim != 1) {
             throw std::runtime_error("Expected a 1D buffer of uint8_t");
           }
           const std::byte* model_data = static_cast<std::byte*>(info.ptr);
-          config.RegisterModelData(model_filename, model_data, info.size);
+          config.AddModelData(model_filename, model_data, info.size);
         } else {
           throw std::runtime_error("Unsupported input type. Expected bytes or buffer.");
         }
+      })
+      .def("remove_model_data", [](OgaConfig& config, const std::string& model_filename) {
+        config.RemoveModelData(model_filename.c_str());
       });
 
   pybind11::class_<OgaModel>(m, "Model")

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -306,7 +306,7 @@ TEST(CAPITests, LoadModelFromMemory) {
   ASSERT_TRUE(model_file.is_open()) << "Failed to open model file: " << model_path;
   std::streamsize size = model_file.tellg();
   model_file.seekg(0, std::ios::beg);
-  std::vector<uint8_t> model_data(size);
+  std::vector<std::byte> model_data(size);
   model_file.read(reinterpret_cast<char*>(model_data.data()), size);
 
   auto config = OgaConfig::Create(PHI2_PATH);

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <cstring>  // for memcmp
+#include <fstream>
 #include <numeric>
 #include <iostream>
 #include <thread>
@@ -261,6 +262,56 @@ TEST(CAPITests, EndToEndPhiBatch) {
 TEST(CAPITests, EndToEndPhi) {
 #if TEST_PHI2
   auto model = OgaModel::Create(PHI2_PATH);
+  auto tokenizer = OgaTokenizer::Create(*model);
+
+  const char* input_string = "This is a test.";
+  auto input_sequence = OgaSequences::Create();
+  tokenizer->Encode(input_string, *input_sequence);
+
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 40);
+
+  auto generator = OgaGenerator::Create(*model, *params);
+  generator->AppendTokenSequences(*input_sequence);
+
+  while (!generator->IsDone()) {
+    generator->GenerateNextToken();
+  }
+
+  // Decode The Batch
+  auto out_string = tokenizer->Decode(generator->GetSequenceData(0), generator->GetSequenceCount(0));
+  std::cout << "Decoded string:" << out_string << std::endl;
+
+  // Verify outputs match expected outputs
+  std::vector<int32_t> expected_output{
+      1212, 318, 257, 1332, 13, 198, 50280, 2, 16926, 1330, 1635, 10412, 6617, 278,
+      6335, 32994, 21857, 13849, 38665, 82, 21815, 1108, 9557, 40755, 27446, 2417,
+      6381, 6, 7131, 6, 14870, 31314, 21411, 46009, 3974, 82, 1039, 889, 263, 3684};
+
+  const auto sequence_length = generator->GetSequenceCount(0);
+  const auto* sequence_data = generator->GetSequenceData(0);
+
+  ASSERT_LE(sequence_length, 40);
+
+  const auto* expected_output_start = &expected_output[0];
+  EXPECT_TRUE(0 == std::memcmp(expected_output_start, sequence_data, sequence_length * sizeof(int32_t)));
+#endif
+}
+
+TEST(CAPITests, LoadModelFromMemory) {
+#if TEST_PHI2
+
+  const char* model_path = PHI2_PATH "/model.onnx";
+  std::ifstream model_file(model_path, std::ios::binary | std::ios::ate);
+  ASSERT_TRUE(model_file.is_open()) << "Failed to open model file: " << model_path;
+  std::streamsize size = model_file.tellg();
+  model_file.seekg(0, std::ios::beg);
+  std::vector<uint8_t> model_data(size);
+  model_file.read(reinterpret_cast<char*>(model_data.data()), size);
+
+  auto config = OgaConfig::Create(PHI2_PATH);
+  config->RegisterModelData("model.onnx", model_data);
+  auto model = OgaModel::Create(*config);
   auto tokenizer = OgaTokenizer::Create(*model);
 
   const char* input_string = "This is a test.";

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -310,8 +310,9 @@ TEST(CAPITests, LoadModelFromMemory) {
   model_file.read(reinterpret_cast<char*>(model_data.data()), size);
 
   auto config = OgaConfig::Create(PHI2_PATH);
-  config->RegisterModelData("model.onnx", model_data);
+  config->AddModelData("model.onnx", model_data);
   auto model = OgaModel::Create(*config);
+  config->RemoveModelData("model.onnx");
   auto tokenizer = OgaTokenizer::Create(*model);
 
   const char* input_string = "This is a test.";

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -157,7 +157,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
 
                         using (var generator = new Generator(model, generatorParams))
                         {
-                            Assert.NotNull(generatorParams);
+                            Assert.NotNull(generator);
 
                             generator.AppendTokens(inputIDs);
                             Assert.False(generator.IsDone());
@@ -207,7 +207,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
 
                         using (var generator = new Generator(model, generatorParams))
                         {
-                            Assert.NotNull(generatorParams);
+                            Assert.NotNull(generator);
 
                             generator.AppendTokens(inputIDs);
                             Assert.False(generator.IsDone());

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -194,9 +194,10 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
                 Assert.NotNull(config);
                 var modelData = File.ReadAllBytes(Path.Combine(modelPath, "past.onnx"));
                 Assert.NotNull(modelData);
-                config.RegisterModelData("past.onnx", modelData);
+                config.AddModelData("past.onnx", modelData);
                 using (var model = new Model(config))
                 {
+                    config.RemoveModelData("past.onnx");
                     Assert.NotNull(model);
                     using(var generatorParams = new GeneratorParams(model))
                     {

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -194,7 +194,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
                 Assert.NotNull(config);
                 var modelData = File.ReadAllBytes(Path.Combine(modelPath, "past.onnx"));
                 Assert.NotNull(modelData);
-                config.RegisterModelData("tiny-random-gpt2.onnx", modelData);
+                config.RegisterModelData("past.onnx", modelData);
                 using (var model = new Model(config))
                 {
                     Assert.NotNull(model);

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -442,8 +442,9 @@ def test_load_model_from_memory(device, wrapper_bytes_function, phi2_for):
     with open(os.path.join(model_path, "model.onnx"), 'rb') as model_file:
         model_data = wrapper_bytes_function(model_file.read())
 
-    config.register_model_data("model.onnx", model_data)
+    config.add_model_data("model.onnx", model_data)
     model = og.Model(config)
+    config.remove_model_data("model.onnx")
     tokenizer = og.Tokenizer(model)
 
     prompts = [

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -280,12 +280,9 @@ def test_rewind(test_data_path, relative_model_path):
 
 # Test Model Loading with No Chat Template
 
-
-# TODO: CUDA pipelines use python3.6 and do not have a way to download models since downloading models
-# requires pytorch and hf transformers. This test should be re-enabled once the pipeline is updated.
 @pytest.mark.skipif(
-    sysconfig.get_platform().endswith("arm64") or sys.version_info.minor < 8,
-    reason="Python 3.8 is required for downloading models.",
+    sysconfig.get_platform().endswith("arm64"),
+    reason="Model is not available on arm64.",
 )
 @pytest.mark.parametrize("device", devices)
 @pytest.mark.parametrize("batch", [True, False])
@@ -314,8 +311,8 @@ def test_tokenizer_encode_decode(device, phi2_for, batch):
 
 # Test Chat Template Supported Model
 @pytest.mark.skipif(
-    sysconfig.get_platform().endswith("arm64") or sys.version_info.minor < 8,
-    reason="Python 3.8 is required for downloading models.",
+    sysconfig.get_platform().endswith("arm64"),
+    reason="Model is not available on arm64.",
 )
 @pytest.mark.parametrize("device", devices)
 def test_phi3_chat_template(device, phi3_for):
@@ -334,8 +331,8 @@ def test_phi3_chat_template(device, phi3_for):
 
 # Test Chat Template Unsupported Model with Template String Override
 @pytest.mark.skipif(
-    sysconfig.get_platform().endswith("arm64") or sys.version_info.minor < 8,
-    reason="Python 3.8 is required for downloading models.",
+    sysconfig.get_platform().endswith("arm64"),
+    reason="Model is not available on arm64.",
 )
 @pytest.mark.parametrize("device", devices)
 def test_phi2_chat_template(device, phi2_for):
@@ -358,8 +355,8 @@ def test_phi2_chat_template(device, phi2_for):
 
 
 @pytest.mark.skipif(
-    sysconfig.get_platform().endswith("arm64") or sys.version_info.minor < 8,
-    reason="Python 3.8 is required for downloading models.",
+    sysconfig.get_platform().endswith("arm64"),
+    reason="Model is not available on arm64.",
 )
 @pytest.mark.parametrize("device", devices)
 def test_tokenizer_stream(device, phi2_for):
@@ -381,12 +378,9 @@ def test_tokenizer_stream(device, phi2_for):
 
         assert decoded_string == prompt
 
-
-# TODO: CUDA pipelines use python3.6 and do not have a way to download models since downloading models
-# requires pytorch and hf transformers. This test should be re-enabled once the pipeline is updated.
 @pytest.mark.skipif(
-    sysconfig.get_platform().endswith("arm64") or sys.version_info.minor < 8,
-    reason="Python 3.8 is required for downloading models.",
+    sysconfig.get_platform().endswith("arm64"),
+    reason="Model is not available on arm64.",
 )
 @pytest.mark.parametrize("device", devices)
 def test_batching(device, phi2_for):
@@ -412,16 +406,44 @@ def test_batching(device, phi2_for):
     for i in range(len(prompts)):
         print(tokenizer.decode(generator.get_sequence(0)))
 
-
-# TODO: CUDA pipelines use python3.6 and do not have a way to download models since downloading models
-# requires pytorch and hf transformers. This test should be re-enabled once the pipeline is updated.
 @pytest.mark.skipif(
-    sysconfig.get_platform().endswith("arm64") or sys.version_info.minor < 8,
-    reason="Python 3.8 is required for downloading models.",
+    sysconfig.get_platform().endswith("arm64"),
+    reason="Model is not available on arm64.",
 )
 @pytest.mark.parametrize("device", devices)
 def test_e2e(device, phi2_for):
     model = og.Model(phi2_for(device))
+    tokenizer = og.Tokenizer(model)
+
+    prompts = [
+        "This is a test.",
+    ]
+
+    params = og.GeneratorParams(model)
+    params.set_search_options(max_length=20, batch_size=len(prompts))  # To run faster
+
+    generator = og.Generator(model, params)
+    generator.append_tokens(tokenizer.encode_batch(prompts))
+    while not generator.is_done():
+        generator.generate_next_token()
+    for i in range(len(prompts)):
+        print(tokenizer.decode(generator.get_sequence(0)))
+
+@pytest.mark.skipif(
+    sysconfig.get_platform().endswith("arm64"),
+    reason="Model is not available on arm64.",
+)
+@pytest.mark.parametrize("device", devices)
+@pytest.mark.parametrize("wrapper_bytes_function", [lambda x: x, bytearray, memoryview])
+def test_load_model_from_memory(device, wrapper_bytes_function, phi2_for):
+    model_path = phi2_for(device)
+    config = og.Config(model_path)
+    model_data = None
+    with open(os.path.join(model_path, "model.onnx"), 'rb') as model_file:
+        model_data = wrapper_bytes_function(model_file.read())
+
+    config.register_model_data("model.onnx", model_data)
+    model = og.Model(config)
     tokenizer = og.Tokenizer(model)
 
     prompts = [
@@ -524,8 +546,8 @@ def test_get_output(test_data_path, relative_model_path):
 
 
 @pytest.mark.skipif(
-    sysconfig.get_platform().endswith("arm64") or sys.version_info.minor < 8,
-    reason="Python 3.8 is required for downloading models.",
+    sysconfig.get_platform().endswith("arm64"),
+    reason="Model is not available on arm64.",
 )
 @pytest.mark.parametrize("device", devices)
 def test_hidden_states(qwen_for, device):


### PR DESCRIPTION
This pull-request introduces support for loading onnx models from memory instead of from filesystem.

Example usage:

#### Python
```python
model_data = get_model_data(...)

# model_path refers to the directory that contains model files
# The *.onnx files needn't be present in the model_path
# The model_data is used to load the *.onnx model file
config = og.Config(model_path)
config.register_model_data("model.onnx", model_data)

# The model_data is expected to be valid at least until the og.Model has been created
model = og.Model(config)
...
```
#### C++

```cpp
const std::vector<uint8_t> model_data = GetModelData(...);
auto config = OgaConfig::Create(model_path);
config->RegisterModelData("model.onnx", model_data);
auto model = OgaModel::Create(*config);
...
```
#### C#

```csharp
var modelData = GetModelData(...);
using (var config = new Config(modelPath))
{
    config.RegisterModelData("model.onnx", modelData);
    using (var model = new Model(config))
    {
        ...
    }
}
```
</details>
