### PR TITLE
Qwen3.5: drop fp32 cast around RMSNorm in builder

### DIFF
--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -954,16 +954,6 @@ class Qwen35TextModel(Model):
         # SkipSimplifiedLayerNormalization can be used directly.
         self.layernorm_attrs["add_offset"] = 1
 
-        # HF Qwen3_5RMSNorm always computes in float32 regardless of model
-        # dtype.  Force the builder to cast inputs to fp32 before LayerNorm
-        # and cast back after, matching HF behaviour and preventing precision
-        # loss that compounds across 36+ layers in fp16/bf16 builds.
-        self.layernorm_attrs["cast"]["use_fp32"] = True
-        self.layernorm_attrs["cast"]["root_input"] = True
-        self.layernorm_attrs["cast"]["skip_input"] = True
-        self.layernorm_attrs["cast"]["output_0"] = True
-        self.layernorm_attrs["cast"]["output_3"] = True
-
         # 3D position_ids for mRoPE: [3, batch_size, sequence_length]
         self.input_shapes["position_ids"] = [3, "batch_size", "sequence_length"]
         self.input_names["position_ids"] = "position_ids"


### PR DESCRIPTION
Removes the use_fp32 cast flags forcing LayerNorm IO to fp32 for Qwen3_5TextModel. Keeping RMSNorm in the model's native fp16 eliminates ~216 Cast nodes (108 to-fp32 + 108 to-fp16) across input_layernorm, post_attention_layernorm, and attention paths in a 24-layer build.

Measured on Qwen3.5-0.8B int4 WebGPU (3-run avg, prefill-1000 / 100 tok):

  NVIDIA RTX 5080
    gen tps:    76.6 -> 86.8  (+13.2%)
    prompt tps: 6937 -> 7153  (+3.1%)

  Intel iGPU(Xe-LPG, Intel Core Ultra 9 285K)
    gen tps:    33.1 -> 36.1  (+9.1%)
    prompt tps:  785 ->  789  (+0.5%)

  Apple M3 Max
    gen tps:    115.7 -> 122.3  (+5.7%)
    prompt tps: 3149.3 -> 3199.8  (+1.6%)
