### PR TITLE
Fix accessing final norm for Gemma-3 models

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -2597,13 +2597,18 @@ class Model:
         else:
             model = orig_model
 
-        # Hugging Face names
+        # Hugging Face names (all models loaded with AutoModelForCausalLM.from_pretrained)
+        #
+        # hf_norm:                        for most models
+        # hf_final_layernorm:             for Phi-2
+        # hf_transformer_final_layernorm: for ChatGLM-3
+        # hf_language_model_norm:         for Gemma-3 multimodal (4B, 12B, 27B)
         hf_norm = hasattr(model, "model") and hasattr(model.model, "norm") and module == model.model.norm
         hf_final_layernorm = hasattr(model, "model") and hasattr(model.model, "final_layernorm") and module == model.model.final_layernorm
         hf_transformer_final_layernorm = hasattr(model, "transformer") and hasattr(model.transformer, "encoder") and hasattr(model.transformer.encoder, "final_layernorm") and module == model.transformer.encoder.final_layernorm
         hf_language_model_norm = hasattr(model, "model") and hasattr(model.model, "language_model") and hasattr(model.model.language_model, "norm") and module == model.model.language_model.norm
 
-        # GGUF names
+        # GGUF names (all models loaded with GGUFModel.from_pretrained)
         gguf_final_norm = hasattr(model, "final_norm") and module == model.final_norm
 
         hf_names = [hf_norm, hf_final_layernorm, hf_transformer_final_layernorm, hf_language_model_norm]


### PR DESCRIPTION
### Description

This PR fixes how the final norm is identified for the Gemma-3 models. It works with the latest version of Hugging Face's `transformers` (v4.55.2).

### Motivation and Context

Previous versions of `transformers` would modify the class structure for the Gemma-3 models as breaking changes. Since `transformers` has [landed on a stable way](https://github.com/huggingface/transformers/pull/36741) to load multi-modal models with `AutoModelForCausalLM` for now, the current approach is to identify the path to `model.model.language_model.norm` for the Gemma-3 models that are multi-modal.

Gemma-3 1B's final norm is accessible at `model.model.norm` while Gemma-3 4B's final norm is accessible at `model.model.language_model.norm`. For [PEFT's](https://github.com/huggingface/peft) decoder-only models, the core model is accessible at `model.base_model.model` and the final norm is usually accessible at `model.base_model.model.model.norm`.

We can read the parent-most class name to identify whether a model is from PEFT or not. One advantage with this approach is that it allows any adaptations in the path to the final norm of a Transformers model to still be found in the PEFT version of that model.