### PR TITLE
Add WebGPU EP support and repetitions flag to whisper.py

### DIFF
--- a/examples/python/whisper.py
+++ b/examples/python/whisper.py
@@ -3,6 +3,7 @@
 
 import argparse
 import glob
+import json
 import os
 import readline
 
@@ -22,82 +23,115 @@ class Format:
 
 def run(args: argparse.Namespace):
     print("Loading model...")
-    config = og.Config(args.model_path)
-    if args.execution_provider != "follow_config":
-        config.clear_providers()
-        if args.execution_provider != "cpu":
-            print(f"Setting model to {args.execution_provider}")
-            config.append_provider(args.execution_provider)
-    model = og.Model(config)
-    processor = model.create_multimodal_processor()
-    tokenizer = og.Tokenizer(model)
+    _config_modified = False
+    _config_path = os.path.join(args.model_path, "genai_config.json")
+    _config_backup = None
 
-    while True:
-        readline.set_completer_delims(" \t\n;")
-        readline.parse_and_bind("tab: complete")
-        readline.set_completer(_complete)
+    if args.execution_provider not in ("follow_config", "cpu", "cuda"):
+        # For GPU providers like webgpu, update genai_config.json to set the
+        # provider on all sessions (encoder + decoder). The runtime config API
+        # (config.append_provider) only updates the decoder, which causes
+        # encoder-decoder models like Whisper to crash.
+        with open(_config_path, "r") as f:
+            _config_backup = f.read()
+            genai_config = json.loads(_config_backup)
+        provider_entry = [{args.execution_provider: {}}]
+        for section in ("decoder", "encoder", "vision", "speech", "embedding"):
+            sec = genai_config.get("model", {}).get(section)
+            if sec and "session_options" in sec:
+                sec["session_options"]["provider_options"] = provider_entry
+        with open(_config_path, "w") as f:
+            json.dump(genai_config, f, indent=4)
+        _config_modified = True
 
-        if args.non_interactive:
-            audio_paths = [audio_path.strip() for audio_path in args.audio.split(",")]
-        else:
-            audio_paths = [audio_path.strip() for audio_path in input("Audio Paths (comma separated): ").split(",")]
-        if len(audio_paths) == 0:
-            raise ValueError("No audio provided.")
+    try:
+        config = og.Config(args.model_path)
+        if args.execution_provider != "follow_config":
+            config.clear_providers()
+            if args.execution_provider != "cpu":
+                print(f"Setting model to {args.execution_provider}")
+                config.append_provider(args.execution_provider)
+        model = og.Model(config)
+        processor = model.create_multimodal_processor()
+        tokenizer = og.Tokenizer(model)
 
-        print("Loading audio...")
-        for audio_path in audio_paths:
-            if not os.path.exists(audio_path):
-                raise FileNotFoundError(f"Audio file not found: {audio_path}")
-        audios = og.Audios.open(*audio_paths)
+        while True:
+            readline.set_completer_delims(" \t\n;")
+            readline.parse_and_bind("tab: complete")
+            readline.set_completer(_complete)
 
-        print("Processing audio...")
-        batch_size = len(audio_paths)
-        decoder_prompt_tokens = ["<|startoftranscript|>", "<|en|>", "<|transcribe|>", "<|notimestamps|>"]
-        prompts = ["".join(decoder_prompt_tokens)] * batch_size
-        inputs = processor(prompts, audios=audios)
+            if args.non_interactive:
+                audio_paths = [audio_path.strip() for audio_path in args.audio.split(",")]
+            else:
+                audio_paths = [audio_path.strip() for audio_path in input("Audio Paths (comma separated): ").split(",")]
+            if len(audio_paths) == 0:
+                raise ValueError("No audio provided.")
 
-        params = og.GeneratorParams(model)
-        params.set_search_options(
-            do_sample=False,
-            num_beams=args.num_beams,
-            num_return_sequences=args.num_beams,
-            max_length=448,
-            batch_size=batch_size,
-        )
+            print("Loading audio...")
+            for audio_path in audio_paths:
+                if not os.path.exists(audio_path):
+                    raise FileNotFoundError(f"Audio file not found: {audio_path}")
+            audios = og.Audios.open(*audio_paths)
 
-        generator = og.Generator(model, params)
-        generator.set_inputs(inputs)
+            print("Processing audio...")
+            batch_size = len(audio_paths)
+            decoder_prompt_tokens = ["<|startoftranscript|>", "<|en|>", "<|transcribe|>", "<|notimestamps|>"]
+            prompts = ["".join(decoder_prompt_tokens)] * batch_size
+            inputs = processor(prompts, audios=audios)
 
-        while not generator.is_done():
-            generator.generate_next_token()
-
-        print()
-        transcriptions = []
-        for i in range(batch_size * args.num_beams):
-            tokens = generator.get_sequence(i)
-            transcription = processor.decode(tokens)
-
-            print("Transcription:")
-            print(
-                f"    {Format.underline}batch {i // args.num_beams}, beam {i % args.num_beams}{Format.end}: {transcription}"
+            params = og.GeneratorParams(model)
+            params.set_search_options(
+                do_sample=False,
+                num_beams=args.num_beams,
+                num_return_sequences=args.num_beams,
+                max_length=448,
+                batch_size=batch_size,
             )
-            transcriptions.append(transcription.strip())
 
-        for _ in range(3):
-            print()
+            num_reps = args.repetitions if args.non_interactive else 1
+            for rep in range(num_reps):
+                generator = og.Generator(model, params)
+                generator.set_inputs(inputs)
 
-        if args.non_interactive:
-            args.output = args.output.strip()
-            matching = False
-            for transcription in transcriptions:
-                if transcription == args.output:
-                    matching = True
-                    break
+                while not generator.is_done():
+                    generator.generate_next_token()
 
-            if matching:
-                print("One of the model's transcriptions matches the expected transcription.")
+                if rep < num_reps - 1:
+                    continue
+
+                print()
+                transcriptions = []
+                for i in range(batch_size * args.num_beams):
+                    tokens = generator.get_sequence(i)
+                    transcription = processor.decode(tokens)
+
+                    print("Transcription:")
+                    print(
+                        f"    {Format.underline}batch {i // args.num_beams}, beam {i % args.num_beams}{Format.end}: {transcription}"
+                    )
+                    transcriptions.append(transcription.strip())
+
+            for _ in range(3):
+                print()
+
+            if args.non_interactive:
+                if args.output:
+                    args.output = args.output.strip()
+                    matching = False
+                    for transcription in transcriptions:
+                        if transcription == args.output:
+                            matching = True
+                            break
+
+                    if matching:
+                        print("One of the model's transcriptions matches the expected transcription.")
+                        return
+                    raise Exception("None of the model's transcriptions match the expected transcription.")
                 return
-            raise Exception("None of the model's transcriptions match the expected transcription.")
+    finally:
+        if _config_modified and _config_backup is not None:
+            with open(_config_path, "w") as f:
+                f.write(_config_backup)
 
 
 if __name__ == "__main__":
@@ -109,7 +143,7 @@ if __name__ == "__main__":
         type=str,
         required=False,
         default="follow_config",
-        choices=["cpu", "cuda", "follow_config"],
+        choices=["cpu", "cuda", "webgpu", "follow_config"],
         help="Execution provider to run the ONNX Runtime session with. Defaults to follow_config that uses the execution provider listed in the genai_config.json instead.",
     )
     parser.add_argument("-b", "--num_beams", type=int, default=4, help="Number of beams")
@@ -124,5 +158,6 @@ if __name__ == "__main__":
         action="store_true",
         help="Non-interactive mode for CI testing purposes",
     )
+    parser.add_argument("-r", "--repetitions", type=int, default=1, help="Number of repetitions in non-interactive mode (default: 1). Use >1 for profiling warmup.")
     args = parser.parse_args()
     run(args)


### PR DESCRIPTION
Changes:
- Add WebGPU to the execution provider choices (-e webgpu)
- For encoder-decoder models on WebGPU, temporarily update genai_config.json to set WebGPU provider on all sessions (encoder + decoder), since the runtime config API (config.append_provider) only updates the decoder session. The original config is restored in a finally block.
- Add -r/--repetitions flag for non-interactive mode (default: 1). Use -r 2+ for profiling to include GPU warmup runs.
- Allow -ni without -o to run inference and print results without CI validation.

Problem: whisper.py crashed silently when using -e webgpu because the encoder session ran on CPU while the decoder ran on WebGPU. The encoder on CPU could not write cross-attention KV cache outputs to WebGPU GPU-allocated tensors.

Verified: whisper-tiny-int4 model produces correct transcriptions on WebGPU EP with both -r 1 and -r 2.