### PR TITLE
Fix typo in C API header

### DIFF
--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -78,7 +78,7 @@ typedef struct OgaAudios OgaAudios;
 typedef struct OgaStringArray OgaStringArray;
 typedef struct OgaAdapters OgaAdapters;
 typedef struct OgaEngine OgaEngine;
-typedef struct OgaRequest OgqRequest;
+typedef struct OgaRequest OgaRequest;
 
 //! @}
 


### PR DESCRIPTION
### Description

This PR fixes a typo in the C API header with `OgaRequest`.

### Motivation and Context

This PR fixes [this issue](https://github.com/microsoft/onnxruntime-genai/issues/1752).