### PR TITLE
[Builder] Add cuda-bfloat16 entry to valid_gqa_configurations

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -396,8 +396,6 @@ class Model:
             if self.attention_attrs["use_rope_in_attn"]:
                 # GQA + Rot.Emb. does not require `position_ids` as input
                 self.input_names.remove("position_ids")
-        else:
-            assert False, (self.ep, self.io_dtype, "is not a valid EP and io_dtype combination for GroupQueryAttention. Please use one of the following combinations: ", valid_gqa_configurations)
 
         self.past_present_share_buffer = self.attention_attrs["op_type"] == "GroupQueryAttention"
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -370,6 +370,7 @@ class Model:
         valid_gqa_configurations = {
             ("cpu", ir.DataType.FLOAT),
             ("cuda", ir.DataType.FLOAT16),
+            ("cuda", ir.DataType.BFLOAT16),
             ("rocm", ir.DataType.FLOAT16),
             ("dml", ir.DataType.FLOAT16),
             ("webgpu", ir.DataType.FLOAT16),
@@ -395,6 +396,8 @@ class Model:
             if self.attention_attrs["use_rope_in_attn"]:
                 # GQA + Rot.Emb. does not require `position_ids` as input
                 self.input_names.remove("position_ids")
+        else:
+            assert False, (self.ep, self.io_dtype, "is not a valid EP and io_dtype combination for GroupQueryAttention. Please use one of the following combinations: ", valid_gqa_configurations)
 
         self.past_present_share_buffer = self.attention_attrs["op_type"] == "GroupQueryAttention"
 


### PR DESCRIPTION
The `("cuda", ir.DataType.BFLOAT16)` entry was missing probably due to merge conflicts. This should resolve issues with the `google/gemma-3-4b-it` model. To test:

`python src/python/py/models/builder.py -m google/gemma-3-4b-it   -o ./onnx_model_gemma3-bf16  -p bf16  -e cuda  -c ./cache`