### PR TITLE
[VitisAI] external_ep_libray support fix for WinML

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -846,6 +846,7 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
         values.emplace_back(option.second.c_str());
       }
       session_options.AppendExecutionProvider(provider_options.name.c_str(), keys.data(), values.data(), keys.size());
+#endif
 #if defined(_WIN32)
       if (provider_options.name == "VitisAI") {
         if (const auto opt_it = std::find_if(provider_options.options.begin(), provider_options.options.end(),
@@ -864,7 +865,6 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
         }
       }
 #endif  // WIN32
-#endif
     }  // end if (provider not cuda/rocm/DML)
   }
   return p_device;


### PR DESCRIPTION
VitisAI+external_ep_libray was disabled for WinML. The change enables it.