### PR TITLE
Use updated Decoder API with `skip_special_tokens`

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -14,7 +14,7 @@ pybind11;https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.zip;f78029
 googletest;https://github.com/google/googletest/archive/530d5c8c84abd2a46f38583ee817743c9b3a42b4.zip;5e3a61db2aa975cfd0f97ba92c818744e7fa7034
 microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.zip;e4a542a323c070376f7c2d1973d0f7ddbc1d2fa5
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
-onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;5f8f774ff31df644eed9fbb2f0384661aca531ef
+onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;48a110c8c96a30fe13375d85fc53f05d1969dc96
 
 # These two dependencies are for the optional constrained decoding feature (USE_GUIDANCE)
 llguidance;https://github.com/microsoft/llguidance.git;2d2f1de3c87e3289528affc346f734f7471216d9

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -274,7 +274,7 @@ std::vector<int32_t> Tokenizer::Encode(const char* text) const {
 
 std::string Tokenizer::Decode(std::span<const int32_t> tokens) const {
   OrtxPtr<OrtxStringArray> ortx_string_array;
-  CheckResult(OrtxDetokenize1D(tokenizer_, reinterpret_cast<const uint32_t*>(tokens.data()), tokens.size(), ortx_string_array.Address()));
+  CheckResult(OrtxDetokenize1DWithOptions(tokenizer_, reinterpret_cast<const uint32_t*>(tokens.data()), tokens.size(), ortx_string_array.Address(), true /* skip_special_tokens */));
 
   const char* string;
   CheckResult(OrtxStringArrayGetItem(ortx_string_array, 0, &string));


### PR DESCRIPTION
### Updates

Inside the foundry catalog for [Foundry Local](https://github.com/[microsoft/Foundry-Local](https://github.com/microsoft/Foundry-Local)), all tool call tokens are marked as special such that we can use them with guidance inside [GenAI](https://github.com/microsoft/onnxruntime-genai). Now, in order for decoding to work with these tokens, we need to expose using special tokens as an option in our Decoder API in Extensions. Hence, ORT Extensions now adds `skip_special_tokens` to `OrtxDetokenize1DWithOptions`, which this PR leverages in the GenAI `Decoder`.

Note that we leave `OrtxDetokenize1D` as is for backward compatibility. In the future, we shall be adding an extensible options map API into ORT Extensions that will reduce the need for messy parameter additions to our Encoder/Decoder APIs, and can be easily consumed by GenAI and other partners.

### Validation
- [x] Native C++ testing in ORT Extensions against HuggingFace benchmark.