### PR TITLE
[Java] Add a dependency on onnxruntime (#2030)

### DIFF
--- a/src/java/build.gradle
+++ b/src/java/build.gradle
@@ -30,7 +30,7 @@ def mavenPwd = System.properties['mavenPwd']
 def mavenArtifactId = useCUDA == null ? project.name : project.name + "_gpu"
 
 def onnxruntimeArtifactId = useCUDA == null ? "onnxruntime" : "onnxruntime_gpu"
-def onnxruntimeVersion = System.properties["ONNXRUNTIME_VERSION"] ?: "1.24.3"
+def onnxruntimeVersion = System.properties["ONNXRUNTIME_VERSION"] ?: "1.23.0"
 
 def defaultDescription = 'ONNX Runtime GenAI is <TODO>'
 


### PR DESCRIPTION
This PR addresses the concern raised in #2030 (and before in microsoft/onnxruntime#27656) regarding the missing dependency between `onnxruntime-genai` and the core `onnxruntime` Java artifact.

Currently, `GenAI.java` assumes that the native ONNX Runtime libraries are available on the classpath and attempts to load them directly. However, without an explicit Maven dependency, this is not guaranteed and can lead to runtime issues.

Additionally, this setup duplicates native library loading logic that already exists in `OrtRuntime.java`, creating unnecessary maintenance overhead and inconsistencies (e.g., missing extraction of `onnxruntime_providers_shared`).

Other ecosystem packages already declare this dependency:

* The NuGet package includes a [dependency on ONNX Runtime](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntimeGenAI)
* The PyPI package does as well (see the `METADATA` file in a [onnxruntime-genai wheel](https://pypi.org/project/onnxruntime-genai))

Aligning the Java package with this behavior ensures consistency across platforms and provides a more predictable and reliable setup for users.

Adding this dependency makes the expectation explicit and lays the groundwork for potentially reusing the existing native loading logic in the future.