### PR TITLE
Update Extensions commit for Qwen 2.5 Chat Template Tools Fix

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -14,7 +14,7 @@ pybind11;https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.zip;f78029
 googletest;https://github.com/google/googletest/archive/530d5c8c84abd2a46f38583ee817743c9b3a42b4.zip;5e3a61db2aa975cfd0f97ba92c818744e7fa7034
 microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.zip;e4a542a323c070376f7c2d1973d0f7ddbc1d2fa5
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
-onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;b1f36813cf0cef9749aa479ccce0a8f44a2bf5d7
+onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;a0d4ff582cf0391344408b9763caf5b045c06322
 
 # These two dependencies are for the optional constrained decoding feature (USE_GUIDANCE)
 llguidance;https://github.com/microsoft/llguidance.git;2d2f1de3c87e3289528affc346f734f7471216d9


### PR DESCRIPTION
### Updates
For Qwen, and some other models, `tools` should be a list of functions stored in JSON format, passed in separately, as an additional input to `apply_chat_template`. These tools were not handled correctly in the C++ backend in ApplyChatTemplate in ORT Extensions and were leading to extra newlines. This is now fixed by this [PR](https://github.com/microsoft/onnxruntime-extensions/pull/992).

### Validation
- [x] Python unit testing against HuggingFace.