### PR TITLE
Append eos token to the end of input sequence for marian models

### DIFF
--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -153,11 +153,10 @@ def main(args):
         # Apply Chat Template
         if model.type == "marian-ssru":
             prompt = text
-            input_tokens = tokenizer.encode(prompt)
-            input_tokens = np.append(input_tokens, 0)
         else:
             prompt = tokenizer.apply_chat_template(messages=messages, add_generation_prompt=True)
-            input_tokens = tokenizer.encode(prompt)
+
+        input_tokens = tokenizer.encode(prompt)
         generator.append_tokens(input_tokens)
 
         if args.verbose: print("Running generation loop ...")

--- a/src/models/marian.cpp
+++ b/src/models/marian.cpp
@@ -107,10 +107,19 @@ DeviceSpan<float> MarianState::Run(int current_length, DeviceSpan<int32_t>& next
     encoder_input_ids_.name_ = model_.config_->model.encoder.inputs.input_ids.c_str();
     encoder_input_ids_.Add();
 
-    // encoder_attention_mask_.attention_mask_name_ = model_.config_->model.encoder.inputs.attention_mask;
     encoder_attention_mask_.Add();
 
-    encoder_input_ids_.Update(next_tokens);
+    // Create a new DeviceSpan with one additional token (0) appended
+    auto original_cpu_span = next_tokens.CpuSpan();
+    auto extended_tokens = model_.p_device_inputs_->Allocate<int32_t>(original_cpu_span.size() + 1);
+    auto extended_cpu_span = extended_tokens.CpuSpan();
+
+    // Copy original tokens and append eos_token_id
+    std::copy(original_cpu_span.begin(), original_cpu_span.end(), extended_cpu_span.begin());
+    extended_cpu_span[original_cpu_span.size()] = model_.config_->model.eos_token_id[0];  // Append eos_token_id
+    extended_tokens.CopyCpuToDevice();
+
+    encoder_input_ids_.Update(extended_tokens);
     const size_t new_length = static_cast<size_t>(encoder_input_ids_.GetShape()[1]);
     encoder_attention_mask_.Update(next_tokens, current_length, static_cast<int>(new_length));
 


### PR DESCRIPTION
SPM encoding that is used for marian model append eos token by default after every prompt. To make that work we need to set add_special_tokens to true but we cannot do in our case now. So we need to find a work around to append eos. 
Option 1: Append eos in the client code. But the user does not want to do that
Option 2: Append </s> after the prompt --> This can be a back up option, but 
Option 3: Set add_special_tokens to true. --> Can discuss on this

Current change appends 0 to the end of input sequence which works as eos.