### PR TITLE
Handle VLM weight name prefixes in QuantizedModel loader

### DIFF
--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -217,6 +217,13 @@ class QuantizedModel:
 
                 # Map weights to modules
                 for name, tensor in weights.items():
+                    # Skip vision tower weights in VLM checkpoints
+                    if name.startswith(("model.visual.", "model.vision.", "visual.")):
+                        continue
+                    # Normalize common VLM prefix so existing LLM regex + parsing keeps working
+                    if name.startswith("model.language_model."):
+                        name = "model." + name[len("model.language_model."):]
+                        
                     # Per-layer quantization support
                     local_bits = self.get_layer_bits(name)  # codeql[py/init-calls-subclass]
                     local_group_size = self.get_layer_group_size(name)  # codeql[py/init-calls-subclass]


### PR DESCRIPTION
This change makes the quantized model weight loader work with VLM checkpoints where weight names include extra prefixes like `model.language_model.*` and vision tower weights like `model.visual.*`.

- Skip weights under `model.visual.*`

- Normalize `model.language_model.* → model.*` before existing pattern matching and layer parsing

No functional change for pure LLM checkpoints.