### PR TITLE
 Update pytorch > 2.6.0

### DIFF
--- a/tools/python/model_validation/requirements.txt
+++ b/tools/python/model_validation/requirements.txt
@@ -12,4 +12,4 @@ onnxruntime-genai
 sentencepiece
 pandas
 datasets
-torch
+torch>=2.6.0


### PR DESCRIPTION
Update pytorch to address
https://nvd.nist.gov/vuln/detail/CVE-2025-32434