### PR TITLE
Fix bug in Squeeze for getting the value of total_seq_len

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -911,7 +911,7 @@ class Model:
         self.make_node("Expand", inputs=inputs, outputs=[output], name=name)
         self.make_value(output, dtype, shape=shape)
 
-    def make_reduce_sum(self, name, inputs, dtype, shape, keepdims=True):
+    def make_reduce_sum(self, name, inputs, dtype, shape, keepdims=False):
         output = f"{name}/output_0"
         self.make_node("ReduceSum", inputs=inputs, outputs=[output], name=name, keepdims=keepdims)
         self.make_value(output, dtype, shape=shape)
@@ -4187,7 +4187,7 @@ class Model:
         )
         reduce_sum_name = f"{attn_mask_basename}/ReduceSum"
         reduce_sum_inputs = [f"{cast_1_name}/output_0", "/model/constants/INT64/[1]"]
-        self.make_reduce_sum(reduce_sum_name, reduce_sum_inputs, dtype=ir.DataType.INT32, shape=["batch_size"], keepdims=False)
+        self.make_reduce_sum(reduce_sum_name, reduce_sum_inputs, dtype=ir.DataType.INT32, shape=["batch_size"])
 
         # Left branch: Calculate seqlens_k = ReduceSum - 1
         sub_name = f"{attn_mask_basename}/Sub"
@@ -4221,7 +4221,7 @@ class Model:
         # Left path
         reduce_sum_name = f"{attn_mask_basename}/ReduceSum"
         reduce_sum_inputs = ["attention_mask", "/model/constants/INT64/[1]"]
-        self.make_reduce_sum(reduce_sum_name, reduce_sum_inputs, dtype=ir.DataType.INT64, shape=["batch_size"], keepdims=False)
+        self.make_reduce_sum(reduce_sum_name, reduce_sum_inputs, dtype=ir.DataType.INT64, shape=["batch_size"])
         sub_name = f"{attn_mask_basename}/Sub"
         sub_inputs = [f"{reduce_sum_name}/output_0", "/model/constants/INT64/[1]"]
         self.make_sub(sub_name, sub_inputs, dtype=ir.DataType.INT64, shape=["batch_size"])
@@ -4273,7 +4273,7 @@ class Model:
         # Left path
         reduce_sum_name = f"{attn_mask_basename}/ReduceSum"
         reduce_sum_inputs = ["attention_mask", "/model/constants/INT64/[1]"]
-        self.make_reduce_sum(reduce_sum_name, reduce_sum_inputs, dtype=ir.DataType.INT64, shape=["batch_size"], keepdims=False)
+        self.make_reduce_sum(reduce_sum_name, reduce_sum_inputs, dtype=ir.DataType.INT64, shape=["batch_size"])
         cast_1_name = f"{attn_mask_basename}/ReduceSum/Cast"
         self.make_cast(cast_1_name, f"{reduce_sum_name}/output_0", dtype=ir.DataType.INT32, shape=["batch_size"])
 

--- a/src/python/py/models/builders/gptoss.py
+++ b/src/python/py/models/builders/gptoss.py
@@ -519,7 +519,6 @@ class GPTOSSModel(Model):
             reduce_sum_inputs,
             dtype=ir.DataType.FLOAT,
             shape=["batch_size", "sequence_length", self.intermediate_size, 1],
-            keepdims=False,
         )
         weighted_sum_squeeze_name = f"{basename}/weighted_sum/Squeeze"
         weighted_sum_squeeze_inputs = [f"{reduce_sum_name}/output_0", "/model/constants/INT64/[-1]"]


### PR DESCRIPTION
The `Squeeze` op is used for removing single-dimensional entries from the shape of a tensor. In this node the `axes` input is set to `[0]` which would only eliminate the first axis and lead to the output shape to be `[1]` if the `batch_size` is 1.This would cause ShapeInference error at https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/graph/graph.cc#L111-L132 if it is not a strict mode.

This PR fixes the issue by:
-  Changing the ReduceSum output shape to [batch_size] by adding keepdims=0 attribute
-  Using ReduceMax instead of Squeeze to get the value of total_seq_len and make it as a scalar, this would cover scenarios when batch_size > 1