### PR TITLE
Enable GPU based sampling for TRT-RTX

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -720,8 +720,8 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
   CreateSessionOptions();
   EnsureDeviceOrtInit(*p_device_, *config_);
 
-  // Only CUDA and DML does every input on the device
-  if (p_device_->GetType() == DeviceType::CUDA || p_device_->GetType() == DeviceType::DML)
+  // Only CUDA, TRT-RTX and DML does every input on the device
+  if (p_device_->GetType() == DeviceType::CUDA || p_device_->GetType() == DeviceType::DML || p_device_->GetType() == DeviceType::NvTensorRtRtx)
     p_device_inputs_ = p_device_;
   else
     p_device_inputs_ = GetDeviceInterface(DeviceType::CPU);


### PR DESCRIPTION
It shows an improvement of about ~6% in throughput for small models those have large vocab.

**Before Gen phase**:

<img width="565" height="331" alt="image" src="https://github.com/user-attachments/assets/60325966-8f19-4944-9bbf-2e656c88ff2f" />

**Before pre-fill phase**: The full logits are being copied to host. This screenshot is for 100 ISL. The time increases further for larger seq length as logit size increases.

<img width="724" height="320" alt="image" src="https://github.com/user-attachments/assets/06a5b5c1-e356-4157-b37f-b77a79b69c58" />


**After Gen phase**: GPU idle time is gone as sampling is done on GPU

<img width="457" height="350" alt="image" src="https://github.com/user-attachments/assets/fda6c004-9a02-4845-9d38-b4d06ecfdc94" />

**After pre-fill phase**: large mem copy is gone

<img width="446" height="349" alt="image" src="https://github.com/user-attachments/assets/470d3412-f91c-4c0f-8011-963826aef11c" />
