### PR TITLE
Add AMDGPU execution provider support

### DIFF
--- a/cmake/global_variables.cmake
+++ b/cmake/global_variables.cmake
@@ -81,6 +81,8 @@ file(GLOB generator_srcs CONFIGURE_DEPENDS
   "${GENERATORS_ROOT}/cuda/session_options.cpp"
   "${GENERATORS_ROOT}/nvtensorrtrtx/*.h"
   "${GENERATORS_ROOT}/nvtensorrtrtx/*.cpp"
+  "${GENERATORS_ROOT}/amdgpu/*.h"
+  "${GENERATORS_ROOT}/amdgpu/*.cpp"
   "${GENERATORS_ROOT}/vitisai/*.h"
   "${GENERATORS_ROOT}/vitisai/*.cpp"
   "${GENERATORS_ROOT}/dml/session_options.h"

--- a/src/amdgpu/session_options.cpp
+++ b/src/amdgpu/session_options.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "session_options.h"
+
+#include "../models/session_options.h"
+
+namespace Generators::AMDGPUExecutionProvider {
+
+DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
+                                         const Config::ProviderOptions& provider_options,
+                                         const Config& config,
+                                         bool /*disable_graph_capture*/) {
+  // AMDGPU does not have a device type specific allocator in OGA yet,
+  // so we use CPU as the device type. The AMDGPU EP handles CPU<->GPU
+  // transfers internally.
+  // V2 path: plugin EP registers as "AMDGPUExecutionProvider"
+  if (!AppendExecutionProviderV2(session_options, provider_options,
+                                 DeviceType::CPU, "AMDGPUExecutionProvider")) {
+    // V1 fallback: legacy ORT recognizes "MIGraphX"
+    std::vector<const char*> keys, values;
+    for (auto& option : provider_options.options) {
+      keys.emplace_back(option.first.c_str());
+      values.emplace_back(option.second.c_str());
+    }
+    session_options.AppendExecutionProvider("MIGraphX", keys.data(), values.data(), keys.size());
+  }
+
+  return nullptr;
+}
+
+}  // namespace Generators::AMDGPUExecutionProvider

--- a/src/amdgpu/session_options.h
+++ b/src/amdgpu/session_options.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#pragma once
+
+#include "../generators.h"
+
+namespace Generators::AMDGPUExecutionProvider {
+
+DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
+                                         const Config::ProviderOptions& provider_options,
+                                         const Config& config,
+                                         bool disable_graph_capture = false);
+
+}  // namespace Generators::AMDGPUExecutionProvider

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -30,6 +30,8 @@ std::string_view NormalizeProviderName(std::string_view name) {
     return "VitisAI";
   } else if (lower_name == "nvtensorrtrtx") {
     return "NvTensorRtRtx";
+  } else if (lower_name == "amdgpu") {
+    return "AMDGPU";
   }
   return name;  // Return name unchanged
 }
@@ -1385,6 +1387,8 @@ bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options) {
         }
       } else if (provider_options->name == "DML") {
         return true;
+      } else if (provider_options->name == "AMDGPU") {
+        return true;
       } else if (provider_options->name == "WebGPU") {
         for (const auto& value : provider_options->options) {
           if (value.first == "enableGraphCapture" && value.second == "1") {
@@ -1403,6 +1407,22 @@ bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options) {
     }
   }
 
+  return false;
+}
+
+bool NeedsStaticInputShapes(const Config::SessionOptions& session_options) {
+  for (const auto& provider : session_options.providers) {
+    const auto provider_options = std::find_if(session_options.provider_options.begin(),
+                                               session_options.provider_options.end(),
+                                               [&provider](const Config::ProviderOptions& po) {
+                                                 return po.name == provider;
+                                               });
+    if (provider_options != session_options.provider_options.end()) {
+      if (provider_options->name == "AMDGPU") {
+        return true;
+      }
+    }
+  }
   return false;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -427,6 +427,7 @@ void ClearProviders(Config& config);
 void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value);
 void OverlayConfig(Config& config, std::string_view json);
 bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options);
+bool NeedsStaticInputShapes(const Config::SessionOptions& session_options);
 bool IsMultiProfileEnabled(const Config::SessionOptions& session_options);
 
 void SetDecoderProviderOptionsHardwareDeviceType(Config& config, std::string_view provider_name, std::string_view hardware_device_type);

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -270,6 +270,7 @@ GeneratorParams::GeneratorParams(const Config& config)
 GeneratorParams::GeneratorParams(const Model& model)
     : config{*model.config_.get()},
       use_graph_capture{IsGraphCaptureEnabled(model.config_->model.decoder.session_options)},
+      use_static_input_shapes{NeedsStaticInputShapes(model.config_->model.decoder.session_options)},
       use_multi_profile{IsMultiProfileEnabled(model.config_->model.decoder.session_options)},
       p_device{model.p_device_scoring_} {
   if (use_graph_capture) {
@@ -432,6 +433,7 @@ void Generator::AppendTokens(cpu_span<const int32_t> input_ids) {
   auto input_ids_device = AllocateInputIdsOnDevice(input_ids);
   search_->AppendTokens(input_ids_device);
   computed_logits_ = false;
+  state_->prompt_gen_ = state_->params_->use_static_input_shapes;
   ComputeLogits(input_ids_device);
 }
 
@@ -587,6 +589,8 @@ void Generator::GenerateNextToken() {
     auto next_tokens = search_->GetNextTokens();
     if (last_action_ == Action::rewound)
       search_->AppendTokens(next_tokens);
+
+    state_->prompt_gen_ = false;
     ComputeLogits(next_tokens);
   }
   if (guidance_logits_processor_) {

--- a/src/generators.h
+++ b/src/generators.h
@@ -81,6 +81,7 @@ struct GeneratorParams : std::enable_shared_from_this<GeneratorParams>, LeakChec
 
   int max_batch_size{0};
   bool use_graph_capture{};
+  bool use_static_input_shapes{};
   bool use_multi_profile{};
   int BatchBeamSize() const { return search.num_beams * search.batch_size; }
 

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -107,6 +107,9 @@ void Logits::Update(const DeviceSpan<int32_t>& next_tokens, size_t new_kv_length
   }
 
   shape_[1] = new_kv_length;
+  if (state_.prompt_gen_) {
+    shape_[1] = state_.params_->search.max_length;
+  }
   output_raw_->CreateTensor(shape_, state_.params_->use_graph_capture && shape_[1] == 1);
   state_.outputs_[output_index_] = output_raw_->GetOrtTensor();
 }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -154,8 +154,51 @@ void State::Run(OrtSession& session, bool graph_capture_this_run) {
     run_options_->AddConfigEntry("disable_synchronize_execution_providers", "1");
   }
 
+  std::unique_ptr<OrtValue> new_input_ids;
+
+  if (prompt_gen_) {
+    for (int i = 0; i < inputs_.size(); i++) {
+      std::string input_name = input_names_[i];
+
+      if (input_name == "input_ids") {
+        int64_t batch_size = params_->search.batch_size;
+        int64_t padded_seq_len = static_cast<int64_t>(params_->search.max_length);
+        std::vector<int64_t> new_shape{batch_size, padded_seq_len};
+
+        OrtValue* value = inputs_[i];
+        auto info = value->GetTensorTypeAndShapeInfo();
+        ONNXTensorElementDataType elem_type = info->GetElementType();
+        std::vector<int64_t> dims = info->GetShape();
+        int64_t orig_seq_len = std::min(dims[1], padded_seq_len);
+
+        new_input_ids = OrtValue::CreateTensor(model_.allocator_cpu_, new_shape, elem_type);
+
+        if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
+          auto* src = value->GetTensorMutableData<int64_t>();
+          auto* dst = new_input_ids->GetTensorMutableData<int64_t>();
+          std::fill(dst, dst + batch_size * padded_seq_len, int64_t{0});
+          for (int64_t b = 0; b < batch_size; ++b) {
+            std::copy(src + b * orig_seq_len, src + b * orig_seq_len + orig_seq_len,
+                      dst + b * padded_seq_len);
+          }
+        } else {
+          auto* src = value->GetTensorMutableData<int32_t>();
+          auto* dst = new_input_ids->GetTensorMutableData<int32_t>();
+          std::fill(dst, dst + batch_size * padded_seq_len, int32_t{0});
+          for (int64_t b = 0; b < batch_size; ++b) {
+            std::copy(src + b * orig_seq_len, src + b * orig_seq_len + orig_seq_len,
+                      dst + b * padded_seq_len);
+          }
+        }
+        inputs_[i] = new_input_ids.get();
+        break;
+      }
+    }
+  }
   session.Run(run_options_.get(), input_names_.data(), inputs_.data(), input_names_.size(),
               output_names_.data(), outputs_.data(), output_names_.size());
+
+  new_input_ids.reset();
 
   extra_outputs_.RegisterOutputs();
 

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -51,6 +51,7 @@ struct State {
   std::vector<OrtValue*> inputs_, outputs_;
 
   std::vector<std::pair<std::string, std::string>> ep_dynamic_options_next_run_;
+  bool prompt_gen_{};
 
  protected:
   void Run(OrtSession& session, bool graph_capture_this_run = false);

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -131,10 +131,12 @@ void DefaultPositionInputs::Update(DeviceSpan<int32_t> next_tokens, int total_le
     // Initialize on first update
     if (is_first_update_) {
       position_ids_shape_[1] = new_length;
+      if (state_.prompt_gen_)
+        position_ids_shape_[1] = state_.params_->search.max_length;
       if (type_ == Ort::TypeToTensorType<int32_t>)
-        CreateAndInitializePositionIDs<int32_t>(next_tokens, position_ids_shape_);
+        CreateAndInitializePositionIDs<int32_t>(next_tokens, position_ids_shape_, new_length);
       else
-        CreateAndInitializePositionIDs<int64_t>(next_tokens, position_ids_shape_);
+        CreateAndInitializePositionIDs<int64_t>(next_tokens, position_ids_shape_, new_length);
     } else {
       UpdatePositionIDs(total_length, new_length);
     }
@@ -201,6 +203,8 @@ void DefaultPositionInputs::UpdatePositionIDs(int total_length, int new_kv_lengt
   // Reallocate position_ids when new_kv_length changes
   if (position_ids_shape_[1] != new_kv_length) {
     position_ids_shape_[1] = new_kv_length;
+    if (state_.prompt_gen_)
+      position_ids_shape_[1] = state_.params_->search.max_length;
     CreateNextPositionIDsTensor();
     state_.inputs_[posid_input_index_] = position_ids_->GetOrtTensor();
   }
@@ -252,28 +256,34 @@ void DefaultPositionInputs::UpdateAttentionMask(int total_length, int new_kv_len
 }
 
 template <typename T>
-void DefaultPositionInputs::CreateAndInitializePositionIDs(DeviceSpan<int32_t> next_tokens, std::array<int64_t, 2> shape) {
-  // Set attention mask to be 0 for pad tokens, and 1 for all other tokens.
-  // Set position id to be 0 for pad tokens, and accumulated sum of mask in a batch for other tokens
+void DefaultPositionInputs::CreateAndInitializePositionIDs(DeviceSpan<int32_t> next_tokens, std::array<int64_t, 2> shape,
+                                                           int seq_length) {
+  // shape[1] may be larger than seq_length when padded for AMDGPU static shapes.
+  // seq_length is the actual number of tokens per batch row in next_tokens.
   auto position_ids = OrtValue::CreateTensor(model_.allocator_cpu_, shape, type_);
   auto* position_data = position_ids->GetTensorMutableData<T>();
   auto position_ids_next = OrtValue::CreateTensor(model_.allocator_cpu_, std::array<int64_t, 2>{shape[0], 1}, type_);
   auto* position_data_next = position_ids_next->GetTensorMutableData<T>();
+
+  // Zero-fill entire tensor (covers padded region beyond seq_length)
+  std::fill(position_data, position_data + shape[0] * shape[1], T{0});
+
   // If batch_size is 1 we have no padding, so we do simple ascending
   if (shape[0] == 1) {
-    for (int i = 0; i < shape[1]; ++i) {
+    for (int i = 0; i < seq_length; ++i) {
       position_data[i] = static_cast<T>(i);
     }
-    position_data_next[0] = static_cast<T>(shape[1]) - 1;
+    position_data_next[0] = static_cast<T>(seq_length) - 1;
     // Otherwise we iterate backwards as to not misinterpret any right pad tokens
   } else {
-    const auto* word_id = const_cast<DeviceSpan<int32_t>&>(next_tokens).CpuSpan().data() + shape[0] * shape[1] - 1;
-    auto* position = position_data + shape[0] * shape[1] - 1;
+    // Use seq_length to index into next_tokens safely (it may be shorter than shape[1])
+    const auto* word_id = const_cast<DeviceSpan<int32_t>&>(next_tokens).CpuSpan().data() + shape[0] * seq_length - 1;
     bool found_first_non_pad = false;
     for (int i = static_cast<int>(shape[0] - 1); i >= 0; i--) {
-      T abs_position = static_cast<T>(shape[1] - 1);
+      T abs_position = static_cast<T>(seq_length - 1);
       found_first_non_pad = false;
-      for (int j = static_cast<int>(shape[1] - 1); j >= 0; j--, word_id--, position--) {
+      auto* position = position_data + i * shape[1] + seq_length - 1;
+      for (int j = seq_length - 1; j >= 0; j--, word_id--, position--) {
         // Non-pad tokens are set to their corresponding position
         if (found_first_non_pad) {
           *position = abs_position;

--- a/src/models/position_inputs.h
+++ b/src/models/position_inputs.h
@@ -30,7 +30,7 @@ struct DefaultPositionInputs : PositionInputs {
   template <typename T>
   void InitializeSequenceLengths(std::array<int64_t, 2> shape, cpu_span<int32_t> sequence_lengths_unk);
   template <typename T>
-  void CreateAndInitializePositionIDs(DeviceSpan<int32_t> next_tokens, std::array<int64_t, 2> shape);
+  void CreateAndInitializePositionIDs(DeviceSpan<int32_t> next_tokens, std::array<int64_t, 2> shape, int seq_length);
   template <typename T>
   void CreateAndInitializeAttentionMask(DeviceSpan<int32_t> next_tokens, std::array<int64_t, 2> shape);
   template <typename T>

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -12,6 +12,7 @@
 #include "../openvino/session_options.h"
 #include "../qnn/session_options.h"
 #include "../ryzenai/session_options.h"
+#include "../amdgpu/session_options.h"
 #include "../vitisai/session_options.h"
 #include "../webgpu/session_options.h"
 
@@ -153,6 +154,7 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
       {"OpenVINO", OpenVINOExecutionProvider::AppendExecutionProvider},
       {"RyzenAI", RyzenAIExecutionProvider::AppendExecutionProvider},
       {"QNN", QNNExecutionProvider::AppendExecutionProvider},
+      {"AMDGPU", AMDGPUExecutionProvider::AppendExecutionProvider},
       {"VitisAI", VitisAIExecutionProvider::AppendExecutionProvider},
       {"WebGPU", WebGPUExecutionProvider::AppendExecutionProvider},
   };


### PR DESCRIPTION
Add AMD GPU (MIGraphX) execution provider support to ONNX Runtime GenAI. The provider is exposed as "amdgpu" to users and maps to the MIGraphX EP in ONNX Runtime internally.

Changes:
- Create src/amdgpu/session_options.{h,cpp} with AppendExecutionProvider that tries V2 plugin path then falls back to V1 legacy API
- Add provider name normalization ("amdgpu" -> "AMDGPU") and register in the dispatch table
- Enable graph capture for AMDGPU to allow compiled graph reuse during token generation
- Add static input shape padding (prompt_gen_ flag) so the EP avoids recompilation on varying prompt lengths. Gated behind NeedsStaticInputShapes() to only activate for AMDGPU, not other EPs
- Fix input_ids padding to handle both int32 and int64 element types, and correct per-row copy for batch_size > 1
- Fix position_ids padding to prevent out-of-bounds read on next_tokens when tensor shape is padded to max_length for batch_size > 1

Configuration:
  "provider_options": [{ "amdgpu": {} }] or: config.append_provider("amdgpu")

Known limitations:
- Beam search not supported (requires past_present_share_buffer=true which requires num_beams=1)
- Inputs allocated on CPU; the MIGraphX EP handles CPU<->GPU transfers internally