### PR TITLE
Support Qwen2.5-VL pre-quantized models in qwen.py

### DIFF
--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -670,7 +670,7 @@ class Qwen25VLTextModel(Model):
 
     def load_weights(self, input_path):
         # For quantized models (e.g., Quark, AWQ, GPTQ) or GGUF, use base class logic
-        # which loads weights directly from safetensors via QuantModel
+        # which loads weights directly via QuantModel
         if self.quant_type is not None or input_path.endswith(".gguf"):
             return super().load_weights(input_path)
 


### PR DESCRIPTION
- Fix `Qwen25VLTextModel.load_weights()` to support pre-quantized models.
- The `load_weights()` method in `Qwen25VLTextModel` completely overrides the base class, bypassing the OGA support for loading pre-quantized models. This causes a `NotImplementedError: "normal_kernel_cpu" not implemented for 'Int'` when trying to convert quantized Qwen2.5-VL models.
- This PR checks `self.quant_type` and delegates to `super().load_weights()` for quantized/GGUF models, consistent with the pattern used in `internlm.py`