### PR TITLE
Fixes all packaging pipelines

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -94,12 +94,12 @@ jobs:
         run: |
           set -e -x
           rm -rf build
-          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --update
+          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --update --skip_wheel
 
       - name: Run Android build
         run: |
           set -e -x
-          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --build
+          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --build --skip_wheel
 
       - name: Enable KVM group perms so Android emulator can run
         run: |

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -38,4 +38,5 @@ jobs:
               --osx_arch arm64 \
               --apple_deploy_target 15.4 \
               --cmake_generator 'Xcode' \
-              --build_dir build_iphonesimulator
+              --build_dir build_iphonesimulator \
+              --skip_wheel

--- a/.github/workflows/linux-cpu-arm64-build.yml
+++ b/.github/workflows/linux-cpu-arm64-build.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           docker run --rm \
           --volume $GITHUB_WORKSPACE:/onnxruntime_src \
-          -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c "/usr/bin/cmake --build --preset linux_gcc_cpu_release"
+          -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c "/usr/bin/cmake --build --preset linux_gcc_cpu_release && /usr/bin/cmake --build --preset linux_gcc_cpu_release --target PyPackageBuild"
 
       - name: Docker -- Check test directory
         run: |

--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -95,6 +95,7 @@ jobs:
           rm -rf build
           cmake --preset linux_gcc_cpu_release
           cmake --build --preset linux_gcc_cpu_release
+          cmake --build --preset linux_gcc_cpu_release --target PyPackageBuild
 
       - name: Install the python wheel and test dependencies
         run: |

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -51,6 +51,7 @@ jobs:
           rm -rf build
           cmake --preset linux_gcc_cpu_release
           cmake --build --preset linux_gcc_cpu_release
+          cmake --build --preset linux_gcc_cpu_release --target PyPackageBuild
 
       - name: Install the python wheel and test dependencies
         run: |

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -135,7 +135,7 @@ jobs:
             --volume $GITHUB_WORKSPACE:/ort_genai_src \
             -w /ort_genai_src onnxruntimecudabuildx64 \
             bash -c " \
-              /usr/bin/cmake --build --preset linux_gcc_cuda_release"
+              /usr/bin/cmake --build --preset linux_gcc_cuda_release && /usr/bin/cmake --build --preset linux_gcc_cuda_release --target PyPackageBuild"
 
       - name: Install the onnxruntime-genai Python wheel and run python test
         run: |

--- a/.github/workflows/mac-cpu-arm64-build.yml
+++ b/.github/workflows/mac-cpu-arm64-build.yml
@@ -73,6 +73,7 @@ jobs:
           export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | cut -d. -f1,2)
           export RUSTFLAGS='-C link-arg=-Wl,-undefined,dynamic_lookup -C link-arg=-Wl,-no_dead_strip_inits_and_terms'
           cmake --build --preset macos_arm64_cpu_release --parallel
+          cmake --build --preset macos_arm64_cpu_release --target PyPackageBuild
         continue-on-error: false
 
       - name: Install the python wheel and test dependencies

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Build with CMake
         run: |
           cmake --build --preset windows_arm64_cpu_release --parallel
+          cmake --build --preset windows_arm64_cpu_release --target PyPackageBuild
 
       - name: Install the Python Wheel and Test Dependencies
         run: |

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Build with CMake
         run: |
           cmake --build --preset windows_x64_cpu_release --parallel
+          cmake --build --preset windows_x64_cpu_release --target PyPackageBuild
 
       - name: Install the python wheel and test dependencies
         run: |

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Build with CMake
         run: |
           cmake --build --preset windows_x64_cuda_release --parallel
+          cmake --build --preset windows_x64_cuda_release --target PyPackageBuild
 
       - name: Add CUDA to PATH
         run: |

--- a/.github/workflows/win-directml-x64-build.yml
+++ b/.github/workflows/win-directml-x64-build.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Build with CMake
         run: |
           cmake --build --preset windows_x64_directml_release --parallel
+          cmake --build --preset windows_x64_directml_release --target PyPackageBuild
 
       - name: Install the Python Wheel and Test Dependencies
         run: |

--- a/.pipelines/stages/jobs/steps/capi-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-linux-step.yml
@@ -73,7 +73,7 @@ steps:
       -w /ort_genai_src/ ortgenai$(ep)build$(arch) \
       bash -c " \
           /usr/bin/cmake --preset linux_gcc_$(ep)_$(build_config) \
-            -DENABLE_TESTS=OFF && \
+            -DENABLE_TESTS=OFF -DENABLE_PYTHON=OFF && \
           /usr/bin/cmake --build --preset linux_gcc_$(ep)_$(build_config) \
             --target onnxruntime-genai"
     displayName: 'Build GenAi'

--- a/.pipelines/stages/jobs/steps/capi-macos-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-macos-step.yml
@@ -141,7 +141,7 @@ steps:
           $env:_PYTHON_HOST_PLATFORM = "macosx-12.0-x86_64"
           $env:ARCHFLAGS = "-arch x86_64"
       }
-      cmake --build --preset macos_$(arch)_$(ep)_$(build_config) --parallel --PyPackageBuild
+      cmake --build --preset macos_$(arch)_$(ep)_$(build_config) --parallel --target PyPackageBuild
     displayName: 'Build Python Wheel'
     workingDirectory: '$(Build.Repository.LocalPath)'
 

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -104,7 +104,7 @@ steps:
   workingDirectory: '$(Build.Repository.LocalPath)'
 
 
-- ${{ if or(eq(parameters.target, 'onnxruntime-genai'), eq(parameters.target, 'python')) }}:
+- ${{ if eq(parameters.target, 'onnxruntime-genai') }}:
   - template: compliant/win-esrp-dll-step.yml
     parameters:
       FolderPath: '$(Build.Repository.LocalPath)\$(buildDir)'
@@ -136,6 +136,12 @@ steps:
       DisplayName: 'ESRP - PYD Sign'
       DoEsrp: true
       Pattern: '*.pyd'
+  
+  - template: compliant/win-esrp-dll-step.yml
+    parameters:
+      FolderPath: '$(Build.Repository.LocalPath)\build\$(ep)\$(os)-$(arch)\wheel\onnxruntime_genai'
+      DisplayName: 'ESRP - Sign C++ dlls'
+      Pattern: '*genai*.dll'
 
   - powershell: |
       Get-ChildItem -Path $(Build.Repository.LocalPath) -Recurse

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -98,8 +98,8 @@ steps:
       $build_config = 'Debug'
     }
     python -m pip install requests
-    python build.py --use_guidance --parallel $cuda_home $use_dml $package_c $skip_wheel --config=$build_config --build_dir='$(Build.Repository.LocalPath)\$(buildDir)'
-    Rename-Item -Path '$(Build.Repository.LocalPath)\$(buildDir)\Release' -NewName '$(os)-$(arch)' -Force
+    python build.py --use_guidance --parallel $cuda_home $use_dml $package_c $skip_wheel --config=$build_config --build_dir='$(Build.Repository.LocalPath)\$(buildDir)' --skip_tests
+    Rename-Item -Path '$(Build.Repository.LocalPath)\$(buildDir)\$build_config' -NewName '$(os)-$(arch)' -Force
   displayName: 'Build C API and package / wheel'
   workingDirectory: '$(Build.Repository.LocalPath)'
 

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -78,31 +78,21 @@ steps:
   workingDirectory: '$(Build.Repository.LocalPath)'
 
 - powershell: |
-    $ep = '${{ parameters.ep }}'
-    $target = '${{ parameters.target }}'
-    $config = '${{ parameters.build_config }}'
-    $cuda_home = if ($ep -eq 'cuda') { '--cuda_home=$(Build.Repository.LocalPath)\cuda_sdk\v$(cuda_version)' } else { '' }
-    $use_dml = if ($ep -eq 'directml') { '--use_dml' } else { '' }
-    $package_c = if ($target -eq 'onnxruntime-genai') { '--package' } else { '' }
-    if ($target -ne 'python') {
-      $skip_wheel = '--skip_wheel'
-    } else {
-      $skip_wheel = ''
-      python -m pip install wheel
-    }
-    if ($config -eq 'release') {
-      $build_config = 'Release'
-    } elseif ($config -eq 'relwithdebinfo') {
-      $build_config = 'RelWithDebInfo'
-    } else {
-      $build_config = 'Debug'
-    }
-    python -m pip install requests
-    python build.py --use_guidance --parallel $cuda_home $use_dml $package_c $skip_wheel --config=$build_config --build_dir='$(Build.Repository.LocalPath)\$(buildDir)' --skip_tests
-    Rename-Item -Path '$(Build.Repository.LocalPath)\$(buildDir)\$(build_config)' -NewName '$(os)-$(arch)' -Force
-  displayName: 'Build C API and package / wheel'
+    cmake --preset windows_$(arch)_$(ep)_$(build_config) -T cuda='$(Build.Repository.LocalPath)\cuda_sdk\v$(cuda_version)'
+  displayName: 'Configure CMake C API with CUDA'
+  condition: eq(variables['ep'], 'cuda')
   workingDirectory: '$(Build.Repository.LocalPath)'
 
+- powershell: |
+    cmake --preset windows_$(arch)_$(ep)_$(build_config)
+  displayName: 'Configure CMake C API without CUDA'
+  condition: ne(variables['ep'], 'cuda')
+  workingDirectory: '$(Build.Repository.LocalPath)'
+
+- powershell: |
+    cmake --build --preset windows_$(arch)_$(ep)_$(build_config) --parallel --target ${{ parameters.target }}
+  displayName: 'Build C API'
+  workingDirectory: '$(Build.Repository.LocalPath)'
 
 - ${{ if eq(parameters.target, 'onnxruntime-genai') }}:
   - template: compliant/win-esrp-dll-step.yml
@@ -116,6 +106,15 @@ steps:
     inputs:
       AnalyzeTargetGlob: '$(Build.Repository.LocalPath)\**\*genai.dll'
     continueOnError: true
+
+  - powershell: |
+      python -m pip install wheel
+    displayName: 'Install wheel'
+
+  - powershell: |
+      cmake --build --preset windows_$(arch)_$(ep)_$(build_config) --target package
+    displayName: 'Package C/C++ API'
+    workingDirectory: '$(Build.Repository.LocalPath)'
 
   - task: 1ES.PublishPipelineArtifact@1
     displayName: 'Publish Artifact: ONNXRuntime Genai capi'
@@ -135,13 +134,15 @@ steps:
       FolderPath: '$(Build.Repository.LocalPath)\build\$(ep)\$(os)-$(arch)\wheel\onnxruntime_genai'
       DisplayName: 'ESRP - PYD Sign'
       DoEsrp: true
-      Pattern: '*.pyd'
-  
-  - template: compliant/win-esrp-dll-step.yml
-    parameters:
-      FolderPath: '$(Build.Repository.LocalPath)\build\$(ep)\$(os)-$(arch)\wheel\onnxruntime_genai'
-      DisplayName: 'ESRP - Sign C++ dlls'
-      Pattern: '*genai*.dll'
+      Pattern: '*.pyd,*.dll'
+
+  - powershell: |
+      python -m pip install wheel
+    displayName: 'Install wheel'
+
+  - powershell: |
+      cmake --build --preset windows_$(arch)_$(ep)_$(build_config) --parallel --PyPackageBuild
+    displayName: 'Build Python Wheel'
 
   - powershell: |
       Get-ChildItem -Path $(Build.Repository.LocalPath) -Recurse

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -141,7 +141,7 @@ steps:
     displayName: 'Install wheel'
 
   - powershell: |
-      cmake --build --preset windows_$(arch)_$(ep)_$(build_config) --parallel --PyPackageBuild
+      cmake --build --preset windows_$(arch)_$(ep)_$(build_config) --parallel --target PyPackageBuild
     displayName: 'Build Python Wheel'
 
   - powershell: |

--- a/.pipelines/stages/jobs/steps/capi-win-step.yml
+++ b/.pipelines/stages/jobs/steps/capi-win-step.yml
@@ -99,7 +99,7 @@ steps:
     }
     python -m pip install requests
     python build.py --use_guidance --parallel $cuda_home $use_dml $package_c $skip_wheel --config=$build_config --build_dir='$(Build.Repository.LocalPath)\$(buildDir)' --skip_tests
-    Rename-Item -Path '$(Build.Repository.LocalPath)\$(buildDir)\$build_config' -NewName '$(os)-$(arch)' -Force
+    Rename-Item -Path '$(Build.Repository.LocalPath)\$(buildDir)\$(build_config)' -NewName '$(os)-$(arch)' -Force
   displayName: 'Build C API and package / wheel'
   workingDirectory: '$(Build.Repository.LocalPath)'
 

--- a/build.py
+++ b/build.py
@@ -628,6 +628,10 @@ def build(args: argparse.Namespace, env: dict[str, str]):
 
     util.run(make_command, env=env)
 
+    if not args.skip_wheel:
+        make_command += ["--target", "PyPackageBuild"]
+        util.run(make_command, env=env)
+
     lib_dir = args.build_dir
     if util.is_windows():
         # On Windows, the library files are in a subdirectory named after the configuration (e.g. Debug, Release, etc.)

--- a/build.py
+++ b/build.py
@@ -596,10 +596,11 @@ def update(args: argparse.Namespace, env: dict[str, str]):
             "-DMAC_CATALYST=1",
         ]
 
-    if args.arm64:
-        command += ["-A", "ARM64"]
-    elif args.arm64ec:
-        command += ["-A", "ARM64EC"]
+    if args.cmake_generator.startswith("Visual Studio"):
+        if args.arm64:
+            command += ["-A", "ARM64"]
+        elif args.arm64ec:
+            command += ["-A", "ARM64EC"]
 
     if args.arm64 or args.arm64ec:
         if args.test:
@@ -735,10 +736,14 @@ def build_examples(args: argparse.Namespace, env: dict[str, str]):
         "-DORT_GENAI_LIB_DIR=" + str(lib_dir),
     ]
 
-    if args.arm64:
-        cmake_command += ["-A", "ARM64"]
-    elif args.arm64ec:
-        cmake_command += ["-A", "ARM64EC"]
+    if args.cmake_generator.startswith("Visual Studio"):
+        if args.arm64:
+            cmake_command += ["-A", "ARM64"]
+        elif args.arm64ec:
+            cmake_command += ["-A", "ARM64EC"]
+
+    if args.cmake_extra_defines != []:
+        cmake_command += args.cmake_extra_defines
 
     util.run(cmake_command, env=env)
     util.run([str(args.cmake_path), "--build", str(build_dir), "--config", args.config], env=env)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -97,19 +97,20 @@ if(BUILD_WHEEL)
   endif()
 
   if(MANYLINUX)
-    add_custom_target(PyPackageBuild ALL
+    add_custom_target(PyPackageBuild
       COMMAND ${PYTHON_EXECUTABLE} -m pip wheel --no-deps .
       COMMAND ${CMAKE_COMMAND} -E remove ${WHEEL_TARGET_NAME}/onnxruntime_genai.cpython-*
       COMMAND auditwheel repair onnxruntime_genai*linux_x86_64.whl -w ${WHEEL_FILES_DIR} ${modified_exclude_list}
       WORKING_DIRECTORY "${WHEEL_FILES_DIR}"
       COMMENT "Building wheel with MANYLINUX on ${WHEEL_FILES_DIR}"
+      EXCLUDE_FROM_ALL
     )
   else()
-    add_custom_target(PyPackageBuild ALL
+    add_custom_target(PyPackageBuild
       COMMAND ${PYTHON_EXECUTABLE} -m pip wheel --no-deps .
       WORKING_DIRECTORY "${WHEEL_FILES_DIR}"
       COMMENT "Building wheel on ${WHEEL_FILES_DIR}"
+      EXCLUDE_FROM_ALL
     )
   endif()
-  add_dependencies(PyPackageBuild python)
 endif()

--- a/tools/ci_build/github/android/default_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_aar_build_settings.json
@@ -10,6 +10,7 @@
         "--parallel",
         "--cmake_generator=Ninja",
         "--build_java",
-        "--skip_tests"
+        "--skip_tests",
+        "--skip_wheel"
     ]
 }

--- a/tools/ci_build/github/apple/build_apple_framework.py
+++ b/tools/ci_build/github/apple/build_apple_framework.py
@@ -171,6 +171,7 @@ def _build_package(args):
             + build_settings["build_params"]["base"]
             + build_settings["build_params"][sysroot]
             + ["--config=" + build_config]
+            + ["--skip_examples", "--skip_tests"]
         )
 
         if args.ort_home:

--- a/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
@@ -13,11 +13,12 @@
         ]
     },
     "build_params": {
-      "base": [
-        "--parallel",
-        "--build_apple_framework",
-        "--skip_tests"
-      ],
+        "base": [
+            "--parallel",
+            "--build_apple_framework",
+            "--skip_tests",
+            "--skip_wheel"
+        ],
         "iphoneos": [
             "--ios",
             "--cmake_generator",
@@ -30,7 +31,7 @@
             "Xcode",
             "--apple_deploy_target=13.0"
         ],
-        "macabi":[
+        "macabi": [
             "--macos=Catalyst",
             "--apple_deploy_target=14.0"
         ]


### PR DESCRIPTION
Recent pull-requests broke the packaging pipeline. This pull-request addresses the issues.

I also discovered that the binaries were no longer getting correctly signed. The primary reason is that our `python build.py ` or `cmake --preset ... --build` script does two things:

- Build the binaries
- Package them (into *.zip, *.tar.gz or *.whl)

As a result, there is no room to codesign the binaries (since codesigning is an intermediate step and we cannot yield from a python script before continuing).
In order to codesign the binaries, we need to break down the build process in two phases.

1. Build the biaries
2. -- intermediate step to codesign --
3. Build the package

This pr introduces that change as well.