### PR TITLE
Fix sliding window alignment regression in QNN models

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -318,14 +318,14 @@ DeviceSpan<int32_t> Generator::AllocateInputIdsOnDevice(cpu_span<const int32_t> 
 
   auto input_ids_device = state_->params_->p_device->Allocate<int32_t>(padded_input_ids_size);
   auto cpu_span = input_ids_device.CpuSpan();
-
-  // Handle padding based on alignment setting for sliding window models
-  if (padded_input_ids_size > input_ids.size()) {
-    std::copy(input_ids.begin(), input_ids.end(), cpu_span.begin());
-    std::fill(cpu_span.begin() + input_ids.size(), cpu_span.end(), model_->config_->model.pad_token_id);
-  } else {
-    std::copy(input_ids.begin(), input_ids.end(), cpu_span.begin());
+  auto padding_begin = cpu_span.begin();
+  auto data_end = cpu_span.end();
+  if (model_->config_->model.decoder.sliding_window.has_value() && model_->config_->model.decoder.sliding_window->alignment == "left") {
+    padding_begin = cpu_span.begin() + input_ids.size();
+    data_end = padding_begin;
   }
+  std::fill_n(padding_begin, padded_input_ids_size - input_ids.size(), model_->config_->model.pad_token_id);
+  std::copy_backward(input_ids.begin(), input_ids.end(), data_end);
   input_ids_device.CopyCpuToDevice();
   return input_ids_device;
 }


### PR DESCRIPTION
Revert back the alignment logic to the original way it was in 0.11.2 since it works for all the models.
For FARA model we will update the genai_config alignment value to "left"