### PR TITLE
Improve TopK CUDA execution path while sampling and when vocab size is sufficiently large

### DIFF
--- a/src/cuda/cuda_sampling.cu
+++ b/src/cuda/cuda_sampling.cu
@@ -556,7 +556,7 @@ void GetTopKSubset(SamplingData* data, cudaStream_t stream, float* scores_in, fl
   // sampling (batch_size == 1) and when vocab_size is "pretty large"
   // (also needs benchmarking to identify cut-off).
   if (batch_size == 1 && vocab_size >= 100000) {
-    use_sort_and_pick_topk = false;
+    use_sort_and_pick_topk = true;
   }
 
   if (!use_sort_and_pick_topk && k <= 4) {

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -654,11 +654,11 @@ TEST(SamplingTests, RandomizedSamplingSelectTopCuda_BatchSize1_LargeVocabSize) {
   // This combination of `batch_size` and `vocab_size` will use the Sort + TopK
   // algorithm to optimally use the hardware.
   int batch_size = 1;
-  int vocab_size = 55000;
+  int vocab_size = 100001;
   std::vector<int32_t> input_ids{3};
 
   auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
-  config->Overlay(R"({ "model": { "vocab_size" : 55000 } })");
+  config->Overlay(R"({ "model": { "vocab_size" : 100001 } })");
   config->ClearProviders();
   config->AppendProvider("cuda");
 


### PR DESCRIPTION
The 20B GPT OSS model has a vocab size of 200k+ and while sampling (with no batching), the top_k sampling boils down to finding the top_k elements in a large array (batch_size == 1) which is a hard-problem to parallelize and optimally use hardware resources on modern GPUs. 

A profile of the 20B GPT OSS model on A100 with default top_k parameter (top_k = 50) shows the top_k kernel as a huge bottleneck (about 50%) of the forward pass as can be seen from this nsys snapshot:

<img width="927" height="94" alt="image" src="https://github.com/user-attachments/assets/692b2566-9081-4452-8386-9b275305cb7b" />

As can be seen from the kernel launch parameters, only one threadblock (since batch_size = 1 in sampling) is used and 256 threads are utilized to search top_k elements from an array of about 200k+elements

<img width="1009" height="103" alt="image" src="https://github.com/user-attachments/assets/4f40bae9-b3b2-452a-b406-5e1ecd9cb0d1" />

This leads to severe under-utilization of the hardware.

To mitigate the problem, thje following were tried:

1) Do distributed "top_k" search:
    Use multiple threadblocks to each individually pick top_k elements from their own individual shards of the array and do a final "reduction" tro pick the final top_k elements. This gave about 5% speed-up. The bottleneck was the reduction step.

2) Use sort and pick top_k
    For sufficiently large arrays, sorting using CUB's device fragmented radix sort (which has clever bit manipulation tricks to perform radix sort for `floats` and `halfs`  uses the hardware at hand much more optimally and outperforms any tradional top_k picking algorithms on device. See https://github.com/pytorch/pytorch/issues/22812 and https://github.com/pytorch/pytorch/pull/68632.

Hence, the final approach is to go with option 2 based on a tunable heuristic.

Here are the before and after sampling TPS numbers for 20B GPT OSS on A100 for this optimization for the same prompt (for top_k = 50 which seems to be FoundryLocal's default config) - about **35%** more sampling throughput
 
<img width="536" height="134" alt="image" src="https://github.com/user-attachments/assets/f6f40623-fa0c-4aa5-84ea-9ad7cd442aff" />

