### PR TITLE
[RyzenAI] Linux compatibility fixes

### DIFF
--- a/src/ryzenai/interface.cpp
+++ b/src/ryzenai/interface.cpp
@@ -20,9 +20,8 @@ static constexpr auto ep_name_ = "RyzenAILightExecutionProvider";
 #if defined(_WIN32)
 static constexpr auto ep_filename_ = "onnxruntime_providers_ryzenai.dll";
 #else
-static constexpr auto ep_filename_ = "onnxruntime_providers_ryzenai.so";
+static constexpr auto ep_filename_ = "libonnxruntime_providers_ryzenai.so";
 #endif
-static constexpr auto func_custom_ops_ = "RyzenAI_RegisterCustomOps";
 static constexpr auto func_shutdown_ = "RyzenAI_Shutdown";
 
 static Ort::Allocator* ort_allocator_{};
@@ -161,7 +160,7 @@ struct Interface : RyzenAIInterface {
                                                                            ep_keys.data(), ep_values.data(), ep_keys.size()));
     }
 
-    Ort::ThrowOnError(Ort::api->RegisterCustomOpsUsingFunction(&session_options, func_custom_ops_));
+    Ort::ThrowOnError(Ort::api->RegisterCustomOpsLibrary_V2(&session_options, ep_path_.native().c_str()));
   }
 
   DeviceType GetType() const override { return DeviceType::RyzenAI; }


### PR DESCRIPTION
Aligned shared library name for Linux and switched to `RegisterCustomOpsLibrary_V2` instead of `RegisterCustomOpsUsingFunction`, which behaves unexpectedly on Linux. 
