### PR TITLE
Include C++ header in native nuget and fix compiler warnings

### DIFF
--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -425,13 +425,9 @@ std::span<TAlloc> Allocate(OrtAllocator& allocator,
   return std::span(unique_ptr.get(), size);
 }
 
-inline void RegisterExecutionProviderLibrary(OrtEnv* env, const char* registration_name, const ORTCHAR_T* path) {
-  Ort::api->RegisterExecutionProviderLibrary(env, registration_name, path);
-}
+void RegisterExecutionProviderLibrary(OrtEnv* env, const char* registration_name, const ORTCHAR_T* path);
 
-inline void UnregisterExecutionProviderLibrary(OrtEnv* env, const char* registration_name) {
-  Ort::api->UnregisterExecutionProviderLibrary(env, registration_name);
-}
+void UnregisterExecutionProviderLibrary(OrtEnv* env, const char* registration_name);
 
 }  // namespace Ort
 

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -185,6 +185,14 @@ inline int GetCurrentGpuDeviceId() {
   return id;
 }
 
+inline void RegisterExecutionProviderLibrary(OrtEnv* env, const char* registration_name, const ORTCHAR_T* path) {
+  ThrowOnError(Ort::api->RegisterExecutionProviderLibrary(env, registration_name, path));
+}
+
+inline void UnregisterExecutionProviderLibrary(OrtEnv* env, const char* registration_name) {
+  ThrowOnError(Ort::api->UnregisterExecutionProviderLibrary(env, registration_name));
+}
+
 }  // namespace Ort
 
 inline std::unique_ptr<OrtStatus> OrtStatus::Create(OrtErrorCode code, const std::string& what) {

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -155,6 +155,7 @@ def generate_files(lines, args):
 
     # include
     lines.append(f'<file src="{args.sources_path}\src\ort_genai_c.h" target="build\\native\include" />')
+    lines.append(f'<file src="{args.sources_path}\src\ort_genai.h" target="build\\native\include" />')
     lines.append('</files>')
 
 


### PR DESCRIPTION
This pull request enhances the native NuGet package by including both the C and C++ header files. Previously, only the C header was bundled. With this update, the package now supports both languages more comprehensively.

Additionally, this PR resolves several compiler warnings that stemmed from unchecked return values in calls to the ONNX Runtime API.