### PR TITLE
Fix incorrect batch responses when using multiple prompts

### DIFF
--- a/examples/python/model-generate.py
+++ b/examples/python/model-generate.py
@@ -30,7 +30,7 @@ def main(args):
             text = input("Input: ")
             prompts = [text]
     setattr(args, "batch_size", len(prompts))
-    search_config = {"batch_size": len(prompts), "chunk_size": args.chunk_size, "num_beams": args.num_beams}
+    search_config = {"batch_size": args.batch_size, "chunk_size": args.chunk_size, "num_beams": args.num_beams}
     config = get_config(args.model_path, args.execution_provider, ep_options={}, search_options=search_config)
 
     model = og.Model(config)


### PR DESCRIPTION
When running with batch_size > 1, only the last prompt's response was correct; other responses decoded as "!!!!". The generator was created with batch_size=1 because search options were taken only from CLI args (which have no --batch_size), so get_search_options() defaulted it to 1 while the model config correctly had batch_size=len(prompts).

Fix: In model-generate.py, set search_options["batch_size"] = len(prompts) before calling params.set_search_options() so the generator's batch size matches the number of prompts.