### PR TITLE
WinML - Remove the inclusive Microsoft.WindowsAppSDK.ML range check

### DIFF
--- a/.pipelines/nuget-publishing.yml
+++ b/.pipelines/nuget-publishing.yml
@@ -68,11 +68,6 @@ parameters:
     type: string
     default: '1.8.2091'
 
-  - name: ort_nuget_winml_package_reference_version
-    displayName: 'Reference verison for Microsoft.WindowsAppSDK.ML.'
-    type: string
-    default: '[1.8.2001,1.8.3000]'
-
   - name: ort_cuda_version
     displayName: 'OnnxRuntime GPU version'
     type: string
@@ -178,7 +173,6 @@ extends:
           nuget_version_type: ${{ parameters.nuget_version_type }}
           enable_winml: ${{ parameters.enable_winml }}
           ort_winml_version: ${{ parameters.ort_winml_version }}
-          ort_nuget_winml_package_reference_version: ${{ parameters.ort_nuget_winml_package_reference_version }}
 
       - ${{ if eq(parameters.enable_post_packaging_validation, true) }}:
           - template: stages/nuget-validation-stage.yml

--- a/.pipelines/stages/jobs/winml-nuget-packaging-job.yml
+++ b/.pipelines/stages/jobs/winml-nuget-packaging-job.yml
@@ -8,9 +8,6 @@ parameters:
   - name: ort_winml_version
     type: string
 
-  - name: ort_nuget_winml_package_reference_version
-    type: string
-
 jobs:
   - job: winml_nuget_packaging
     displayName: 'WinML NuGet Packaging'
@@ -84,7 +81,8 @@ jobs:
           Write-Host $artifacts
 
           Write-Host "${{ parameters.ort_winml_version }}"
-          Write-Host "${{ parameters.ort_nuget_winml_package_reference_version }}"  
+
+          $ort_winml_version = "${{ parameters.ort_winml_version }}"
 
           $outputDir = '$(Build.BinariesDirectory)/artifact-downloads'
           Write-Host "List extracted artifacts"
@@ -126,13 +124,13 @@ jobs:
           addToPath: true
 
       - powershell: |
-          # Package dependencie
+          # Package dependencies
 
           $ort_nuget_package_name = "Microsoft.WindowsAppSDK.ML"
-          $ort_nuget_winml_package_reference_version = "${{ parameters.ort_nuget_winml_package_reference_version }}"
+          $ort_nuget_winml_package_reference_version = "${{ parameters.ort_winml_version }}"
 
-          Write-Host "ort_nuget_package_name: $ort_nuget_package_name "
-          Write-Host "ort_nuget_winml_package_reference_version: $ort_nuget_winml_package_reference_version "
+          Write-Host "ort_nuget_package_name: $ort_nuget_package_name"
+          Write-Host "ort_nuget_winml_package_reference_version: $ort_nuget_winml_package_reference_version"
 
           $genai_nuget_package_name = "Microsoft.ML.OnnxRuntimeGenAI.WinML"
           Write-Host "##vso[task.setvariable variable=genai_nuget_package_name;]$genai_nuget_package_name"

--- a/.pipelines/stages/nuget-packaging-stage.yml
+++ b/.pipelines/stages/nuget-packaging-stage.yml
@@ -73,9 +73,6 @@ parameters:
 - name: ort_winml_version
   type: string
 
-- name: ort_nuget_winml_package_reference_version
-  type: string
-
 stages:
 - stage: nuget_packaging
   jobs:
@@ -85,7 +82,6 @@ stages:
           nuget_version_type: ${{ parameters.nuget_version_type }}
           ort_winml_version: ${{ parameters.ort_winml_version }}
           build_config: ${{ parameters.build_config }}
-          ort_nuget_winml_package_reference_version: ${{ parameters.ort_nuget_winml_package_reference_version }}
 
     - ${{ if or(eq(parameters.enable_linux_cpu, true), eq(parameters.enable_win_cpu, true), eq(parameters.enable_macos_cpu, true)) }}:
       - template: jobs/nuget-packaging-job.yml


### PR DESCRIPTION
We originally worried about combability issues between GenAI and the OnnxRuntime provided by `Microsoft.WindowsAppSDK.ML`.  We have since confirmed we only need the lower bound.

- Remove the `ort_nuget_winml_package_reference_version` pipeline parameters.
- Use the version of `Microsoft.WindowsAppSDK.ML` as the lower bound in the dependency reference.
