### PR TITLE
Enable If Node Support for TRT-RTX in Phi-3.5/Phi-4 LongRoPE Models

### DIFF
--- a/.github/workflows/win-winml-x64-build.yml
+++ b/.github/workflows/win-winml-x64-build.yml
@@ -15,8 +15,8 @@ env:
   AZCOPY_AUTO_LOGIN_TYPE: MSI
   AZCOPY_MSI_CLIENT_ID: 63b63039-6328-442f-954b-5a64d124e5b4
   cuda_dir: "${{ github.workspace }}\\cuda_sdk"
-  cuda_version: "12.4"
-  CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v12.4
+  cuda_version: "12.2"
+  CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v12.2
   binaryDir: 'build/cuda/win-x64'
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Windows&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime.Gpu.Windows"


### PR DESCRIPTION
## Problem

Models with LongRoPE (Phi-3.5, Phi-4) use If nodes to conditionally select between small (4K) and large (128K) rotary embedding caches. TRT-RTX execution provider has two issues preventing proper If node execution:

### Issue 1: Mismatched Dimensions
TRT-RTX requires uniform output dimensions in both If node branches. Current implementation has mismatched shapes:
- Then branch (large cache): (131072, 48)
- Else branch (small cache): (4096, 48)

**Previous workaround**: Concatenate both caches into a single tensor, avoiding If nodes entirely.

### Issue 2: trt-rtx Multi-Output Bug
TRT-RTX has a bug where If nodes with multiple outputs cause tensor overwriting. When outputting `[cos_cache, sin_cache]` together, assigns both to the same memory location, corrupting `cos_cache`.

## Solution

Implemented **two workarounds** specifically for TRT-RTX:

### Workaround 1: Padding to Uniform Dimensions

Pad small cache from (4096, 48) to (131072, 48) using mathematically correct values:
- **cos_cache**: Pad with `1.0` (cos(0) = 1)
- **sin_cache**: Pad with `0.0` (sin(0) = 0)

This achieves uniform dimensions while preserving rotary embedding correctness.

### Workaround 2: Split Multi-Output If Nodes

Split one If node with 2 outputs into two separate If nodes with 1 output each:

**Before**:
```
If node → outputs: [cos_cache, sin_cache]  (2 outputs = trt-rtx bug)
```

**After**:
```
If_cos node → output: cos_cache  (1 output)
If_sin node → output: sin_cache  (1 output)
```

Both If nodes use the same condition and select their respective caches independently, avoiding the trt-rtx tensor overwriting bug.

## Changes

### Modified Files
- `src/python/py/models/builder.py`

### Key Modifications
1. Added `_pad_cache_to_uniform_shape()` helper method for padding
2. Removed TRT-RTX from DML concatenation workaround
3. Apply padding to small caches for TRT-RTX (cos=1, sin=0)
4. Create 2 separate If nodes for TRT-RTX instead of 1 multi-output If node
5. Preserve original single If node behavior for other EPs

**Please note that this is a temporary workaround, final fix will come in the trt-rtx backend** 