### PR TITLE
Add custom ops library path resolution using EP metadata

### DIFF
--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -107,6 +107,30 @@ class path {
 #endif
   }
 
+  bool is_relative() const {
+#ifdef _WIN32
+    // On Windows, check if path starts with drive letter or UNC path
+    if (path_.length() >= 2 && path_[1] == ':') {
+      return false;  // Absolute path with drive letter (e.g., "C:\")
+    }
+    if (path_.length() >= 2 && path_[0] == '\\' && path_[1] == '\\') {
+      return false;  // UNC path (e.g., "\\server\share")
+    }
+    return true;  // Relative path
+#else
+    // On Unix-like systems, absolute paths start with '/'
+    return !path_.empty() && path_[0] != '/';
+#endif
+  }
+
+  path parent_path() const {
+    size_t pos = path_.find_last_of("/\\");
+    if (pos == std::string::npos) {
+      return path();  // No parent directory found
+    }
+    return path(path_.substr(0, pos));
+  }
+
  private:
   std::string path_;
 
@@ -148,5 +172,10 @@ class path {
   }
 #endif  // _WIN32
 };
+
+// Namespace-level functions
+inline bool exists(const path& p) {
+  return p.exists();
+}
 
 }  // namespace fs

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -21,7 +21,6 @@
 #include "marian.h"
 #include "decoder_only_pipeline.h"
 #include "../dml/interface.h"
-#include "onnxruntime_ep_device_ep_metadata_keys.h"
 
 #if defined(_WIN32)
 #include <direct.h>
@@ -872,7 +871,7 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
         for (size_t kvi = 0; kvi < num_entries; kvi++) {
           const std::string key = keys[kvi];
           const std::string val = values[kvi];
-          if (key == kOrtEpDevice_EpMetadataKey_LibraryPath) {
+          if (key == "library_path") {
             fs::path ep_library_dir = fs::path(val).parent_path();
             fs::path resolved_path = ep_library_dir / custom_library_path;
             if (fs::exists(resolved_path)) {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -856,14 +856,14 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
     fs::path custom_library_path{custom_library_file_prefix};
     if (custom_library_path.is_relative()) {
       // Get EP devices to check for library_path metadata
-      size_t num_devices;
-      const OrtEpDevice* const* device_ptrs;
+      size_t num_devices = 0;
+      const OrtEpDevice* const* device_ptrs = nullptr;
       Ort::api->GetEpDevices(&GetOrtEnv(), &device_ptrs, &num_devices);
 
       bool resolved = false;
       for (size_t i = 0; i < num_devices && !resolved; ++i) {
         const OrtKeyValuePairs* keyvals = Ort::api->EpDevice_EpMetadata(device_ptrs[i]);
-        size_t num_entries;
+        size_t num_entries = 0;
         const char* const* keys = nullptr;
         const char* const* values = nullptr;
         Ort::api->GetKeyValuePairs(keyvals, &keys, &values, &num_entries);

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -885,7 +885,9 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
       }
     }
 
-    session_options.RegisterCustomOpsLibrary(custom_library_file_prefix.c_str());
+    // Convert to fs::path for proper wide string handling on Windows
+    fs::path custom_ops_lib_path(custom_library_file_prefix);
+    session_options.RegisterCustomOpsLibrary(custom_ops_lib_path.c_str());
   }
 
   if (config_session_options.graph_optimization_level.has_value()) {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -850,6 +850,9 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
 
   // Register custom ops libraries only if explicitly configured
   if (config_session_options.custom_ops_library.has_value()) {
+    // From include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h
+    static const char* const kOrtEpDevice_EpMetadataKey_LibraryPath = "library_path";
+
     std::string custom_library_file_prefix = config_session_options.custom_ops_library.value();
 
     // If relative path, try to resolve using EP library path from metadata
@@ -871,7 +874,7 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
         for (size_t kvi = 0; kvi < num_entries; kvi++) {
           const std::string key = keys[kvi];
           const std::string val = values[kvi];
-          if (key == "library_path") {
+          if (key == kOrtEpDevice_EpMetadataKey_LibraryPath) {
             fs::path ep_library_dir = fs::path(val).parent_path();
             fs::path resolved_path = ep_library_dir / custom_library_path;
             if (fs::exists(resolved_path)) {


### PR DESCRIPTION
## Summary
Adds support for automatic custom ops library path resolution using execution provider metadata.

## Changes
- Enhanced custom ops library registration to resolve relative paths using EP metadata
- Added path resolution logic that checks EP devices for library_path metadata
- Improved filesystem utility functions for cross-platform path handling

## Key Features
- Automatically resolves relative custom ops library paths using EP library metadata
- Maintains backward compatibility with absolute paths
- Cross-platform path handling (Windows/Unix)

## Testing
- Build verified on Windows with MSVC

```
1: [----------] Global test environment tear-down
1: [==========] 37 tests from 6 test suites ran. (4785 ms total)
1: [  PASSED  ] 37 tests.
1: Shutting down OnnxRuntime... done
1/1 Test #1: UnitTests ........................   Passed    4.90 sec
```


Fixes custom ops library loading issues for execution providers.