### PR TITLE
Add missing Quark 0.11 weight patterns for ChatGLM3 output layer

### DIFF
--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -238,10 +238,10 @@ class QuantizedModel:
                     elif name == "lm_head.qweight" or name == "transformer.output_layer.qweight":
                         self._initialize_quantized_lm_head(local_bits, local_group_size)
                         self.lm_head.qweight = tensor
-                    elif name in {"lm_head.qzeros", "lm_head.weight_zero_point", "transformer.output_layer.qzeros"}:
+                    elif name in {"lm_head.qzeros", "lm_head.weight_zero_point", "transformer.output_layer.qzeros", "transformer.output_layer.weight_zero_point"}:
                         self._initialize_quantized_lm_head(local_bits, local_group_size)
                         self.lm_head.qzeros = tensor
-                    elif name in {"lm_head.scales", "lm_head.weight_scale", "transformer.output_layer.scales"}:
+                    elif name in {"lm_head.scales", "lm_head.weight_scale", "transformer.output_layer.scales", "transformer.output_layer.weight_scale"}:
                         self._initialize_quantized_lm_head(local_bits, local_group_size)
                         self.lm_head.scales = tensor
                     elif name == "lm_head.g_idx" or name == "transformer.output_layer.g_idx":


### PR DESCRIPTION
AMD Quark 0.11 uses `weight_zero_point` and `weight_scale` naming convention instead of `qzeros` and `scales`. Support for this was added for `lm_head.*` patterns but the equivalent `transformer.output_layer.*` patterns used by ChatGLM3 were not included, causing ChatGLM3 model loading to fail

Added the two missing patterns:
- `transformer.output_layer.weight_zero_point`
- `transformer.output_layer.weight_scale`