### PR TITLE
Add Support for Toggling Guidance

### DIFF
--- a/src/csharp/Generator.cs
+++ b/src/csharp/Generator.cs
@@ -121,6 +121,25 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
                                                                    StringUtils.ToUtf8(adapterName)));
         }
 
+        /// <summary>
+        /// Toggles the guidance (constrained decoding) on or off.
+        /// Throws on error.
+        /// </summary>
+        /// <param name="enable">true to enable, false to disable</param>
+        public void ToggleGuidance(bool enable)
+        {
+            Result.VerifySuccess(NativeMethods.OgaGeneratorToggleGuidance(_generatorHandle, enable));
+        }
+
+        /// <summary>
+        /// Returns whether the guidance (constrained decoding) is enabled.
+        /// </summary>
+        /// <returns>true if guidance is enabled, false otherwise</returns>
+        public bool IsGuidanceEnabled()
+        {
+            return NativeMethods.OgaGeneratorIsGuidanceEnabled(_generatorHandle);
+        }
+        
         ~Generator()
         {
             Dispose(false);

--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -119,6 +119,12 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
                                                                                    bool /* boolean */ enable_ff_tokens);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern IntPtr /* OgaResult* */ OgaGeneratorToggleGuidance(IntPtr /* OgaGenerator* */ generator, bool /* boolean */ enable);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
+        public static extern bool OgaGeneratorIsGuidanceEnabled(IntPtr /* const OgaGenerator* */ generator);
+
+        [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern void OgaDestroyGenerator(IntPtr /* OgaGenerator* */ generator);
 
         // This function is used to check if the generator has finished generating all sequences.

--- a/src/generators.h
+++ b/src/generators.h
@@ -98,6 +98,8 @@ struct Generator : LeakChecked<Generator> {
   void AppendTokens(cpu_span<const int32_t> input_ids);
   void GenerateNextToken();
   void RewindToLength(size_t new_length);  // Rewind state to new_length
+  void ToggleGuidance(bool enable);
+  bool IsGuidanceEnabled();
   DeviceSpan<float> GetLogits();
   void SetLogits(DeviceSpan<float> logits);
   void SetRuntimeOption(const char* key, const char* value);
@@ -116,6 +118,7 @@ struct Generator : LeakChecked<Generator> {
 
   bool computed_logits_{};       // Set to true in ComputeLogits() and false after appending a token to ensure a 1 to 1 call ratio
   bool set_extra_inputs_{true};  // Set to false once SetExtraInputs() is called once
+  bool guidance_enabled_{true};  // Track whether guidance is enabled
 
  private:
   DeviceSpan<int32_t> AllocateInputIdsOnDevice(cpu_span<const int32_t> input_ids);

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -443,6 +443,14 @@ struct OgaGenerator : OgaAbstract {
     OgaCheckResult(OgaCreateGenerator(&model, &params, &p));
     return std::unique_ptr<OgaGenerator>(p);
   }
+  
+  void ToggleGuidance(bool enable) {
+    OgaCheckResult(OgaGeneratorToggleGuidance(this, enable));
+  }
+
+  bool IsGuidanceEnabled() {
+    return OgaGeneratorIsGuidanceEnabled(this);
+  }
 
   bool IsDone() {
     return OgaGenerator_IsDone(this);

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -402,6 +402,17 @@ OgaResult* OGA_API_CALL OgaGeneratorParamsSetGuidance(OgaGeneratorParams* params
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaGeneratorToggleGuidance(OgaGenerator* generator, bool enable) {
+  OGA_TRY
+  generator->ToggleGuidance(enable);
+  return nullptr;
+  OGA_CATCH
+}
+
+bool OGA_API_CALL OgaGeneratorIsGuidanceEnabled(OgaGenerator* generator) {
+  return generator->IsGuidanceEnabled();
+}
+
 OgaResult* OgaCreateGenerator(const OgaModel* model, const OgaGeneratorParams* params, OgaGenerator** out) {
   OGA_TRY
   *out = ReturnUnique<OgaGenerator>(CreateGenerator(*model, *params));

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -441,6 +441,22 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateGenerator(const OgaModel* model, con
 OGA_EXPORT void OGA_API_CALL OgaDestroyGenerator(OgaGenerator* generator);
 
 /**
+ * \brief Returns true if guidance (constrained decoding) is enabled for the generator.
+ * \param[in] generator The generator to check if guidance is enabled.
+ * \param[out] out True if guidance is enabled, false otherwise.
+ * \return OgaResult containing the error message if the checking of guidance status failed.
+ */
+OGA_EXPORT bool OGA_API_CALL OgaGeneratorIsGuidanceEnabled(OgaGenerator* generator);
+
+/**
+ * \brief Toggles guidance (constrained decoding) for the generator.
+ * \param[in] generator The generator to toggle guidance on.
+ * \param[in] enable True to enable guidance, false to disable.
+ * \return OgaResult containing the error message if toggling guidance failed.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaGeneratorToggleGuidance(OgaGenerator* generator, bool enable);
+
+/**
  * \brief Returns true if the generator has finished generating all the sequences.
  * \param[in] generator The generator to check if it is done with generating all sequences.
  * \return True if the generator has finished generating all the sequences, false otherwise.


### PR DESCRIPTION
### Add Support for Toggling Guidance

## Issue
When JSON guidance constraints are enabled, features like Chain of Thought and Tool Calling are disabled, since the model is forced to only output valid JSON at all times. Note: The Generator object is immutable, and guidance constraints (such as JSON output enforcement) must be set during generator initialization.

## Resolution
This PR introduces the ability to toggle guidance constraints on and off. This allows guidance constraints to be set at generator initialization, but only enforced when needed (e.g., at the Final channel). This enables workflows where Chain of Thought and Tool Calling can proceed unconstrained, and strict JSON output is enforced only at the appropriate stage.

- Enables dynamic toggling of guidance constraints.
- Preserves generator immutability and initialization patterns.
- Supports advanced workflows requiring staged constraint enforcement.



Additional Notes:
- Guidance will be enabled by default and only enforced when SetGuidance() is called with constraint and constraint schema passed in.