### PR TITLE
Fix BF16 CUDA version of OpenAI's gpt-oss

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -4148,8 +4148,8 @@ class GPTOSSModel(Model):
 
         if op_type == "MoE":
             # Save non-quantized MoE weights as initializers
-            self.make_initializer(mlp.experts.gate_up_proj.view(self.moe_attrs["num_experts"], -1, self.hidden_size), gate_up_proj_weight, to=self.io_dtype)
-            self.make_initializer(mlp.experts.down_proj.view(self.moe_attrs["num_experts"], self.hidden_size, self.intermediate_size), down_proj_weight, to=self.io_dtype)
+            self.make_initializer(mlp.experts.gate_up_proj.transpose(-1, -2).view(self.moe_attrs["num_experts"], -1, self.hidden_size), gate_up_proj_weight, to=self.io_dtype)
+            self.make_initializer(mlp.experts.down_proj.transpose(-1, -2).view(self.moe_attrs["num_experts"], self.hidden_size, self.intermediate_size), down_proj_weight, to=self.io_dtype)
         else:
             # Create and save quantized MoE weights as initializers
             gate_up_proj_qweight_list, gate_up_proj_scales_list = [], []


### PR DESCRIPTION
### Description

This PR fixes a bug with generating the BF16 CUDA version of OpenAI's `gpt-oss` models.

### Motivation and Context

The shape of the MLP 1 weights in the MoE layer is different between the OpenAI and Hugging Face implementations. OpenAI's implementation has the following shape: `(32, 5760, 2880)`. Hugging Face's implementation has the following shape: `(32, 2880, 5760)`. The [original PR changes](https://github.com/microsoft/onnxruntime-genai/pull/1678) were made with the OpenAI implementation so a transpose is inserted to fix this gap.