### PR TITLE
Update artifact name for python wheel download

### DIFF
--- a/.pipelines/stages/jobs/py-validation-job.yml
+++ b/.pipelines/stages/jobs/py-validation-job.yml
@@ -76,6 +76,8 @@ jobs:
 
   - name: py_dot_ver
     value: '3.12'
+  - name: py_no_dot_ver
+    value: '312'
 
   - name: pip_package_name
     ${{ if eq(parameters.ep, 'cpu') }}:
@@ -160,7 +162,7 @@ jobs:
   - template: steps/utils/flex-download-pipeline-artifact.yml
     parameters:
       StepName: 'Download Python Wheel Artifacts'
-      ArtifactName: $(ArtifactName)-wheel
+      ArtifactName: $(ArtifactName)-$(py_no_dot_ver)-wheel
       TargetPath: '$(Build.BinariesDirectory)/wheel'
       SpecificArtifact: ${{ parameters.specificArtifact }}
       BuildId: ${{ parameters.BuildId }}


### PR DESCRIPTION
Update artifact name for python wheel download as the artifact name now contains the python version without the dot.

There are further fixes required, for the entire python validation pipeline to work correctly. Currently it fails in vision and multi-modal steps, will work on it later.