### PR TITLE
Fix DML Memory Leak

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -462,7 +462,6 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
 
       if (!disable_graph_capture) {
         session_options.AddConfigEntry("ep.dml.enable_graph_capture", "1");
-        session_options.AddConfigEntry("ep.dml.disable_memory_arena", "1");
       }
 
       SetDmlProvider(session_options);

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -16,6 +16,7 @@ Tensor::Tensor(std::unique_ptr<OrtValue> ort_tensor) : ort_tensor_{std::move(ort
 Tensor::~Tensor() {
   if (buffer_ != nullptr) {
     p_device_->GetAllocator().Free(buffer_);
+    buffer_ = nullptr;
   }
 }
 


### PR DESCRIPTION
A memory leak where DML would take up more and more memory was found. This should fix it by enabling memory arena.