### PR TITLE
Change OpenVINO ep device selection priority

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -664,9 +664,9 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
       // for OpenVINO, fallback to "device_type" in provider_options if no device filtering is specified
       std::optional<std::string> config_ov_device_type = std::nullopt;
       if (provider_options.name == "OpenVINO" &&
-        !config_device_id.has_value() &&
-        !config_vendor_id.has_value() &&
-        !config_device_type_enum.has_value()) {
+          !config_device_id.has_value() &&
+          !config_vendor_id.has_value() &&
+          !config_device_type_enum.has_value()) {
         for (auto& option : provider_options.options) {
           if (option.first == "device_type") {
             config_ov_device_type = option.second;


### PR DESCRIPTION
## Why is this change made
GenAI added the ep device selection APIs for selecting ep devices according to the given ep name, device type, device vendor id and device id. However, the legacy OpenVINO specific device filtering logic has a higher priority than the new API. Causing the APIs ineffective when the "device_type" is specified in a OpenVINO genai_config.json. 
## What changed
This PR adjusts the two method's priority. So the new API can override what's provided in the config file.