### PR TITLE
Enable bfloat16 multi-modal models

### DIFF
--- a/src/cpu/interface.cpp
+++ b/src/cpu/interface.cpp
@@ -74,11 +74,21 @@ struct CpuInterface : DeviceInterface {
       auto* fp16 = static_cast<uint16_t*>(output_data);
       for (size_t i = 0; i < element_count; i++)
         fp16[i] = FastFloat32ToFloat16(fp32[i]);
+    } else if (input_type == Ort::TypeToTensorType<float> && output_type == Ort::TypeToTensorType<Ort::BFloat16_t>) {
+      auto* fp32 = static_cast<float*>(input_data);
+      auto* bf16 = static_cast<uint16_t*>(output_data);
+      for (size_t i = 0; i < element_count; i++)
+        bf16[i] = Float32ToBFloat16(fp32[i]);
     } else if (input_type == Ort::TypeToTensorType<Ort::Float16_t> && output_type == Ort::TypeToTensorType<float>) {
       auto* fp16 = static_cast<uint16_t*>(input_data);
       auto* fp32 = static_cast<float*>(output_data);
       for (size_t i = 0; i < element_count; i++)
         fp32[i] = FastFloat16ToFloat32(fp16[i]);
+    } else if (input_type == Ort::TypeToTensorType<Ort::BFloat16_t> && output_type == Ort::TypeToTensorType<float>) {
+      auto* bf16 = static_cast<uint16_t*>(input_data);
+      auto* fp32 = static_cast<float*>(output_data);
+      for (size_t i = 0; i < element_count; i++)
+        fp32[i] = BFloat16ToFloat32(bf16[i]);
     } else if (input_type == Ort::TypeToTensorType<int32_t> && output_type == Ort::TypeToTensorType<int64_t>) {
       auto* int32 = static_cast<int32_t*>(input_data);
       auto* int64 = static_cast<int64_t*>(output_data);

--- a/src/models/gemma_image_processor.cpp
+++ b/src/models/gemma_image_processor.cpp
@@ -112,6 +112,9 @@ std::unique_ptr<NamedTensors> GemmaImageProcessor::Process(const Tokenizer& toke
   if (pixel_values_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
     named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
                            std::make_shared<Tensor>(ProcessTensor<float>(pixel_values, allocator)));
+  } else if (pixel_values_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16) {
+    named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
+                           std::make_shared<Tensor>(ProcessTensor<Ort::BFloat16_t>(pixel_values, allocator)));
   } else {
     named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
                            std::make_shared<Tensor>(ProcessTensor<Ort::Float16_t>(pixel_values, allocator)));

--- a/src/models/phi_image_processor.cpp
+++ b/src/models/phi_image_processor.cpp
@@ -123,6 +123,9 @@ std::unique_ptr<NamedTensors> PhiImageProcessor::Process(const Tokenizer& tokeni
   if (pixel_values_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
     named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
                            std::make_shared<Tensor>(ProcessTensor<float>(pixel_values, allocator)));
+  } else if (pixel_values_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16) {
+    named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
+                           std::make_shared<Tensor>(ProcessTensor<Ort::BFloat16_t>(pixel_values, allocator)));
   } else {
     named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
                            std::make_shared<Tensor>(ProcessTensor<Ort::Float16_t>(pixel_values, allocator)));

--- a/src/models/phi_multimodal_processor.cpp
+++ b/src/models/phi_multimodal_processor.cpp
@@ -156,6 +156,9 @@ std::unique_ptr<NamedTensors> PhiMultiModalProcessor::Process(const Tokenizer& t
     if (pixel_values_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
       named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
                              std::make_shared<Tensor>(ProcessTensor<float>(pixel_values, allocator)));
+    } else if (pixel_values_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16) {
+      named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
+                             std::make_shared<Tensor>(ProcessTensor<Ort::BFloat16_t>(pixel_values, allocator)));
     } else {
       named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
                              std::make_shared<Tensor>(ProcessTensor<Ort::Float16_t>(pixel_values, allocator)));
@@ -164,8 +167,11 @@ std::unique_ptr<NamedTensors> PhiMultiModalProcessor::Process(const Tokenizer& t
     named_tensors->emplace(std::string(Config::Defaults::ImageSizesName),
                            std::make_shared<Tensor>(ProcessTensor<int64_t>(image_sizes, allocator)));
     if (attention_mask_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
-      named_tensors->emplace(std::string(Config::Defaults::AttentionMaskName),
+      named_tensors->emplace(std::string(Config::Defaults::ImageAttentionMaskName),
                              std::make_shared<Tensor>(ProcessTensor<float>(image_attention_mask, allocator)));
+    } else if (attention_mask_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16) {
+      named_tensors->emplace(std::string(Config::Defaults::ImageAttentionMaskName),
+                             std::make_shared<Tensor>(ProcessTensor<Ort::BFloat16_t>(image_attention_mask, allocator)));
     } else {
       named_tensors->emplace(std::string(Config::Defaults::ImageAttentionMaskName),
                              std::make_shared<Tensor>(ProcessTensor<Ort::Float16_t>(image_attention_mask, allocator)));
@@ -179,6 +185,9 @@ std::unique_ptr<NamedTensors> PhiMultiModalProcessor::Process(const Tokenizer& t
     if (audio_features_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
       named_tensors->emplace(std::string(Config::Defaults::AudioEmbedsName),
                              std::make_shared<Tensor>(ProcessTensor<float>(audio_embeds, allocator)));
+    } else if (audio_features_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16) {
+          named_tensors->emplace(std::string(Config::Defaults::AudioEmbedsName),
+                                std::make_shared<Tensor>(ProcessTensor<Ort::BFloat16_t>(audio_embeds, allocator)));
     } else {
       named_tensors->emplace(std::string(Config::Defaults::AudioEmbedsName),
                              std::make_shared<Tensor>(ProcessTensor<Ort::Float16_t>(audio_embeds, allocator)));

--- a/src/models/processor.cpp
+++ b/src/models/processor.cpp
@@ -105,6 +105,26 @@ std::unique_ptr<OrtValue> ProcessTensor<Ort::Float16_t>(OrtxTensor* tensor, Ort:
 }
 
 template <>
+std::unique_ptr<OrtValue> ProcessTensor<Ort::BFloat16_t>(OrtxTensor* tensor, Ort::Allocator& allocator) {
+  const float* tensor_data{};
+  const int64_t* tensor_shape{};
+  size_t tensor_num_dims;
+  CheckResult(OrtxGetTensorData(tensor, reinterpret_cast<const void**>(&tensor_data),
+                                &tensor_shape, &tensor_num_dims));
+  const int64_t tensor_num_elements = std::accumulate(tensor_shape,
+                                                      tensor_shape + tensor_num_dims,
+                                                      1LL, std::multiplies<int64_t>());
+  auto tensor_value = OrtValue::CreateTensor<Ort::BFloat16_t>(allocator, std::span<int64_t>(const_cast<int64_t*>(tensor_shape), tensor_num_dims));
+  auto tensor_value_fp32 = OrtValue::CreateTensor<float>(
+      allocator.GetInfo(),
+      std::span<float>(const_cast<float*>(tensor_data), tensor_num_elements),
+      std::span<int64_t>(const_cast<int64_t*>(tensor_shape), tensor_num_dims));
+  auto p_device = GetDeviceInterface(DeviceType::CPU);
+  Cast(*tensor_value_fp32, tensor_value, *p_device, Ort::TypeToTensorType<Ort::BFloat16_t>);
+  return tensor_value;
+}
+
+template <>
 std::unique_ptr<OrtValue> ProcessTensor<int64_t, float>(OrtxTensor* tensor, Ort::Allocator& allocator) {
   const int64_t* tensor_data{};
   const int64_t* tensor_shape{};

--- a/src/models/processor.cpp
+++ b/src/models/processor.cpp
@@ -162,6 +162,26 @@ std::unique_ptr<OrtValue> ProcessTensor<int64_t, Ort::Float16_t>(OrtxTensor* ten
 }
 
 template <>
+std::unique_ptr<OrtValue> ProcessTensor<int64_t, Ort::BFloat16_t>(OrtxTensor* tensor, Ort::Allocator& allocator) {
+  const int64_t* tensor_data{};
+  const int64_t* tensor_shape{};
+  size_t tensor_num_dims;
+  CheckResult(OrtxGetTensorData(tensor, reinterpret_cast<const void**>(&tensor_data),
+                                &tensor_shape, &tensor_num_dims));
+  const int64_t tensor_num_elements = std::accumulate(tensor_shape,
+                                                      tensor_shape + tensor_num_dims,
+                                                      1LL, std::multiplies<int64_t>());
+  auto tensor_value = OrtValue::CreateTensor<Ort::BFloat16_t>(allocator, std::span<int64_t>(const_cast<int64_t*>(tensor_shape), tensor_num_dims));
+  auto tensor_value_fp32 = OrtValue::CreateTensor<float>(allocator, std::span<int64_t>(const_cast<int64_t*>(tensor_shape), tensor_num_dims));
+  std::transform(tensor_data, tensor_data + tensor_num_elements,
+                 tensor_value_fp32->GetTensorMutableData<float>(),
+                 [](int64_t value) { return static_cast<float>(value); });
+  auto p_device = GetDeviceInterface(DeviceType::CPU);
+  Cast(*tensor_value_fp32, tensor_value, *p_device, Ort::TypeToTensorType<Ort::BFloat16_t>);
+  return tensor_value;
+}
+
+template <>
 std::unique_ptr<OrtValue> ProcessTensor<float, int64_t>(OrtxTensor* tensor, Ort::Allocator& allocator) {
   const float* tensor_data{};
   const int64_t* tensor_shape{};

--- a/src/models/utils.cpp
+++ b/src/models/utils.cpp
@@ -85,6 +85,7 @@ float BFloat16ToFloat32(uint16_t v) {
   return TFloatToFloat32<8, 7>(v);
 }
 
+// Get most significant 16 bits
 uint16_t Float32ToBFloat16(float v) {
   uint32_t bits;
   std::memcpy(&bits, &v, sizeof(bits));

--- a/src/models/utils.cpp
+++ b/src/models/utils.cpp
@@ -85,6 +85,12 @@ float BFloat16ToFloat32(uint16_t v) {
   return TFloatToFloat32<8, 7>(v);
 }
 
+uint16_t Float32ToBFloat16(float v) {
+  uint32_t bits;
+  std::memcpy(&bits, &v, sizeof(bits));
+  return static_cast<uint16_t>(bits >> 16);
+}
+
 // C++17 compatible version of bit_cast for the code below
 template <typename TTo, typename TFrom>
 TTo bit_cast(TFrom x) {

--- a/src/models/utils.h
+++ b/src/models/utils.h
@@ -29,6 +29,7 @@ int64_t ElementCountFromShape(std::span<const int64_t> shape);
 // Slower fp16 to fp32 conversion that handles NaN and Inf (useful for debugging vs runtime conversion)
 float Float16ToFloat32(uint16_t v);
 float BFloat16ToFloat32(uint16_t v);
+uint16_t Float32ToBFloat16(float v);
 
 inline float ToFloat32(Ort::Float16_t v) { return Float16ToFloat32(v); }
 inline float ToFloat32(Ort::BFloat16_t v) { return BFloat16ToFloat32(v); }

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -293,7 +293,7 @@ class Model:
 
     def make_outputs_init(self):
         # Always use float32 logits to improve accuracy in the case of bf16 models.
-        if self.onnx_dtype == ir.DataType.BFLOAT16:
+        if self.io_dtype == ir.DataType.BFLOAT16:
             self.output_types["logits"] = ir.DataType.FLOAT
 
         self.exclude_lm_head = self.extra_options.get("exclude_lm_head", False)
@@ -4319,14 +4319,10 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
         elif config.architectures[0] == "GemmaForCausalLM":
             onnx_model = GemmaModel(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Gemma2ForCausalLM":
-            if precision == "fp16":
-                print("WARNING: This model loses accuracy with float16 precision. Setting `--precision bf16` by default.")
-                onnx_dtype = ir.DataType.BFLOAT16
+            print("WARNING: This model loses accuracy with float16 precision. It is recommended to set `--precision bf16` or `--precision int4 --extra_options use_cuda_bf16=1` by default.")
             onnx_model = Gemma2Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
         elif config.architectures[0] == "Gemma3ForCausalLM":
-            if precision == "fp16":
-                print("WARNING: This model loses accuracy with float16 precision. Setting `--precision bf16` by default.")
-                onnx_dtype = ir.DataType.BFLOAT16
+            print("WARNING: This model loses accuracy with float16 precision. It is recommended to set `--precision bf16` or `--precision int4 --extra_options use_cuda_bf16=1` by default.")
             onnx_model = Gemma3Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
             onnx_model.model_type = "gemma3_text"
         elif config.architectures[0] == "Gemma3ForConditionalGeneration":
@@ -4334,9 +4330,7 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
             for key in text_config:
                 if not hasattr(config, key):
                     setattr(config, key, getattr(text_config, key))
-            if precision == "fp16":
-                print("WARNING: This model loses accuracy with float16 precision. Setting `--precision bf16` by default.")
-                onnx_dtype = ir.DataType.BFLOAT16
+            print("WARNING: This model loses accuracy with float16 precision. It is recommended to set `--precision bf16` or `--precision int4 --extra_options use_cuda_bf16=1` by default.")
             print("WARNING: This is only generating the text component of the model. Setting `--extra_options exclude_embeds=true` by default.")
             extra_options["exclude_embeds"] = True
             onnx_model = Gemma3Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)


### PR DESCRIPTION
### Description

This PR enables multi-modal models to use bfloat16 precision for other models besides the text decoder. It requires the changes from this [ORT PR](https://github.com/microsoft/onnxruntime/pull/26102).

### Motivation and Context

Models from the Gemma-3 family can lose accuracy with float16 precision and require bfloat16 precision for higher quality output.