### PR TITLE
Fix CUDA synchronization issue between ORT-GenAI and TRT-RTX inference

### DIFF
--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -98,7 +98,6 @@ def main(args):
 
     search_options = {name:getattr(args, name) for name in ['do_sample', 'max_length', 'min_length', 'top_p', 'top_k', 'temperature', 'repetition_penalty'] if name in args}
     search_options['batch_size'] = 1
-    search_options['do_sample'] = False
 
     if args.verbose: print(search_options)
 

--- a/examples/python/model-qa.py
+++ b/examples/python/model-qa.py
@@ -98,6 +98,7 @@ def main(args):
 
     search_options = {name:getattr(args, name) for name in ['do_sample', 'max_length', 'min_length', 'top_p', 'top_k', 'temperature', 'repetition_penalty'] if name in args}
     search_options['batch_size'] = 1
+    search_options['do_sample'] = False
 
     if args.verbose: print(search_options)
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -734,7 +734,7 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
   EnsureDeviceOrtInit(*p_device_, *config_);
 
   // Only CUDA, TRT-RTX and DML does every input on the device
-  if (p_device_->GetType() == DeviceType::CUDA || p_device_->GetType() == DeviceType::DML || p_device_->GetType() == DeviceType::NvTensorRtRtx)
+  if (p_device_->GetType() == DeviceType::CUDA || p_device_->GetType() == DeviceType::DML)
     p_device_inputs_ = p_device_;
   else
     p_device_inputs_ = GetDeviceInterface(DeviceType::CPU);

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -750,7 +750,7 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
   EnsureDeviceOrtInit(*p_device_, *config_);
 
   // Only CUDA, TRT-RTX and DML does every input on the device
-  if (p_device_->GetType() == DeviceType::CUDA || p_device_->GetType() == DeviceType::DML)
+  if (p_device_->GetType() == DeviceType::CUDA || p_device_->GetType() == DeviceType::DML || p_device_->GetType() == DeviceType::NvTensorRtRtx)
     p_device_inputs_ = p_device_;
   else
     p_device_inputs_ = GetDeviceInterface(DeviceType::CPU);


### PR DESCRIPTION
Fix CUDA synchronization issue between ORT-GenAI and TRT-RTX inference

Problem:
- Race condition between ORT-GenAI CUDA operations 
  and TRT-RTX inference execution
- CUDA operations were not completing before session.Run() was called
- This caused incorrect inference outputs when GPU sampling was enabled

Solution:
- configure user_compute_stream for NvTensorRtRtx provider