### PR TITLE
Pin cmake and vcpkg versions in macOS workflows

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -18,6 +18,15 @@ jobs:
         with:
           submodules: true
 
+      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
+        with:
+          vcpkg-version: '2025.06.13'
+          vcpkg-hash: '735923258c5187966698f98ce0f1393b8adc6f84d44fd8829dda7db52828639331764ecf41f50c8e881e497b569f463dbd02dcb027ee9d9ede0711102de256cc'
+          cmake-version: '3.31.8'
+          cmake-hash: '99cc9c63ae49f21253efb5921de2ba84ce136018abf08632c92c060ba91d552e0f6acc214e9ba8123dee0cf6d1cf089ca389e321879fd9d719a60d975bcffcc8'
+          add-cmake-to-path: 'true'
+          disable-terrapin: 'true'
+
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12.x'

--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           gradle-version: '8.6'
 
-      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
         with:
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout OnnxRuntime GenAI repo
         uses: actions/checkout@v5
 
-      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
         with:
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
         with:
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
@@ -50,7 +50,7 @@ jobs:
           add-cmake-to-path: 'true'
           disable-terrapin: 'true'
 
-      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
         with:
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'

--- a/.github/workflows/mac-cpu-arm64-build.yml
+++ b/.github/workflows/mac-cpu-arm64-build.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           submodules: true
 
+      - uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
+        with:
+          vcpkg-version: '2025.06.13'
+          vcpkg-hash: '735923258c5187966698f98ce0f1393b8adc6f84d44fd8829dda7db52828639331764ecf41f50c8e881e497b569f463dbd02dcb027ee9d9ede0711102de256cc'
+          cmake-version: '3.31.8'
+          cmake-hash: '99cc9c63ae49f21253efb5921de2ba84ce136018abf08632c92c060ba91d552e0f6acc214e9ba8123dee0cf6d1cf089ca389e321879fd9d719a60d975bcffcc8'
+          add-cmake-to-path: 'true'
+          disable-terrapin: 'true'
+
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12.x'

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -33,7 +33,7 @@ jobs:
           architecture: 'x64'
 
       - name: Setup VCPKG
-        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
         with:
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -14,9 +14,9 @@ concurrency:
 env:
   AZCOPY_AUTO_LOGIN_TYPE: MSI
   AZCOPY_MSI_CLIENT_ID: 63b63039-6328-442f-954b-5a64d124e5b4
-  cuda_dir: "${{ github.workspace }}\cuda_sdk"
+  cuda_dir: "${{ github.workspace }}\\cuda_sdk"
   cuda_version: "12.2"
-  CUDA_PATH: ${{ github.workspace }}\cuda_sdk\v12.2
+  CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v12.2
   binaryDir: 'build/cuda/win-x64'
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Windows&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime.Gpu.Windows"

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake --preset windows_x64_cuda_release -T cuda=${{ env.cuda_dir }}\v${{ env.cuda_version }}
+          cmake --preset windows_x64_cuda_release -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }}
 
       - name: Build with CMake
         run: |
@@ -89,7 +89,7 @@ jobs:
 
       - name: Add CUDA to PATH
         run: |
-          echo "${{ env.cuda_dir }}\v${{ env.cuda_version }}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install the Python Wheel and Test Dependencies
         run: |
@@ -111,13 +111,13 @@ jobs:
 
       - name: Build the C# API and Run the C# Tests
         run: |
-          $env:PATH = "${{ env.cuda_dir }}\v${{ env.cuda_version }}\bin;" + $env:PATH
+          $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH
           cd test\csharp
           dotnet test /p:Configuration=release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib"
 
       - name: Prepend CUDA to PATH and Run tests
         run: |-
-          $env:PATH = "${{ env.cuda_dir }}\v${{ env.cuda_version }}\bin;" + $env:PATH 
+          $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
           echo "Current PATH variable is: $env:PATH" 
           copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
           & .\$env:binaryDir\Release\unit_tests.exe

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -14,9 +14,9 @@ concurrency:
 env:
   AZCOPY_AUTO_LOGIN_TYPE: MSI
   AZCOPY_MSI_CLIENT_ID: 63b63039-6328-442f-954b-5a64d124e5b4
-  cuda_dir: "${{ github.workspace }}\\cuda_sdk"
+  cuda_dir: "${{ github.workspace }}\cuda_sdk"
   cuda_version: "12.2"
-  CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v12.2
+  CUDA_PATH: ${{ github.workspace }}\cuda_sdk\v12.2
   binaryDir: 'build/cuda/win-x64'
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Windows&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime.Gpu.Windows"
@@ -36,7 +36,7 @@ jobs:
           architecture: 'x64'
 
       - name: Setup VCPKG
-        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
         with:
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
@@ -80,7 +80,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake --preset windows_x64_cuda_release -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }}
+          cmake --preset windows_x64_cuda_release -T cuda=${{ env.cuda_dir }}\v${{ env.cuda_version }}
 
       - name: Build with CMake
         run: |
@@ -89,7 +89,7 @@ jobs:
 
       - name: Add CUDA to PATH
         run: |
-          echo "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "${{ env.cuda_dir }}\v${{ env.cuda_version }}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install the Python Wheel and Test Dependencies
         run: |
@@ -111,13 +111,13 @@ jobs:
 
       - name: Build the C# API and Run the C# Tests
         run: |
-          $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH
+          $env:PATH = "${{ env.cuda_dir }}\v${{ env.cuda_version }}\bin;" + $env:PATH
           cd test\csharp
           dotnet test /p:Configuration=release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:OrtLibDir="$env:GITHUB_WORKSPACE\ort\lib"
 
       - name: Prepend CUDA to PATH and Run tests
         run: |-
-          $env:PATH = "${{ env.cuda_dir }}\\v${{ env.cuda_version }}\\bin;" + $env:PATH 
+          $env:PATH = "${{ env.cuda_dir }}\v${{ env.cuda_version }}\bin;" + $env:PATH 
           echo "Current PATH variable is: $env:PATH" 
           copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
           & .\$env:binaryDir\Release\unit_tests.exe

--- a/.github/workflows/win-directml-x64-build.yml
+++ b/.github/workflows/win-directml-x64-build.yml
@@ -41,7 +41,7 @@ jobs:
           architecture: 'x64'
 
       - name: Setup VCPKG
-        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
         with:
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'

--- a/.github/workflows/win-winml-x64-build.yml
+++ b/.github/workflows/win-winml-x64-build.yml
@@ -14,9 +14,9 @@ concurrency:
 env:
   AZCOPY_AUTO_LOGIN_TYPE: MSI
   AZCOPY_MSI_CLIENT_ID: 63b63039-6328-442f-954b-5a64d124e5b4
-  cuda_dir: "${{ github.workspace }}\cuda_sdk"
+  cuda_dir: "${{ github.workspace }}\\cuda_sdk"
   cuda_version: "12.2"
-  CUDA_PATH: ${{ github.workspace }}\cuda_sdk\v12.2
+  CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v12.2
   binaryDir: 'build/cuda/win-x64'
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Windows&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime.Gpu.Windows"
@@ -62,7 +62,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake --preset windows_x64_winml_relwithdebinfo -T cuda=${{ env.cuda_dir }}\v${{ env.cuda_version }} -DWINML_SDK_VERSION='1.8.2091'
+          cmake --preset windows_x64_winml_relwithdebinfo -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }} -DWINML_SDK_VERSION='1.8.2091'
 
       - name: Build with CMake
         run: |

--- a/.github/workflows/win-winml-x64-build.yml
+++ b/.github/workflows/win-winml-x64-build.yml
@@ -14,9 +14,9 @@ concurrency:
 env:
   AZCOPY_AUTO_LOGIN_TYPE: MSI
   AZCOPY_MSI_CLIENT_ID: 63b63039-6328-442f-954b-5a64d124e5b4
-  cuda_dir: "${{ github.workspace }}\\cuda_sdk"
+  cuda_dir: "${{ github.workspace }}\cuda_sdk"
   cuda_version: "12.2"
-  CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v12.2
+  CUDA_PATH: ${{ github.workspace }}\cuda_sdk\v12.2
   binaryDir: 'build/cuda/win-x64'
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Windows&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime.Gpu.Windows"
@@ -36,7 +36,7 @@ jobs:
           architecture: 'x64'
 
       - name: Setup VCPKG
-        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.6
+        uses: microsoft/onnxruntime-github-actions/setup-build-tools@v0.0.8
         with:
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
@@ -62,9 +62,10 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake --preset windows_x64_winml_relwithdebinfo -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }} -DWINML_SDK_VERSION='1.8.2091'
+          cmake --preset windows_x64_winml_relwithdebinfo -T cuda=${{ env.cuda_dir }}\v${{ env.cuda_version }} -DWINML_SDK_VERSION='1.8.2091'
 
       - name: Build with CMake
         run: |
           cmake --build --preset windows_x64_winml_relwithdebinfo --parallel
           cmake --build --preset windows_x64_winml_relwithdebinfo --target PyPackageBuild
+


### PR DESCRIPTION
This PR pins the versions of cmake and vcpkg in the macOS workflows to ensure a consistent build environment.

It also upgrades the `microsoft/onnxruntime-github-actions/setup-build-tools` action to `v0.0.8` in all workflows.