### PR TITLE
Add quant mode for qwen3.5

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -51,6 +51,9 @@ from transformers import (
 )
 
 
+VALID_QUANT_MODES = frozenset({"default", "hybrid", "int4"})
+
+
 def check_extra_options(kv_pairs, execution_provider):
     """
     Check key-value pairs and set values correctly
@@ -75,15 +78,14 @@ def check_extra_options(kv_pairs, execution_provider):
     # Validate quant_mode if provided. Empty or whitespace-only values are
     # treated as unset so downstream builders can apply their default behavior.
     if "quant_mode" in kv_pairs:
-        valid_modes = {"default", "hybrid", "int4"}
         quant_mode = kv_pairs["quant_mode"]
         if isinstance(quant_mode, str):
-            quant_mode = quant_mode.strip()
+            quant_mode = quant_mode.strip().lower()
 
         if not quant_mode:
             del kv_pairs["quant_mode"]
-        elif quant_mode not in valid_modes:
-            valid_modes_display = ", ".join(sorted(valid_modes))
+        elif quant_mode not in VALID_QUANT_MODES:
+            valid_modes_display = ", ".join(sorted(VALID_QUANT_MODES))
             raise ValueError(
                 f"quant_mode must be one of {valid_modes_display}, got '{kv_pairs['quant_mode']}'"
             )

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -72,11 +72,23 @@ def check_extra_options(kv_pairs, execution_provider):
         "prune_lm_head",
     ]
 
-    # Validate quant_mode if provided
+    # Validate quant_mode if provided. Empty or whitespace-only values are
+    # treated as unset so downstream builders can apply their default behavior.
     if "quant_mode" in kv_pairs:
         valid_modes = {"default", "hybrid", "int4"}
-        if kv_pairs["quant_mode"] not in valid_modes:
-            raise ValueError(f"quant_mode must be one of {valid_modes}, got '{kv_pairs['quant_mode']}'")
+        quant_mode = kv_pairs["quant_mode"]
+        if isinstance(quant_mode, str):
+            quant_mode = quant_mode.strip()
+
+        if not quant_mode:
+            del kv_pairs["quant_mode"]
+        elif quant_mode not in valid_modes:
+            valid_modes_display = ", ".join(sorted(valid_modes))
+            raise ValueError(
+                f"quant_mode must be one of {valid_modes_display}, got '{kv_pairs['quant_mode']}'"
+            )
+        else:
+            kv_pairs["quant_mode"] = quant_mode
     for key in bools:
         if key in kv_pairs:
             if kv_pairs[key] in {"false", "False", "0"}:

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -71,6 +71,12 @@ def check_extra_options(kv_pairs, execution_provider):
         "disable_qkv_fusion",
         "prune_lm_head",
     ]
+
+    # Validate quant_mode if provided
+    if "quant_mode" in kv_pairs:
+        valid_modes = {"default", "hybrid", "int4"}
+        if kv_pairs["quant_mode"] not in valid_modes:
+            raise ValueError(f"quant_mode must be one of {valid_modes}, got '{kv_pairs['quant_mode']}'")
     for key in bools:
         if key in kv_pairs:
             if kv_pairs[key] in {"false", "False", "0"}:

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -1021,32 +1021,25 @@ class Qwen35TextModel(Model):
         # unlike softmax attention which normalizes per-step.
         #
         # Control via extra_options quant_mode:
-        #   "default"  - INT8 for all linear attn + MLP layers (original, most accurate)
+        #   "default"  - INT8 for all linear attn + MLP layers (most accurate)
         #   "hybrid"   - INT8 for linear attn projections only, INT4 for MLPs (balanced)
         #   "int4"     - INT4 for everything (fastest, may degrade quality)
         quant_mode = extra_options.get("quant_mode", "").strip().lower() or "default"
-        valid_modes = {"default", "hybrid", "int4"}
-        if quant_mode not in valid_modes:
-            raise ValueError(f"quant_mode must be one of {', '.join(sorted(valid_modes))}, got '{quant_mode}'")
+        if quant_mode not in ("default", "hybrid", "int4"):
+            raise ValueError(f"quant_mode must be one of default, hybrid, int4, got '{quant_mode}'")
+
+        linear_attn_projs = ("in_proj_a", "in_proj_b", "in_proj_qkv", "in_proj_z", "out_proj")
+        mlp_projs = ("gate_proj", "up_proj", "down_proj")
 
         int8_nodes = {}
-        if quant_mode == "default":
+        if quant_mode in ("default", "hybrid"):
             for i, lt in enumerate(self.layer_types):
                 if lt == "linear_attention":
-                    # All linear attention projections: INT8
-                    for proj in ("in_proj_a", "in_proj_b", "in_proj_qkv", "in_proj_z", "out_proj"):
+                    for proj in linear_attn_projs:
                         int8_nodes[f"/model/layers.{i}/linear_attn/{proj}/MatMul"] = {"bits": 8}
-                    # MLP projections in linear attention layers: INT8
-                    for proj in ("gate_proj", "up_proj", "down_proj"):
-                        int8_nodes[f"/model/layers.{i}/mlp/{proj}/MatMul"] = {"bits": 8}
-        elif quant_mode == "hybrid":
-            for i, lt in enumerate(self.layer_types):
-                if lt == "linear_attention":
-                    # Only linear attention projections: INT8 (recurrence-sensitive)
-                    for proj in ("in_proj_a", "in_proj_b", "in_proj_qkv", "in_proj_z", "out_proj"):
-                        int8_nodes[f"/model/layers.{i}/linear_attn/{proj}/MatMul"] = {"bits": 8}
-                    # MLP layers stay INT4 (feedforward, no error accumulation)
-        # quant_mode == "int4": no overrides, everything INT4
+                    if quant_mode == "default":
+                        for proj in mlp_projs:
+                            int8_nodes[f"/model/layers.{i}/mlp/{proj}/MatMul"] = {"bits": 8}
 
         if int8_nodes:
             algo_config = self.quant_attrs["int4"].get("algo_config")

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -1020,14 +1020,14 @@ class Qwen35TextModel(Model):
         # Linear attention recurrence accumulates errors across the full sequence,
         # unlike softmax attention which normalizes per-step.
         #
-        # Control via extra_options quant_mode or QWEN35_QUANT_MODE env var:
+        # Control via extra_options quant_mode:
         #   "default"  - INT8 for all linear attn + MLP layers (original, most accurate)
         #   "hybrid"   - INT8 for linear attn projections only, INT4 for MLPs (balanced)
         #   "int4"     - INT4 for everything (fastest, may degrade quality)
-        import os
-        quant_mode = extra_options.get("quant_mode", "") or os.environ.get("QWEN35_QUANT_MODE", "")
-        if not quant_mode:
-            quant_mode = "default"
+        quant_mode = extra_options.get("quant_mode", "").strip().lower() or "default"
+        valid_modes = {"default", "hybrid", "int4"}
+        if quant_mode not in valid_modes:
+            raise ValueError(f"quant_mode must be one of {', '.join(sorted(valid_modes))}, got '{quant_mode}'")
 
         int8_nodes = {}
         if quant_mode == "default":

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -1019,15 +1019,34 @@ class Qwen35TextModel(Model):
         #
         # Linear attention recurrence accumulates errors across the full sequence,
         # unlike softmax attention which normalizes per-step.
+        #
+        # Control via extra_options quant_mode or QWEN35_QUANT_MODE env var:
+        #   "default"  - INT8 for all linear attn + MLP layers (original, most accurate)
+        #   "hybrid"   - INT8 for linear attn projections only, INT4 for MLPs (balanced)
+        #   "int4"     - INT4 for everything (fastest, may degrade quality)
+        import os
+        quant_mode = extra_options.get("quant_mode", "") or os.environ.get("QWEN35_QUANT_MODE", "")
+        if not quant_mode:
+            quant_mode = "default"
+
         int8_nodes = {}
-        for i, lt in enumerate(self.layer_types):
-            if lt == "linear_attention":
-                # All linear attention projections: INT8
-                for proj in ("in_proj_a", "in_proj_b", "in_proj_qkv", "in_proj_z", "out_proj"):
-                    int8_nodes[f"/model/layers.{i}/linear_attn/{proj}/MatMul"] = {"bits": 8}
-                # MLP projections in linear attention layers: INT8
-                for proj in ("gate_proj", "up_proj", "down_proj"):
-                    int8_nodes[f"/model/layers.{i}/mlp/{proj}/MatMul"] = {"bits": 8}
+        if quant_mode == "default":
+            for i, lt in enumerate(self.layer_types):
+                if lt == "linear_attention":
+                    # All linear attention projections: INT8
+                    for proj in ("in_proj_a", "in_proj_b", "in_proj_qkv", "in_proj_z", "out_proj"):
+                        int8_nodes[f"/model/layers.{i}/linear_attn/{proj}/MatMul"] = {"bits": 8}
+                    # MLP projections in linear attention layers: INT8
+                    for proj in ("gate_proj", "up_proj", "down_proj"):
+                        int8_nodes[f"/model/layers.{i}/mlp/{proj}/MatMul"] = {"bits": 8}
+        elif quant_mode == "hybrid":
+            for i, lt in enumerate(self.layer_types):
+                if lt == "linear_attention":
+                    # Only linear attention projections: INT8 (recurrence-sensitive)
+                    for proj in ("in_proj_a", "in_proj_b", "in_proj_qkv", "in_proj_z", "out_proj"):
+                        int8_nodes[f"/model/layers.{i}/linear_attn/{proj}/MatMul"] = {"bits": 8}
+                    # MLP layers stay INT4 (feedforward, no error accumulation)
+        # quant_mode == "int4": no overrides, everything INT4
 
         if int8_nodes:
             algo_config = self.quant_attrs["int4"].get("algo_config")

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -15,8 +15,6 @@ from transformers import (
     Qwen3VLForConditionalGeneration,
 )
 
-from builder import VALID_QUANT_MODES
-
 from .base import Model
 
 
@@ -1027,8 +1025,8 @@ class Qwen35TextModel(Model):
         #   "hybrid"   - INT8 for linear attn projections only, INT4 for MLPs (balanced)
         #   "int4"     - INT4 for everything (fastest, may degrade quality)
         quant_mode = extra_options.get("quant_mode", "").strip().lower() or "default"
-        if quant_mode not in VALID_QUANT_MODES:
-            raise ValueError(f"quant_mode must be one of {', '.join(sorted(VALID_QUANT_MODES))}, got '{quant_mode}'")
+        if quant_mode not in ("default", "hybrid", "int4"):
+            raise ValueError(f"quant_mode must be one of default, hybrid, int4, got '{quant_mode}'")
 
         linear_attn_projs = ("in_proj_a", "in_proj_b", "in_proj_qkv", "in_proj_z", "out_proj")
         mlp_projs = ("gate_proj", "up_proj", "down_proj")

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -15,6 +15,8 @@ from transformers import (
     Qwen3VLForConditionalGeneration,
 )
 
+from builder import VALID_QUANT_MODES
+
 from .base import Model
 
 
@@ -1025,8 +1027,8 @@ class Qwen35TextModel(Model):
         #   "hybrid"   - INT8 for linear attn projections only, INT4 for MLPs (balanced)
         #   "int4"     - INT4 for everything (fastest, may degrade quality)
         quant_mode = extra_options.get("quant_mode", "").strip().lower() or "default"
-        if quant_mode not in ("default", "hybrid", "int4"):
-            raise ValueError(f"quant_mode must be one of default, hybrid, int4, got '{quant_mode}'")
+        if quant_mode not in VALID_QUANT_MODES:
+            raise ValueError(f"quant_mode must be one of {', '.join(sorted(VALID_QUANT_MODES))}, got '{quant_mode}'")
 
         linear_attn_projs = ("in_proj_a", "in_proj_b", "in_proj_qkv", "in_proj_z", "out_proj")
         mlp_projs = ("gate_proj", "up_proj", "down_proj")


### PR DESCRIPTION
This pull request introduces a new `quant_mode` option for configuring quantization behavior in Qwen model builders, allowing users to balance inference speed and model accuracy. The changes validate the `quant_mode` parameter, document its usage, and implement three quantization strategies: "default", "hybrid", and "int4".

Key changes:

**Quantization Mode Validation and Configuration**
* Added validation for the `quant_mode` option in the `check_extra_options` function to ensure only supported values ("default", "hybrid", "int4") are accepted.
* In the Qwen model builder, now reads `quant_mode` from `extra_options` or the `QWEN35_QUANT_MODE` environment variable, defaulting to "default" if unset.

**Quantization Strategy Implementation**
* Implemented three quantization strategies:
  - `"default"`: INT8 quantization for all linear attention and MLP layers (most accurate).
  - `"hybrid"`: INT8 for linear attention projections, INT4 for MLPs (balanced speed and accuracy).
  - `"int4"`: INT4 for all layers (fastest, may degrade quality).

**Documentation**
* Added inline documentation describing the quantization modes and their effects on model performance and quality.