### PR TITLE
fix: patch `llguidance` to remove reference to `ring` crate

### DIFF
--- a/cmake/external/llguidance/remove-ring-ref-in-cargo-lock.patch
+++ b/cmake/external/llguidance/remove-ring-ref-in-cargo-lock.patch
@@ -1,28 +1,3 @@
-diff --git a/Cargo.lock b/Cargo.lock
-index 031d0c5..c2fda96 100644
---- a/Cargo.lock
-+++ b/Cargo.lock
-@@ -1937,20 +1937,6 @@ dependencies = [
-  "web-sys",
- ]
-
--[[package]]
--name = "ring"
--version = "0.17.14"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
--dependencies = [
-- "cc",
-- "cfg-if",
-- "getrandom 0.2.16",
-- "libc",
-- "untrusted",
-- "windows-sys 0.52.0",
--]
--
- [[package]]
- name = "rstest"
- version = "0.25.0"
 diff --git a/Cargo.toml b/Cargo.toml
 index c23c372..8637592 100644
 --- a/Cargo.toml
@@ -61,7 +36,7 @@ index c23c372..8637592 100644
 +    # "toktrie_tiktoken",
  ]
  resolver = "2"
-
+ 
 @@ -41,6 +41,6 @@ opt-level = 3
  [workspace.dependencies]
  toktrie = { path = "toktrie" }

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -108,9 +108,12 @@ if(USE_GUIDANCE)
   )
   onnxruntime_fetchcontent_makeavailable(llguidance)
 
-  # HACK: Patch llguidance's cargo.lock to avoid tripping component governance due to unused `ring`.
+  # HACK: Patch llguidance's `/Cargo.toml` to avoid tripping component governance due to unused `ring` dep.
   #       `ring` is deprecated in favour of `rust-openssl`.
-  #       `ring` is a transitive dep of several (unused by onnx-rt) modules in `llguidance`.
+  #       `ring` is a transitive dep of several (unused by onnx-rt) libs in `llguidance`.
+  #       We only use the `parser` lib.
+  #       Governance trips on `/Cargo.lock` but that is expected to be regenerated as part of the build,
+  #       dropping the reference to `ring`.
   if(NOT EXISTS "${llguidance_SOURCE_DIR}/.onnx-rt-applied-remove-ring-ref-in-cargo-lock")
     execute_process(
       COMMAND git apply -- "${CMAKE_CURRENT_LIST_DIR}/llguidance/remove-ring-ref-in-cargo-lock.patch"


### PR DESCRIPTION
Fix MVS-2022-374v-6mvc by purging references to `ring` from `Cargo.lock`.