### PR TITLE
Make phi model of webgpu ep always use long RoPE to improve tps performance for long context scenario

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -497,8 +497,10 @@ void Generator::GenerateNextToken() {
   // at this stage which is achieved by rewinding to zero and appending the current sequence
   // Scenarios where this solution works: Batch size = 1, Num beams = 1, decoder model, EP is either CPU or CUDA
   // Scenarios where it doesn't work: Batch size > 1 OR Num beams > 1 OR Multimodal model (like phi3 vision) OR EP is DML
+  // Skip this logic for WebGPU EP as it already uses long RoPE scaling graph for all sequence lengths
   if (search_->params_->BatchBeamSize() == 1 && !epUsesSingleRopeFactor) {
-    if (((search_->GetSequenceLength() == 4097) && (model_->config_->model.type == "phi3" || model_->config_->model.type == "phimoe")) || ((search_->GetSequenceLength() == 8193) && (model_->config_->model.type == "phi3small"))) {
+    if (model_->p_device_->GetType() != DeviceType::WEBGPU &&
+      (((search_->GetSequenceLength() == 4097) && (model_->config_->model.type == "phi3" || model_->config_->model.type == "phimoe")) || ((search_->GetSequenceLength() == 8193) && (model_->config_->model.type == "phi3small")))) {
       auto current_seq = cpu_span<int32_t>(GetSequence(0).CopyDeviceToCpu());
       RewindToLength(0);
       AppendTokens(current_seq);

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1921,8 +1921,6 @@ class Model:
 
         # Determine which EPs don't support the If operator
         self.eps_without_if_support = ["dml"]
-        if self.extra_options.get("enable_webgpu_graph", False):
-            self.eps_without_if_support.append("webgpu")
 
         if self.ep in self.eps_without_if_support:
             cos_cache = torch.cat((cos_cache_small, cos_cache_large), dim=0)
@@ -1931,6 +1929,16 @@ class Model:
             self.make_initializer(cos_cache, cos_cache_name)
             self.make_initializer(sin_cache, sin_cache_name)
             # Do NOT make the subgraph with the If node for DML EP.
+            return
+        
+        # WebGPU: Always use large caches to avoid the short to long factor switch
+        # if there is no correctness issue for all lengths of tokens
+        if self.ep == "webgpu":
+            cos_cache = cos_cache_large
+            sin_cache = sin_cache_large
+            # Save cos/sin caches to disk
+            self.make_initializer(cos_cache, cos_cache_name)
+            self.make_initializer(sin_cache, sin_cache_name)
             return
 
         # TRT-RTX: Apply padding and create split If nodes with early return


### PR DESCRIPTION
We found a perf regression issue for long context which is described in this ticket https://github.com/microsoft/onnxruntime-genai/issues/1910. This PR proposed a fix to avoid the switch from short factor to long factor on webgpu ep of phi model to mitigate above issues caused by recomputation of position IDs and KV cache when switching to long factor. The experimental results from benchmark_e2e.py shows that it can generate the response tokens without perf regression for short(< 1000), middle(> 1000 and < 4097) and long(> 4097) sequence length. The fix includes two pieces:
1. In src/python/py/models/builders/base.py, for webgpu ep, we always use large cos/sin so that the model doesn't need the short-long switch.
`cos_cache = cos_cache_large`
`sin_cache = sin_cache_large`
2. In src/generators.cpp, for webgpu ep, we will skip the workaround fix of recomputation of position IDs and KV cache for the short to long factor switch, and always use the long factor for the model which is converted by above base.py.

Pls note this is not final fix for the issue, just demonstrating a reasonable direction to discuss and move forward.

I have tested against this change with below command:

Convert model: `python3 builder.py -m /Volumes/workspace/ort-web-perf/models/Phi-4-mini-instruct -o /Volumes/workspace/ort-web-perf/models/Phi-4-mini-instruct-onnx-optimized -p int4 -e webgpu --extra_options int4_accuracy_level=4 int4_algo_config=k_quant_last`

Run beachmark like below commands:
- Long context (7936+6000): `benchmark/python/benchmark_e2e.py -i /Volumes/workspace/ort-web-perf/models/Phi-4-mini-instruct-onnx-optimized -l 7936 -g 6000 --use_prompt_set -mo`
- Long context (4096+6000): `benchmark/python/benchmark_e2e.py -i /Volumes/workspace/ort-web-perf/models/Phi-4-mini-instruct-onnx-optimized -l 4096 -g 6000 --use_prompt_set -mo`
- Long context (4096+2000): `benchmark/python/benchmark_e2e.py -i /Volumes/workspace/ort-web-perf/models/Phi-4-mini-instruct-onnx-optimized -l 4096 -g 2000 --use_prompt_set -mo`
- Middle context: `benchmark/python/benchmark_e2e.py -i /Volumes/workspace/ort-web-perf/models/Phi-4-mini-instruct-onnx-optimized -l 2048 -g 1000 --use_prompt_set -mo`
- Short context: `benchmark/python/benchmark_e2e.py -i /Volumes/workspace/ort-web-perf/models/Phi-4-mini-instruct-onnx-optimized -l 256 -g 300 --use_prompt_set -mo`

Perf and Correctness Comparsion(Metrics: tps - average tokens generated per second, Original Solution means original model+generator, Proposed Solution means the updated model+generator by this pr)
| Length  | Original Solution | Proposed Solution |
|-------|-----|-----------|
| Long Context (7936+6000) | 22.62(Correctness: True) | 24.49(Correctness: True) |
| Long Context (4096+6000) | 26.26(Correctness: True) | 29.83(Correctness: True) |
| Long Context (4096+2000) | 26.84(Correctness: True) | 34.1(Correctness: True) |
| Middle Context (2048+1000) | 38.35(Correctness: True) | 38.54(Correctness: True) |
| Short Context (256+300) | 43.74(Correctness: True) | 43.54(Correctness: True) |