### PR TITLE
NvTensorRtRtx: Pass the dynamic shapes (ISL and batch_size) to the ep at runtime as nv profile. 

### DIFF
--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -112,11 +112,12 @@ void WriteE2EStats(std::string_view label,
             << "\n";
 }
 
-std::string GeneratePrompt(size_t num_prompt_tokens, const OgaModel& model, const OgaTokenizer& tokenizer) {
+std::string GeneratePrompt(size_t num_prompt_tokens, const OgaModel& model, const OgaTokenizer& tokenizer, size_t batch_size) {
   const char* const base_prompt = "A";
   auto base_prompt_sequences = OgaSequences::Create();
-
-  tokenizer.Encode(base_prompt, *base_prompt_sequences);
+  for (size_t i = 0; i < batch_size; ++i) {
+    tokenizer.Encode(base_prompt, *base_prompt_sequences);
+  }
 
   auto params = OgaGeneratorParams::Create(model);
   params->SetSearchOption("max_length", static_cast<double>(num_prompt_tokens));
@@ -134,12 +135,23 @@ std::string GeneratePrompt(size_t num_prompt_tokens, const OgaModel& model, cons
 }
 
 void RunBenchmark(const benchmark::Options& opts) {
-  auto model = OgaModel::Create(opts.model_path.c_str());
+  std::unique_ptr<OgaModel> model;
+
+  if (opts.batch_size > 1 && opts.execution_provider == "NvTensorRtRtx")  {
+    // Note: For NvTensorRtRtx with batch_size > 1, we need to use runtime settings
+    auto settings = OgaRuntimeSettings::Create();
+    size_t batch_size = opts.batch_size;
+    settings->SetHandle("batch_size", &batch_size);
+    model = OgaModel::Create(opts.model_path.c_str(), *settings);
+  } else {
+    model = OgaModel::Create(opts.model_path.c_str());
+  }
+
   auto tokenizer = OgaTokenizer::Create(*model);
 
   const auto prompt = [&]() -> std::string {
     if (const size_t* num_prompt_tokens = std::get_if<size_t>(&opts.prompt_num_tokens_or_content)) {
-      return GeneratePrompt(*num_prompt_tokens, *model, *tokenizer);
+      return GeneratePrompt(*num_prompt_tokens, *model, *tokenizer, opts.batch_size);
     }
     return std::get<std::string>(opts.prompt_num_tokens_or_content);
   }();

--- a/benchmark/c/options.cpp
+++ b/benchmark/c/options.cpp
@@ -29,6 +29,8 @@ namespace {
     << "  Options:\n"
     << "    -i,--input_folder <path>\n"
     << "      Path to the ONNX model directory to benchmark, compatible with onnxruntime-genai.\n"
+    << "    -e,--execution_provider <provider>\n"
+    << "      Execution provider to use. Valid values: cpu, cuda, dml, NvTensorRtRtx. Default: " << defaults.execution_provider << "\n"
     << "    -b,--batch_size <number>\n"
     << "      Number of sequences to generate in parallel. Default: " << defaults.batch_size << "\n"
     << "    Prompt options:\n"
@@ -76,10 +78,19 @@ std::string ReadFileContent(std::string_view file_path) {
   return std::string{input_begin, input_end};
 }
 
+void ValidateExecutionProvider(const std::string& provider) {
+  if (provider != "cpu" && provider != "cuda" && provider != "dml" && provider != "NvTensorRtRtx") {
+    throw std::runtime_error("Invalid execution provider: " + provider + ". Valid values are: cpu, cuda, dml, NvTensorRtRtx");
+  }
+}
+
 void VerifyOptions(const Options& opts) {
   if (opts.model_path.empty()) {
     throw std::runtime_error("ONNX model directory path must be provided.");
   }
+
+  // validate execution provider since it has a valid value
+  ValidateExecutionProvider(opts.execution_provider);
 }
 
 }  // namespace
@@ -103,6 +114,8 @@ Options ParseOptionsFromCommandLine(int argc, const char* const* argv) {
 
       if (arg == "-i" || arg == "--input_folder") {
         opts.model_path = next_arg(i);
+      } else if (arg == "-e" || arg == "--execution_provider") {
+        opts.execution_provider = next_arg(i);
       } else if (arg == "-b" || arg == "--batch_size") {
         opts.batch_size = ParseNumber<size_t>(next_arg(i));
       } else if (arg == "-l" || arg == "--prompt_length") {

--- a/benchmark/c/options.h
+++ b/benchmark/c/options.h
@@ -13,6 +13,7 @@ using PromptNumberOfTokensOrContent = std::variant<size_t, std::string>;
 
 struct Options {
   std::string model_path;
+  std::string execution_provider{"cpu"};
   PromptNumberOfTokensOrContent prompt_num_tokens_or_content{size_t{16}};
   size_t num_tokens_to_generate{128};
   size_t batch_size{1};

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -332,100 +332,148 @@ int32_t Tokenizer::TokenToTokenId(const char* token) const {
 }
 
 /**
- * @brief Creates multi-profile shapes for TensorRT execution provider optimization.
+ * @brief Creates profile shapes for NvTensorRtRtx execution provider optimization.
  *
- * This function generates separate profiles for each of the context and generation phases to optimize performance
- * Each profile includes shapes for input tensors (input_ids, attention_mask, position_ids)
- * and key-value cache tensors with appropriate dimensions based on the model configuration.
+ * This function generates profiles for TensorRT execution provider optimization.
+ * If multi-profile is enabled, it creates separate profiles for context and generation phases.
+ * If multi-profile is disabled, it creates a single profile with simple shapes.
  *
  */
-void ConfigureMultiProfile(const Config& config, OrtSessionOptions& session_options) {
+ void ConfigureNvTensorRtRTxProfile(const Config& config, OrtSessionOptions& session_options, bool is_multi_profile_enabled) {
   // Get model parameters from decoder config
   const int num_layers = config.model.decoder.num_hidden_layers;
   const int num_kv_heads = config.model.decoder.num_key_value_heads;
   const int head_dim = config.model.decoder.head_size;
+  const int batch_size = config.search.batch_size;
 
   // Get max context length from config
   const int max_context_len = config.model.context_length;
-  const int opt_context_len = config.model.context_length / 2;
-  const int min_seq_len = 1;
 
   // Extract KV cache name patterns from decoder config
   std::string_view past_key_pattern = config.model.decoder.inputs.past_key_names;
   std::string_view past_value_pattern = config.model.decoder.inputs.past_value_names;
 
-  // Helper function to add input shapes (input_ids, attention_mask, position_ids)
-  const auto add_input_shapes = [](std::ostringstream& shapes, int seq_len, bool append = false) {
-    if (append) shapes << ",";
-    shapes << Config::Defaults::InputIdsName << ":1x" << seq_len << ","
-           << Config::Defaults::AttentionMaskName << ":1x" << seq_len;
-  };
+  if (is_multi_profile_enabled) {
+    // Multi-profile mode: existing logic for context and generation phases
+    const int opt_context_len = config.model.context_length / 2;
+    const int min_seq_len = 1;
 
-  // Helper function to add generation phase input shapes
-  const auto add_generation_input_shapes = [](std::ostringstream& shapes, int context_len) {
-    shapes << "," << Config::Defaults::AttentionMaskName << ":1x" << context_len << ","
-           << Config::Defaults::InputIdsName << ":1x1";
-  };
+    // Helper function to add input shapes (input_ids, attention_mask, position_ids)
+    const auto add_input_shapes = [](std::ostringstream& shapes, int batch_size, int seq_len, bool append = false) {
+      if (append) shapes << ",";
+      shapes << Config::Defaults::InputIdsName << ":" << batch_size << "x" << seq_len << ","
+             << Config::Defaults::AttentionMaskName << ":" << batch_size << "x" << seq_len;
+    };
 
-  // Helper function to add empty KV cache shapes for all layers
-  const auto add_empty_key_value_cache_shapes = [](std::ostringstream& shapes,
-                                                   std::string_view key_pattern,
-                                                   std::string_view value_pattern,
-                                                   int num_layers,
-                                                   int num_kv_heads,
-                                                   int head_dim) {
-    for (int i = 0; i < num_layers; i++) {
-      // Use the existing function to format the key/value names
-      const std::string key_name = ComposeKeyValueName(std::string(key_pattern), i);
-      const std::string value_name = ComposeKeyValueName(std::string(value_pattern), i);
+    // Helper function to add generation phase input shapes
+    const auto add_generation_input_shapes = [](std::ostringstream& shapes, int batch_size, int context_len) {
+      shapes << "," << Config::Defaults::AttentionMaskName << ":" << batch_size << "x" << context_len << ","
+             << Config::Defaults::InputIdsName << ":" << batch_size << "x1";
+    };
 
-      shapes << "," << key_name << ":1x" << num_kv_heads << "x0x" << head_dim;
-      shapes << "," << value_name << ":1x" << num_kv_heads << "x0x" << head_dim;
-    }
-  };
+    // Helper function to add empty KV cache shapes for all layers
+    const auto add_empty_key_value_cache_shapes = [](std::ostringstream& shapes,
+                                                     int batch_size,
+                                                     std::string_view key_pattern,
+                                                     std::string_view value_pattern,
+                                                     int num_layers,
+                                                     int num_kv_heads,
+                                                     int head_dim) {
+      for (int i = 0; i < num_layers; i++) {
+        // Use the existing function to format the key/value names
+        const std::string key_name = ComposeKeyValueName(std::string(key_pattern), i);
+        const std::string value_name = ComposeKeyValueName(std::string(value_pattern), i);
 
-  // Helper function to add KV cache with sequence length
-  const auto add_key_value_cache_shapes = [](std::ostringstream& shapes,
-                                             std::string_view key_pattern,
-                                             std::string_view value_pattern,
-                                             int seq_len,
-                                             int num_layers,
-                                             int num_kv_heads,
-                                             int head_dim) {
-    for (int i = 0; i < num_layers; i++) {
-      // Use the existing function to format the key/value names
-      const std::string key_name = ComposeKeyValueName(std::string(key_pattern), i);
-      const std::string value_name = ComposeKeyValueName(std::string(value_pattern), i);
+        shapes << "," << key_name << ":" << batch_size << "x" << num_kv_heads << "x0x" << head_dim;
+        shapes << "," << value_name << ":" << batch_size << "x" << num_kv_heads << "x0x" << head_dim;
+      }
+    };
 
-      shapes << "," << key_name << ":1x" << num_kv_heads << "x" << seq_len << "x" << head_dim;
-      shapes << "," << value_name << ":1x" << num_kv_heads << "x" << seq_len << "x" << head_dim;
-    }
-  };
+    // Helper function to add KV cache with sequence length
+    const auto add_key_value_cache_shapes = [](std::ostringstream& shapes,
+                                               int batch_size,
+                                               std::string_view key_pattern,
+                                               std::string_view value_pattern,
+                                               int seq_len,
+                                               int num_layers,
+                                               int num_kv_heads,
+                                               int head_dim) {
+      for (int i = 0; i < num_layers; i++) {
+        // Use the existing function to format the key/value names
+        const std::string key_name = ComposeKeyValueName(std::string(key_pattern), i);
+        const std::string value_name = ComposeKeyValueName(std::string(value_pattern), i);
 
-  std::ostringstream min_shapes, opt_shapes, max_shapes;
+        shapes << "," << key_name << ":" << batch_size << "x" << num_kv_heads << "x" << seq_len << "x" << head_dim;
+        shapes << "," << value_name << ":" << batch_size << "x" << num_kv_heads << "x" << seq_len << "x" << head_dim;
+      }
+    };
 
-  // MIN SHAPES (context phase and first token generation)
-  add_input_shapes(min_shapes, min_seq_len);
-  add_empty_key_value_cache_shapes(min_shapes, past_key_pattern, past_value_pattern, num_layers, num_kv_heads, head_dim);
-  add_generation_input_shapes(min_shapes, min_seq_len);
-  add_key_value_cache_shapes(min_shapes, past_key_pattern, past_value_pattern, min_seq_len, num_layers, num_kv_heads, head_dim);
+    std::ostringstream min_shapes, opt_shapes, max_shapes;
 
-  // OPT SHAPES (prefill with medium context and generation after medium context)
-  add_input_shapes(opt_shapes, opt_context_len);
-  add_empty_key_value_cache_shapes(opt_shapes, past_key_pattern, past_value_pattern, num_layers, num_kv_heads, head_dim);
-  add_generation_input_shapes(opt_shapes, opt_context_len);
-  add_key_value_cache_shapes(opt_shapes, past_key_pattern, past_value_pattern, opt_context_len - 1, num_layers, num_kv_heads, head_dim);
+    // MIN SHAPES (context phase and first token generation)
+    add_input_shapes(min_shapes, batch_size, min_seq_len);
+    add_empty_key_value_cache_shapes(min_shapes, batch_size, past_key_pattern, past_value_pattern, num_layers, num_kv_heads, head_dim);
+    add_generation_input_shapes(min_shapes, batch_size, min_seq_len);
+    add_key_value_cache_shapes(min_shapes, batch_size, past_key_pattern, past_value_pattern, min_seq_len, num_layers, num_kv_heads, head_dim);
 
-  // MAX SHAPES (prefill with maximum context and generation after maximum context)
-  add_input_shapes(max_shapes, max_context_len);
-  add_key_value_cache_shapes(max_shapes, past_key_pattern, past_value_pattern, max_context_len - 1, num_layers, num_kv_heads, head_dim);
-  add_generation_input_shapes(max_shapes, max_context_len);
-  add_key_value_cache_shapes(max_shapes, past_key_pattern, past_value_pattern, max_context_len - 1, num_layers, num_kv_heads, head_dim);
+    // OPT SHAPES (prefill with medium context and generation after medium context)
+    add_input_shapes(opt_shapes, batch_size, opt_context_len);
+    add_empty_key_value_cache_shapes(opt_shapes, batch_size, past_key_pattern, past_value_pattern, num_layers, num_kv_heads, head_dim);
+    add_generation_input_shapes(opt_shapes, batch_size, opt_context_len);
+    add_key_value_cache_shapes(opt_shapes, batch_size, past_key_pattern, past_value_pattern, opt_context_len - 1, num_layers, num_kv_heads, head_dim);
 
-  // Add the constructed profiles to session options
-  session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_profile_min_shapes", min_shapes.str().c_str());
-  session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_profile_opt_shapes", opt_shapes.str().c_str());
-  session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_profile_max_shapes", max_shapes.str().c_str());
+    // MAX SHAPES (prefill with maximum context and generation after maximum context)
+    add_input_shapes(max_shapes, batch_size, max_context_len);
+    add_key_value_cache_shapes(max_shapes, batch_size, past_key_pattern, past_value_pattern, max_context_len - 1, num_layers, num_kv_heads, head_dim);
+    add_generation_input_shapes(max_shapes, batch_size, max_context_len);
+    add_key_value_cache_shapes(max_shapes, batch_size, past_key_pattern, past_value_pattern, max_context_len - 1, num_layers, num_kv_heads, head_dim);
+
+    // Add the constructed profiles to session options
+    session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_profile_min_shapes", min_shapes.str().c_str());
+    session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_profile_opt_shapes", opt_shapes.str().c_str());
+    session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_profile_max_shapes", max_shapes.str().c_str());
+  } else {
+    // Single profile mode: simple shapes with batch_dim=[0,1,1] and seq_dim=[0,1,max_context_len]
+    std::ostringstream min_shapes, opt_shapes, max_shapes;
+
+    // Helper function to add single profile KV cache shapes
+    const auto add_single_profile_kv_shapes = [](std::ostringstream& shapes,
+                                                  int batch_size,
+                                                  std::string_view key_pattern,
+                                                  std::string_view value_pattern,
+                                                  int seq_len,
+                                                  int num_layers,
+                                                  int num_kv_heads,
+                                                  int head_dim) {
+      for (int i = 0; i < num_layers; i++) {
+        const std::string key_name = ComposeKeyValueName(std::string(key_pattern), i);
+        const std::string value_name = ComposeKeyValueName(std::string(value_pattern), i);
+
+        shapes << "," << key_name << ":" << batch_size << "x" << num_kv_heads << "x" << seq_len << "x" << head_dim;
+        shapes << "," << value_name << ":" << batch_size << "x" << num_kv_heads << "x" << seq_len << "x" << head_dim;
+      }
+    };
+
+    // MIN SHAPES: batch_dim=0, seq_dim=0
+    min_shapes << Config::Defaults::InputIdsName << ":0x0,"
+               << Config::Defaults::AttentionMaskName << ":0x0";
+    add_single_profile_kv_shapes(min_shapes, 0, past_key_pattern, past_value_pattern, 0, num_layers, num_kv_heads, head_dim);
+
+    // OPT SHAPES: batch_dim=1, seq_dim=1
+    opt_shapes << Config::Defaults::InputIdsName << ":1x1,"
+               << Config::Defaults::AttentionMaskName << ":1x1";
+    add_single_profile_kv_shapes(opt_shapes, 1, past_key_pattern, past_value_pattern, 1, num_layers, num_kv_heads, head_dim);
+
+    // MAX SHAPES: batch_dim=1, seq_dim=max_context_len
+    max_shapes << Config::Defaults::InputIdsName << ":" << batch_size << "x" << max_context_len << ","
+               << Config::Defaults::AttentionMaskName << ":" << batch_size << "x" << max_context_len;
+    add_single_profile_kv_shapes(max_shapes, batch_size, past_key_pattern, past_value_pattern, max_context_len, num_layers, num_kv_heads, head_dim);
+
+    // Add the constructed profiles to session options
+    session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_profile_min_shapes", min_shapes.str().c_str());
+    session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_profile_opt_shapes", opt_shapes.str().c_str());
+    session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_profile_max_shapes", max_shapes.str().c_str());
+  }
 }
 
 DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
@@ -538,9 +586,8 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
         session_options.AddConfigEntry("session.inter_op.allow_spinning", "0");
         session_options.AddConfigEntry("session.intra_op.allow_spinning", "0");
       } else if (provider_options.name == "NvTensorRtRtx") {
-        if (IsMultiProfileEnabled(config.model.decoder.session_options)) {
-          ConfigureMultiProfile(config, session_options);
-        }
+        bool is_multi_profile_enabled = IsMultiProfileEnabled(config.model.decoder.session_options);
+        ConfigureNvTensorRtRTxProfile(config, session_options, is_multi_profile_enabled);
         if (IsGraphCaptureEnabled(config.model.decoder.session_options)) {
           session_options.AddConfigEntry("ep.nvtensorrtrtxexecutionprovider.nv_cuda_graph_enable", "1");
         }

--- a/src/runtime_settings.cpp
+++ b/src/runtime_settings.cpp
@@ -25,18 +25,38 @@ std::string RuntimeSettings::GenerateConfigOverlay() const {
 }
 )";
 
-  auto it = handles_.find("dawnProcTable");
-  if (it != handles_.end()) {
-    void* dawn_proc_table_handle = it->second;
-    std::string overlay;
-    overlay.reserve(webgpu_overlay_pre.size() + webgpu_overlay_post.size() + 20);  // Optional small optimization of buffer size
-    overlay += webgpu_overlay_pre;
-    overlay += std::to_string((size_t)(dawn_proc_table_handle));
-    overlay += webgpu_overlay_post;
-    return overlay;
-  }
+    constexpr std::string_view batch_size_overlay = R"({
+  "search": {
+  "batch_size": )";
 
-  return {};
+    // Handle WebGPU dawnProcTable
+    auto webgpu_it = handles_.find("dawnProcTable");
+    if (webgpu_it != handles_.end()) {
+        void* dawn_proc_table_handle = webgpu_it->second;
+        std::string overlay;
+        overlay.reserve(webgpu_overlay_pre.size() + webgpu_overlay_post.size() + 20);
+        overlay += webgpu_overlay_pre;
+        overlay += std::to_string((size_t)(dawn_proc_table_handle));
+        overlay += webgpu_overlay_post;
+        return overlay;
+    }
+
+    // Handle batch_size
+    auto batch_size_it = handles_.find("batch_size");
+    if (batch_size_it != handles_.end()) {
+        int* batch_size_ptr = static_cast<int*>(batch_size_it->second);
+        std::string overlay;
+        overlay.reserve(batch_size_overlay.size() + 50);
+        overlay += batch_size_overlay;
+        overlay += std::to_string(*batch_size_ptr);
+        overlay += R"(
+  }
+}
+)";
+        return overlay;
+    }
+
+    return {};
 }
 
 }  // namespace Generators


### PR DESCRIPTION
1. Pass the dynamic shapes (ISL and `batch_size`) to the NV EP.  
2. Update the C++ benchmark:  
   - For the `NvTensorRtRTx` EP,  need to pass `batch_size` at `OgaModel::Create` time, as it is required to build the engine.
