### PR TITLE
[Builder] Add support for Olive quantized models

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -901,6 +901,9 @@ class Model:
             # print(f"Quantizing to {self.onnx_dtype} on-the-fly is not currently supported.")
             # print(f"Saving as {self.io_dtype} on-the-fly and quantizing to {self.onnx_dtype} at the end.")
             return self.make_matmul_float(matmul, matmul_name, root_input, **kwargs)
+        
+        if matmul.bits != 4:
+            raise NotImplementedError(f"{matmul.bits} bits precision is not currently supported in QDQ format.")
 
         dequantize_output = self.make_dequantize_linear(f"{matmul_name}/DequantizeLinear", matmul)
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -994,6 +994,10 @@ class Model:
         # Create dummy PackedMatMul class
         class PackedMatMul:
             def __init__(self):
+                if q_matmul.bits != k_matmul.bits or q_matmul.bits != v_matmul.bits:
+                    raise ValueError("All MatMuls must have the same bits for packed MatMul.")
+                if q_matmul.group_size != k_matmul.group_size or q_matmul.group_size != v_matmul.group_size:
+                    raise ValueError("All MatMuls must have the same group size for packed MatMul.")
                 self.qweight = torch.cat([q_matmul.qweight, k_matmul.qweight, v_matmul.qweight], dim=0)
                 self.scales = torch.cat([q_matmul.scales, k_matmul.scales, v_matmul.scales], dim=0)
                 self.qzeros = torch.cat([q_matmul.qzeros, k_matmul.qzeros, v_matmul.qzeros], dim=0)


### PR DESCRIPTION
- Support new `"olive"` quant type
- Weight and zero-point packings are the same as gptq. No g_idx.
- Similar to the `k_quant` mixed precision `int4_algo`, select matmuls can be in 8 bits.
   - Currently, we ensure that the `q_proj`, `k_proj`, `v_proj` matmuls use the same configuration (bits and group_size) so that they can be merged without issues.
- The modules are generalized to remove the requirement that all matmuls in a layer must have the same bits and group_size.
- `quant_weight` and `dequant_weight` support no `g_idx` by using `repeat_interleave`. Otherwise, we have to create a trivial g_idx like the quark model does.
- `pack_ort_format` supports 8 bit packing.