### PR TITLE
Correct model type as expected by genai CreateModel function for llm …

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -3762,6 +3762,7 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
                 print("WARNING: This model loses accuracy with float16 precision. Setting `--precision bf16` by default.")
                 onnx_dtype = ir.DataType.BFLOAT16
             onnx_model = Gemma3Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
+            onnx_model.model_type = "gemma3_text"
         elif config.architectures[0] == "GraniteForCausalLM":
             onnx_model = GraniteModel(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "LlamaForCausalLM":


### PR DESCRIPTION
Problem
create_model() in src/models/model.cpp (line [899](https://github.com/microsoft/onnxruntime-genai/blob/main/src/models/model.cpp#L899)) expects the model_type field to be "gemma3_text" when loading a Gemma3ForConditionalGeneration model.
During export, builder.py writes only the top-level family name—"gemma3"—into genai_config.json.
This mismatch prevents onnxruntime-genai from instantiating the model at runtime.

Fix
Update builder.py so that, when exporting a Gemma 3 checkpoint, it writes the correct subtype "gemma3_text" to genai_config.json. The generated config now aligns with create_model(), allowing Gemma 3 LLMs to load and run without manual edits.

Added @baijumeswani to review the changes 