### PR TITLE
Add support for inference using EP context model

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -692,8 +692,6 @@ struct EpContext_Element : JSON::Element {
   void OnValue(std::string_view name, JSON::Value value) override {
     if (name == "enable") {
       v_.enable = JSON::Get<bool>(value);
-    } else if (name == "filename") {
-      v_.filename = JSON::Get<std::string_view>(value);
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -692,8 +692,8 @@ struct EpContext_Element : JSON::Element {
   void OnValue(std::string_view name, JSON::Value value) override {
     if (name == "enable") {
       v_.enable = JSON::Get<bool>(value);
-    } else if (name == "filepath") {
-      v_.filepath = JSON::Get<std::string_view>(value);
+    } else if (name == "filename") {
+      v_.filename = JSON::Get<std::string_view>(value);
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -686,6 +686,23 @@ struct Embedding_Element : JSON::Element {
   EmbeddingOutputs_Element outputs_{v_.outputs};
 };
 
+struct EpContext_Element : JSON::Element {
+  explicit EpContext_Element(Config::Model::EpContext& v) : v_(v) {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "enable") {
+      v_.enable = JSON::Get<bool>(value);
+    } else if (name == "filepath") {
+      v_.filepath = JSON::Get<std::string_view>(value);
+    } else {
+      throw JSON::unknown_value_error{};
+    }
+  }
+
+  private:
+    Config::Model::EpContext& v_;
+};
+
 struct Model_Element : JSON::Element {
   explicit Model_Element(Config::Model& v) : v_{v} {}
 
@@ -733,6 +750,10 @@ struct Model_Element : JSON::Element {
     if (name == "speech") {
       return speech_;
     }
+    if (name == "ep_context") {
+      return ep_context_;
+    }
+
     throw JSON::unknown_value_error{};
   }
 
@@ -744,6 +765,7 @@ struct Model_Element : JSON::Element {
   Vision_Element vision_{v_.vision};
   Embedding_Element embedding_{v_.embedding};
   Speech_Element speech_{v_.speech};
+  EpContext_Element ep_context_{v_.ep_context};
 };
 
 struct Search_Element : JSON::Element {

--- a/src/config.h
+++ b/src/config.h
@@ -60,9 +60,6 @@ struct Config {
     static constexpr std::string_view EncoderOutputsName = "encoder_outputs";
     static constexpr std::string_view EncoderAttentionMaskName = "encoder_attention_mask";
 
-    // EP context model default file name
-    static constexpr std::string_view EpContextFileName = "model_ctx.onnx";
-
   };
 
   fs::path config_path;  // Path of the config directory
@@ -111,9 +108,8 @@ struct Config {
 
     struct EpContext {
       // use EP context model for inference
+      // it assumes the EP context model is in the same directory as the base model with name as "filename_ctx.onnx"
       bool enable{false};
-      // file name for EP context model. Default is "model_ctx.onnx"
-      std::string filename{""};
     } ep_context;
 
 

--- a/src/config.h
+++ b/src/config.h
@@ -112,8 +112,8 @@ struct Config {
     struct EpContext {
       // use EP context model for inference
       bool enable{false};
-      // file path for EP context model. Default is config_path / "model_ctx.onnx"
-      std::string filepath{""};
+      // file name for EP context model. Default is "model_ctx.onnx"
+      std::string filename{""};
     } ep_context;
 
 

--- a/src/config.h
+++ b/src/config.h
@@ -59,6 +59,10 @@ struct Config {
     static constexpr std::string_view EncoderHiddenStatesName = "encoder_hidden_states";
     static constexpr std::string_view EncoderOutputsName = "encoder_outputs";
     static constexpr std::string_view EncoderAttentionMaskName = "encoder_attention_mask";
+
+    // EP context model default file name
+    static constexpr std::string_view EpContextFileName = "model_ctx.onnx";
+
   };
 
   fs::path config_path;  // Path of the config directory
@@ -104,6 +108,14 @@ struct Config {
     int decoder_start_token_id{};   // If an encoder-decoder model starts decoding with a different token than bos, the id of that token.
     int vocab_size{};
     int context_length{};
+
+    struct EpContext {
+      // use EP context model for inference
+      bool enable{false};
+      // file path for EP context model. Default is config_path / "model_ctx.onnx"
+      std::string filepath{""};
+    } ep_context;
+
 
     struct Encoder {
       std::string filename;

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -923,17 +923,15 @@ std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::str
   auto model_path_ = config_->config_path / fs::path(model_filename);
   
   if(config_->model.ep_context.enable) {
-    auto model_ctx_path_ = config_->config_path / fs::path(std::string(Config::Defaults::EpContextFileName));
-    
-    // use ep context model if specified in genai config
-    if(!config_->model.ep_context.filename.empty())
-      model_ctx_path_ = config_->config_path / fs::path(config_->model.ep_context.filename);
+    size_t dot_pos = model_filename.find('.'); // get the base name of the model from model.onnx
+    std::string model_base_name = model_filename.substr(0, dot_pos);
+    auto model_ctx_path = config_->config_path / fs::path(model_base_name + "_ctx.onnx");
 
     // if ep context model doesn't exist, fallback to original base ONNX
-    if(model_ctx_path_.exists())
-      model_path_ = model_ctx_path_;
+    if(model_ctx_path.exists())
+      model_path_ = model_ctx_path;
     else
-      Log("warning", "Using base ONNX model, EP context model doesn't exist: " + model_ctx_path_.string());
+      Log("warning", "Using base ONNX model, EP context model doesn't exist: " + model_ctx_path.string());
   }
   
   return OrtSession::Create(ort_env, model_path_.c_str(), session_options);

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -926,8 +926,8 @@ std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::str
     auto model_ctx_path_ = config_->config_path / fs::path(std::string(Config::Defaults::EpContextFileName));
     
     // use ep context model if specified in genai config
-    if(!config_->model.ep_context.filepath.empty())
-      model_ctx_path_ = fs::path(config_->model.ep_context.filepath);
+    if(!config_->model.ep_context.filename.empty())
+      model_ctx_path_ = config_->config_path / fs::path(config_->model.ep_context.filename);
 
     // if ep context model doesn't exist, fallback to original base ONNX
     if(model_ctx_path_.exists())

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -415,6 +415,10 @@ class Model:
                 "pad_token_id": config.pad_token_id if hasattr(config, "pad_token_id") and config.pad_token_id is not None else config.eos_token_id[0] if isinstance(config.eos_token_id, list) else config.eos_token_id,
                 "type": self.model_type[ : self.model_type.find("For") if "For" in self.model_type else len(self.model_type)].lower(),
                 "vocab_size": self.vocab_size,
+                "ep_context": {
+                    "enable": False,
+                    "filepath": "",
+                },
             },
             "search": {
                 "diversity_penalty": config.diversity_penalty if hasattr(config, "diversity_penalty") else 0.0,

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -438,7 +438,7 @@ class Model:
             genai_config["model"]["decoder"]["sliding_window"] = {"window_size": self.window_size, "slide_key_value_cache": False, "slide_inputs": False}
         
         if self.ep == "NvTensorRtRtx":
-            genai_config["model"]["ep_context"] = {"enable": False, "filename": "model_ctx.onnx"}
+            genai_config["model"]["ep_context"] = {"enable": False}
 
         if self.ep != "cpu":
             ep_options = { self.ep : self.ep_attrs[self.ep] }

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -415,10 +415,6 @@ class Model:
                 "pad_token_id": config.pad_token_id if hasattr(config, "pad_token_id") and config.pad_token_id is not None else config.eos_token_id[0] if isinstance(config.eos_token_id, list) else config.eos_token_id,
                 "type": self.model_type[ : self.model_type.find("For") if "For" in self.model_type else len(self.model_type)].lower(),
                 "vocab_size": self.vocab_size,
-                "ep_context": {
-                    "enable": False,
-                    "filepath": "",
-                },
             },
             "search": {
                 "diversity_penalty": config.diversity_penalty if hasattr(config, "diversity_penalty") else 0.0,
@@ -440,6 +436,9 @@ class Model:
 
         if self.ep == "NvTensorRtRtx" and self.window_size is not None and self.window_size > 0:
             genai_config["model"]["decoder"]["sliding_window"] = {"window_size": self.window_size, "slide_key_value_cache": False, "slide_inputs": False}
+        
+        if self.ep == "NvTensorRtRtx":
+            genai_config["model"]["ep_context"] = {"enable": False, "filename": "model_ctx.onnx"}
 
         if self.ep != "cpu":
             ep_options = { self.ep : self.ep_attrs[self.ep] }


### PR DESCRIPTION
This PR adds support for inference using compiled EP context model by updating genai config. 

Added a new `ep_context` object inside `model` object in genai config
```json
"ep_context": {
  "enable": false,
}
```

The expected workflow is as follows
* compile EP context model ahead-of-time and use it only during inference by updating genai config
* if `enable` then uses EP context model for inference
* EP context model should be in the same folder as the base model and the name should be  `{filename}_ctx.onnx`. `{filename}` is the name of the base model name set in genai config
* if EP context model not found, inference fallbacks to using original base ONNX at `config_path / model.onnx`
* supports multiple models in a pipeline, e.g. VLMs. Each EP context model should be saved as  `{filename}_ctx.onnx`