### PR TITLE
Make default top_k=50 in model builder

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -251,7 +251,7 @@ struct Config {
     int num_beams{1};                  // 1 means no beam search.
     int num_return_sequences{1};       // Number of sequences to return after search. Default is 1.
     float repetition_penalty{1.0f};    // 1.0 means no penalty.
-    int top_k{};                       // Number of highest probability vocabulary tokens to keep for top-k-filtering that will be used by default in the generate method of the model.
+    int top_k{50};                     // Number of highest probability vocabulary tokens to keep for top-k-filtering that will be used by default in the generate method of the model.
     float top_p{};                     // If set to float >0 and <1, only the most probable tokens with probabilities that add up to top_p or higher are kept for generation.
     float temperature{1.0f};           // Temperature to control during generation. Default is 1.0.
     bool early_stopping{true};         //  Whether to stop the beam search when at least num_beams sentences are finished per batch or not.

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -424,7 +424,7 @@ class Model:
                 "past_present_share_buffer": False if "config_only" in self.extra_options else self.past_present_share_buffer,
                 "repetition_penalty": config.repetition_penalty if hasattr(config, "repetition_penalty") else 1.0,
                 "temperature": config.temperature if hasattr(config, "temperature") else 1.0,
-                "top_k": 1,
+                "top_k": config.top_k if hasattr(config, "top_k") else 50,
                 "top_p": config.top_p if hasattr(config, "top_p") else 1.0,
             },
         }

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -32,6 +32,7 @@ TEST(SamplingTests, BatchedSamplingTopPCpu) {
   auto params = OgaGeneratorParams::Create(*model);
   params->SetSearchOption("max_length", 10);
   params->SetSearchOptionBool("do_sample", true);
+  params->SetSearchOption("top_k", 1);
   params->SetSearchOption("top_p", 0.25f);
   params->SetSearchOption("batch_size", 4);
 


### PR DESCRIPTION
According to huggingface, top_k (int, optional, defaults to 50) — The number of highest probability vocabulary tokens to keep for top-k-filtering. This value is set in a model’s generation_config.json file. If it isn’t set, the default value is 50.

Our sampling algorithm has deficiency before so top_k=50 is not working for ort-genai.
Now we merged the new sampling algorithm https://github.com/microsoft/onnxruntime-genai/pull/1617, https://github.com/microsoft/onnxruntime-genai/pull/1631
So we can use top_k=50 to align with hf now.