### PR TITLE
Explicitly specify setup-java architecture in win-cpu-arm64-build.yml.

### DIFF
--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          architecture: 'aarch64'
           cache: 'gradle'
 
       - name: Setup Gradle


### PR DESCRIPTION
Fix a CI build issue. For some reason, the Windows ARM64 CI job was using the x64 Java SDK.