### PR TITLE
Fix KV cache handling for TensorRT execution provider when in place kv is disable

### DIFF
--- a/src/models/kv_cache.h
+++ b/src/models/kv_cache.h
@@ -85,6 +85,8 @@ struct DefaultKeyValueCache : KeyValueCache {
   template <typename T>
   void RewindPastTensorsTo(size_t index);
 
+  void CopyPastToPresentForNvTensorRtRtx(int layer_index);
+
   DeviceInterface& Device() { return *model_.p_device_kvcache_; }
   Ort::Allocator& Allocator() { return model_.p_device_kvcache_->GetAllocator(); }
 


### PR DESCRIPTION
Fix KV cache handling for TensorRT execution provider

TensorRT reads and writes KV values from the same present buffer, unlike other execution providers. When past_present_share_buffer is false, GenAI dynamically allocates memory for the present buffer and expects past KV values to be read from the past buffer.

However, since TensorRT only operates on the present buffer, it reads zero values for the previous KV embeddings when past_present_share_buffer is disabled results in garbage output. To resolve this issue, we now copy past KV values to the present buffer specifically for TensorRT, ensuring the execution provider has access to the complete KV cache history.

@BLSharda 
