### PR TITLE
Shared emb_tokens/lm_head on fp16 & uint4 weights

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -385,8 +385,8 @@ class Model:
             )
 
             # Allow extra_options to override use_packed_matmul
-            if "unpack_matmul" in extra_options:
-                self.attention_attrs["use_packed_matmul"] = not extra_options.get("unpack_matmul", False)
+            if "unpack_matmul" in self.extra_options:
+                self.attention_attrs["use_packed_matmul"] = not self.extra_options.get("unpack_matmul", False)
 
             # Some EPs don't support fusing rotary embeddings inside GQA yet
             self.attention_attrs["use_rope_in_attn"] = self.ep not in ["dml"]


### PR DESCRIPTION
## Problem

The current model builder doesn't support shared embeddings layers with 4bit qweights and 16bit float weights, which occupies more room in disk (unnecessary for originally tied embeddings models) and hurts compression rate for quantized models. builder.py doesn't provide flexible options to toggle the graph construction and quantization config, like unpacked/packed matmul, rtn, kquant, etc. 

## Solution

Calculated flat_dim in a more generic way on reshape node before `GatherBlockQuantized` (support 4bit and 8bit).
Added CUDA kernel support in ORT [#26484](https://github.com/microsoft/onnxruntime/pull/26484).  
Added more extra_options to enable different quant configs and pack options, and shared embeddings.

Running examples:
**unpacked qkv_projs and shared 4 bit RTN on Llama3.2 1B Instruct**:
```
python src/python/py/models/builder.py -m meta-llama/Llama-3.2-1B-Instruct -p int4 -e cuda -o export_model/llama32_1bi_rtn_4_4_unpacked_tied --extra_options int4_is_symmetric=false unpack_matmul=true int4_algo_config=rtn
```

**shared 4 bit k_quant on Phi-4-Mini Instruct**:
```
python src/python/py/models/builder.py -m microsoft/Phi-4-Mini-Instruct -p int4 -e cuda -o export_model/phi4mini_i_kquant_4_4_tied --extra_options int4_is_symmetric=false unpack_matmul=true int4_algo_config=k_quant
```

**shared 16 bit float emb on Phi-4-Mini Instruct**:
```
python src/python/py/models/builder.py -m microsoft/Phi-4-Mini-Instruct -p fp16 -e cuda -o export_model/phi4mini_i_fp16_tied --extra_options shared_embeddings=true
```

## Changes

### Modified Files
- `src/python/py/models/builder.py`

### Key Modifications
1. Computed `flat_dim` in a generic manner before feeding in `GatherBlockQuantized`.
2. Explicitly defined gather_axis and quantize_axis for clarity.
3. Added `unpack_matmul` option to separate qvk_proj if needed.
4. Added `shared_embeddings` option to tied embed_tokens/lm_head.
5. Added `rtn_last` like `k_quant_last` as a new mixed precision option
6. Added `k_quant` like `rtn` as a new 4 bit quantizer option
