### PR TITLE
Set default top_k and top_p if it is None

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -551,7 +551,7 @@ class Model:
             }
             for key, default_val in defaults.items():
                 val = getattr(gen_config, key)
-                if val != default_val:
+                if val is not None and val != default_val:
                     setattr(config, key, getattr(gen_config, key))
         except:
             pass


### PR DESCRIPTION
Set default top_k and top_p if it is None.

Exporting Qwen VL model will get 
```
"top_k": null,
"top_p": null
```