### PR TITLE
Update Microsoft.Extensions.AI to 9.8.0

### DIFF
--- a/nuget/Microsoft.ML.OnnxRuntimeGenAI.Managed.nuspec
+++ b/nuget/Microsoft.ML.OnnxRuntimeGenAI.Managed.nuspec
@@ -14,19 +14,19 @@
     <tags>ONNX;ONNX Runtime;ONNX Runtime Gen AI;Machine Learning</tags>
     <dependencies>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.7.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.7.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
       </group>
       <group targetFramework="net8.0-android31.0">
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.7.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
       </group>
       <group targetFramework="net8.0-ios15.4">
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.7.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
       </group>
       <group targetFramework="net8.0-maccatalyst14.0">
-        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.7.0" />
+        <dependency id="Microsoft.Extensions.AI.Abstractions" version="9.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/csharp/Microsoft.ML.OnnxRuntimeGenAI.csproj
+++ b/src/csharp/Microsoft.ML.OnnxRuntimeGenAI.csproj
@@ -123,7 +123,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.7.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.8.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 Updating to the latest package version for Microsoft.Extensions.AI 9.8.0 bringing the latest features introduced in the new version.

This change is also welcomed for the packages that rely on latest MEAI versions to support ONNX runtime. 
i.e: Semantic Kernel ONNX Connector.

CC: @baijumeswani