### PR TITLE
Also clear provider_options when ClearProviders is called

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1053,6 +1053,7 @@ void SetSearchBool(Config::Search& search, std::string_view name, bool value) {
 
 void ClearProviders(Config& config) {
   config.model.decoder.session_options.providers.clear();
+  config.model.decoder.session_options.provider_options.clear();
 }
 
 void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value) {


### PR DESCRIPTION
When SetProviderOption is called with a new options, it creates a new provider_option that gets appended to the existing provider_option array set by the json config, and since the first one is used it doesn't enable that option for that provider.

This commit here seems to only erase the options in the first element:
https://github.com/microsoft/onnxruntime-genai/commit/9cff9fe1218b6dc47a243286ad3386cf43d9e6ee

This seems to be the behavior
```cpp
// After calling set_provider_option("NvTensorRtRtx", "enable_cuda_graph", "0")
provider_options = [
  {"name": "NvTensorRtRtx", "options": []},  // Original from genai_config.json erased by SetProviderOption 
  {"name": "NvTensorRtRtx", "options": [("enable_cuda_graph", "0")]}   // Newly appended
]
```

This fix will clear provider_options when ClearProviders is called so when SetProviderOption is used it only adds single array