### PR TITLE
Fix new/delete override and Enable cuda kernel test in Windows

### DIFF
--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -221,15 +221,15 @@ void Sequences::RewindTo(size_t new_length) { return gp_genai->Sequences_RewindT
 // But memory allocation might be called before gp_genai created so gp_genai might be nullptr, which causes crash.
 // Here we just copy the implementation of HeapAllocate and HeapFree to avoid initialization order issue.
 _Ret_notnull_ _Post_writable_byte_size_(n) void* operator new(size_t n) {
-    return std::malloc(n);
-  }
-void operator delete(void* p) noexcept { 
-    return std::free(p);
-  }
+  return std::malloc(n);
+}
+void operator delete(void* p) noexcept {
+  return std::free(p);
+}
 
 void operator delete(void* p, size_t /*size*/) noexcept {
-    return std::free(p);
-  }
+  return std::free(p);
+}
 #endif
 
 extern "C" {

--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -217,9 +217,19 @@ void Sequences::RewindTo(size_t new_length) { return gp_genai->Sequences_RewindT
 
 #ifdef _WIN32
 // Override default new/delete so that we match the host's allocator
-_Ret_notnull_ _Post_writable_byte_size_(n) void* operator new(size_t n) { return Generators::gp_genai->HeapAllocate(n); }
-void operator delete(void* p) noexcept { Generators::gp_genai->HeapFree(p); }
-void operator delete(void* p, size_t /*size*/) noexcept { Generators::gp_genai->HeapFree(p); }
+// Previous implementation calls Generators::gp_genai->HeapAllocate(n) or HeapFree(p).
+// But memory allocation might be called before gp_genai created so gp_genai might be nullptr, which causes crash.
+// Here we just copy the implementation of HeapAllocate and HeapFree to avoid initialization order issue.
+_Ret_notnull_ _Post_writable_byte_size_(n) void* operator new(size_t n) {
+    return std::malloc(n);
+  }
+void operator delete(void* p) noexcept { 
+    return std::free(p);
+  }
+
+void operator delete(void* p, size_t /*size*/) noexcept {
+    return std::free(p);
+  }
 #endif
 
 extern "C" {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/cxx_standard.cmake)
 
 # Add an option to enable/disable CUDA kernel tests. This option is ON by default
 # if building on non-Windows platform with CUDA available, and OFF otherwise.
-cmake_dependent_option(ENABLE_CUDA_KERNEL_TESTS "Build cuda kernel tests" ON "NOT WIN32;USE_CUDA;CMAKE_CUDA_COMPILER" OFF)
+cmake_dependent_option(ENABLE_CUDA_KERNEL_TESTS "Build cuda kernel tests" ON "USE_CUDA;CMAKE_CUDA_COMPILER" OFF)
 
 # unit tests program
 add_executable(unit_tests)

--- a/test/cuda_kernel/cuda_sampling_tests.cpp
+++ b/test/cuda_kernel/cuda_sampling_tests.cpp
@@ -73,7 +73,7 @@ TEST_P(CudaSamplingTopKTopPTest, StatisticalVerification) {
   const int vocab_size = 512;  // Smaller vocab for faster test execution
   const int k = GetParam();
   const float p = 0.9f;
-  const float temperature = 0.7f;
+  constexpr float temperature = 0.7f;
   const int num_iter = 5000;
   const unsigned long long initial_seed = 42;
   const double tolerance = 0.015;  // Tolerance for statistical comparison

--- a/test/cuda_kernel/cuda_sampling_tests.cpp
+++ b/test/cuda_kernel/cuda_sampling_tests.cpp
@@ -101,7 +101,7 @@ TEST_P(CudaSamplingTopKTopPTest, StatisticalVerification) {
 
   // 4.1. Apply temperature to the logits upfront, just like the kernel.
   std::vector<float> scaled_logits = top_k_logits;
-  if (temperature != 0.0f) {
+  if constexpr (temperature != 0.0f) {
     for (auto& logit : scaled_logits) {
       logit /= temperature;
     }


### PR DESCRIPTION
Previously, cuda kernel test was disabled in Windows CI since test failed to start.
It is caused by new/delete override, which has assumption that the genai object is created before any other object. The global initialization order depends on compiler.

In Windows, when new is called, the genai object might not be created yet.

Here we change the implementation of the override to fix such potential crash in Windows.