### PR TITLE
Gemma 4 builder scaffolding (Part 1 of N, #2062)

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -21,6 +21,7 @@ from builders import (
     ErnieModel,
     Gemma2Model,
     Gemma3Model,
+    Gemma4TextModel,
     GemmaModel,
     GPTOSSModel,
     GraniteModel,
@@ -233,6 +234,27 @@ def create_model(
         print("WARNING: This is only generating the text component of the model. Setting `--extra_options exclude_embeds=true` by default.")
         extra_options["exclude_embeds"] = True
         onnx_model = Gemma3Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
+    elif config.architectures[0] in {"Gemma4ForConditionalGeneration", "Gemma4ForCausalLM"}:
+        # Gemma 4 ships multimodal-first. The text decoder config lives under
+        # `text_config` on the conditional-generation wrapper; weights are
+        # stored under the `model.language_model.*` prefix. We flatten the
+        # text_config onto the top-level config the way the Gemma 3 branch
+        # does, then hand off to the scaffolded Gemma 4 builder.
+        # NOTE (issue #2062): Gemma 4 support is incomplete. This branch
+        # currently only supports `--extra_options config_only=true`. See
+        # `builders/gemma4.py` for the full scope statement and the list
+        # of runtime changes required for end-to-end support.
+        if hasattr(config, "text_config"):
+            text_config = config.text_config
+            for key in text_config:
+                if not hasattr(config, key):
+                    setattr(config, key, getattr(text_config, key))
+        print("WARNING: Gemma 4 support is scaffolded but not yet end-to-end functional. See issue #2062.")
+        print("WARNING: This model loses accuracy with float16 precision. It is recommended to set `--precision bf16` or `--precision int4 --extra_options use_cuda_bf16=true` by default.")
+        print("WARNING: This is only generating the text component of the model. Setting `--extra_options exclude_embeds=true` by default.")
+        extra_options["exclude_embeds"] = True
+        onnx_model = Gemma4TextModel(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
+        onnx_model.model_type = "gemma4_text"
     elif config.architectures[0] == "GptOssForCausalLM":
         print("WARNING: This model only supports symmetric quantization for `QMoE`.")
         if hasattr(config, "quantization_config") and config.quantization_config.get("quant_method") != "quark":

--- a/src/python/py/models/builders/__init__.py
+++ b/src/python/py/models/builders/__init__.py
@@ -10,6 +10,7 @@ from .base import Model
 from .chatglm import ChatGLMModel
 from .ernie import ErnieModel
 from .gemma import Gemma2Model, Gemma3Model, GemmaModel
+from .gemma4 import Gemma4TextModel
 from .gptoss import GPTOSSModel
 from .granite import GraniteModel
 from .internlm import InternLM2Model
@@ -37,6 +38,7 @@ __all__ = [
     "GPTOSSModel",
     "Gemma2Model",
     "Gemma3Model",
+    "Gemma4TextModel",
     "GemmaModel",
     "GraniteModel",
     "InternLM2Model",

--- a/src/python/py/models/builders/gemma4.py
+++ b/src/python/py/models/builders/gemma4.py
@@ -1,0 +1,246 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+"""
+Gemma 4 model builder (Part 1 of N: scaffolding).
+
+This builder adds partial support for Google's Gemma 4 model family
+(E2B / E4B / 26B-A4B / 31B), released April 2026. It covers the architectural
+features that can be handled entirely on the builder side by inheriting
+from Gemma 3 and overriding the right hooks:
+
+  * `layer_types`-driven sliding-vs-full attention pattern (Gemma 3 used a
+    hard-coded every-6th-layer rule; Gemma 4 exposes a full per-layer list).
+  * Per-layer KV-cache head dimension (sliding layers use `head_dim=256`,
+    full layers use `global_head_dim=512`) - emitted through the existing
+    `make_key_value_cache_shape(layer_id, shape)` extension point.
+  * Proportional RoPE for full-attention layers (`rope_theta=1_000_000`,
+    `partial_rotary_factor=0.25`), alongside the default sliding RoPE
+    (`rope_theta=10_000`).
+  * Multimodal wrapper (`Gemma4ForConditionalGeneration`) weight prefix
+    stripping - handled at dispatch in `builder.py`.
+
+The following items are explicitly NOT handled by this scaffold and will
+raise `NotImplementedError` at build time. They require C++ runtime changes
+tracked as follow-up work (see PR description and issue #2062):
+
+  * Per-Layer Embeddings (PLE). Gemma 4's `embed_tokens` produces both
+    `inputs_embeds` [B, S, hidden] and `per_layer_inputs`
+    [B, S, num_hidden_layers, hidden_size_per_layer_input]. Each transformer
+    layer consumes its own slice. The GenAI runtime currently routes a single
+    embedding tensor through the decoder stack; supporting PLE requires a
+    new side-channel input plumbed through `make_inputs_and_outputs` and the
+    C++ model loader.
+
+  * KV cache sharing. Gemma 4 E2B has 35 decoder layers but only 15 own
+    unique KV caches (`num_kv_shared_layers=20`). Shared layers alias the
+    KV I/O of an earlier layer. The runtime's `kv_cache.cpp` currently
+    assumes one cache pair per layer.
+
+  * Per-layer `head_size` in the runtime. Even once this builder emits
+    correctly-shaped per-layer `past_key_values.{i}` tensors, `kv_cache.cpp`
+    allocates buffers with a single `model.decoder.head_size` value from
+    `genai_config.json`. The config schema needs to grow support for either
+    a per-layer list or a `head_size` + `global_head_size` pair driven by
+    the same `layer_types` pattern.
+
+This file is deliberately small and documented heavily so a maintainer
+picking up the follow-up work has a clear, verifiable starting point.
+
+References:
+  * Issue: https://github.com/microsoft/onnxruntime-genai/issues/2062
+  * Gemma 4 E2B config:
+    https://huggingface.co/google/gemma-4-E2B-it/blob/main/config.json
+  * HuggingFace model card:
+    https://huggingface.co/google/gemma-4-E2B-it
+  * Community ONNX export (for architectural reference only; uses a
+    different I/O contract than GenAI):
+    https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX
+"""
+
+from .gemma import Gemma3Model
+
+
+class Gemma4TextModel(Gemma3Model):
+    """Text-only decoder for Gemma 4 (E2B / E4B / 26B / 31B).
+
+    Inherits everything that still applies from Gemma 3:
+      - Gemma-family layer norm / embedding scaling
+      - q_norm / k_norm inside attention
+      - Sliding-window attention toggle per layer
+      - Multi-cache RoPE (global vs local theta)
+
+    Overrides:
+      - `is_local`            -> driven by `config.layer_types`
+      - `make_key_value_cache_shape` -> per-layer `head_size` selection
+      - `_rope_config_for_layer` / cache wiring for Gemma 4's two RoPE flavours
+      - `__init__`            -> records Gemma 4-specific attrs (global head
+        dim, KV sharing count, PLE dims, double-wide MLP flag) and raises
+        `NotImplementedError` when those features are actually required.
+    """
+
+    _SLIDING = "sliding_attention"
+    _FULL = "full_attention"
+
+    def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
+        # Gemma 4's multimodal wrapper stores the decoder config under
+        # `text_config`; the dispatcher in `builder.py` flattens it before
+        # we get here (see the `Gemma4ForConditionalGeneration` branch),
+        # but we defensively re-read the fields we need regardless.
+        self._layer_types = list(getattr(config, "layer_types", []))
+        self._head_dim_sliding = int(getattr(config, "head_dim", 256))
+        self._head_dim_full = int(getattr(config, "global_head_dim", self._head_dim_sliding))
+        self._hidden_size_per_layer_input = int(getattr(config, "hidden_size_per_layer_input", 0))
+        self._vocab_size_per_layer_input = int(getattr(config, "vocab_size_per_layer_input", 0))
+        self._num_kv_shared_layers = int(getattr(config, "num_kv_shared_layers", 0))
+        self._use_double_wide_mlp = bool(getattr(config, "use_double_wide_mlp", False))
+
+        rope_params = getattr(config, "rope_parameters", {}) or {}
+        full_params = rope_params.get(self._FULL, {}) if isinstance(rope_params, dict) else {}
+        slid_params = rope_params.get(self._SLIDING, {}) if isinstance(rope_params, dict) else {}
+        self._rope_theta_full = float(full_params.get("rope_theta", 1_000_000.0))
+        self._rope_theta_sliding = float(slid_params.get("rope_theta", getattr(config, "rope_theta", 10_000.0)))
+        self._rope_partial_factor_full = float(full_params.get("partial_rotary_factor", 1.0))
+        self._rope_type_full = str(full_params.get("rope_type", "default"))
+
+        # Bail early if the caller asks us to actually emit any of the
+        # not-yet-implemented pieces. We can still build config-only output
+        # so downstream tooling can at least inspect a minimal genai_config.
+        if not extra_options.get("config_only", False):
+            self._raise_if_unsupported_requested(extra_options)
+
+        super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
+
+        # After Gemma3's __init__ runs, `self.rope_local_theta` has been
+        # used to build the "local" (sliding) RoPE cache and the "global"
+        # RoPE cache uses `config.rope_theta`. For Gemma 4 the split lives
+        # inside `rope_parameters`; we re-point the attributes so inherited
+        # code that reads them does the right thing for Gemma 4.
+        self.rope_local_theta = self._rope_theta_sliding
+
+    def _raise_if_unsupported_requested(self, extra_options):
+        """Fail fast with an actionable message before we emit half a graph.
+
+        A future PR will flip each of these to a supported path once the
+        corresponding runtime change lands. Until then the only supported
+        workflow against this builder is `config_only=true`, which is still
+        useful for validating the dispatcher and genai_config shape.
+        """
+        missing = []
+        if self._hidden_size_per_layer_input > 0:
+            missing.append(
+                "Per-Layer Embeddings (PLE): "
+                f"hidden_size_per_layer_input={self._hidden_size_per_layer_input}. "
+                "Requires a new `per_layer_inputs` side-channel input both in "
+                "the ONNX graph and in the C++ model loader."
+            )
+        if self._num_kv_shared_layers > 0:
+            missing.append(
+                "KV cache sharing: "
+                f"num_kv_shared_layers={self._num_kv_shared_layers}. "
+                "Requires per-layer KV aliasing in kv_cache.cpp."
+            )
+        if self._head_dim_full != self._head_dim_sliding:
+            missing.append(
+                "Variable attention head dimension: "
+                f"head_dim={self._head_dim_sliding} on sliding layers, "
+                f"global_head_dim={self._head_dim_full} on full layers. "
+                "This builder can emit correct per-layer shapes via "
+                "`make_key_value_cache_shape`, but kv_cache.cpp allocates "
+                "using a single `model.decoder.head_size` value from "
+                "genai_config.json and must be taught to read per-layer shapes."
+            )
+        if missing:
+            details = "\n  - ".join(missing)
+            raise NotImplementedError(
+                "Gemma 4 support in onnxruntime-genai is not yet complete. "
+                "This builder scaffolding (tracked in issue #2062) currently "
+                "supports `config_only=true` runs only. Blockers:\n  - "
+                f"{details}\n"
+                "Use `--extra_options config_only=true` to generate "
+                "genai_config.json and processing files while runtime support "
+                "is being implemented."
+            )
+
+    # -- Attention pattern -------------------------------------------------
+
+    def is_local(self, layer_id):
+        """Gemma 4 exposes the attention type explicitly in `layer_types`.
+
+        Return True when the layer is sliding (local), False for full (global).
+        Falls back to Gemma 3's every-6th rule if `layer_types` was not
+        provided (shouldn't happen on published checkpoints but keeps tests
+        with trimmed configs working).
+        """
+        if self._layer_types and layer_id < len(self._layer_types):
+            return self._layer_types[layer_id] == self._SLIDING
+        return super().is_local(layer_id)
+
+    # -- KV cache shape ----------------------------------------------------
+
+    def make_key_value_cache_shape(self, layer_id, shape):
+        """Emit per-layer KV cache shapes for Gemma 4's variable head dim.
+
+        Gemma 4 uses `head_dim=256` on sliding-attention layers and
+        `global_head_dim=512` on full-attention layers. `shape` comes in
+        as `[batch, num_kv_heads, past_sequence_length, head_size]` where
+        `head_size` reflects the base (sliding) value.
+
+        We replace the last dim with the layer-specific head dim. The
+        trt-rtx 'sliding' token-name rewrite from the base implementation
+        is preserved.
+        """
+        base_shape = super().make_key_value_cache_shape(layer_id, shape)
+        if not self._layer_types or layer_id >= len(self._layer_types):
+            return base_shape
+        layer_head_dim = (
+            self._head_dim_sliding
+            if self._layer_types[layer_id] == self._SLIDING
+            else self._head_dim_full
+        )
+        return [base_shape[0], base_shape[1], base_shape[2], layer_head_dim]
+
+    # -- RoPE --------------------------------------------------------------
+
+    def make_rotary_embedding_multi_cache(self):
+        """Build the two RoPE caches Gemma 4 needs.
+
+        Sliding layers: standard RoPE with theta=10_000, partial_rotary=1.0.
+        Full layers:    'proportional' RoPE with theta=1_000_000 and
+                        partial_rotary_factor=0.25.
+
+        Gemma 3's implementation already emits two caches (global + local),
+        but assumes both share the same head dim. Until the runtime learns
+        per-layer head-dim awareness, we continue emitting both caches
+        sized to the sliding head dim. This is why any config with
+        `global_head_dim != head_dim` trips `_raise_if_unsupported_requested`
+        above. When that gate lifts, this method should be extended to
+        emit each cache at its own head-dim using a temporary
+        `self.head_size` swap (same pattern as `make_attention` uses for
+        `window_size`).
+        """
+        # Full-attention (global) cache. Gemma 3's own
+        # `make_rotary_embedding_caches` override accepts explicit
+        # cos/sin_cache_name kwargs and forwards to its super, so we
+        # delegate through the normal MRO rather than skipping Gemma 3.
+        self.rope_attrs["partial_rotary_factor"] = self._rope_partial_factor_full
+        self.rope_attrs["theta"] = self._rope_theta_full
+        self.cos_cache_global_name = "cos_cache_global"
+        self.sin_cache_global_name = "sin_cache_global"
+        super().make_rotary_embedding_caches(
+            cos_cache_name=self.cos_cache_global_name,
+            sin_cache_name=self.sin_cache_global_name,
+        )
+
+        # Sliding (local) cache
+        self.rope_attrs["create_caches"] = True
+        self.rope_attrs["partial_rotary_factor"] = 1.0
+        self.rope_attrs["theta"] = self._rope_theta_sliding
+        self.cos_cache_local_name = "cos_cache_local"
+        self.sin_cache_local_name = "sin_cache_local"
+        super().make_rotary_embedding_caches(
+            cos_cache_name=self.cos_cache_local_name,
+            sin_cache_name=self.sin_cache_local_name,
+        )

--- a/test/python/test_gemma4_builder.py
+++ b/test/python/test_gemma4_builder.py
@@ -1,0 +1,229 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+"""
+Tests for the Gemma 4 builder scaffolding (issue #2062).
+
+These tests avoid importing the full builder stack (which pulls in torch,
+transformers, and a recent onnxruntime). They validate the new Gemma 4-specific
+hooks (`is_local`, `make_key_value_cache_shape`, unsupported-feature gate) by
+loading `builders/gemma4.py` with a stubbed `Gemma3Model` parent so the
+test suite can run in a clean Python env.
+
+When you have the full build env set up, also run `builder.py` with
+`--extra_options config_only=true` against a Gemma 4 checkpoint to validate
+end-to-end config generation - that path is intentionally not mocked here.
+"""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_gemma4_with_stubbed_parent():
+    """Import `builders/gemma4.py` with a lightweight Gemma3Model stand-in.
+
+    We cannot just `from builders import Gemma4TextModel` because that
+    pulls in `base.py` -> onnx_ir + torch + a modern onnxruntime. For the
+    tests below we only need the Gemma 4-specific overrides, so we replace
+    the `.gemma` module with a shim that exposes a minimal `Gemma3Model`.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    gemma4_path = repo_root / "src" / "python" / "py" / "models" / "builders" / "gemma4.py"
+
+    fake_pkg = types.ModuleType("gemma4_test_pkg")
+    fake_pkg.__path__ = [str(gemma4_path.parent)]
+    sys.modules["gemma4_test_pkg"] = fake_pkg
+
+    gemma_shim = types.ModuleType("gemma4_test_pkg.gemma")
+
+    class _StubGemma3Model:
+        def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
+            self.config = config
+            self.io_dtype = io_dtype
+            self.onnx_dtype = onnx_dtype
+            self.ep = ep
+            self.cache_dir = cache_dir
+            self.extra_options = extra_options
+            self.rope_local_theta = getattr(config, "rope_theta", 10_000.0)
+            self.rope_attrs = {"create_caches": False, "partial_rotary_factor": 1.0, "theta": 10_000.0}
+            self._rope_cache_calls = []
+
+        def is_local(self, layer_id):
+            return bool((layer_id + 1) % 6)
+
+        def make_key_value_cache_shape(self, layer_id, shape):
+            # Mirrors the base-class trt-rtx branch so our Gemma 4 override
+            # can delegate without special-casing.
+            if getattr(self, "ep", None) == "trt-rtx" and self.is_local(layer_id):
+                return [shape[0], shape[1], shape[2].replace("sequence", "sliding"), shape[3]]
+            return shape
+
+        def make_rotary_embedding_caches(self, **kwargs):
+            self._rope_cache_calls.append({
+                "cos_cache_name": kwargs.get("cos_cache_name"),
+                "sin_cache_name": kwargs.get("sin_cache_name"),
+                "theta": self.rope_attrs["theta"],
+                "partial_rotary_factor": self.rope_attrs["partial_rotary_factor"],
+            })
+
+    gemma_shim.Gemma3Model = _StubGemma3Model
+    sys.modules["gemma4_test_pkg.gemma"] = gemma_shim
+
+    spec = importlib.util.spec_from_file_location(
+        "gemma4_test_pkg.gemma4", str(gemma4_path)
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Layer pattern matches google/gemma-4-E2B-it (35 layers, every 5th is full)
+GEMMA4_E2B_LAYER_TYPES = [
+    "sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+    "sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+    "sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+    "sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+    "sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+    "sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+    "sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+]
+
+
+def _make_e2b_config(**overrides):
+    cfg = SimpleNamespace(
+        layer_types=list(GEMMA4_E2B_LAYER_TYPES),
+        head_dim=256,
+        global_head_dim=512,
+        hidden_size_per_layer_input=256,
+        vocab_size_per_layer_input=262144,
+        num_kv_shared_layers=20,
+        use_double_wide_mlp=True,
+        rope_parameters={
+            "full_attention": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1_000_000.0,
+                "rope_type": "proportional",
+            },
+            "sliding_attention": {
+                "rope_theta": 10_000.0,
+                "rope_type": "default",
+            },
+        },
+        rope_theta=10_000.0,
+    )
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+class Gemma4BuilderScaffoldingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load_gemma4_with_stubbed_parent()
+        cls.Gemma4TextModel = cls.module.Gemma4TextModel
+
+    def _make(self, config=None, extra_options=None):
+        # We always pass config_only=True so the unsupported-feature gate
+        # doesn't fire; each test that wants to exercise the gate flips
+        # that flag off explicitly.
+        extra_options = {"config_only": True, **(extra_options or {})}
+        cfg = config or _make_e2b_config()
+        return self.Gemma4TextModel(cfg, None, None, "cpu", "", extra_options)
+
+    # is_local ------------------------------------------------------------
+
+    def test_is_local_uses_layer_types(self):
+        model = self._make()
+        # Full-attention layers on E2B are at 4, 9, 14, 19, 24, 29, 34.
+        full_layers = [4, 9, 14, 19, 24, 29, 34]
+        for i in range(35):
+            expected_local = i not in full_layers
+            self.assertEqual(
+                model.is_local(i),
+                expected_local,
+                f"layer {i}: expected is_local={expected_local}",
+            )
+
+    def test_is_local_falls_back_when_layer_types_missing(self):
+        cfg = _make_e2b_config(layer_types=[])
+        model = self._make(config=cfg)
+        # Should defer to the stub Gemma 3 every-6th rule.
+        self.assertTrue(model.is_local(0))
+        self.assertFalse(model.is_local(5))
+
+    # make_key_value_cache_shape -----------------------------------------
+
+    def test_kv_cache_shape_uses_sliding_head_dim_on_sliding_layers(self):
+        model = self._make()
+        base = ["batch", 1, "past_seq", 256]
+        self.assertEqual(
+            model.make_key_value_cache_shape(0, base),
+            ["batch", 1, "past_seq", 256],
+        )
+
+    def test_kv_cache_shape_uses_full_head_dim_on_full_layers(self):
+        model = self._make()
+        base = ["batch", 1, "past_seq", 256]
+        # Layers 4, 9, 14, ... should be full => head_dim 512.
+        for layer_id in (4, 9, 14, 19, 24, 29, 34):
+            with self.subTest(layer_id=layer_id):
+                shape = model.make_key_value_cache_shape(layer_id, base)
+                self.assertEqual(shape[3], 512, f"layer {layer_id} should use global_head_dim=512")
+
+    def test_kv_cache_shape_preserves_non_head_dim_axes(self):
+        model = self._make()
+        base = ["b", 4, "past_sequence_length", 256]
+        shape = model.make_key_value_cache_shape(0, base)
+        self.assertEqual(shape[:3], ["b", 4, "past_sequence_length"])
+
+    # Unsupported-feature gate -------------------------------------------
+
+    def test_gate_raises_on_ple(self):
+        cfg = _make_e2b_config(num_kv_shared_layers=0, global_head_dim=256)
+        with self.assertRaises(NotImplementedError) as cm:
+            self._make(config=cfg, extra_options={"config_only": False})
+        self.assertIn("Per-Layer Embeddings", str(cm.exception))
+
+    def test_gate_raises_on_kv_sharing(self):
+        cfg = _make_e2b_config(hidden_size_per_layer_input=0, global_head_dim=256)
+        with self.assertRaises(NotImplementedError) as cm:
+            self._make(config=cfg, extra_options={"config_only": False})
+        self.assertIn("KV cache sharing", str(cm.exception))
+
+    def test_gate_raises_on_variable_head_dim(self):
+        cfg = _make_e2b_config(hidden_size_per_layer_input=0, num_kv_shared_layers=0)
+        with self.assertRaises(NotImplementedError) as cm:
+            self._make(config=cfg, extra_options={"config_only": False})
+        self.assertIn("Variable attention head dimension", str(cm.exception))
+
+    def test_gate_quiet_in_config_only_mode(self):
+        # The whole point of the scaffold: config_only must still succeed so
+        # downstream tooling can generate genai_config.json.
+        model = self._make(extra_options={"config_only": True})
+        self.assertIsNotNone(model)
+
+    # RoPE cache wiring --------------------------------------------------
+
+    def test_rope_caches_are_emitted_for_both_attention_types(self):
+        model = self._make()
+        model.make_rotary_embedding_multi_cache()
+        calls = model._rope_cache_calls
+        self.assertEqual(len(calls), 2, "expected one cache each for full and sliding RoPE")
+
+        global_call = next(c for c in calls if c["cos_cache_name"] == "cos_cache_global")
+        local_call = next(c for c in calls if c["cos_cache_name"] == "cos_cache_local")
+
+        self.assertEqual(global_call["theta"], 1_000_000.0)
+        self.assertEqual(global_call["partial_rotary_factor"], 0.25)
+        self.assertEqual(local_call["theta"], 10_000.0)
+        self.assertEqual(local_call["partial_rotary_factor"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Scaffolds Gemma 4 support in the Python model builder, addressing part of #2062. Intentionally opened as a **Draft** because this is **Part 1 of N** — the builder-side work only. See "Scope" below for exactly what is and isn't covered, and why a functional end-to-end path requires paired C++ runtime changes.

Credit to @elbruno for the original architectural write-up in #2062; this PR follows that decomposition.

## Motivation

Google released the [Gemma 4 family](https://blog.google/technology/developers/gemma-4/) (E2B / E4B / 26B-A4B / 31B) in April 2026. All variants use a new architecture with three features that don't fit GenAI's current assumptions:

1. **Per-Layer Embeddings (PLE)** — `embed_tokens` emits two tensors; each decoder layer consumes its own slice.
2. **Variable attention head dimension** — sliding layers use `head_dim=256`, full-attention layers use `global_head_dim=512`.
3. **KV cache sharing** — E2B has 35 decoder layers but only 15 own unique KV caches (`num_kv_shared_layers=20`).

Existing workarounds (patching `builder.py` to route through Gemma 3, or using the `onnx-community/gemma-4-E2B-it-ONNX` export) fail with shape errors or I/O-contract mismatches. See #2062 for the full analysis.

## Scope

### ✅ Covered by this PR

- `builders/gemma4.py` (new): `Gemma4TextModel(Gemma3Model)` overriding:
  - `is_local(layer_id)` driven by `config.layer_types` (Gemma 3 used a hard-coded every-6th-layer rule; Gemma 4 exposes the full list).
  - `make_key_value_cache_shape(layer_id, shape)` using the existing per-layer extension point to emit `head_dim=256` on sliding layers and `global_head_dim=512` on full-attention layers.
  - `make_rotary_embedding_multi_cache()` building the two RoPE caches Gemma 4 needs (sliding: `theta=10_000`, `partial_rotary_factor=1.0`; full: `theta=1_000_000`, `partial_rotary_factor=0.25`, `rope_type=proportional`) from `config.rope_parameters`.
- `builder.py`: dispatch for `Gemma4ForConditionalGeneration` and `Gemma4ForCausalLM`, with `text_config` flattening and `exclude_embeds=true` defaulting, matching the existing Gemma 3 pattern.
- `builders/__init__.py`: exports `Gemma4TextModel`.
- `test/python/test_gemma4_builder.py` (new): 10 unit tests for the Gemma 4-specific overrides. Runs in a clean Python env — no torch / transformers / onnxruntime needed — by stubbing the `Gemma3Model` parent.

### ❌ Not covered — requires C++ runtime changes (Parts 2/3/4)

These are explicitly out of scope. The builder raises `NotImplementedError` listing exactly which ones were tripped, so users get an actionable error rather than a broken graph:

1. **Per-Layer Embeddings routing.** Needs a new `per_layer_inputs` side-channel input both in the ONNX graph (new `make_inputs_and_outputs` branch) and in the C++ model loader. Touches `src/models/model.cc` and friends.
2. **KV cache sharing.** `src/models/kv_cache.cpp` currently allocates one past/present pair per layer. Gemma 4 needs layer aliasing (20 of 35 layers reuse an earlier layer's KV).
3. **Per-layer `head_size` in the runtime.** Even with this builder emitting correct per-layer past_kv shapes, `kv_cache.cpp:17` reads a single `model_.config_->model.decoder.head_size` and applies it uniformly. The `genai_config.json` schema and the KV cache manager need per-layer awareness, or a `head_size` + `global_head_size` split driven by the same `layer_types` pattern the builder already understands.

Until those land, this builder supports `--extra_options config_only=true` only. That's still useful for validating the dispatcher and for downstream tooling that only needs `genai_config.json` / processing files. The gate makes that explicit rather than silently emitting a broken graph.

## Verification

```
cd test/python && python test_gemma4_builder.py -v
```

```
test_gate_quiet_in_config_only_mode ... ok
test_gate_raises_on_kv_sharing ... ok
test_gate_raises_on_ple ... ok
test_gate_raises_on_variable_head_dim ... ok
test_is_local_falls_back_when_layer_types_missing ... ok
test_is_local_uses_layer_types ... ok
test_kv_cache_shape_preserves_non_head_dim_axes ... ok
test_kv_cache_shape_uses_full_head_dim_on_full_layers ... ok
test_kv_cache_shape_uses_sliding_head_dim_on_sliding_layers ... ok
test_rope_caches_are_emitted_for_both_attention_types ... ok

Ran 10 tests in 0.009s
OK
```

The tests pin down:
- `is_local` matches the expected E2B pattern — full layers at exactly 4, 9, 14, 19, 24, 29, 34.
- `make_key_value_cache_shape` emits 512 on those seven layers and 256 everywhere else.
- The unsupported-feature gate raises individually for each of the three runtime blockers.
- `config_only=true` mode bypasses the gate cleanly.
- Both RoPE caches are emitted with the correct theta and partial-rotary factor.

## Request for maintainer review

Three specific things I'd welcome feedback on before taking Parts 2/3 further:

1. **PR decomposition.** Happy to split Parts 2/3/4 into separate PRs (runtime PLE, runtime KV sharing, runtime per-layer head_size) or keep them together — whichever matches your preference.
2. **Config schema.** For per-layer `head_size`, do you prefer (a) a `head_size` list in `genai_config.json`, (b) a `head_size` + `global_head_size` pair plus a `layer_types`-like pattern, or (c) keeping both values in the model metadata only and teaching `kv_cache.cpp` to read them from the ONNX graph? I have mild preference for (b) for symmetry with how `is_local` already works.
3. **RoPE caches at different head dims.** Currently the builder emits both RoPE caches sized to the sliding `head_dim`. Once per-layer head_size support lands in the runtime, the builder should emit the full-attention RoPE cache at `global_head_dim` — open to suggestions on the cleanest way to thread that through `make_rotary_embedding_caches` without duplicating logic.

## References

- Issue: #2062 (with @elbruno's analysis)
- Config: [`google/gemma-4-E2B-it/config.json`](https://huggingface.co/google/gemma-4-E2B-it/blob/main/config.json)
- Community ONNX export (architectural reference only; uses a GenAI-incompatible I/O contract): [`onnx-community/gemma-4-E2B-it-ONNX`](https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX)
