### PR TITLE
whisper: Allow session options to be used for encoder

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -969,6 +969,10 @@ Config::Config(const fs::path& path, std::string_view json_overlay) : config_pat
   for (const auto& provider_option : model.decoder.session_options.provider_options) {
     model.decoder.session_options.providers.push_back(provider_option.name);
   }
+
+  for (const auto& provider_option : model.encoder.session_options.provider_options) {
+    model.encoder.session_options.providers.push_back(provider_option.name);
+  }
 }
 
 void Config::AddMapping(const std::string& nominal_name, const std::string& graph_name) {

--- a/src/models/whisper.h
+++ b/src/models/whisper.h
@@ -16,6 +16,8 @@ struct WhisperModel : Model {
 
   std::unique_ptr<OrtSession> session_encoder_;  // audio_features -> encoder_hidden_states, cross_kv_cache
   std::unique_ptr<OrtSession> session_decoder_;  // input_ids, self_kv_cache, cross_kv_cache -> logits, self_kv_cache
+
+  std::unique_ptr<OrtSessionOptions> encoder_session_options_;
 };
 
 struct AudioEncoderState : State {


### PR DESCRIPTION
This PR adds the ability to set `session_options` (with `provider_options`) specific to the `encoder` (via `genai_config.json`).

Before this change-set, the `session_options` specified in the `decoder` section within `genai_config.json` is used to initialize both the encoder & decoder ORT sessions.

Note that, this PR still preserves the *default* behavior -- If no `provider_options` are specified by the `encoder` section of `genai_config.json`, then it will still use the `session_options` specified for the decoder. I did this to preserve any existing use-cases, where perhaps the assumption is that the `decoder` session options will also be used for the `encoder`.

In our (OpenVINO EP) case, we would like the flexibility to run encoder/decoder models across separate OpenVINO devices -- hence we need the ability to specify differing `provider_options` between decoder & encoder.