### PR TITLE
Use the correct filename in the targets

### DIFF
--- a/nuget/targets/net8.0-ios/Microsoft.ML.OnnxRuntimeGenAI.targets
+++ b/nuget/targets/net8.0-ios/Microsoft.ML.OnnxRuntimeGenAI.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
-    <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\onnxruntime-genai.xcframework">
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\onnxruntime-genai.xcframework.zip">
       <Kind>Static</Kind>
       <IsCxx>True</IsCxx>
       <SmartLink>True</SmartLink>


### PR DESCRIPTION
I was getting a warning:

> /usr/local/share/dotnet/packs/Microsoft.iOS.Sdk.net10.0_18.4/18.4.10621-net10-p5/tools/msbuild/Xamarin.Shared.targets(153,3): warning : The file '/Users/matthew/.nuget/packages/microsoft.ml.onnxruntimegenai/0.8.2/buildTransitive/net8.0-ios15.4/../../runtimes/ios/native/onnxruntime-genai.xcframework/Info.plist' does not exist.

The `Microsoft.ML.OnnxRuntime` nuget uses the .zip and adding the .zip fixes the warning.