### PR TITLE
[WIP] Support for decoder pipeline based multimodel

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -547,6 +547,10 @@ struct Vision_Element : JSON::Element {
       return inputs_;
     } else if (name == "outputs") {
       return outputs_;
+    } else if (name == "session_options") {
+      v_.session_options = Config::SessionOptions{};
+      session_options_ = std::make_unique<SessionOptions_Element>(*v_.session_options);
+      return *session_options_;
     } else {
       throw JSON::unknown_value_error{};
     }
@@ -556,6 +560,7 @@ struct Vision_Element : JSON::Element {
   Config::Model::Vision& v_;
   VisionInputs_Element inputs_{v_.inputs};
   VisionOutputs_Element outputs_{v_.outputs};
+  std::unique_ptr<SessionOptions_Element> session_options_;
 };
 
 struct SpeechInputs_Element : JSON::Element {

--- a/src/config.h
+++ b/src/config.h
@@ -148,6 +148,7 @@ struct Config {
       std::string filename;
       std::string config_filename{"processor_config.json"};
       std::optional<std::string> adapter_filename{};
+      std::optional<SessionOptions> session_options;
 
       struct Inputs {
         std::string pixel_values{Defaults::PixelValuesName};

--- a/src/models/multi_decoder_pipeline_modal.h
+++ b/src/models/multi_decoder_pipeline_modal.h
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "model.h"
+#include "input_ids.h"
+#include "multi_modal_features.h"
+#include "embeddings.h"
+#include "extra_inputs.h"
+#include "logits.h"
+#include "kv_cache.h"
+#include "position_inputs.h"
+#include "decoder_only_pipeline.h"
+
+namespace Generators {
+
+struct MultiModalPipelineLanguageModel : Model {
+  MultiModalPipelineLanguageModel(std::unique_ptr<Config> config, OrtEnv& ort_env, bool vision, bool speech);
+  MultiModalPipelineLanguageModel(const MultiModalPipelineLanguageModel&) = delete;
+  MultiModalPipelineLanguageModel& operator=(const MultiModalPipelineLanguageModel&) = delete;
+
+  std::unique_ptr<State> CreateState(DeviceSpan<int32_t> sequence_lengths, const GeneratorParams& params) const;
+
+  std::unique_ptr<OrtSession> vision_session_;     // pixel_values, [image_attention_mask], image_sizes -> image_features
+  std::unique_ptr<OrtSession> speech_session_;     // audio_embeds, audio_sizes, audio_projection_mode -> audio_features
+  std::unique_ptr<OrtSession> embedding_session_;  // input_ids, image_features, audio_features -> inputs_embeds
+
+  std::unique_ptr<DecoderOnlyPipelineModel> decoder_pipeline_model_;
+};
+
+struct VisionState : State {
+  VisionState(const MultiModalLanguageModel& model, const GeneratorParams& params);
+  VisionState(const VisionState&) = delete;
+  VisionState& operator=(const VisionState&) = delete;
+
+  void SetExtraInputs(const std::vector<ExtraInput>& extra_inputs, const int64_t num_images, const int64_t num_image_tokens);
+  DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices = {}) override;
+
+ private:
+  friend struct MultiModalPipelineState;
+
+  const MultiModalLanguageModel& model_;
+  int64_t num_image_tokens_;
+  int64_t num_images_{};
+  ExtraInputs extra_inputs_{*this};  // Model inputs
+  std::unique_ptr<MultiModalFeatures> image_features_;
+};
+
+struct SpeechState : State {
+  SpeechState(const MultiModalLanguageModel& model, const GeneratorParams& params);
+  SpeechState(const SpeechState&) = delete;
+  SpeechState& operator=(const SpeechState&) = delete;
+
+  void SetExtraInputs(const std::vector<ExtraInput>& extra_inputs, const int64_t num_audio_tokens);
+  DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices = {}) override;
+
+ private:
+  friend struct MultiModalPipelineState;
+
+  const MultiModalLanguageModel& model_;
+  int64_t num_audio_tokens_;
+  ExtraInputs extra_inputs_{*this};  // Model inputs
+  std::unique_ptr<MultiModalFeatures> audio_features_;
+};
+
+struct EmbeddingState : State {
+  EmbeddingState(const MultiModalLanguageModel& model, const GeneratorParams& params);
+  EmbeddingState(const EmbeddingState&) = delete;
+  EmbeddingState& operator=(const EmbeddingState&) = delete;
+
+  void SetExtraInputs(const int64_t num_images_, const int64_t num_image_tokens_, const int64_t num_audio_tokens_);
+  DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices = {});
+
+ private:
+  friend struct MultiModalPipelineState;
+
+  void UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, bool is_prompt);
+
+  const MultiModalLanguageModel& model_;
+  int64_t num_image_tokens_;
+  int64_t num_audio_tokens_;
+
+  DefaultInputIDs input_ids_{*this};                          // Model input
+  std::unique_ptr<MultiModalFeatures> image_features_;        // Optional model input
+  std::unique_ptr<MultiModalFeatures> audio_features_;        // Optional model input
+  Embeddings inputs_embeds_{*this, Embeddings::Mode::Output,  // Model output
+                            model_.config_->model.embedding.outputs.embeddings};
+};
+
+struct DecoderState : State {
+  DecoderState(const MultiModalLanguageModel& model, DeviceSpan<int32_t> sequence_lengths,
+               const GeneratorParams& params);
+  DecoderState(const DecoderState&) = delete;
+  DecoderState& operator=(const DecoderState&) = delete;
+
+  DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices) override;
+
+ private:
+  friend struct MultiModalPipelineState;
+
+  void UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int current_length, DeviceSpan<int32_t> beam_indices);
+
+  const MultiModalLanguageModel& model_;
+  Embeddings inputs_embeds_{*this, Embeddings::Mode::Input,  // Model input
+                            model_.config_->model.decoder.inputs.embeddings};
+  DefaultPositionInputs position_inputs_;  // Model input
+  DefaultKeyValueCache kv_cache_{*this};   // Model input
+  Logits logits_{*this};                   // Model output
+};
+
+struct MultiModalPipelineState : State {
+  MultiModalPipelineState(const MultiModalLanguageModel& model, DeviceSpan<int32_t> sequence_lengths,
+                          const GeneratorParams& params);
+  MultiModalPipelineState(const MultiModalPipelineState&) = delete;
+  MultiModalPipelineState& operator=(const MultiModalPipelineState&) = delete;
+
+  void SetExtraInputs(const std::vector<ExtraInput>& extra_inputs) override;
+
+  DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens,
+                        DeviceSpan<int32_t> next_indices) override;
+
+  OrtValue* GetInput(const char* name) override;
+
+  OrtValue* GetOutput(const char* name) override;
+
+ private:
+  void UpdateInputsOutputs(const DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices,
+                           int current_length);
+
+  const MultiModalLanguageModel& model_;
+  int64_t num_image_tokens_{};
+  int64_t num_audio_tokens_{};
+  int64_t num_images_{};
+  std::unique_ptr<VisionState> vision_state_;
+  std::unique_ptr<SpeechState> speech_state_;
+  std::unique_ptr<EmbeddingState> embedding_state_;
+  std::unique_ptr<DecoderState> decoder_state_;
+  std::shared_ptr<Adapters> adapters_;
+  bool is_prompt_{true};
+
+  const std::string vision_adapter_name_{"vision"};
+  const std::string speech_adapter_name_{"speech"};
+};
+
+}  // namespace Generators

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -535,6 +535,8 @@ class Model:
         # Save ONNX model with only one external data file and delete any existing duplicate copies
         out_path = os.path.join(out_dir, self.filename)
         data_path = os.path.join(out_dir, os.path.basename(out_path) + ".data")
+        print("### inside save_model")
+        print("data_path", data_path)
         if os.path.exists(out_path):
             print(f"Overwriting {out_path}")
             os.remove(out_path)


### PR DESCRIPTION
- Add support to run pipeline based decoder gen ai configs with mutli-model
- Add support for using a separate session_options for vision model rather than using decoder's session_options 