### PR TITLE
Generate pyd type info

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -60,7 +60,7 @@ if(BUILD_WHEEL)
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${WHEEL_TARGET_NAME} ${GENERATE_TYPE_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${ORT_LIB_DIR} ${GENERATE_TYPE_DIR}
     # Also installing numpy as a dependency for stub generation
-    COMMAND ${PYTHON_EXECUTABLE} -m pip install pybind11-stubgen numpy
+    COMMAND ${PYTHON_EXECUTABLE} -m pip install --user pybind11-stubgen numpy
     COMMAND ${PYTHON_EXECUTABLE} -m pybind11_stubgen $<TARGET_FILE_BASE_NAME:python> --output-dir ${WHEEL_TARGET_NAME}
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/fix_pyi.py -i ${WHEEL_TARGET_NAME}/$<TARGET_FILE_BASE_NAME:python>.pyi
     WORKING_DIRECTORY ${GENERATE_TYPE_DIR}

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -59,7 +59,8 @@ if(BUILD_WHEEL)
     # Use a new directory to fix the onnxruntime_genai runtime dependency and avoid contamination
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${WHEEL_TARGET_NAME} ${GENERATE_TYPE_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${ORT_LIB_DIR} ${GENERATE_TYPE_DIR}
-    COMMAND ${PYTHON_EXECUTABLE} -m pip install pybind11-stubgen
+    # Also installing numpy as a dependency for stub generation
+    COMMAND ${PYTHON_EXECUTABLE} -m pip install pybind11-stubgen numpy
     COMMAND ${PYTHON_EXECUTABLE} -m pybind11_stubgen $<TARGET_FILE_BASE_NAME:python> --output-dir ${WHEEL_TARGET_NAME}
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/fix_pyi.py -i ${WHEEL_TARGET_NAME}/$<TARGET_FILE_BASE_NAME:python>.pyi
     WORKING_DIRECTORY ${GENERATE_TYPE_DIR}

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -37,8 +37,12 @@ if(BUILD_WHEEL)
   endif()
   set(PACKAGE_DIR_NAME "onnxruntime_genai")
   set(WHEEL_TARGET_NAME "${WHEEL_FILES_DIR}/${PACKAGE_DIR_NAME}")
+  set(GENERATE_TYPE_DIR_NAME "onnxruntime_genai-generate-type")
+  set(GENERATE_TYPE_DIR "${WHEEL_FILES_DIR}/${GENERATE_TYPE_DIR_NAME}")
+  file(MAKE_DIRECTORY ${GENERATE_TYPE_DIR})
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in ${WHEEL_FILES_DIR}/setup.py @ONLY)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py.in ${WHEEL_TARGET_NAME}/__init__.py @ONLY)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.pyi.in ${WHEEL_TARGET_NAME}/__init__.pyi @ONLY)
 
   # Copy over any additional python files
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/py/" DESTINATION ${WHEEL_TARGET_NAME}/)
@@ -50,6 +54,16 @@ if(BUILD_WHEEL)
     ${ortgenai_embed_libs} $<TARGET_FILE:python>
     ${WHEEL_TARGET_NAME}
     COMMENT "Copying files to wheel directory: ${WHEEL_TARGET_NAME}"
+  )
+  add_custom_command(TARGET python POST_BUILD
+    # Use a new directory to fix the onnxruntime_genai runtime dependency and avoid contamination
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${WHEEL_TARGET_NAME} ${GENERATE_TYPE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${ORT_LIB_DIR} ${GENERATE_TYPE_DIR}
+    COMMAND ${PYTHON_EXECUTABLE} -m pip install pybind11-stubgen
+    COMMAND ${PYTHON_EXECUTABLE} -m pybind11_stubgen $<TARGET_FILE_BASE_NAME:python> --output-dir ${WHEEL_TARGET_NAME}
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/fix_pyi.py -i ${WHEEL_TARGET_NAME}/$<TARGET_FILE_BASE_NAME:python>.pyi
+    WORKING_DIRECTORY ${GENERATE_TYPE_DIR}
+    COMMENT "Generate type stubs for onnxruntime_genai"
   )
   set(auditwheel_exclude_list
     "libcublas.so.11"

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -59,8 +59,8 @@ if(BUILD_WHEEL)
     # Use a new directory to fix the onnxruntime_genai runtime dependency and avoid contamination
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${WHEEL_TARGET_NAME} ${GENERATE_TYPE_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${ORT_LIB_DIR} ${GENERATE_TYPE_DIR}
-    # Also installing numpy as a dependency for stub generation
-    COMMAND ${PYTHON_EXECUTABLE} -m pip install --user pybind11-stubgen numpy
+    # Be compatible with both system-wide but unprivileged env and virtual env where --user is not available
+    COMMAND ${PYTHON_EXECUTABLE} -m pip install --user pybind11-stubgen numpy || ${PYTHON_EXECUTABLE} -m pip install pybind11-stubgen numpy
     COMMAND ${PYTHON_EXECUTABLE} -m pybind11_stubgen $<TARGET_FILE_BASE_NAME:python> --output-dir ${WHEEL_TARGET_NAME}
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/fix_pyi.py -i ${WHEEL_TARGET_NAME}/$<TARGET_FILE_BASE_NAME:python>.pyi
     WORKING_DIRECTORY ${GENERATE_TYPE_DIR}

--- a/src/python/__init__.pyi.in
+++ b/src/python/__init__.pyi.in
@@ -1,0 +1,1 @@
+from onnxruntime_genai.@PACKAGE_DIR_NAME@ import *

--- a/src/python/fix_pyi.py
+++ b/src/python/fix_pyi.py
@@ -1,0 +1,17 @@
+"""
+The generated type file is using C++ class names instead of python class names 
+when used as parameters and return types.
+Thus we need to fix it manually here.
+"""
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+parser = ArgumentParser()
+parser.add_argument("--input", "-i", required=True, help="Input .pyi file")
+args = parser.parse_args()
+
+pyi_file = Path(args.input)
+content = pyi_file.read_text()
+fixed_content = content.replace("Oga", "")
+pyi_file.write_text(fixed_content)

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -314,6 +314,25 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       });
   m.add_object("_cleanup", cleanup);
 
+  pybind11::enum_<OgaElementType>(m, "ElementType")
+      .value("undefined", OgaElementType_undefined)
+      .value("float32", OgaElementType_float32)
+      .value("uint8", OgaElementType_uint8)
+      .value("int8", OgaElementType_int8)
+      .value("uint16", OgaElementType_uint16)
+      .value("int16", OgaElementType_int16)
+      .value("int32", OgaElementType_int32)
+      .value("int64", OgaElementType_int64)
+      .value("string", OgaElementType_string)
+      .value("bool", OgaElementType_bool)
+      .value("float16", OgaElementType_float16)
+      .value("float64", OgaElementType_float64)
+      .value("uint32", OgaElementType_uint32)
+      .value("uint64", OgaElementType_uint64)
+      .value("complex64", OgaElementType_complex64)
+      .value("complex128", OgaElementType_complex128)
+      .value("bfloat16", OgaElementType_bfloat16);
+
   pybind11::class_<PyGeneratorParams>(m, "GeneratorParams")
       .def(pybind11::init<const OgaModel&>())
       .def("try_graph_capture_with_max_batch_size", &PyGeneratorParams::TryGraphCaptureWithMaxBatchSize)


### PR DESCRIPTION
## Changes
* Generate type info in the wheel. This enables type hints and checks.
* Expose the enum OgaElementType which is used as a return type but not declared in python.