### PR TITLE
Fix WinML CI & Update Extensions Commit to Support Array Type for Tool Calling Function

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -14,7 +14,7 @@ pybind11;https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.zip;f78029
 googletest;https://github.com/google/googletest/archive/530d5c8c84abd2a46f38583ee817743c9b3a42b4.zip;5e3a61db2aa975cfd0f97ba92c818744e7fa7034
 microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.zip;e4a542a323c070376f7c2d1973d0f7ddbc1d2fa5
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
-onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;305272a3f085cf33eac9ef9916f90ad2e4a72a62
+onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;7b9699c1cc580f1a31bc0d59a90b9a3f22567d17
 
 # These two dependencies are for the optional constrained decoding feature (USE_GUIDANCE)
 llguidance;https://github.com/microsoft/llguidance.git;94fa39128ef184ffeda33845f6d333f332a34b4d

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -14,7 +14,7 @@ pybind11;https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.zip;f78029
 googletest;https://github.com/google/googletest/archive/530d5c8c84abd2a46f38583ee817743c9b3a42b4.zip;5e3a61db2aa975cfd0f97ba92c818744e7fa7034
 microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.zip;e4a542a323c070376f7c2d1973d0f7ddbc1d2fa5
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
-onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;8a4184920cc81967ca1a706c56e99745d954e4a3
+onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;305272a3f085cf33eac9ef9916f90ad2e4a72a62
 
 # These two dependencies are for the optional constrained decoding feature (USE_GUIDANCE)
 llguidance;https://github.com/microsoft/llguidance.git;94fa39128ef184ffeda33845f6d333f332a34b4d

--- a/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
+++ b/src/java/src/main/java/ai/onnxruntime/genai/Generator.java
@@ -133,6 +133,7 @@ public final class Generator implements AutoCloseable, Iterable<Integer> {
   /**
    * Returns the token count in the generator.
    *
+   * @return The number of tokens.
    * @throws GenAIException If the call to the GenAI native API fails.
    */
   public long tokenCount() throws GenAIException {


### PR DESCRIPTION
Includes this fix: https://github.com/microsoft/onnxruntime-extensions/pull/1043 (more context in PR descr) and adds a missing javadoc return tag that was breaking the WinML CI.