### PR TITLE
Disable CUDA graph for Phi LongRoPE models with IF nodes on TRT-RTX

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -118,7 +118,6 @@ class Model:
 
         # EP-specific variables
         self.ep = ep
-        self.has_if_nodes = False  # Track whether model contains IF nodes
         self.ep_attrs = {
             "cpu": {},
             "cuda": {
@@ -1969,7 +1968,7 @@ class Model:
                 sin_cache_small_name=sin_cache_small_name,
                 small_cache_shape=cos_cache_large.shape,
             )
-            self.has_if_nodes = True
+            self.ep_attrs["trt-rtx"]["enable_cuda_graph"] = "0"
             return
 
         # For other EPs (CUDA, CPU, WebGPU), create regular If node with multiple outputs
@@ -2067,7 +2066,6 @@ class Model:
                 name="small_rotemb_caches_graph",
             ),
         )
-        self.has_if_nodes = True
         self.make_value(cos_cache_name, self.io_dtype, shape=["max_sequence_length", "head_dim / 2"])
         self.make_value(sin_cache_name, self.io_dtype, shape=["max_sequence_length", "head_dim / 2"])
 

--- a/src/python/py/models/builders/phi.py
+++ b/src/python/py/models/builders/phi.py
@@ -57,10 +57,6 @@ class Phi3MiniLongRoPEModel(Phi3MiniModel):
         super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
         self.make_rotary_embedding_multi_cache()
 
-        # Disable CUDA graph for TRT-RTX when IF nodes are present
-        if self.ep == "trt-rtx" and self.has_if_nodes:
-            self.ep_attrs["trt-rtx"]["enable_cuda_graph"] = "0"
-
         # Set position_ids_name based on whether position_ids is available as an input
         if "position_ids" in self.input_names:
             position_ids_result = self.make_position_ids_reformatting()
@@ -444,10 +440,6 @@ class Phi3SmallLongRoPEModel(Phi3SmallModel):
         super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
         self.make_rotary_embedding_multi_cache()
 
-        # Disable CUDA graph for TRT-RTX when IF nodes are present
-        if self.ep == "trt-rtx" and self.has_if_nodes:
-            self.ep_attrs["trt-rtx"]["enable_cuda_graph"] = "0"
-
 
 class Phi3VModel(Phi3MiniLongRoPEModel):
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
@@ -461,10 +453,6 @@ class Phi3MoELongRoPEModel(MistralModel):
         self.layernorm_attrs["simple"] = False
         self.moe_attrs["use_sparse_mixer"] = True
         self.make_rotary_embedding_multi_cache()
-
-        # Disable CUDA graph for TRT-RTX when IF nodes are present
-        if self.ep == "trt-rtx" and self.has_if_nodes:
-            self.ep_attrs["trt-rtx"]["enable_cuda_graph"] = "0"
 
     def make_layer(self, layer_id, layer):
         # Each LLM decoder layer is typically defined as:


### PR DESCRIPTION
Disable CUDA graph for Phi LongRoPE models with IF nodes on TRT-RTX

This change disables CUDA graph for the following
models when targeting TRT-RTX:
- Phi3MiniLongRoPEModel
- Phi3SmallLongRoPEModel
- Phi3MoELongRoPEModel
