### PR TITLE
Support 4 inputs for nemotron model

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -334,8 +334,6 @@ struct DecoderInputs_Element : JSON::Element {
       v_.block_table = JSON::Get<std::string_view>(value);
     } else if (name == "targets") {
       v_.targets = JSON::Get<std::string_view>(value);
-    } else if (name == "target_length") {
-      v_.target_length = JSON::Get<std::string_view>(value);
     } else if (name == "lstm_hidden_state") {
       v_.lstm_hidden_state = JSON::Get<std::string_view>(value);
     } else if (name == "lstm_cell_state") {
@@ -367,8 +365,6 @@ struct DecoderOutputs_Element : JSON::Element {
       v_.rnn_states = JSON::Get<std::string_view>(value);
     } else if (name == "outputs") {
       v_.outputs = JSON::Get<std::string_view>(value);
-    } else if (name == "prednet_lengths") {
-      v_.prednet_lengths = JSON::Get<std::string_view>(value);
     } else if (name == "lstm_hidden_state") {
       v_.lstm_hidden_state = JSON::Get<std::string_view>(value);
     } else if (name == "lstm_cell_state") {

--- a/src/config.h
+++ b/src/config.h
@@ -319,7 +319,6 @@ struct Config {
 
         // RNNT decoder inputs
         std::string targets;
-        std::string target_length;
         std::string lstm_hidden_state;
         std::string lstm_cell_state;
       } inputs;
@@ -334,7 +333,6 @@ struct Config {
 
         // RNNT decoder outputs
         std::string outputs;
-        std::string prednet_lengths;
         std::string lstm_hidden_state;
         std::string lstm_cell_state;
       } outputs;

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -64,11 +64,9 @@ void NemotronCacheConfig::PopulateFromConfig(const Config& config) {
 
   // Decoder I/O names (RNNT prediction network)
   dec_in_targets = dec.inputs.targets;
-  dec_in_target_length = dec.inputs.target_length;
   dec_in_lstm_hidden = dec.inputs.lstm_hidden_state;
   dec_in_lstm_cell = dec.inputs.lstm_cell_state;
   dec_out_outputs = dec.outputs.outputs;
-  dec_out_prednet_lengths = dec.outputs.prednet_lengths;
   dec_out_lstm_hidden = dec.outputs.lstm_hidden_state;
   dec_out_lstm_cell = dec.outputs.lstm_cell_state;
 }
@@ -177,19 +175,25 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
 
   cache_.Initialize(cfg, model_.session_info_, allocator, device);
 
-  // Create signal_length tensor
-  auto len_type = model_.session_info_.GetInputDataType(cfg.enc_in_length);
-  auto len_shape = std::array<int64_t, 1>{1};
-  signal_length_ = OrtValue::CreateTensor(allocator, len_shape, len_type);
+  has_length_input_ = model_.session_info_.HasInput(cfg.enc_in_length);
 
-  // Register inputs: mel, length, cache_channel, cache_time, cache_channel_len
+  // Create signal_length tensor if the encoder model expects it
+  if (has_length_input_) {
+    auto len_type = model_.session_info_.GetInputDataType(cfg.enc_in_length);
+    auto len_shape = std::array<int64_t, 1>{1};
+    signal_length_ = OrtValue::CreateTensor(allocator, len_shape, len_type);
+  }
+
+  // Register inputs: mel, [length], cache_channel, cache_time, cache_channel_len
   mel_input_idx_ = inputs_.size();
   input_names_.push_back(cfg.enc_in_audio.c_str());
   inputs_.push_back(nullptr);
 
-  length_input_idx_ = inputs_.size();
-  input_names_.push_back(cfg.enc_in_length.c_str());
-  inputs_.push_back(signal_length_.get());
+  if (has_length_input_) {
+    length_input_idx_ = inputs_.size();
+    input_names_.push_back(cfg.enc_in_length.c_str());
+    inputs_.push_back(signal_length_.get());
+  }
 
   cache_channel_input_idx_ = inputs_.size();
   input_names_.push_back(cfg.enc_in_cache_channel.c_str());
@@ -227,7 +231,9 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
 
 void NemotronEncoderSubState::SetMelInput(OrtValue* mel_tensor, int64_t total_mel_frames) {
   inputs_[mel_input_idx_] = mel_tensor;
-  *signal_length_->GetTensorMutableData<int64_t>() = total_mel_frames;
+  if (has_length_input_) {
+    *signal_length_->GetTensorMutableData<int64_t>() = total_mel_frames;
+  }
 }
 
 void NemotronEncoderSubState::UpdateCacheInputs() {
@@ -250,24 +256,15 @@ NemotronPredictionSubState::NemotronPredictionSubState(const NemotronSpeechModel
 
   lstm_state_.Initialize(cfg, model_.session_info_, allocator, device);
 
-  // Create targets and target_length tensors
+  // Create targets tensor
   auto targets_type = model_.session_info_.GetInputDataType(cfg.dec_in_targets);
   auto targets_shape = std::array<int64_t, 2>{1, 1};
   targets_ = OrtValue::CreateTensor(allocator, targets_shape, targets_type);
-
-  auto tgt_len_type = model_.session_info_.GetInputDataType(cfg.dec_in_target_length);
-  auto tgt_len_shape = std::array<int64_t, 1>{1};
-  target_length_ = OrtValue::CreateTensor(allocator, tgt_len_shape, tgt_len_type);
-  *target_length_->GetTensorMutableData<int64_t>() = 1;
 
   // Register inputs
   targets_input_idx_ = inputs_.size();
   input_names_.push_back(cfg.dec_in_targets.c_str());
   inputs_.push_back(targets_.get());
-
-  target_length_input_idx_ = inputs_.size();
-  input_names_.push_back(cfg.dec_in_target_length.c_str());
-  inputs_.push_back(target_length_.get());
 
   lstm_hidden_input_idx_ = inputs_.size();
   input_names_.push_back(cfg.dec_in_lstm_hidden.c_str());
@@ -277,11 +274,8 @@ NemotronPredictionSubState::NemotronPredictionSubState(const NemotronSpeechModel
   input_names_.push_back(cfg.dec_in_lstm_cell.c_str());
   inputs_.push_back(lstm_state_.lstm_cell_state.get());
 
-  // Register outputs
+  // Register outputs: outputs, lstm_hidden, lstm_cell
   output_names_.push_back(cfg.dec_out_outputs.c_str());
-  outputs_.push_back(nullptr);
-
-  output_names_.push_back(cfg.dec_out_prednet_lengths.c_str());
   outputs_.push_back(nullptr);
 
   output_names_.push_back(cfg.dec_out_lstm_hidden.c_str());
@@ -511,10 +505,10 @@ std::span<const int32_t> NemotronSpeechState::StepToken() {
 
     // Non-blank: emit token, update LSTM state from prediction outputs
     prediction_state_->lstm_state_.last_token = best_token;
-    prediction_state_->lstm_state_.lstm_hidden_state.reset(prediction_state_->outputs_[2]);
+    prediction_state_->lstm_state_.lstm_hidden_state.reset(prediction_state_->outputs_[1]);
+    prediction_state_->outputs_[1] = nullptr;
+    prediction_state_->lstm_state_.lstm_cell_state.reset(prediction_state_->outputs_[2]);
     prediction_state_->outputs_[2] = nullptr;
-    prediction_state_->lstm_state_.lstm_cell_state.reset(prediction_state_->outputs_[3]);
-    prediction_state_->outputs_[3] = nullptr;
 
     symbol_step_++;
     if (symbol_step_ >= cache_config_.max_symbols_per_step) {

--- a/src/models/nemotron_speech.h
+++ b/src/models/nemotron_speech.h
@@ -56,11 +56,9 @@ struct NemotronCacheConfig {
 
   // Decoder (prediction network) I/O names
   std::string dec_in_targets;
-  std::string dec_in_target_length;
   std::string dec_in_lstm_hidden;
   std::string dec_in_lstm_cell;
   std::string dec_out_outputs;
-  std::string dec_out_prednet_lengths;
   std::string dec_out_lstm_hidden;
   std::string dec_out_lstm_cell;
 
@@ -130,6 +128,9 @@ struct NemotronEncoderSubState : State {
   NemotronEncoderCache cache_;
   std::unique_ptr<OrtValue> signal_length_;
 
+  // Whether the encoder model has a "length" input
+  bool has_length_input_{};
+
   // Indices into inputs_/outputs_ vectors
   size_t mel_input_idx_{};
   size_t length_input_idx_{};
@@ -154,10 +155,8 @@ struct NemotronPredictionSubState : State {
   const NemotronSpeechModel& model_;
   NemotronDecoderState lstm_state_;
   std::unique_ptr<OrtValue> targets_;
-  std::unique_ptr<OrtValue> target_length_;
 
   size_t targets_input_idx_{};
-  size_t target_length_input_idx_{};
   size_t lstm_hidden_input_idx_{};
   size_t lstm_cell_input_idx_{};
 };


### PR DESCRIPTION
We want to make the encoder input `length` optional, because this can help constant folding a lot of operators at the beginning. The value of `length` is equal to the 2nd dim value of `audio_signal`.
name: audio_signal
tensor: float32[1,65,128]

Manually tested in `test/python/test_onnxruntime_genai_e2e.py` using a 4-input nemotron model, and it works well.

We also remove `target_length_orig` and `target_length` from decoder graph, and here we support it in genai.