### PR TITLE
Enable guidance ff tokens for faster inference

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -17,5 +17,5 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;bd8fb6d86e98c17e397c42fc001913cc2e035597
 
 # These two dependencies are for the optional constrained decoding feature (USE_GUIDANCE)
-llguidance;https://github.com/microsoft/llguidance.git;2d2f1de3c87e3289528affc346f734f7471216d9
+llguidance;https://github.com/microsoft/llguidance.git;866e6921fd11fbddd604f2193055c62146c412cc
 corrosion;https://github.com/corrosion-rs/corrosion.git;b1fab721655c5c4b1b08a083d3cd29f163af75d0

--- a/examples/python/guidance-example.py
+++ b/examples/python/guidance-example.py
@@ -1,0 +1,91 @@
+import onnxruntime_genai as og
+import argparse
+import time
+import json
+
+from datasets import load_dataset
+
+def main(args):
+    dataset = load_dataset(path="epfl-dlab/JSONSchemaBench", name="Github_hard", split="test")
+    schema = json.loads(dataset[0]['json_schema'])
+
+    system_prompt = "You need to generate a JSON object that matches the schema below."
+    user_prompt = json.dumps(schema, indent=2)
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt}
+    ]
+
+    config = og.Config(args.model_path)
+    if args.execution_provider != "follow_config":
+        config.clear_providers()
+        if args.execution_provider != "cpu":
+            config.append_provider(args.execution_provider)
+    model = og.Model(config)
+
+    tokenizer = og.Tokenizer(model)
+    tokenizer_stream = tokenizer.create_stream()
+
+    search_options = {name:getattr(args, name) for name in ['do_sample', 'max_length', 'min_length', 'top_p', 'top_k', 'temperature', 'repetition_penalty'] if name in args}
+    search_options['batch_size'] = 1
+    search_options['temperature'] = 0.0
+
+    params = og.GeneratorParams(model)
+    params.set_search_options(**search_options)
+
+    schema["x-guidance"] = {
+        "whitespace_flexible": False,
+        "key_separator": ": ",
+        "item_separator": ", "
+    }
+    guidance_type = "lark_grammar"
+    guidance_input = f"""start: %json {json.dumps(schema)}\n"""
+    params.set_search_options(**search_options)
+    params.set_guidance(guidance_type, guidance_input) # set guidance
+    params.set_guidance_ff_tokens(args.enable_ff_tokens)  # enable guidance feed-forward tokens
+
+    generator = og.Generator(model, params)
+
+    final_prompt = tokenizer.apply_chat_template(messages=json.dumps(messages), add_generation_prompt=True)
+    final_input = tokenizer.encode(final_prompt)
+    generator.append_tokens(final_input)
+    
+    start_len = len(generator.get_sequence(0))
+    prev_len = start_len
+    t0 = time.time()
+    # for i in range(15):
+    full_seq_str = ""
+    while not generator.is_done():    
+        generator.generate_next_token()
+
+        # NOTE: since get_next_tokens returns only the last token, we'll need to use get_sequence instead
+        # new_tokens = generator.get_next_tokens()[0]
+        # print(tokenizer_stream.decode(new_tokens), end='', flush=True)
+
+        seq = generator.get_sequence(0)
+        new_tokens = seq[prev_len:]
+        seq_str = ""
+        for token in new_tokens:
+            seq_str += tokenizer_stream.decode(token)
+        print(seq_str, end='', flush=True)
+        prev_len = len(seq)
+        full_seq_str += seq_str
+    latency = time.time() - t0
+    print()
+
+    # verify valid json
+    _json = json.loads(full_seq_str)
+    print(json.dumps(_json, indent=2))
+
+    tps = (len(generator.get_sequence(0)) - start_len) / latency
+    print(f"Generation Latency: {latency:.2f} sec")
+    print(f"Tokens/sec: {tps:.2f} ")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS, description="End-to-end AI Question/Answer example for gen-ai")
+    parser.add_argument('-m', '--model_path', type=str, required=True, help='Onnx model folder path (must contain genai_config.json and model.onnx)')
+    parser.add_argument('-e', '--execution_provider', type=str, required=False, default='follow_config', choices=["cpu", "cuda", "dml", "follow_config"], help="Execution provider to run the ONNX Runtime session with. Defaults to follow_config that uses the execution provider listed in the genai_config.json instead.")
+    parser.add_argument('--enable_ff_tokens', action='store_true', default=False, help='Enable feed-forward tokens in the model session if supported (default: False)')
+    args = parser.parse_args()
+    main(args)

--- a/src/constrained_logits_processor.cpp
+++ b/src/constrained_logits_processor.cpp
@@ -74,6 +74,7 @@ GuidanceLogitsProcessor::GuidanceLogitsProcessor(const State& state)
   for (int i = 0; i < params_->search.batch_size; i++) {
     LlgConstraintInit constraint_init;
     llg_constraint_init_set_defaults(&constraint_init, llg_tokenizer_.get());
+    constraint_init.ff_tokens_ok = params_->guidance_ff_tokens_enabled && params_->search.batch_size == 1 && params_->search.num_beams == 1;
     LlgConstraint* constraint_ptr = nullptr;
     if (params_->guidance_type == "json_schema") {
       constraint_ptr = llg_new_constraint_json(&constraint_init, params_->guidance_data.data());
@@ -88,6 +89,8 @@ GuidanceLogitsProcessor::GuidanceLogitsProcessor(const State& state)
       throw std::runtime_error("Error creating grammar: " + error_message);
     }
     llg_constraints_[i] = std::unique_ptr<LlgConstraint, LlgConstraintDeleter>(constraint_ptr);
+    // create ff_tokens buffer for each batch item
+    ff_tokens_batch_.push_back(std::vector<int32_t>());
   }
 
   // Compute the mask asynchronously to avoid blocking the model inference on device
@@ -129,6 +132,17 @@ std::vector<std::vector<uint32_t>> GuidanceLogitsProcessor::ComputeMask() {
   return masks;
 }
 
+std::vector<int32_t> GuidanceLogitsProcessor::GetFFTokens(size_t index) {
+  if (index >= ff_tokens_batch_.size()) {
+    // in case guidance is not being used, return empty vector
+    return std::vector<int32_t>();
+  }
+
+  auto v = std::vector<int32_t>(ff_tokens_batch_[index]);
+  ff_tokens_batch_[index].clear();
+  return v;
+}
+
 void GuidanceLogitsProcessor::CommitTokens(std::span<int32_t> tokens) {
   for (int i = 0; i < params_->search.batch_size; i++) {
     LlgCommitResult commit_result;
@@ -136,6 +150,13 @@ void GuidanceLogitsProcessor::CommitTokens(std::span<int32_t> tokens) {
     if (error != 0) {
       std::string error_message = llg_get_error(llg_constraints_[i].get());
       throw std::runtime_error("Error committing tokens: " + error_message);
+    }
+
+    auto& ff_tokens = ff_tokens_batch_[i];
+    ff_tokens.clear();
+    // Store forced tokens (i.e. index >= 1) to process outside of this logits processor
+    for (size_t j = 1; j < commit_result.n_tokens; j++) {
+      ff_tokens.push_back((int32_t)commit_result.tokens[j]);
     }
   }
   mask_future_ = std::async(std::launch::async, [&]() {

--- a/src/constrained_logits_processor.h
+++ b/src/constrained_logits_processor.h
@@ -29,6 +29,8 @@ struct ConstrainedLogitsProcessor {
   virtual void Reset() = 0;
   // ResetWithoutCompute is used to reset the masks and constraints for logits processor without computing the mask for chat
   virtual void ResetWithoutCompute() = 0;
+  // Return a clone of the ff_tokens for the given index
+  virtual std::vector<int32_t> GetFFTokens(size_t index) = 0;
 };
 
 #if USE_GUIDANCE
@@ -43,6 +45,7 @@ struct GuidanceLogitsProcessor : public ConstrainedLogitsProcessor {
   void CommitTokens(std::span<int32_t> tokens) override;
   void Reset() override;
   void ResetWithoutCompute() override;
+  std::vector<int32_t> GetFFTokens(size_t index) override;
   // GetMask is used to get the logits mask
   std::vector<std::vector<uint32_t>> GetMask();
   // tokenize_partial is used to tokenize the input tokens with special prefix, this will get stable
@@ -73,6 +76,7 @@ struct GuidanceLogitsProcessor : public ConstrainedLogitsProcessor {
 
   std::future<std::vector<std::vector<uint32_t>>> mask_future_;
   std::vector<std::vector<uint32_t>> logits_masks_;
+  std::vector<std::vector<int32_t>> ff_tokens_batch_;
 
   struct TokenizeData {
     Tokenizer* tokenizer;

--- a/src/csharp/GeneratorParams.cs
+++ b/src/csharp/GeneratorParams.cs
@@ -39,6 +39,11 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
             Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetGuidance(_generatorParamsHandle, StringUtils.ToUtf8(type), StringUtils.ToUtf8(data)));
         }
 
+        public void SetGuidanceFFTokens(bool enabled)
+        {
+            Result.VerifySuccess(NativeMethods.OgaGeneratorParamsSetGuidanceFFTokens(_generatorParamsHandle, enabled));
+        }
+
         ~GeneratorParams()
         {
             Dispose(false);

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -266,6 +266,10 @@ void GeneratorParams::SetGuidance(std::string_view type, std::string_view data) 
   guidance_data = data;
 }
 
+void GeneratorParams::SetGuidanceFFTokens(bool enabled) {
+  guidance_ff_tokens_enabled = enabled;
+}
+
 std::unique_ptr<Generator> CreateGenerator(const Model& model, const GeneratorParams& params) {
   return std::make_unique<Generator>(model, params);
 }
@@ -385,10 +389,12 @@ void Generator::SetInputs(const NamedTensors& named_tensors) {
 void Generator::ComputeLogits(DeviceSpan<int32_t> next_tokens) {
   if (computed_logits_)
     throw std::runtime_error("ComputeLogits called again without calling AppendTokens or GenerateNextToken first");
+
   if (last_action_ == Action::generated && guidance_logits_processor_) {
     auto next_tokens_span = next_tokens.CopyDeviceToCpu();
     guidance_logits_processor_->CommitTokens(next_tokens_span);
   }
+
   auto logits = state_->Run(search_->GetSequenceLength(), next_tokens, search_->GetNextIndices());
   if (g_log.enabled && g_log.model_logits) {
     auto& stream = Log("model_logits");
@@ -396,6 +402,27 @@ void Generator::ComputeLogits(DeviceSpan<int32_t> next_tokens) {
     stream << std::endl;
   }
   SetLogits(logits);
+
+  if (last_action_ == Action::generated && guidance_logits_processor_) {
+    auto ff_tokens = guidance_logits_processor_->GetFFTokens(0);
+    if (!ff_tokens.empty()) {
+      // process fast-forward tokens
+      std::span<int32_t> forced_tokens_span {ff_tokens};
+      auto forced_tokens = AllocateInputIdsOnDevice(forced_tokens_span);
+      search_->AppendTokens(forced_tokens);
+
+      std::span<int32_t> new_next_token_span{ff_tokens};
+      auto new_next_token = AllocateInputIdsOnDevice(new_next_token_span);
+      auto logits = state_->Run(search_->GetSequenceLength(), new_next_token, search_->GetNextIndices());
+      if (g_log.enabled && g_log.model_logits) {
+        auto& stream = Log("model_logits");
+        DumpValues(stream, Ort::TypeToTensorType<float>, logits.CopyDeviceToCpu().data(), logits.size());
+        stream << std::endl;
+      }
+      SetLogits(logits);
+    }
+  }
+
   last_action_ = Action::standard;
   computed_logits_ = true;
 }

--- a/src/generators.h
+++ b/src/generators.h
@@ -83,7 +83,9 @@ struct GeneratorParams : std::enable_shared_from_this<GeneratorParams>, LeakChec
 
   std::string guidance_type;  // e.g. json_schema or regex
   std::string guidance_data;  // e.g. rules data in json_schema or regex
+  bool guidance_ff_tokens_enabled{false};  // Whether to enable ff_tokens during constrained decoding
   void SetGuidance(std::string_view type, std::string_view data);
+  void SetGuidanceFFTokens(bool enabled);
 };
 
 struct Generator : LeakChecked<Generator> {

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -400,6 +400,10 @@ struct OgaGeneratorParams : OgaAbstract {
     OgaCheckResult(OgaGeneratorParamsSetGuidance(this, type, data));
   }
 
+  void SetGuidanceFFTokens(bool enabled) {
+    OgaCheckResult(OgaGeneratorParamsSetGuidanceFFTokens(this, enabled));
+  }
+
   static void operator delete(void* p) { OgaDestroyGeneratorParams(reinterpret_cast<OgaGeneratorParams*>(p)); }
 };
 

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -402,6 +402,13 @@ OgaResult* OGA_API_CALL OgaGeneratorParamsSetGuidance(OgaGeneratorParams* params
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaGeneratorParamsSetGuidanceFFTokens(OgaGeneratorParams* params, bool enabled) {
+  OGA_TRY
+  params->SetGuidanceFFTokens(enabled);
+  return nullptr;
+  OGA_CATCH
+}
+
 OgaResult* OgaCreateGenerator(const OgaModel* model, const OgaGeneratorParams* params, OgaGenerator** out) {
   OGA_TRY
   *out = ReturnUnique<OgaGenerator>(CreateGenerator(*model, *params));

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -425,6 +425,14 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaGeneratorParamsTryGraphCaptureWithMaxBatch
 OGA_EXPORT OgaResult* OGA_API_CALL OgaGeneratorParamsSetGuidance(OgaGeneratorParams* params, const char* type, const char* data);
 
 /**
+ * \brief Sets whether to enable ff_tokens during constrained decoding for the Generator params
+ * \param[in] params The generator params to set the guidance on
+ * \param[in] enabled Whether to enable ff_tokens generation. Only valid when guidance type is set and batch_size is 1.
+ * \return OgaResult containing the error message if the setting of the guidance failed
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaGeneratorParamsSetGuidanceFFTokens(OgaGeneratorParams* params, bool enabled);
+
+/**
  * \brief Creates a generator from the given model and generator params.
  * \param[in] model The model to use for generation.
  * \param[in] params The parameters to use for generation.

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -200,6 +200,10 @@ struct PyGeneratorParams {
     params_->SetGuidance(type.c_str(), data.c_str());
   }
 
+  void SetGuidanceFFTokens(bool enabled) {
+    params_->SetGuidanceFFTokens(enabled);
+  }
+
   std::vector<pybind11::object> refs_;  // References to data we want to ensure doesn't get garbage collected
 };
 
@@ -337,7 +341,8 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def(pybind11::init<const OgaModel&>())
       .def("try_graph_capture_with_max_batch_size", &PyGeneratorParams::TryGraphCaptureWithMaxBatchSize)
       .def("set_search_options", &PyGeneratorParams::SetSearchOptions)  // See config.h 'struct Search' for the options
-      .def("set_guidance", &PyGeneratorParams::SetGuidance);
+      .def("set_guidance", &PyGeneratorParams::SetGuidance)
+      .def("set_guidance_ff_tokens", &PyGeneratorParams::SetGuidanceFFTokens);
 
   pybind11::class_<OgaTokenizerStream>(m, "TokenizerStream")
       .def("decode", [](OgaTokenizerStream& t, int32_t token) { return t.Decode(token); });


### PR DESCRIPTION
### What changed
Add params.set_guidance_ff_tokens(enabled) function to enable fast-forward tokens in llguidance library.

When using constrained grammar, llguidance can `suggest` the next multiple tokens because those tokens are the only valid tokens in the next few steps (e.g., `{"name": ` in json constraint). 

So instead generating one token per generation, we can generate more than one per iter, hence improving tokens/s metric.

### How to use
```
    guidance_type = "lark_grammar"
    guidance_input = f"""start: %json {json.dumps(schema)}\n"""
    params.set_search_options(**search_options)
    params.set_guidance(guidance_type, guidance_input) # set guidance
    params.set_guidance_ff_tokens(True)  # enable guidance feed-forward tokens
```