### PR TITLE
Avoid Processing EOS Token During Continuous Decoding

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -350,10 +350,6 @@ void Generator::AppendTokens(cpu_span<const int32_t> input_ids) {
     set_extra_inputs_ = false;
   }
 
-  if (last_action_ == Action::generated) {
-    ComputeLogits(search_->GetNextTokens());
-  }
-
   auto input_ids_device = AllocateInputIdsOnDevice(input_ids);
   search_->AppendTokens(input_ids_device);
   computed_logits_ = false;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -155,7 +155,8 @@ void GreedySearch_Cpu::SelectTop() {
     SetNextToken(batch_id, token);
   }
 
-  AppendNextTokensToSequences();
+  if (!done_)
+    AppendNextTokensToSequences();
 }
 
 void GreedySearch_Cpu::SampleTopK(int k, float temperature) {
@@ -176,7 +177,8 @@ void GreedySearch_Cpu::SampleTopK(int k, float temperature) {
     std::discrete_distribution<> dis(top_k_scores.begin(), top_k_scores.end());
     SetNextToken(batch_id, indices[dis(gen_)]);
   }
-  AppendNextTokensToSequences();
+  if (!done_)
+    AppendNextTokensToSequences();
 }
 
 void GreedySearch_Cpu::SampleTopP(float p, float temperature) {
@@ -214,7 +216,8 @@ void GreedySearch_Cpu::SampleTopP(float p, float temperature) {
 
     SetNextToken(batch_id, token);
   }
-  AppendNextTokensToSequences();
+  if (!done_)
+    AppendNextTokensToSequences();
 }
 
 void GreedySearch_Cpu::SampleTopKTopP(int k, float p, float temperature) {
@@ -273,7 +276,8 @@ void GreedySearch_Cpu::SampleTopKTopP(int k, float p, float temperature) {
     int32_t token = indices[sampled_k_index];
     SetNextToken(batch_id, token);
   }
-  AppendNextTokensToSequences();
+  if (!done_)
+    AppendNextTokensToSequences();
 }
 
 bool GreedySearch_Cpu::PadIfAlreadyEOS(size_t batch_id) {


### PR DESCRIPTION
A previous pull request https://github.com/microsoft/onnxruntime-genai/pull/1110 introduced a change that caused the generator to compute the key-value cache for end-of-sequence tokens during continuous decoding.

However, EOS tokens should not be included in the input sequence being processed, nor should they be accounted for in the key-value cache. This pull request updates the logic to entirely skip processing of EOS tokens, ensuring they are excluded from the key-value cache computation.