### PR TITLE
Disable lmhead while prompt processing

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -324,6 +324,8 @@ struct PipelineModel_Element : JSON::Element {
       v_.run_on_prompt = JSON::Get<bool>(value);
     } else if (name == "run_on_token_gen") {
       v_.run_on_token_gen = JSON::Get<bool>(value);
+    } else if (name == "is_lm_head") {
+      v_.is_lm_head = JSON::Get<bool>(value);
     } else if (name == "reset_session_idx") {
       v_.reset_session_idx = static_cast<int>(JSON::Get<double>(value));
     } else {

--- a/src/config.h
+++ b/src/config.h
@@ -237,6 +237,7 @@ struct Config {
         std::unordered_map<std::string, std::string> output_names_forwarder;
         bool run_on_prompt{true};
         bool run_on_token_gen{true};
+        bool is_lm_head{false};
         int reset_session_idx{-1};  // Some models cannot keep all the ort sessions in memory at once due to memory constraints.
                                     // This is the index of the session that needs to be reset during the execution of the current session.
                                     // This is a temporary solution until the QNN driver updates are available.

--- a/src/models/decoder_only_pipeline.h
+++ b/src/models/decoder_only_pipeline.h
@@ -67,7 +67,7 @@ struct DecoderOnlyPipelineState : State {
   OrtValue* GetOutput(const char* name) override;
 
   void RunPipeline(int total_length, DeviceSpan<int32_t>& next_tokens,
-                   DeviceSpan<int32_t> next_indices);
+                   DeviceSpan<int32_t> next_indices, bool is_last_chunk);
 
  private:
   void UpdateKeyValueCache(DeviceSpan<int32_t> beam_indices, int total_length);


### PR DESCRIPTION
Disable executing lm head model in the decoder-only pipeline while prompt is being processed for all except the last sliding window. This reduces the time taken in the prefill phase and leads to better ttft metric, especially for larger prompts.
To enable this, set `"is_lm_head": true` for lm_head model in the genai_config.json