### PR TITLE
Fix Android x64 CI failure

### DIFF
--- a/tools/python/util/android.py
+++ b/tools/python/util/android.py
@@ -126,7 +126,7 @@ def start_emulator(
             "-no-audio",
             "-no-boot-anim",
             "-gpu",
-            "guest",
+            "swiftshader_indirect",
             "-delay-adb",
         ]
 


### PR DESCRIPTION
### Description

This PR fixes the Android x64 CI failure.

### Motivation and Context

The CI is required and the failure is blocking other PRs from being merged.