### PR TITLE
Update C++, C# and Python Examples

### DIFF
--- a/examples/c/src/model_vision.cpp
+++ b/examples/c/src/model_vision.cpp
@@ -52,9 +52,9 @@ void CXX_API(const char* model_path, const char* execution_provider) {
     std::string text;
     std::cout << "Prompt: " << std::endl;
     std::getline(std::cin, text);
-    
+
     // Construct messages string with special tokens for ApplyChatTemplate.
-    
+
     // Note: The Phi-3 Vision chat template expects content to be string, whereas in
     // Gemma-3-like models, content type is supported, so we handle these differently.
 

--- a/examples/c/src/model_vision.cpp
+++ b/examples/c/src/model_vision.cpp
@@ -21,6 +21,8 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   std::cout << "Creating multimodal processor..." << std::endl;
   auto processor = OgaMultiModalProcessor::Create(*model);
 
+  auto tokenizer = OgaTokenizer::Create(*model);
+
   auto tokenizer_stream = OgaTokenizerStream::Create(*processor);
 
   while (true) {
@@ -50,18 +52,33 @@ void CXX_API(const char* model_path, const char* execution_provider) {
     std::string text;
     std::cout << "Prompt: " << std::endl;
     std::getline(std::cin, text);
-    std::string prompt;
+    
+    // Construct messages string with special tokens for ApplyChatTemplate.
+    
+    // Note: The Phi-3 Vision chat template expects content to be string, whereas in
+    // Gemma-3-like models, content type is supported, so we handle these differently.
+
+    std::string messages;
     if (std::string(model->GetType()) == "phi3v") {
-      prompt = "<|user|>\n";
+      // Phi-3 Vision-style multimodal usage with image tags
+      std::string content;
       for (size_t i = 0; i < image_paths.size(); ++i)
-        prompt += "<|image_" + std::to_string(i + 1) + "|>\n";
-      prompt += text + "<|end|>\n<|assistant|>\n";
-    } else if (std::string(model->GetType()) == "gemma3") {
-      prompt += "<start_of_turn>user\n";
-      for (size_t i = 0; i < image_paths.size(); ++i)
-        prompt += "<start_of_image>";
-      prompt += text + "<end_of_turn>\n<start_of_turn>model\n";
+        content += "<|image_" + std::to_string(i + 1) + "|>\\n";
+      content += text;
+      messages = R"([{"role": "user", "content": ")" + content + R"("}])";
+    } else {
+      // Gemma-style multimodal usage with content type
+      const std::string image_content = R"({ "type": "image" })";
+      std::string content = "[";
+      for (size_t i = 0; i < image_paths.size(); ++i) {
+        content += image_content + ", ";
+      }
+      const std::string text_content = R"({ "type": "text", "text": ")";
+      content += text_content + text + R"(" }])";
+      messages = R"([{"role": "user", "content": )" + content + R"(}])";
     }
+
+    std::string prompt = std::string(tokenizer->ApplyChatTemplate("", messages.c_str(), "", true));
 
     std::cout << "Processing images and prompt..." << std::endl;
     auto input_tensors = processor->ProcessImages(prompt.c_str(), images.get());

--- a/examples/c/src/model_vision.cpp
+++ b/examples/c/src/model_vision.cpp
@@ -23,7 +23,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
 
   auto tokenizer = OgaTokenizer::Create(*model);
 
-  auto tokenizer_stream = OgaTokenizerStream::Create(*processor);
+  auto stream = OgaTokenizerStream::Create(*processor);
 
   while (true) {
     std::string image_paths_str;
@@ -95,7 +95,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
 
       const auto num_tokens = generator->GetSequenceCount(0);
       const auto new_token = generator->GetSequenceData(0)[num_tokens - 1];
-      std::cout << tokenizer_stream->Decode(new_token) << std::flush;
+      std::cout << stream->Decode(new_token) << std::flush;
     }
 
     for (int i = 0; i < 3; ++i)

--- a/examples/c/src/phi4-mm.cpp
+++ b/examples/c/src/phi4-mm.cpp
@@ -23,7 +23,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
   std::cout << "Creating multimodal processor..." << std::endl;
   auto processor = OgaMultiModalProcessor::Create(*model);
 
-  auto tokenizer_stream = OgaTokenizerStream::Create(*processor);
+  auto stream = OgaTokenizerStream::Create(*processor);
   auto tokenizer = OgaTokenizer::Create(*model);
 
   while (true) {
@@ -106,7 +106,7 @@ void CXX_API(const char* model_path, const char* execution_provider) {
 
       const auto num_tokens = generator->GetSequenceCount(0);
       const auto new_token = generator->GetSequenceData(0)[num_tokens - 1];
-      std::cout << tokenizer_stream->Decode(new_token) << std::flush;
+      std::cout << stream->Decode(new_token) << std::flush;
     }
 
     for (int i = 0; i < 3; ++i)

--- a/examples/csharp/HelloPhi/Program.cs
+++ b/examples/csharp/HelloPhi/Program.cs
@@ -116,7 +116,8 @@ if (option == 1 || option == 2)
         {
             break;
         }
-        var sequences = tokenizer.Encode(tokenizer.ApplyChatTemplate("", prompt, "", true));
+        string messages = $@"[{{""role"":""system"",""content"":""You are a helpful AI assistant.""}},{{""role"":""user"",""content"":""{prompt}""}}]";
+        var sequences = tokenizer.Encode(tokenizer.ApplyChatTemplate("", messages, "", true));
 
         if (option == 1) // Complete Output
         {
@@ -183,7 +184,8 @@ if (option == 3) // Streaming Chat
         {
             break;
         }
-        var sequences = tokenizer.Encode(tokenizer.ApplyChatTemplate("", prompt, "", true));
+        string messages = $@"[{{""role"":""system"",""content"":""You are a helpful AI assistant.""}},{{""role"":""user"",""content"":""{prompt}""}}]";
+        var sequences = tokenizer.Encode(tokenizer.ApplyChatTemplate("", messages, "", true));
         var watch = System.Diagnostics.Stopwatch.StartNew();
         generator.AppendTokenSequences(sequences);
         while (!generator.IsDone())

--- a/examples/csharp/HelloPhi3V/Program.cs
+++ b/examples/csharp/HelloPhi3V/Program.cs
@@ -114,7 +114,7 @@ if (executionProvider != "cpu") {
 using Model model = new Model(config);
 using MultiModalProcessor processor = new MultiModalProcessor(model);
 using Tokenizer tokenizer = new Tokenizer(model);
-using var tokenizerStream = processor.CreateStream();
+using var stream = processor.CreateStream();
 
 do
 {
@@ -171,7 +171,7 @@ do
     while (!generator.IsDone())
     {
         generator.GenerateNextToken();
-        Console.Write(tokenizerStream.Decode(generator.GetSequence(0)[^1]));
+        Console.Write(stream.Decode(generator.GetSequence(0)[^1]));
     }
     watch.Stop();
     var runTimeInSeconds = watch.Elapsed.TotalSeconds;

--- a/examples/csharp/HelloPhi3V/Program.cs
+++ b/examples/csharp/HelloPhi3V/Program.cs
@@ -113,6 +113,7 @@ if (executionProvider != "cpu") {
 }
 using Model model = new Model(config);
 using MultiModalProcessor processor = new MultiModalProcessor(model);
+using Tokenizer tokenizer = new Tokenizer(model);
 using var tokenizerStream = processor.CreateStream();
 
 do
@@ -147,15 +148,15 @@ do
         text = Console.ReadLine();
     }
 
-    string prompt = "<|user|>\n";
+    string content = "";
     if (images != null)
     {
-        for (int i = 0; i < imagePaths.Count; i++)
-        {
-            prompt += "<|image_" + (i + 1) + "|>\n";
-        }
+        content = string.Join("\\n", imagePaths.Select((_, idx) => $"<|image_{idx + 1}|>")) + "\\n";
     }
-    prompt += text + "<|end|>\n<|assistant|>\n";
+    content += text;
+
+    string messages = $"[{{\"role\":\"user\",\"content\":\"{content}\"}}]";
+    string prompt = tokenizer.ApplyChatTemplate("", messages, "", true);
 
     Console.WriteLine("Processing image and prompt...");
     using var inputTensors = processor.ProcessImages(prompt, images);

--- a/examples/csharp/HelloPhi4MM/Program.cs
+++ b/examples/csharp/HelloPhi4MM/Program.cs
@@ -122,6 +122,7 @@ if (executionProvider != "cpu") {
     }
 }
 using Model model = new Model(config);
+using Tokenizer tokenizer = new Tokenizer(model);
 using MultiModalProcessor processor = new MultiModalProcessor(model);
 using var tokenizerStream = processor.CreateStream();
 
@@ -180,23 +181,29 @@ do
         text = Console.ReadLine();
     }
 
-    // Combine prompt, images, and audios
-    string prompt = "<|user|>\n";
+    // Combine prompt, images, and audios and construct multimodal content
+    string content = "";
     if (images != null)
     {
         for (int i = 0; i < imagePaths.Count; i++)
         {
-            prompt += "<|image_" + (i + 1) + "|>\n";
+            content += $"<|image_{i + 1}|>\n";
         }
     }
     if (audios != null)
     {
         for (int i = 0; i < audioPaths.Count; i++)
         {
-            prompt += "<|audio_" + (i + 1) + "|>\n";
+            content += $"<|audio_{i + 1}|>\n";
         }
     }
-    prompt += text + "<|end|>\n<|assistant|>\n";
+    content += text;
+
+    // Format message string
+    string messages = $"[{{\"role\":\"user\",\"content\":\"{content}\"}}]";
+
+    // Apply chat template to get prompt
+    string prompt = tokenizer.ApplyChatTemplate("", messages, "", true);
 
     Console.WriteLine("Processing inputs...");
     using var inputTensors = processor.ProcessImagesAndAudios(prompt, images, audios);

--- a/examples/csharp/HelloPhi4MM/Program.cs
+++ b/examples/csharp/HelloPhi4MM/Program.cs
@@ -124,7 +124,7 @@ if (executionProvider != "cpu") {
 using Model model = new Model(config);
 using Tokenizer tokenizer = new Tokenizer(model);
 using MultiModalProcessor processor = new MultiModalProcessor(model);
-using var tokenizerStream = processor.CreateStream();
+using var stream = processor.CreateStream();
 
 do
 {
@@ -218,7 +218,7 @@ do
     while (!generator.IsDone())
     {
         generator.GenerateNextToken();
-        Console.Write(tokenizerStream.Decode(generator.GetSequence(0)[^1]));
+        Console.Write(stream.Decode(generator.GetSequence(0)[^1]));
     }
     watch.Stop();
     var runTimeInSeconds = watch.Elapsed.TotalSeconds;

--- a/examples/python/model-vision.py
+++ b/examples/python/model-vision.py
@@ -40,7 +40,7 @@ def run(args: argparse.Namespace):
 
     tokenizer = og.Tokenizer(model)
     processor = model.create_multimodal_processor()
-    tokenizer_stream = processor.create_stream()
+    stream = processor.create_stream()
 
     interactive = not args.non_interactive
 
@@ -118,7 +118,7 @@ def run(args: argparse.Namespace):
             generator.generate_next_token()
 
             new_token = generator.get_next_tokens()[0]
-            print(tokenizer_stream.decode(new_token), end="", flush=True)
+            print(stream.decode(new_token), end="", flush=True)
 
         print()
         total_run_time = time.time() - start_time

--- a/examples/python/model-vision.py
+++ b/examples/python/model-vision.py
@@ -68,18 +68,6 @@ def run(args: argparse.Namespace):
 
         image_paths = [image_path for image_path in image_paths if image_path]
 
-        user_tag = image_tag = assistant_tag = end_tag = ""
-        if model.type == "phi3v":
-            user_tag = "<|user|>\n"
-            image_tag = "<|image_{image_id}|>\n"
-            assistant_tag = "<|assistant|>\n"
-            end_tag = "<|end|>\n"
-        elif model.type == "gemma3":
-            user_tag = "<start_of_turn>user\n"
-            image_tag = "<start_of_image>"
-            assistant_tag = "<start_of_turn>model\n"
-            end_tag = "<end_of_turn>\n"
-
         images = None
         if len(image_paths) == 0:
             print("No image provided")
@@ -113,7 +101,6 @@ def run(args: argparse.Namespace):
 
         # Apply the chat template using the tokenizer
         message_json = json.dumps(messages)
-        print(repr(message_json))
         prompt = tokenizer.apply_chat_template(message_json, add_generation_prompt=True)
 
         print("Processing images and prompt...")

--- a/examples/python/phi4-mm.py
+++ b/examples/python/phi4-mm.py
@@ -66,7 +66,7 @@ def run(args: argparse.Namespace):
 
     tokenizer = og.Tokenizer(model)
     processor = model.create_multimodal_processor()
-    tokenizer_stream = processor.create_stream()
+    stream = processor.create_stream()
 
     interactive = not args.non_interactive
 
@@ -140,7 +140,7 @@ def run(args: argparse.Namespace):
             generator.generate_next_token()
 
             new_token = generator.get_next_tokens()[0]
-            print(tokenizer_stream.decode(new_token), end="", flush=True)
+            print(stream.decode(new_token), end="", flush=True)
 
         print()
         total_run_time = time.time() - start_time

--- a/examples/python/phi4-mm.py
+++ b/examples/python/phi4-mm.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import glob
 import time
+import json
 from pathlib import Path
 
 import onnxruntime_genai as og
@@ -63,6 +64,7 @@ def run(args: argparse.Namespace):
     model = og.Model(config)
     print("Model loaded")
 
+    tokenizer = og.Tokenizer(model)
     processor = model.create_multimodal_processor()
     tokenizer_stream = processor.create_stream()
 
@@ -84,40 +86,44 @@ def run(args: argparse.Namespace):
 
         images = None
         audios = None
-        prompt = "<|user|>\n"
 
-        # Get images
+        # Validate and open image paths
         if len(image_paths) == 0:
             print("No image provided")
         else:
-            for i, image_path in enumerate(image_paths):
+            for image_path in image_paths:
                 if not os.path.exists(image_path):
                     raise FileNotFoundError(f"Image file not found: {image_path}")
                 print(f"Using image: {image_path}")
-                prompt += f"<|image_{i+1}|>\n"
             images = og.Images.open(*image_paths)
 
-        # Get audios
+        # Validate and open audio paths
         if len(audio_paths) == 0:
             print("No audio provided")
         else:
-            for i, audio_path in enumerate(audio_paths):
+            for audio_path in audio_paths:
                 if not os.path.exists(audio_path):
                     raise FileNotFoundError(f"Audio file not found: {audio_path}")
                 print(f"Using audio: {audio_path}")
-                prompt += f"<|audio_{i+1}|>\n"
             audios = og.Audios.open(*audio_paths)
 
-
+        # Get prompt text
         if interactive:
             text = input("Prompt: ")
         else:
-            if args.prompt:
-                text = args.prompt
-            else:
-                text = "Does the audio summarize what is shown in the image? If not, what is different?"
-        prompt += f"{text}<|end|>\n<|assistant|>\n"
-        
+            text = args.prompt or "Does the audio summarize what is shown in the image? If not, what is different?"
+
+        # Build multimodal content list
+        content_list = []
+        content_list.extend([{"type": "image"} for _ in image_paths])
+        content_list.extend([{"type": "audio"} for _ in audio_paths])
+        content_list.append({"type": "text", "text": text})
+
+        # Construct messages and apply template
+        messages = [{"role": "user", "content": content_list}]
+        message_json = json.dumps(messages)
+        prompt = processor.tokenizer.apply_chat_template(message_json, add_generation_prompt=True)
+
         print("Processing inputs...")
         inputs = processor(prompt, images=images, audios=audios)
         print("Processor complete.")

--- a/examples/python/phi4-mm.py
+++ b/examples/python/phi4-mm.py
@@ -122,7 +122,7 @@ def run(args: argparse.Namespace):
         # Construct messages and apply template
         messages = [{"role": "user", "content": content_list}]
         message_json = json.dumps(messages)
-        prompt = processor.tokenizer.apply_chat_template(message_json, add_generation_prompt=True)
+        prompt = tokenizer.apply_chat_template(message_json, add_generation_prompt=True)
 
         print("Processing inputs...")
         inputs = processor(prompt, images=images, audios=audios)


### PR DESCRIPTION
### Updates

Updates examples to now use ApplyChatTemplate, including in multimodal cases as it now supports multimodal templating with a Minja-powered C++ templating engine.

Note that we decided not to use the newly added whisper chat template functionality (https://github.com/microsoft/onnxruntime-extensions/pull/981) for the examples, because specifically for our examples itself, the chat template functionality (just appending message contents) does not make sense - we do not need it.

### Validation
- [x] Native C++, Python and C# testing using phi-4, phi-3-vision, and phi-4-mm models
- [x] Ran C# examples e2e with project solutions