### PR TITLE
Fail to build Whisper model

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1289,6 +1289,9 @@ class Model:
         return matmul
     
     def make_packed_matmul_int4_class(self, q_matmul, k_matmul, v_matmul):
+        if not hasattr(q_matmul, "qweight"):
+            return self.make_packed_matmul_float_class(q_matmul, k_matmul, v_matmul)
+
         # Create dummy PackedMatMul class
         class PackedMatMul:
             def __init__(self):


### PR DESCRIPTION
When I generate Whisper model with genai builder 
```python -m onnxruntime_genai.models.builder -p int4 -e webgpu -m openai/whisper-tiny -o whisper-tiny --extra_options int4_algo_config=rtn_last int4_is_symmetric=true prune_lm_head=true enable_webgpu_graph=true```, it reports the error shown as below.

The issue is that `make_packed_matmul_int4_class` doesn't check whether the weights are actually quantized before accessing .bits. The sibling method `make_packed_matmul_int4` already has this guard (`hasattr(q_matmul, "qweight"))`, but `make_packed_matmul_int4_class` does not.



```
File "/opt/homebrew/lib/python3.11/site-packages/onnxruntime_genai/models/builders/base.py", line 2816, in make_attention_input_proj
matmul = self.make_packed_matmul_class(attention.q_proj, attention.k_proj, attention.v_proj)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/homebrew/lib/python3.11/site-packages/onnxruntime_genai/models/builders/base.py", line 1268, in make_packed_matmul_class
return self.make_packed_matmul_int4_class(q_matmul, k_matmul, v_matmul)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/homebrew/lib/python3.11/site-packages/onnxruntime_genai/models/builders/base.py", line 1309, in make_packed_matmul_int4_class
matmul = PackedMatMul()
^^^^^^^^^^^^^^
File "/opt/homebrew/lib/python3.11/site-packages/onnxruntime_genai/models/builders/base.py", line 1295, in init
if q_matmul.bits != k_matmul.bits or q_matmul.bits != v_matmul.bits:
^^^^^^^^^^^^^
File "/opt/homebrew/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1965, in getattr
raise AttributeError(
AttributeError: 'Linear' object has no attribute 'bits'. Did you mean: 'bias'?
```