### PR TITLE
Update the benchmark scripts to account for the time spent in sampling

### DIFF
--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -236,7 +236,8 @@ void RunBenchmark(const benchmark::Options& opts) {
         {
           Timing token_gen_timing{token_gen_times};
           generator->GenerateNextToken();
-          generator_done = generator->IsDone(); // Enforce stream synchronize to compute accurate token generation times
+          // Enforce stream synchronize to compute accurate token generation times
+          generator_done = generator->IsDone();
         }
       }
     }

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -224,15 +224,19 @@ void RunBenchmark(const benchmark::Options& opts) {
         generator->AppendTokenSequences(*prompt_sequences);
       }
 
+      bool generator_done = false;
+
       {
         Timing sampling_timing{sampling_times};
         generator->GenerateNextToken();
+        generator_done = generator->IsDone();
       }
 
-      while (!generator->IsDone()) {
+      while (!generator_done) {
         {
           Timing token_gen_timing{token_gen_times};
           generator->GenerateNextToken();
+          generator_done = generator->IsDone();
         }
       }
     }

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -236,7 +236,7 @@ void RunBenchmark(const benchmark::Options& opts) {
         {
           Timing token_gen_timing{token_gen_times};
           generator->GenerateNextToken();
-          generator_done = generator->IsDone();
+          generator_done = generator->IsDone(); // Enforce stream synchronize to compute accurate token generation times
         }
       }
     }

--- a/benchmark/python/benchmark_e2e.py
+++ b/benchmark/python/benchmark_e2e.py
@@ -6,7 +6,7 @@
 
 # This is an end-to-end benchmarking script for any ONNX model.
 #
-# Prerequisites: 
+# Prerequisites:
 # 0) Install onnxruntime-genai and onnxruntime
 #
 # 1) Use builder.py to build the desired ONNX model
@@ -138,9 +138,9 @@ def save_results(args, results, filename, print_memory_usage=False):
         columns=columns,
     )
     # df = df.transpose()  # This line swaps the rows and columns
-    
+
     genai_package_name, genai_package_version = get_target_pip_package_version(["onnxruntime-genai", "onnxruntime-genai-cuda", "onnxruntime-genai-directml"])
-    
+
     records = []
     for _, row in df.iterrows():
         record = BenchmarkRecord(args.model_name, args.precision, "onnxruntime-genai", args.execution_provider, genai_package_name, genai_package_version )
@@ -155,7 +155,7 @@ def save_results(args, results, filename, print_memory_usage=False):
         record.metrics.customized["token_generation_throughput_tps"] = row["Token Generation Throughput (tps)"]
         record.metrics.customized["token_generation_latency_ms"] = row["Token Generation Latency (ms)"]
         record.metrics.customized["sampling_throughput_tps"] = row["Sampling Throughput (tps)"]
-        record.metrics.customized["sampling_latency_ms"] = row["Sampling Latency (ms)"]   
+        record.metrics.customized["sampling_latency_ms"] = row["Sampling Latency (ms)"]
         record.metrics.customized["wall_clock_throughput_tps"] = row["Wall Clock Throughput (tps)"]
         record.metrics.customized["wall_clock_time_s"] = row["Wall Clock Time (s)"]
 
@@ -164,9 +164,9 @@ def save_results(args, results, filename, print_memory_usage=False):
                 record.metrics.customized["peak_gpu_memory_gb"] = row["peak_gpu_memory (GiB)"]
             else:
                 record.metrics.customized["peak_cpu_memory_gb"] = row["peak_cpu_memory (GiB)"]
-        
+
         records.append(record)
-        
+
     # df.to_csv(filename, header=True, index=False)
     BenchmarkRecord.save_as_json(filename.replace(".csv", ".json"), records)
     print(f"Results saved in {filename}!")
@@ -188,7 +188,7 @@ def run_benchmark_memory(args, batch_size, prompt_length, generation_length, max
         monitor_thread = threading.Thread(target=monitor_gpu_memory)
     else:
         monitor_thread = threading.Thread(target=monitor_cpu_memory)
-    
+
     monitor_thread.start()
 
     metrics = run_benchmark(args, batch_size, prompt_length, generation_length, max_length)
@@ -200,7 +200,7 @@ def run_benchmark_memory(args, batch_size, prompt_length, generation_length, max
         metrics.append(peak_gpu_memory)
     else:
         metrics.append(peak_cpu_memory)
-    
+
     return metrics
 
 def run_benchmark(args, batch_size, prompt_length, generation_length, max_length):
@@ -315,19 +315,21 @@ def run_benchmark(args, batch_size, prompt_length, generation_length, max_length
 
         sampling_start_time = time.perf_counter()
         generator.generate_next_token()
+        generator_done = generator.is_done()
         sampling_end_time = time.perf_counter()
         sampling_times.append(sampling_end_time - sampling_start_time)
 
         # Measure token generation
         i = 1
-        while not generator.is_done() and i < generation_length:
+        while not generator_done and i < generation_length:
             # Run inference
             token_gen_start_time = time.perf_counter()
             generator.generate_next_token()
+            generator_done = generator.is_done()
             token_gen_end_time = time.perf_counter()
             token_gen_times.append(token_gen_end_time - token_gen_start_time)
             i += 1
-        
+
         wall_clock_end_time = time.time()
         wall_clock_times.append(wall_clock_end_time - wall_clock_start_time)
         if args.print_model_output: print(tokenizer.decode(generator.get_sequence(0)))
@@ -357,7 +359,7 @@ def run_benchmark(args, batch_size, prompt_length, generation_length, max_length
     avg_token_gen_thrpt = batch_size * (1 / avg_token_gen_latency_s)
     print(f"Average Token Generation Latency (per token): {avg_token_gen_latency_ms} ms")
     print(f"Average Token Generation Throughput (per token): {avg_token_gen_thrpt} tps")
-    
+
     # Calculate sampling metrics
     avg_sampling_latency_s = sum(sampling_times) / len(sampling_times)
     avg_sampling_latency_ms = avg_sampling_latency_s * 1000
@@ -378,17 +380,17 @@ def run_benchmark(args, batch_size, prompt_length, generation_length, max_length
             print(f"Peak CPU Memory Usage: {peak_cpu_memory} GiB ")
 
     metrics = [
-        batch_size, 
+        batch_size,
         prompt_length,
         generation_length,
         max_length,
-        avg_tokenization_thrpt, 
-        avg_tokenization_latency_ms, 
-        avg_per_token_prompt_thrpt, 
-        avg_per_token_prompt_latency_ms, 
-        avg_token_gen_thrpt, 
-        avg_token_gen_latency_ms, 
-        avg_sampling_thrpt, 
+        avg_tokenization_thrpt,
+        avg_tokenization_latency_ms,
+        avg_per_token_prompt_thrpt,
+        avg_per_token_prompt_latency_ms,
+        avg_token_gen_thrpt,
+        avg_token_gen_latency_ms,
+        avg_sampling_thrpt,
         avg_sampling_latency_ms,
         avg_wall_clock_thrpt,
         avg_wall_clock_time,


### PR DESCRIPTION
This adjustment is crucial for the CUDA Execution Provider (EP), which relies on GPU-based sampling. In the case of CUDA EP, the generation time currently only includes the sampling kernels' launch time, not the execution time, due to synchronization occurring during the `generator.is_done()` call. For other EPs that perform sampling on the CPU, the token generation time already encompasses the sampling time.

I added nvtx marker in the generation loop (shown as gray with text "Decode").

Without the fix, there is a gap in decode steps. This is due to `cudaStreamSynchronize` call in `is_done` call.

<img width="1632" height="292" alt="image" src="https://github.com/user-attachments/assets/385d5500-770a-436f-8760-c79d224dae64" />


With Fix: There is no gap as  `is_done`  is part of the loop.

<img width="1736" height="263" alt="image" src="https://github.com/user-attachments/assets/95731fdc-fb1c-40ae-b4d8-a283c9409f3c" />

