### PR TITLE
Refactor past_present_share_buffer logic into reusable function

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -266,6 +266,14 @@ void GeneratorParams::SetGuidance(std::string_view type, std::string_view data) 
   guidance_data = data;
 }
 
+bool GeneratorParams::IsPastPresentShareBufferEnabled(const std::string& model_type) const {
+  // past_present_share_buffer is only actually enabled when:
+  // 1. The config option is set to true, AND
+  // 2. Either num_beams == 1 OR the model is Whisper
+  return search.past_present_share_buffer &&
+         (search.num_beams == 1 || model_type == "whisper");
+}
+
 std::unique_ptr<Generator> CreateGenerator(const Model& model, const GeneratorParams& params) {
   return std::make_unique<Generator>(model, params);
 }

--- a/src/generators.h
+++ b/src/generators.h
@@ -84,6 +84,10 @@ struct GeneratorParams : std::enable_shared_from_this<GeneratorParams>, LeakChec
   std::string guidance_type;  // e.g. json_schema or regex
   std::string guidance_data;  // e.g. rules data in json_schema or regex
   void SetGuidance(std::string_view type, std::string_view data);
+
+  // Determines if past_present_share_buffer is actually enabled based on config and runtime conditions
+  // Returns true only if config option is true AND (num_beams == 1 OR model is Whisper)
+  bool IsPastPresentShareBufferEnabled(const std::string& model_type) const;
 };
 
 struct Generator : LeakChecked<Generator> {

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -149,7 +149,7 @@ void CombinedKeyValueCache::PickPastState(DeviceSpan<int32_t> beam_indices, int 
 DefaultKeyValueCache::DefaultKeyValueCache(State& state)
     : state_{state},
       layer_count_{model_.config_->model.decoder.num_hidden_layers},
-      past_present_share_buffer_{state_.params_->search.past_present_share_buffer && (state_.params_->search.num_beams == 1 || model_.config_->model.type == "whisper")},
+      past_present_share_buffer_{state_.params_->IsPastPresentShareBufferEnabled(model_.config_->model.type)},
       shape_{state_.params_->BatchBeamSize(), model_.config_->model.decoder.num_key_value_heads, 0, model_.config_->model.decoder.head_size} {
   if (g_log.enabled && g_log.warning && past_present_share_buffer_ != state_.params_->search.past_present_share_buffer)
     Log("warning", "past_present_share_buffer search option set to true, but has been disabled due to the current configuration. See https://aka.ms/generate_config for details");

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -327,7 +327,7 @@ void DefaultPositionInputs::RewindMask(size_t index) {
 
 bool DefaultPositionInputs::ShouldUseStaticMaskHandling() const {
   return state_.params_->use_graph_capture ||
-         (state_.params_->search.past_present_share_buffer &&
+         (state_.params_->IsPastPresentShareBufferEnabled(model_.config_->model.type) &&
           model_.p_device_->GetType() == DeviceType::NvTensorRtRtx);
 }
 


### PR DESCRIPTION
- Add IsPastPresentShareBufferEnabled() method to GeneratorParams
- Consolidate logic for determining if past_present_share_buffer should be enabled
- Replace inline conditions in kv_cache.cpp and position_inputs.cpp with function call
- Improves maintainability by providing single source of truth
- Logic: enabled only when config is true AND (num_beams == 1 OR model is Whisper)