### PR TITLE
Bump onnx-ir to 0.1.2

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -553,6 +553,7 @@ class Model:
             ir.save(
                 model,
                 out_path,
+                format=None,
                 external_data=os.path.basename(data_path),
                 size_threshold_bytes=0,
                 callback=callback,

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -6,6 +6,6 @@ protobuf==5.29.5
 sympy
 pytest
 onnx
-onnx_ir>=0.1.1
+onnx_ir>=0.1.2
 transformers
 huggingface_hub[cli]


### PR DESCRIPTION
Currently it seems that the command "python builder.py -i" in model builder is not working anymore, because there is an API change that it uses "callback" that onnx-ir 0.1.1 does not have
 ir.save(
model,
out_path,
external_data=os.path.basename(data_path),
size_threshold_bytes=0,
callback=callback,
) 