### PR TITLE
expose start/end profiling API in Models class

### DIFF
--- a/src/models/model.h
+++ b/src/models/model.h
@@ -133,8 +133,11 @@ struct SessionInfo {
   std::vector<const char*> GetInputSymbolicShape(const std::string& name) const;
   std::vector<const char*> GetOutputSymbolicShape(const std::string& name) const;
 
+  const std::vector<OrtSession*>& GetSessions() const { return sessions_; }
+
  private:
   std::unordered_map<std::string, std::unique_ptr<OrtTypeInfo>> inputs_, outputs_;
+  std::vector<OrtSession*> sessions_;
 };
 
 struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model>, ExternalRefCounted<Model> {
@@ -146,6 +149,9 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model>, External
   std::shared_ptr<MultiModalProcessor> CreateMultiModalProcessor() const;
 
   virtual std::unique_ptr<State> CreateState(DeviceSpan<int32_t> sequence_lengths, const GeneratorParams& params) const = 0;
+
+  void StartProfiling() const;
+  std::string EndProfiling() const;
 
   std::unique_ptr<OrtValue> ExpandInputs(std::unique_ptr<OrtValue>& input, int num_beams) const;
 

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -718,6 +718,10 @@ struct OrtSession {
    */
   std::vector<std::string> GetOverridableInitializerNames() const;
 
+  /** \brief Starts profiling for this session.
+   */
+  void StartProfiling();  ///< Wraps OrtApi::SessionStartProfiling
+
   /** \brief Returns a copy of the profiling file name.
    */
   std::string EndProfiling();                                  ///< Wraps OrtApi::SessionEndProfiling

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -837,6 +837,10 @@ inline std::vector<std::string> OrtSession::GetOverridableInitializerNames() con
   return out;
 }
 
+inline void OrtSession::StartProfiling() {
+  Ort::ThrowOnError(Ort::api->SessionStartProfiling(this));
+}
+
 inline std::string OrtSession::EndProfiling() {
   Ort::StringAllocator string_allocator;
   Ort::ThrowOnError(Ort::api->SessionEndProfiling(this, &string_allocator, &string_allocator.out));

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -253,6 +253,16 @@ struct OgaModel : OgaAbstract {
     return p;
   }
 
+  void StartProfiling() {
+    OgaCheckResult(OgaModelStartProfiling(this));
+  }
+
+  OgaString EndProfiling() {
+    const char* p;
+    OgaCheckResult(OgaModelEndProfiling(this, &p));
+    return p;
+  }
+
   static void operator delete(void* p) { OgaDestroyModel(reinterpret_cast<OgaModel*>(p)); }
 };
 

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -359,6 +359,20 @@ OgaResult* OGA_API_CALL OgaModelGetDeviceType(const OgaModel* model, const char*
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaModelStartProfiling(OgaModel* model) {
+  OGA_TRY
+  model->StartProfiling();
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OGA_API_CALL OgaModelEndProfiling(OgaModel* model, const char** out) {
+  OGA_TRY
+  *out = AllocOgaString(model->EndProfiling());
+  return nullptr;
+  OGA_CATCH
+}
+
 OgaResult* OGA_API_CALL OgaCreateGeneratorParams(const OgaModel* model, OgaGeneratorParams** out) {
   OGA_TRY
   auto params = std::make_shared<Generators::GeneratorParams>(*model);

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -386,6 +386,21 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaModelGetType(const OgaModel* model, const 
 OGA_EXPORT OgaResult* OGA_API_CALL OgaModelGetDeviceType(const OgaModel* model, const char** out);
 
 /**
+ * \brief Starts profiling for the model.
+ * \param[in] model The model to start profiling for.
+ * \return OgaResult containing the error message if the starting of profiling failed.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaModelStartProfiling(OgaModel* model);
+
+/**
+ * \brief Ends profiling for the model.
+ * \param[in] model The model to end profiling for.
+ * \param[out] out The path to the profile file. Must be destroyed with OgaDestroyString
+ * \return OgaResult containing the error message if the ending of profiling failed.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaModelEndProfiling(OgaModel* model, const char** out);
+
+/**
  * \brief Destroys the given config
  * \param[in] config The config to be destroyed.
  */

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -450,7 +450,9 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def_property_readonly("type", [](const OgaModel& model) -> std::string { return model.GetType().p_; })
       .def_property_readonly(
           "device_type", [](const OgaModel& model) -> std::string { return model.GetDeviceType().p_; }, "The device type the model is running on")
-      .def("create_multimodal_processor", [](const OgaModel& model) { return OgaMultiModalProcessor::Create(model); });
+      .def("create_multimodal_processor", [](const OgaModel& model) { return OgaMultiModalProcessor::Create(model); })
+      .def("start_profiling", [](OgaModel& model) { model.StartProfiling(); })
+      .def("end_profiling", [](OgaModel& model) -> std::string { return model.EndProfiling().p_; });
 
   pybind11::class_<PyGenerator>(m, "Generator")
       .def(pybind11::init<const OgaModel&, PyGeneratorParams&>())


### PR DESCRIPTION
GenAI does not support profiling within a specific time range. This PR addresses it.

This PR introduces `start_profiling()` and `end_profiling()` APIs in the Model class, allowing developers to perform profiling only within a selected time span.

A Model owns an ONNX Runtime Session and the relationship is 1:1. Since profiling in ORT operates at the session level, we expose these APIs at the Model layer to make profiling control more accessible.

Note: We don't want to expose these in Generator layer. Because we have a concern for Generator A start profiling and Generator B end profiling.