### PR TITLE
Pipeline-as-Config: Declarative model dispatch replacing model_type string registry

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -5,6 +5,9 @@
 #include "models/model_type.h"
 #include "runtime_settings.h"
 #include "json.h"
+#include "pipeline_config_schema.h"
+#include "pipeline_presets.h"
+#include "v1_translator.h"
 #include <algorithm>
 #include <fstream>
 #include <sstream>
@@ -1491,6 +1494,152 @@ void ClearDecoderProviderOptionsHardwareVendorId(Config& config, std::string_vie
   }
 }
 
+// --- Pipeline v2 config element parsers (inline in config.cpp) ---
+// These are lightweight visitor classes that populate PipelineConfig
+// from the "pipeline" JSON object in v2 configs.
+
+struct PipelineSession_Element : JSON::Element {
+  explicit PipelineSession_Element(PipelineConfig::Session& s) : s_{s} {}
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "file") { s_.file = std::string(JSON::Get<std::string_view>(value)); return; }
+    if (name == "role") { s_.role = std::string(JSON::Get<std::string_view>(value)); return; }
+    throw JSON::unknown_value_error{};
+  }
+ private:
+  PipelineConfig::Session& s_;
+};
+
+struct PipelineSessions_Element : JSON::Element {
+  explicit PipelineSessions_Element(std::map<std::string, PipelineConfig::Session>& sessions)
+      : sessions_{sessions} {}
+  Element& OnObject(std::string_view name) override {
+    auto [it, _] = sessions_.emplace(std::string(name), PipelineConfig::Session{});
+    current_.emplace(it->second);
+    return *current_;
+  }
+ private:
+  std::map<std::string, PipelineConfig::Session>& sessions_;
+  std::optional<PipelineSession_Element> current_;
+};
+
+struct PipelineFlowStep_Element : JSON::Element {
+  explicit PipelineFlowStep_Element(PipelineConfig::FlowStep& step) : step_{step} {}
+  void OnValue(std::string_view name, JSON::Value value) override {
+    auto sv = JSON::Get<std::string_view>(value);
+    if (name == "run") { step_.run = std::string(sv); return; }
+    if (name == "when") { step_.when = std::string(sv); return; }
+    if (name == "loop") { step_.loop = std::string(sv); return; }
+    throw JSON::unknown_value_error{};
+  }
+ private:
+  PipelineConfig::FlowStep& step_;
+};
+
+struct PipelineFlow_Element : JSON::Element {
+  explicit PipelineFlow_Element(std::vector<PipelineConfig::FlowStep>& flow) : flow_{flow} {}
+  Element& OnObject(std::string_view /*name*/) override {
+    flow_.emplace_back();
+    current_.emplace(flow_.back());
+    return *current_;
+  }
+ private:
+  std::vector<PipelineConfig::FlowStep>& flow_;
+  std::optional<PipelineFlowStep_Element> current_;
+};
+
+struct PipelineDataflowWire_Element : JSON::Element {
+  explicit PipelineDataflowWire_Element(PipelineConfig::DataflowWire& wire) : wire_{wire} {}
+  void OnValue(std::string_view name, JSON::Value value) override {
+    auto sv = JSON::Get<std::string_view>(value);
+    if (name == "from_session") { wire_.from_session = std::string(sv); return; }
+    if (name == "from_output") { wire_.from_output = std::string(sv); return; }
+    if (name == "to_session") { wire_.to_session = std::string(sv); return; }
+    if (name == "to_input") { wire_.to_input = std::string(sv); return; }
+    throw JSON::unknown_value_error{};
+  }
+ private:
+  PipelineConfig::DataflowWire& wire_;
+};
+
+struct PipelineDataflow_Element : JSON::Element {
+  explicit PipelineDataflow_Element(std::vector<PipelineConfig::DataflowWire>& df)
+      : dataflow_{df} {}
+  Element& OnObject(std::string_view /*name*/) override {
+    dataflow_.emplace_back();
+    current_.emplace(dataflow_.back());
+    return *current_;
+  }
+ private:
+  std::vector<PipelineConfig::DataflowWire>& dataflow_;
+  std::optional<PipelineDataflowWire_Element> current_;
+};
+
+struct PipelineKVCache_Element : JSON::Element {
+  explicit PipelineKVCache_Element(PipelineConfig::StateConfig::KVCache& kv) : kv_{kv} {}
+  void OnValue(std::string_view name, JSON::Value value) override {
+    auto sv = JSON::Get<std::string_view>(value);
+    if (name == "format") { kv_.format = std::string(sv); return; }
+    if (name == "past_key_pattern") { kv_.past_key_pattern = std::string(sv); return; }
+    if (name == "present_key_pattern") { kv_.present_key_pattern = std::string(sv); return; }
+    if (name == "past_value_pattern") { kv_.past_value_pattern = std::string(sv); return; }
+    if (name == "present_value_pattern") { kv_.present_value_pattern = std::string(sv); return; }
+    throw JSON::unknown_value_error{};
+  }
+ private:
+  PipelineConfig::StateConfig::KVCache& kv_;
+};
+
+struct PipelinePositionIds_Element : JSON::Element {
+  explicit PipelinePositionIds_Element(PipelineConfig::StateConfig::PositionIds& pos) : pos_{pos} {}
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "strategy") { pos_.strategy = std::string(JSON::Get<std::string_view>(value)); return; }
+    throw JSON::unknown_value_error{};
+  }
+ private:
+  PipelineConfig::StateConfig::PositionIds& pos_;
+};
+
+struct PipelineState_Element : JSON::Element {
+  explicit PipelineState_Element(PipelineConfig::StateConfig& state) : state_{state} {}
+  Element& OnObject(std::string_view name) override {
+    if (name == "kv_cache") { kv_.emplace(state_.kv_cache); return *kv_; }
+    if (name == "position_ids") { pos_.emplace(state_.position_ids); return *pos_; }
+    throw JSON::unknown_value_error{};
+  }
+ private:
+  PipelineConfig::StateConfig& state_;
+  std::optional<PipelineKVCache_Element> kv_;
+  std::optional<PipelinePositionIds_Element> pos_;
+};
+
+// Top-level "pipeline" object element — routes to sessions/flow/dataflow/state
+struct Pipeline_V2_Element : JSON::Element {
+  explicit Pipeline_V2_Element(PipelineConfig& config) : config_{config} {}
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "extends") {
+      config_.extends = std::string(JSON::Get<std::string_view>(value));
+      return;
+    }
+    throw JSON::unknown_value_error{};
+  }
+  Element& OnObject(std::string_view name) override {
+    if (name == "sessions") { sessions_.emplace(config_.sessions); return *sessions_; }
+    if (name == "state") { state_.emplace(config_.state); return *state_; }
+    throw JSON::unknown_value_error{};
+  }
+  Element& OnArray(std::string_view name) override {
+    if (name == "flow") { flow_.emplace(config_.flow); return *flow_; }
+    if (name == "dataflow") { dataflow_.emplace(config_.dataflow); return *dataflow_; }
+    throw JSON::unknown_value_error{};
+  }
+ private:
+  PipelineConfig& config_;
+  std::optional<PipelineSessions_Element> sessions_;
+  std::optional<PipelineFlow_Element> flow_;
+  std::optional<PipelineDataflow_Element> dataflow_;
+  std::optional<PipelineState_Element> state_;
+};
+
 struct Root_Element : JSON::Element {
   explicit Root_Element(Config& config) : config_{config} {}
 
@@ -1506,6 +1655,7 @@ struct Root_Element : JSON::Element {
     if (name == "model") return model_element_;
     if (name == "search") return search_element_;
     if (name == "engine") return engine_element_;
+    if (name == "pipeline") return pipeline_element_;
     throw JSON::unknown_value_error{};
   }
 
@@ -1513,6 +1663,7 @@ struct Root_Element : JSON::Element {
   Model_Element model_element_{config_.model};
   Search_Element search_element_{config_.search};
   Engine_Element engine_element_{config_.engine};
+  Pipeline_V2_Element pipeline_element_{config_.pipeline_config};
 };
 
 struct RootObject_Element : JSON::Element {
@@ -1567,6 +1718,21 @@ void OverlayConfig(Config& config, std::string_view json) {
 
 Config::Config(const fs::path& path, std::string_view json_overlay) : config_path{path} {
   ParseConfig(path / "genai_config.json", json_overlay, *this);
+
+  // Resolve pipeline config: for v2, apply preset + validate; for v1, translate
+  if (version >= 2) {
+    if (pipeline_config.extends.has_value()) {
+      auto preset = GetPreset(pipeline_config.extends.value());
+      // User config overrides preset defaults
+      PipelineConfig user_overrides = std::move(pipeline_config);
+      pipeline_config = std::move(preset);
+      ApplyOverrides(pipeline_config, user_overrides);
+    }
+    ValidatePipelineConfig(pipeline_config);
+  } else {
+    // Auto-translate v1 config so pipeline_config is always populated
+    pipeline_config = TranslateV1Config(*this);
+  }
 
   if (model.context_length == 0 && !ModelType::IsRNNT(model.type)) {
     throw std::runtime_error("model context_length is 0 or was not set. It must be greater than 0");

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1620,6 +1620,10 @@ struct Pipeline_V2_Element : JSON::Element {
       config_.extends = std::string(JSON::Get<std::string_view>(value));
       return;
     }
+    if (name == "generation_loop") {
+      config_.generation_loop = std::string(JSON::Get<std::string_view>(value));
+      return;
+    }
     throw JSON::unknown_value_error{};
   }
   Element& OnObject(std::string_view name) override {
@@ -1728,6 +1732,7 @@ Config::Config(const fs::path& path, std::string_view json_overlay) : config_pat
       pipeline_config = std::move(preset);
       ApplyOverrides(pipeline_config, user_overrides);
     }
+    NormalizePipelineConfig(pipeline_config);
     ValidatePipelineConfig(pipeline_config);
 
     // Sync v2 pipeline decoder session file to model.decoder.filename

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1729,6 +1729,14 @@ Config::Config(const fs::path& path, std::string_view json_overlay) : config_pat
       ApplyOverrides(pipeline_config, user_overrides);
     }
     ValidatePipelineConfig(pipeline_config);
+
+    // Sync v2 pipeline decoder session file to model.decoder.filename
+    // so that DecoderOnly_Model's constructor loads the correct session.
+    auto decoder_it = pipeline_config.sessions.find("decoder");
+    if (decoder_it != pipeline_config.sessions.end() &&
+        !decoder_it->second.file.empty()) {
+      model.decoder.filename = decoder_it->second.file;
+    }
   } else {
     // Auto-translate v1 config so pipeline_config is always populated
     pipeline_config = TranslateV1Config(*this);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1494,8 +1494,12 @@ void ClearDecoderProviderOptionsHardwareVendorId(Config& config, std::string_vie
 struct Root_Element : JSON::Element {
   explicit Root_Element(Config& config) : config_{config} {}
 
-  void OnValue(std::string_view /*name*/, JSON::Value /*value*/) override {
-    // No top-level scalar values currently supported
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "version") {
+      config_.version = static_cast<int>(JSON::Get<double>(value));
+      return;
+    }
+    // Ignore unknown top-level scalars for forward compatibility
   }
 
   Element& OnObject(std::string_view name) override {

--- a/src/config.h
+++ b/src/config.h
@@ -3,6 +3,8 @@
 // Modifications Copyright(C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #pragma once
 
+#include "pipeline_config_schema.h"
+
 namespace Generators {
 
 struct RuntimeSettings;
@@ -84,6 +86,8 @@ struct Config {
   fs::path config_path;  // Path of the config directory
 
   int version{1};  // Config schema version (1 = legacy string dispatch, 2 = pipeline-as-config)
+
+  PipelineConfig pipeline_config;  // v2 pipeline configuration (populated for both v1 and v2 configs)
 
   using NamedString = std::pair<std::string, std::string>;
   struct DeviceFilteringOptions {

--- a/src/config.h
+++ b/src/config.h
@@ -83,6 +83,8 @@ struct Config {
 
   fs::path config_path;  // Path of the config directory
 
+  int version{1};  // Config schema version (1 = legacy string dispatch, 2 = pipeline-as-config)
+
   using NamedString = std::pair<std::string, std::string>;
   struct DeviceFilteringOptions {
     std::optional<OrtHardwareDeviceType> hardware_device_type;  // OrtHardwareDeviceType_CPU, OrtHardwareDeviceType_GPU, OrtHardwareDeviceType_NPU

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -286,7 +286,9 @@ void GeneratorParams::SetGuidance(std::string_view type, std::string_view data, 
 bool GeneratorParams::IsPastPresentShareBufferEnabled(const Config& config) const {
   // past_present_share_buffer is only actually enabled when:
   // 1. The config option is set to true, AND
-  // 2. Either num_beams == 1 OR the model is encoder-decoder (has encoder session)
+  // 2. Either num_beams == 1 OR the model is encoder-decoder (has encoder
+  //    session).  Encoder-decoder models like Whisper use cache_indirection
+  //    for beam reordering, making share buffer safe with beam search.
   bool is_encoder_decoder = config.pipeline_config.sessions.count("encoder") > 0;
   return search.past_present_share_buffer &&
          (search.num_beams == 1 || is_encoder_decoder);

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -283,12 +283,13 @@ void GeneratorParams::SetGuidance(std::string_view type, std::string_view data, 
   guidance_ff_tokens_enabled = enable_ff_tokens;
 }
 
-bool GeneratorParams::IsPastPresentShareBufferEnabled(const std::string& model_type) const {
+bool GeneratorParams::IsPastPresentShareBufferEnabled(const Config& config) const {
   // past_present_share_buffer is only actually enabled when:
   // 1. The config option is set to true, AND
-  // 2. Either num_beams == 1 OR the model is Whisper
+  // 2. Either num_beams == 1 OR the model is encoder-decoder (has encoder session)
+  bool is_encoder_decoder = config.pipeline_config.sessions.count("encoder") > 0;
   return search.past_present_share_buffer &&
-         (search.num_beams == 1 || model_type == "whisper");
+         (search.num_beams == 1 || is_encoder_decoder);
 }
 
 double GeneratorParams::GetSearchNumber(std::string_view name) const {

--- a/src/generators.h
+++ b/src/generators.h
@@ -91,9 +91,9 @@ struct GeneratorParams : std::enable_shared_from_this<GeneratorParams>, LeakChec
   bool guidance_ff_tokens_enabled{false};  // Whether to enable ff_tokens during constrained decoding
   void SetGuidance(std::string_view type, std::string_view data, bool enable_ff_tokens);
 
-  // Determines if past_present_share_buffer is actually enabled based on config and runtime conditions
-  // Returns true only if config option is true AND (num_beams == 1 OR model is Whisper)
-  bool IsPastPresentShareBufferEnabled(const std::string& model_type) const;
+  // Determines if past_present_share_buffer is actually enabled based on config and runtime conditions.
+  // Returns true only if config option is true AND (num_beams == 1 OR model is encoder-decoder).
+  bool IsPastPresentShareBufferEnabled(const Config& config) const;
 };
 
 struct Generator : LeakChecked<Generator> {

--- a/src/models/flow_interpreter.cpp
+++ b/src/models/flow_interpreter.cpp
@@ -11,24 +11,28 @@ FlowInterpreter::FlowInterpreter(const PipelineConfig& pipeline_config)
     : dataflow_{pipeline_config.dataflow} {
   // Partition flow steps by execution phase
   for (const auto& step : pipeline_config.flow) {
-    if (step.when == "prompt" || step.when == "once") {
-      prompt_steps_.push_back(step);
-    }
-    if (step.when == "always") {
-      always_steps_.push_back(step);
+    if (step.when == "init") {
+      init_steps_.push_back(step);
+    } else if (step.when == "step") {
+      step_steps_.push_back(step);
+    } else if (step.when == "final") {
+      final_steps_.push_back(step);
     }
   }
 
   is_multi_session_ = pipeline_config.sessions.size() > 1;
 
-  // Identify prompt-only sessions (sessions that never appear in always_steps)
-  std::set<std::string> always_session_names;
-  for (const auto& step : always_steps_) {
-    always_session_names.insert(step.run);
+  // Identify init-only sessions (sessions that never appear in step_steps or final_steps)
+  std::set<std::string> non_init_session_names;
+  for (const auto& step : step_steps_) {
+    non_init_session_names.insert(step.run);
   }
-  for (const auto& step : prompt_steps_) {
-    if (always_session_names.find(step.run) == always_session_names.end()) {
-      prompt_only_sessions_.insert(step.run);
+  for (const auto& step : final_steps_) {
+    non_init_session_names.insert(step.run);
+  }
+  for (const auto& step : init_steps_) {
+    if (non_init_session_names.find(step.run) == non_init_session_names.end()) {
+      init_only_sessions_.insert(step.run);
     }
   }
 }

--- a/src/models/flow_interpreter.cpp
+++ b/src/models/flow_interpreter.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../generators.h"
+#include "flow_interpreter.h"
+#include <set>
+
+namespace Generators {
+
+FlowInterpreter::FlowInterpreter(const PipelineConfig& pipeline_config)
+    : dataflow_{pipeline_config.dataflow} {
+  // Partition flow steps by execution phase
+  for (const auto& step : pipeline_config.flow) {
+    if (step.when == "prompt" || step.when == "once") {
+      prompt_steps_.push_back(step);
+    }
+    if (step.when == "always") {
+      always_steps_.push_back(step);
+    }
+    // Note: "prompt" steps go into prompt_steps_ only.
+    // "always" steps go into always_steps_ only — they run on both prompt and decode.
+    // "once" steps go into prompt_steps_ only — they run once before generation.
+  }
+
+  // Determine if this is a multi-session pipeline
+  is_multi_session_ = pipeline_config.sessions.size() > 1;
+
+  // Identify prompt-only sessions (sessions that never appear in always_steps)
+  std::set<std::string> always_session_names;
+  for (const auto& step : always_steps_) {
+    always_session_names.insert(step.run);
+  }
+  for (const auto& step : prompt_steps_) {
+    if (always_session_names.find(step.run) == always_session_names.end()) {
+      prompt_only_sessions_.insert(step.run);
+    }
+  }
+}
+
+void FlowInterpreter::StoreIntermediate(const std::string& session_name,
+                                         const std::string& tensor_name,
+                                         OrtValue* value) {
+  intermediates_[session_name + "." + tensor_name] = value;
+}
+
+OrtValue* FlowInterpreter::GetIntermediate(const std::string& session_name,
+                                            const std::string& tensor_name) const {
+  auto key = session_name + "." + tensor_name;
+  auto it = intermediates_.find(key);
+  return it != intermediates_.end() ? it->second : nullptr;
+}
+
+std::vector<std::pair<std::string, OrtValue*>> FlowInterpreter::GetWiredInputs(
+    const std::string& session_name) const {
+  std::vector<std::pair<std::string, OrtValue*>> result;
+  for (const auto& wire : dataflow_) {
+    if (wire.to_session == session_name) {
+      auto* value = GetIntermediate(wire.from_session, wire.from_output);
+      if (value) {
+        result.emplace_back(wire.to_input, value);
+      }
+    }
+  }
+  return result;
+}
+
+void FlowInterpreter::ClearPromptIntermediates() {
+  for (auto it = intermediates_.begin(); it != intermediates_.end();) {
+    // Extract session name from key "session.tensor"
+    auto dot = it->first.find('.');
+    if (dot != std::string::npos) {
+      auto session_name = it->first.substr(0, dot);
+      if (prompt_only_sessions_.count(session_name)) {
+        it = intermediates_.erase(it);
+        continue;
+      }
+    }
+    ++it;
+  }
+}
+
+void FlowInterpreter::ClearAll() {
+  intermediates_.clear();
+}
+
+}  // namespace Generators

--- a/src/models/flow_interpreter.cpp
+++ b/src/models/flow_interpreter.cpp
@@ -17,12 +17,8 @@ FlowInterpreter::FlowInterpreter(const PipelineConfig& pipeline_config)
     if (step.when == "always") {
       always_steps_.push_back(step);
     }
-    // Note: "prompt" steps go into prompt_steps_ only.
-    // "always" steps go into always_steps_ only — they run on both prompt and decode.
-    // "once" steps go into prompt_steps_ only — they run once before generation.
   }
 
-  // Determine if this is a multi-session pipeline
   is_multi_session_ = pipeline_config.sessions.size() > 1;
 
   // Identify prompt-only sessions (sessions that never appear in always_steps)
@@ -37,50 +33,20 @@ FlowInterpreter::FlowInterpreter(const PipelineConfig& pipeline_config)
   }
 }
 
-void FlowInterpreter::StoreIntermediate(const std::string& session_name,
-                                         const std::string& tensor_name,
-                                         OrtValue* value) {
-  intermediates_[session_name + "." + tensor_name] = value;
-}
-
-OrtValue* FlowInterpreter::GetIntermediate(const std::string& session_name,
-                                            const std::string& tensor_name) const {
-  auto key = session_name + "." + tensor_name;
-  auto it = intermediates_.find(key);
-  return it != intermediates_.end() ? it->second : nullptr;
-}
-
 std::vector<std::pair<std::string, OrtValue*>> FlowInterpreter::GetWiredInputs(
-    const std::string& session_name) const {
+    const std::string& session_name,
+    const std::map<std::string, OrtValue*>& intermediates) const {
   std::vector<std::pair<std::string, OrtValue*>> result;
   for (const auto& wire : dataflow_) {
     if (wire.to_session == session_name) {
-      auto* value = GetIntermediate(wire.from_session, wire.from_output);
-      if (value) {
-        result.emplace_back(wire.to_input, value);
+      auto key = wire.from_session + "." + wire.from_output;
+      auto it = intermediates.find(key);
+      if (it != intermediates.end() && it->second) {
+        result.emplace_back(wire.to_input, it->second);
       }
     }
   }
   return result;
-}
-
-void FlowInterpreter::ClearPromptIntermediates() {
-  for (auto it = intermediates_.begin(); it != intermediates_.end();) {
-    // Extract session name from key "session.tensor"
-    auto dot = it->first.find('.');
-    if (dot != std::string::npos) {
-      auto session_name = it->first.substr(0, dot);
-      if (prompt_only_sessions_.count(session_name)) {
-        it = intermediates_.erase(it);
-        continue;
-      }
-    }
-    ++it;
-  }
-}
-
-void FlowInterpreter::ClearAll() {
-  intermediates_.clear();
 }
 
 }  // namespace Generators

--- a/src/models/flow_interpreter.h
+++ b/src/models/flow_interpreter.h
@@ -61,6 +61,9 @@ struct FlowInterpreter {
   // Access the dataflow wires for inspection/debugging.
   const std::vector<PipelineConfig::DataflowWire>& dataflow() const { return dataflow_; }
 
+  // Access prompt-only session names (sessions that only run during prompt phase).
+  const std::set<std::string>& prompt_only_sessions() const { return prompt_only_sessions_; }
+
  private:
   std::vector<PipelineConfig::FlowStep> prompt_steps_;
   std::vector<PipelineConfig::FlowStep> always_steps_;

--- a/src/models/flow_interpreter.h
+++ b/src/models/flow_interpreter.h
@@ -25,8 +25,9 @@ struct FlowInterpreter {
   explicit FlowInterpreter(const PipelineConfig& pipeline_config);
 
   // Partitioned flow steps.  Populated at construction from pipeline_config.flow[].
-  const std::vector<PipelineConfig::FlowStep>& prompt_steps() const { return prompt_steps_; }
-  const std::vector<PipelineConfig::FlowStep>& always_steps() const { return always_steps_; }
+  const std::vector<PipelineConfig::FlowStep>& init_steps() const { return init_steps_; }
+  const std::vector<PipelineConfig::FlowStep>& step_steps() const { return step_steps_; }
+  const std::vector<PipelineConfig::FlowStep>& final_steps() const { return final_steps_; }
 
   // Returns true when the pipeline has more than just a decoder session.
   bool IsMultiSession() const { return is_multi_session_; }
@@ -41,15 +42,16 @@ struct FlowInterpreter {
   // Access the dataflow wires for inspection/debugging.
   const std::vector<PipelineConfig::DataflowWire>& dataflow() const { return dataflow_; }
 
-  // Access prompt-only session names (sessions that only run during prompt phase).
-  const std::set<std::string>& prompt_only_sessions() const { return prompt_only_sessions_; }
+  // Access init-only session names (sessions that only run during init phase).
+  const std::set<std::string>& init_only_sessions() const { return init_only_sessions_; }
 
  private:
-  std::vector<PipelineConfig::FlowStep> prompt_steps_;
-  std::vector<PipelineConfig::FlowStep> always_steps_;
+  std::vector<PipelineConfig::FlowStep> init_steps_;
+  std::vector<PipelineConfig::FlowStep> step_steps_;
+  std::vector<PipelineConfig::FlowStep> final_steps_;
   std::vector<PipelineConfig::DataflowWire> dataflow_;
   bool is_multi_session_{false};
-  std::set<std::string> prompt_only_sessions_;
+  std::set<std::string> init_only_sessions_;
 };
 
 }  // namespace Generators

--- a/src/models/flow_interpreter.h
+++ b/src/models/flow_interpreter.h
@@ -3,19 +3,19 @@
 
 // Flow interpreter for Pipeline-as-Config multi-session pipelines.
 //
-// The FlowInterpreter is a thin orchestration layer that:
+// The FlowInterpreter is a STATELESS orchestration layer that:
 //   1. Partitions flow steps into prompt-phase and decode-phase groups
-//   2. Stores intermediate tensors produced by non-decoder sessions
-//   3. Wires intermediate tensors between sessions based on dataflow config
+//   2. Resolves dataflow wiring between sessions
 //
-// It does NOT own session execution or manage decoder-specific state (KV cache,
-// position inputs, logits).  Each session runs through its own State object.
+// It does NOT store intermediate tensors or manage session execution.
+// Intermediate tensor storage is owned by PipelineConfigState (per-State,
+// not per-Model) to avoid clobbering when multiple States share a Model.
 
 #pragma once
 #include "../pipeline_config_schema.h"
 #include "model.h"
 #include <map>
-#include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -25,38 +25,18 @@ struct FlowInterpreter {
   explicit FlowInterpreter(const PipelineConfig& pipeline_config);
 
   // Partitioned flow steps.  Populated at construction from pipeline_config.flow[].
-  //
-  // prompt_steps: steps with when=="prompt" or when=="once" — run only on first invocation.
-  // always_steps: steps with when=="always" — run every invocation (prompt + decode).
-  //
-  // On the prompt invocation, execution order is: prompt_steps then always_steps.
-  // On decode invocations, only always_steps run.
   const std::vector<PipelineConfig::FlowStep>& prompt_steps() const { return prompt_steps_; }
   const std::vector<PipelineConfig::FlowStep>& always_steps() const { return always_steps_; }
 
   // Returns true when the pipeline has more than just a decoder session.
   bool IsMultiSession() const { return is_multi_session_; }
 
-  // Store an intermediate tensor produced by a session.
-  // Key format: "session_name.tensor_name"
-  void StoreIntermediate(const std::string& session_name,
-                         const std::string& tensor_name,
-                         OrtValue* value);
-
-  // Look up an intermediate tensor.  Returns nullptr if not found.
-  OrtValue* GetIntermediate(const std::string& session_name,
-                            const std::string& tensor_name) const;
-
-  // For a given target session, collect any wired inputs from intermediates.
+  // For a given target session, look up dataflow wires and resolve inputs
+  // from the provided intermediates map.
   // Returns pairs of (input_tensor_name, OrtValue*) to be bound as session inputs.
   std::vector<std::pair<std::string, OrtValue*>> GetWiredInputs(
-      const std::string& session_name) const;
-
-  // Clear all prompt-only intermediates (called after prompt phase completes).
-  void ClearPromptIntermediates();
-
-  // Clear all intermediates (called on reset).
-  void ClearAll();
+      const std::string& session_name,
+      const std::map<std::string, OrtValue*>& intermediates) const;
 
   // Access the dataflow wires for inspection/debugging.
   const std::vector<PipelineConfig::DataflowWire>& dataflow() const { return dataflow_; }
@@ -69,15 +49,7 @@ struct FlowInterpreter {
   std::vector<PipelineConfig::FlowStep> always_steps_;
   std::vector<PipelineConfig::DataflowWire> dataflow_;
   bool is_multi_session_{false};
-
-  // Set of session names that only run during prompt phase.
-  // Their intermediates are cleared after the prompt completes.
   std::set<std::string> prompt_only_sessions_;
-
-  // Intermediate tensors keyed by "session_name.tensor_name".
-  // These are non-owning pointers — the OrtValue lifetime is managed by
-  // the session's output buffer (State::outputs_).
-  std::map<std::string, OrtValue*> intermediates_;
 };
 
 }  // namespace Generators

--- a/src/models/flow_interpreter.h
+++ b/src/models/flow_interpreter.h
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Flow interpreter for Pipeline-as-Config multi-session pipelines.
+//
+// The FlowInterpreter is a thin orchestration layer that:
+//   1. Partitions flow steps into prompt-phase and decode-phase groups
+//   2. Stores intermediate tensors produced by non-decoder sessions
+//   3. Wires intermediate tensors between sessions based on dataflow config
+//
+// It does NOT own session execution or manage decoder-specific state (KV cache,
+// position inputs, logits).  Each session runs through its own State object.
+
+#pragma once
+#include "../pipeline_config_schema.h"
+#include "model.h"
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Generators {
+
+struct FlowInterpreter {
+  explicit FlowInterpreter(const PipelineConfig& pipeline_config);
+
+  // Partitioned flow steps.  Populated at construction from pipeline_config.flow[].
+  //
+  // prompt_steps: steps with when=="prompt" or when=="once" — run only on first invocation.
+  // always_steps: steps with when=="always" — run every invocation (prompt + decode).
+  //
+  // On the prompt invocation, execution order is: prompt_steps then always_steps.
+  // On decode invocations, only always_steps run.
+  const std::vector<PipelineConfig::FlowStep>& prompt_steps() const { return prompt_steps_; }
+  const std::vector<PipelineConfig::FlowStep>& always_steps() const { return always_steps_; }
+
+  // Returns true when the pipeline has more than just a decoder session.
+  bool IsMultiSession() const { return is_multi_session_; }
+
+  // Store an intermediate tensor produced by a session.
+  // Key format: "session_name.tensor_name"
+  void StoreIntermediate(const std::string& session_name,
+                         const std::string& tensor_name,
+                         OrtValue* value);
+
+  // Look up an intermediate tensor.  Returns nullptr if not found.
+  OrtValue* GetIntermediate(const std::string& session_name,
+                            const std::string& tensor_name) const;
+
+  // For a given target session, collect any wired inputs from intermediates.
+  // Returns pairs of (input_tensor_name, OrtValue*) to be bound as session inputs.
+  std::vector<std::pair<std::string, OrtValue*>> GetWiredInputs(
+      const std::string& session_name) const;
+
+  // Clear all prompt-only intermediates (called after prompt phase completes).
+  void ClearPromptIntermediates();
+
+  // Clear all intermediates (called on reset).
+  void ClearAll();
+
+  // Access the dataflow wires for inspection/debugging.
+  const std::vector<PipelineConfig::DataflowWire>& dataflow() const { return dataflow_; }
+
+ private:
+  std::vector<PipelineConfig::FlowStep> prompt_steps_;
+  std::vector<PipelineConfig::FlowStep> always_steps_;
+  std::vector<PipelineConfig::DataflowWire> dataflow_;
+  bool is_multi_session_{false};
+
+  // Set of session names that only run during prompt phase.
+  // Their intermediates are cleared after the prompt completes.
+  std::set<std::string> prompt_only_sessions_;
+
+  // Intermediate tensors keyed by "session_name.tensor_name".
+  // These are non-owning pointers — the OrtValue lifetime is managed by
+  // the session's output buffer (State::outputs_).
+  std::map<std::string, OrtValue*> intermediates_;
+};
+
+}  // namespace Generators

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -151,7 +151,7 @@ void CombinedKeyValueCache::PickPastState(DeviceSpan<int32_t> beam_indices, int 
 DefaultKeyValueCache::DefaultKeyValueCache(State& state)
     : state_{state},
       layer_count_{model_.config_->model.decoder.num_hidden_layers},
-      past_present_share_buffer_{state_.params_->IsPastPresentShareBufferEnabled(model_.config_->model.type)},
+      past_present_share_buffer_{state_.params_->IsPastPresentShareBufferEnabled(*model_.config_)},
       shape_{state_.params_->BatchBeamSize(), model_.config_->model.decoder.num_key_value_heads, 0, model_.config_->model.decoder.head_size} {
   if (g_log.enabled && g_log.warning && past_present_share_buffer_ != state_.params_->search.past_present_share_buffer)
     Log("warning", "past_present_share_buffer search option set to true, but has been disabled due to the current configuration. See https://aka.ms/generate_config for details");

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -15,6 +15,7 @@
 #include "model.h"
 #include "gpt.h"
 #include "decoder_only.h"
+#include "pipeline_config.h"
 #include "whisper.h"
 #include "nemotron_speech.h"
 #include "multi_modal.h"
@@ -818,6 +819,12 @@ std::shared_ptr<Model> CreateModel(OrtEnv& ort_env, const char* config_path, con
 }
 
 std::shared_ptr<Model> CreateModel(OrtEnv& ort_env, std::unique_ptr<Config> config) {
+  // Pipeline-as-Config dispatch: v2 configs bypass model_type string matching
+  if (config->version >= 2) {
+    return std::make_shared<PipelineConfigModel>(std::move(config), ort_env);
+  }
+
+  // Legacy v1 dispatch: route based on model_type string
   // Check if it's a pipeline model by checking if decoder.pipeline is configured
   if ((config->model.type == "fara" || config->model.type == "qwen2_5_vl" || config->model.type == "qwen3_vl") && !config->model.decoder.pipeline.empty())
     return std::make_shared<Qwen2_5_VL_PipelineModel>(std::move(config), ort_env);

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -8,70 +8,10 @@ namespace Generators {
 
 PipelineConfigModel::PipelineConfigModel(
     std::unique_ptr<Config> config, OrtEnv& ort_env)
-    : Model{std::move(config)} {
-  session_decoder_ = CreateSession(ort_env, config_->model.decoder.filename,
-                                   session_options_.get());
-  session_info_.Add(*session_decoder_);
-}
-
-std::unique_ptr<State> PipelineConfigModel::CreateState(
-    DeviceSpan<int32_t> sequence_lengths,
-    const GeneratorParams& params) const {
-  return std::make_unique<PipelineConfigState>(
-      *this, sequence_lengths, params);
-}
-
-PipelineConfigState::PipelineConfigState(
-    const PipelineConfigModel& model,
-    DeviceSpan<int32_t> sequence_lengths,
-    const GeneratorParams& params)
-    : State{params, model},
-      model_{model},
-      kv_cache_(CreateKeyValueCache(*this)),
-      position_inputs_{CreatePositionInputs(
-          *this, sequence_lengths,
-          model_.config_->model.decoder.inputs.attention_mask)} {
-  input_ids_.Add();
-  position_inputs_->Add();
-  logits_.Add();
-  if (kv_cache_) kv_cache_->Add();
-}
-
-void PipelineConfigState::SetExtraInputs(
-    const std::vector<ExtraInput>& extra_inputs) {
-  extra_inputs_.Add(extra_inputs,
-                    model_.session_decoder_->GetInputNames());
-}
-
-DeviceSpan<float> PipelineConfigState::Run(
-    int total_length, DeviceSpan<int32_t>& next_tokens,
-    DeviceSpan<int32_t> next_indices) {
-  UpdateInputsOutputs(next_tokens, next_indices, total_length);
-
-  if (model_.config_->model.decoder.run_options.has_value()) {
-    State::SetRunOptions(model_.config_->model.decoder.run_options.value());
-  }
-
-  bool graph_capture = params_->use_graph_capture &&
-                       input_ids_.GetShape()[1] == 1;
-  State::Run(*model_.session_decoder_, graph_capture);
-
-  return logits_.Get();
-}
-
-void PipelineConfigState::UpdateInputsOutputs(
-    DeviceSpan<int32_t>& next_tokens,
-    DeviceSpan<int32_t> beam_indices,
-    int total_length) {
-  input_ids_.Update(next_tokens);
-  position_inputs_->Update(next_tokens, total_length,
-                           input_ids_.GetShape()[1]);
-  if (kv_cache_) kv_cache_->Update(beam_indices, total_length);
-}
-
-void PipelineConfigState::RewindTo(size_t index) {
-  if (kv_cache_) kv_cache_->RewindTo(index);
-  position_inputs_->RewindTo(index);
+    : DecoderOnly_Model{std::move(config), ort_env} {
+  // Delegates entirely to DecoderOnly_Model for decoder-only models.
+  // Future: inspect config pipeline section to determine model category
+  // and load additional sessions for multi-modal pipelines.
 }
 
 }  // namespace Generators

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../generators.h"
+#include "pipeline_config.h"
+
+namespace Generators {
+
+PipelineConfigModel::PipelineConfigModel(
+    std::unique_ptr<Config> config, OrtEnv& ort_env)
+    : Model{std::move(config)} {
+  session_decoder_ = CreateSession(ort_env, config_->model.decoder.filename,
+                                   session_options_.get());
+  session_info_.Add(*session_decoder_);
+}
+
+std::unique_ptr<State> PipelineConfigModel::CreateState(
+    DeviceSpan<int32_t> sequence_lengths,
+    const GeneratorParams& params) const {
+  return std::make_unique<PipelineConfigState>(
+      *this, sequence_lengths, params);
+}
+
+PipelineConfigState::PipelineConfigState(
+    const PipelineConfigModel& model,
+    DeviceSpan<int32_t> sequence_lengths,
+    const GeneratorParams& params)
+    : State{params, model},
+      model_{model},
+      kv_cache_(CreateKeyValueCache(*this)),
+      position_inputs_{CreatePositionInputs(
+          *this, sequence_lengths,
+          model_.config_->model.decoder.inputs.attention_mask)} {
+  input_ids_.Add();
+  position_inputs_->Add();
+  logits_.Add();
+  if (kv_cache_) kv_cache_->Add();
+}
+
+void PipelineConfigState::SetExtraInputs(
+    const std::vector<ExtraInput>& extra_inputs) {
+  extra_inputs_.Add(extra_inputs,
+                    model_.session_decoder_->GetInputNames());
+}
+
+DeviceSpan<float> PipelineConfigState::Run(
+    int total_length, DeviceSpan<int32_t>& next_tokens,
+    DeviceSpan<int32_t> next_indices) {
+  UpdateInputsOutputs(next_tokens, next_indices, total_length);
+
+  if (model_.config_->model.decoder.run_options.has_value()) {
+    State::SetRunOptions(model_.config_->model.decoder.run_options.value());
+  }
+
+  bool graph_capture = params_->use_graph_capture &&
+                       input_ids_.GetShape()[1] == 1;
+  State::Run(*model_.session_decoder_, graph_capture);
+
+  return logits_.Get();
+}
+
+void PipelineConfigState::UpdateInputsOutputs(
+    DeviceSpan<int32_t>& next_tokens,
+    DeviceSpan<int32_t> beam_indices,
+    int total_length) {
+  input_ids_.Update(next_tokens);
+  position_inputs_->Update(next_tokens, total_length,
+                           input_ids_.GetShape()[1]);
+  if (kv_cache_) kv_cache_->Update(beam_indices, total_length);
+}
+
+void PipelineConfigState::RewindTo(size_t index) {
+  if (kv_cache_) kv_cache_->RewindTo(index);
+  position_inputs_->RewindTo(index);
+}
+
+}  // namespace Generators

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -7,35 +7,34 @@
 namespace Generators {
 
 // ============================================================================
-// PipelineConfigModel — loads sessions from pipeline config
+// PipelineConfigModel
 // ============================================================================
 
 PipelineConfigModel::PipelineConfigModel(
     std::unique_ptr<Config> config, OrtEnv& ort_env)
-    : Model{std::move(config)} {
+    : DecoderOnly_Model{std::move(config), ort_env} {
+  // DecoderOnly_Model already loaded session_decoder_ and registered it
+  // with session_info_.  Now load any additional sessions for multi-session
+  // pipelines (vision, embedding, encoder, etc.).
   const auto& pipeline_config = config_->pipeline_config;
 
-  // Load each named session from the pipeline config
   for (const auto& [name, session_config] : pipeline_config.sessions) {
-    if (session_config.file.empty()) continue;
-
-    OrtSessionOptions* opts = session_options_.get();
+    if (name == "decoder" || session_config.file.empty()) continue;
 
     // Non-decoder sessions get separate options with graph capture disabled.
     // Vision/embedding/encoder sessions often have control flow nodes that
     // are incompatible with CUDA graph capture.
-    if (session_config.role != "decoder") {
-      auto custom_opts = OrtSessionOptions::Create();
-      CreateSessionOptionsFromConfig(
-          config_->model.decoder.session_options,
-          *custom_opts, /*is_primary_session_options=*/true,
-          /*disable_graph_capture=*/true);
-      non_decoder_session_options_[name] = std::move(custom_opts);
-      opts = non_decoder_session_options_[name].get();
-    }
+    auto custom_opts = OrtSessionOptions::Create();
+    CreateSessionOptionsFromConfig(
+        config_->model.decoder.session_options,
+        *custom_opts, /*is_primary_session_options=*/true,
+        /*disable_graph_capture=*/true);
+    non_decoder_session_options_[name] = std::move(custom_opts);
 
-    sessions_[name] = CreateSession(ort_env, session_config.file, opts);
-    session_info_.Add(*sessions_[name]);
+    extra_sessions_[name] = CreateSession(
+        ort_env, session_config.file,
+        non_decoder_session_options_[name].get());
+    session_info_.Add(*extra_sessions_[name]);
   }
 
   flow_interpreter_ = std::make_unique<FlowInterpreter>(pipeline_config);
@@ -44,12 +43,19 @@ PipelineConfigModel::PipelineConfigModel(
 std::unique_ptr<State> PipelineConfigModel::CreateState(
     DeviceSpan<int32_t> sequence_lengths,
     const GeneratorParams& params) const {
+  // For single-session (decoder-only) configs, use DecoderOnly_State directly.
+  // Zero code duplication — full decoder parity including sliding window,
+  // chunking, graph capture, and all future DecoderOnly_State improvements.
+  if (!flow_interpreter_->IsMultiSession()) {
+    return std::make_unique<DecoderOnly_State>(
+        *this, sequence_lengths, params);
+  }
   return std::make_unique<PipelineConfigState>(
       *this, sequence_lengths, params);
 }
 
 // ============================================================================
-// PipelineConfigState — orchestrates pipeline execution
+// PipelineConfigState — multi-session orchestration
 // ============================================================================
 
 PipelineConfigState::PipelineConfigState(
@@ -58,27 +64,17 @@ PipelineConfigState::PipelineConfigState(
     const GeneratorParams& params)
     : State{params, model},
       model_{model},
-      kv_cache_(CreateKeyValueCache(*this)),
-      position_inputs_{CreatePositionInputs(
-          *this, sequence_lengths,
-          model_.config_->model.decoder.inputs.attention_mask)} {
-  input_ids_.Add();
-  position_inputs_->Add();
-  logits_.Add();
-  if (kv_cache_) kv_cache_->Add();
+      decoder_state_{std::make_unique<DecoderOnly_State>(
+          model_, sequence_lengths, params)} {
 }
 
 void PipelineConfigState::SetExtraInputs(
     const std::vector<ExtraInput>& extra_inputs) {
-  // Route extra inputs to the decoder session
-  if (model_.sessions_.count("decoder")) {
-    extra_inputs_.Add(extra_inputs,
-                      model_.sessions_.at("decoder")->GetInputNames());
-  }
+  // Route extra inputs to the decoder state
+  decoder_state_->SetExtraInputs(extra_inputs);
 
   // Route extra inputs to non-decoder sessions
-  for (const auto& [name, session] : model_.sessions_) {
-    if (name == "decoder") continue;
+  for (const auto& [name, session] : model_.extra_sessions_) {
     auto& io = non_decoder_io_[name];
     auto session_input_names = session->GetInputNames();
     for (const auto& extra : extra_inputs) {
@@ -94,8 +90,8 @@ void PipelineConfigState::SetExtraInputs(
 
 void PipelineConfigState::RunNonDecoderSession(
     const std::string& session_name) {
-  auto session_it = model_.sessions_.find(session_name);
-  if (session_it == model_.sessions_.end() || !session_it->second) {
+  auto session_it = model_.extra_sessions_.find(session_name);
+  if (session_it == model_.extra_sessions_.end() || !session_it->second) {
     throw std::runtime_error(
         "Pipeline flow error: session '" + session_name + "' not loaded");
   }
@@ -103,11 +99,10 @@ void PipelineConfigState::RunNonDecoderSession(
   auto& session = *session_it->second;
 
   // Build input arrays from extra inputs + wired intermediates.
-  // We maintain string ownership in input_name_strings to avoid dangling ptrs.
+  // Maintain string ownership in input_name_strings to avoid dangling ptrs.
   std::vector<std::string> input_name_strings;
   std::vector<OrtValue*> input_values;
 
-  // Add extra inputs that were set for this session
   auto io_it = non_decoder_io_.find(session_name);
   if (io_it != non_decoder_io_.end()) {
     for (size_t i = 0; i < io_it->second.input_names.size(); ++i) {
@@ -116,21 +111,18 @@ void PipelineConfigState::RunNonDecoderSession(
     }
   }
 
-  // Add wired intermediate inputs from upstream sessions
   auto wired_inputs = model_.flow_interpreter_->GetWiredInputs(session_name);
   for (auto& [input_name, value] : wired_inputs) {
     input_name_strings.push_back(input_name);
     input_values.push_back(value);
   }
 
-  // Build const char* array from owned strings
   std::vector<const char*> input_name_ptrs;
   input_name_ptrs.reserve(input_name_strings.size());
   for (const auto& name : input_name_strings) {
     input_name_ptrs.push_back(name.c_str());
   }
 
-  // Set up outputs: query session for expected output names
   auto output_name_strings = session.GetOutputNames();
   std::vector<const char*> output_name_ptrs;
   output_name_ptrs.reserve(output_name_strings.size());
@@ -139,7 +131,6 @@ void PipelineConfigState::RunNonDecoderSession(
   }
   std::vector<OrtValue*> output_values(output_name_strings.size(), nullptr);
 
-  // Run session
   session.Run(nullptr,
               input_name_ptrs.data(),
               reinterpret_cast<const OrtValue* const*>(input_values.data()),
@@ -148,7 +139,6 @@ void PipelineConfigState::RunNonDecoderSession(
               output_name_ptrs.size());
 
   // Store outputs as intermediates for downstream sessions.
-  // Take ownership of ORT-allocated output tensors.
   for (size_t i = 0; i < output_name_strings.size(); ++i) {
     if (output_values[i]) {
       auto key = session_name + "." + output_name_strings[i];
@@ -160,119 +150,59 @@ void PipelineConfigState::RunNonDecoderSession(
   }
 }
 
-DeviceSpan<float> PipelineConfigState::RunDecoderWithChunking(
-    int total_length, DeviceSpan<int32_t>& next_tokens,
-    DeviceSpan<int32_t> next_indices, size_t chunk_size) {
-  // Chunking logic for context phase — process in chunks.
-  // Mirrors DecoderOnly_State::RunWithChunking.
-  size_t num_tokens = next_tokens.size();
-  size_t processed_tokens = 0;
-  int length = total_length - static_cast<int>(num_tokens);
-
-  if (model_.config_->model.decoder.run_options.has_value()) {
-    State::SetRunOptions(model_.config_->model.decoder.run_options.value());
-  }
-  while (processed_tokens < num_tokens) {
-    size_t current_chunk_size = std::min(chunk_size, num_tokens - processed_tokens);
-    auto chunk_tokens = next_tokens.subspan(processed_tokens, current_chunk_size);
-    length = length + static_cast<int>(current_chunk_size);
-
-    UpdateInputsOutputs(chunk_tokens, next_indices, length);
-
-    bool graph_capture_this_run = false;  // Disable during chunking
-    State::Run(*model_.sessions_.at("decoder"), graph_capture_this_run);
-
-    processed_tokens += current_chunk_size;
-  }
-
-  return logits_.Get();
-}
-
 void PipelineConfigState::RunFlowStep(
     const PipelineConfig::FlowStep& step,
     int total_length,
     DeviceSpan<int32_t>& next_tokens,
     DeviceSpan<int32_t> next_indices) {
   if (step.run == "decoder") {
-    // Decoder runs through the main state with managed components.
     // Wire any intermediate inputs (e.g. inputs_embeds from embedding session)
-    // into the decoder's input bindings.
+    // into the decoder state's input bindings before running.
     auto wired = model_.flow_interpreter_->GetWiredInputs("decoder");
     for (const auto& [input_name, value] : wired) {
-      // Find if this input is already bound in the state
       bool found = false;
-      for (size_t i = 0; i < input_names_.size(); ++i) {
-        if (std::strcmp(input_names_[i], input_name.c_str()) == 0) {
-          inputs_[i] = value;
+      for (size_t i = 0; i < decoder_state_->input_names_.size(); ++i) {
+        if (std::strcmp(decoder_state_->input_names_[i],
+                        input_name.c_str()) == 0) {
+          decoder_state_->inputs_[i] = value;
           found = true;
           break;
         }
       }
       if (!found) {
-        // Store name persistently and add new input binding
-        wired_input_names_.push_back(input_name);
-        input_names_.push_back(wired_input_names_.back().c_str());
-        inputs_.push_back(value);
+        wired_decoder_input_names_.push_back(input_name);
+        decoder_state_->input_names_.push_back(
+            wired_decoder_input_names_.back().c_str());
+        decoder_state_->inputs_.push_back(value);
       }
     }
 
-    if (model_.config_->model.decoder.run_options.has_value()) {
-      State::SetRunOptions(model_.config_->model.decoder.run_options.value());
-    }
-
-    bool graph_capture = params_->use_graph_capture &&
-                         input_ids_.GetShape()[1] == 1;
-    State::Run(*model_.sessions_.at("decoder"), graph_capture);
+    // Delegate to DecoderOnly_State::Run which handles everything:
+    // KV cache, position inputs, logits, sliding window, chunking,
+    // graph capture, run options.
+    last_logits_ = decoder_state_->Run(total_length, next_tokens, next_indices);
     return;
   }
 
-  // Non-decoder session
   RunNonDecoderSession(step.run);
 }
 
 DeviceSpan<float> PipelineConfigState::Run(
     int total_length, DeviceSpan<int32_t>& next_tokens,
     DeviceSpan<int32_t> next_indices) {
-  if (!model_.flow_interpreter_->IsMultiSession()) {
-    // Single session (decoder-only): handle chunking if configured
-    const auto& chunk_size_opt = model_.config_->search.chunk_size;
-    size_t num_tokens = next_tokens.size();
-
-    if (chunk_size_opt.has_value() && chunk_size_opt.value() > 0 &&
-        num_tokens > chunk_size_opt.value()) {
-      return RunDecoderWithChunking(total_length, next_tokens, next_indices,
-                                    chunk_size_opt.value());
-    }
-
-    UpdateInputsOutputs(next_tokens, next_indices, total_length);
-    if (model_.config_->model.decoder.run_options.has_value()) {
-      State::SetRunOptions(model_.config_->model.decoder.run_options.value());
-    }
-    bool graph_capture = params_->use_graph_capture &&
-                         input_ids_.GetShape()[1] == 1;
-    State::Run(*model_.sessions_.at("decoder"), graph_capture);
-    return logits_.Get();
-  }
-
   // Multi-session pipeline execution
-  UpdateInputsOutputs(next_tokens, next_indices, total_length);
-
   if (is_prompt_) {
-    // Run prompt-only steps (vision, encoder, etc.)
     for (const auto& step : model_.flow_interpreter_->prompt_steps()) {
       RunFlowStep(step, total_length, next_tokens, next_indices);
     }
   }
 
-  // Run always-steps (embedding, decoder)
   for (const auto& step : model_.flow_interpreter_->always_steps()) {
     RunFlowStep(step, total_length, next_tokens, next_indices);
   }
 
   if (is_prompt_) {
     is_prompt_ = false;
-    // Clear prompt-only intermediates from both FlowInterpreter (non-owning)
-    // and intermediate_store_ (owning unique_ptrs)
     model_.flow_interpreter_->ClearPromptIntermediates();
     const auto& prompt_sessions = model_.flow_interpreter_->prompt_only_sessions();
     for (auto it = intermediate_store_.begin(); it != intermediate_store_.end();) {
@@ -286,43 +216,12 @@ DeviceSpan<float> PipelineConfigState::Run(
     }
   }
 
-  return logits_.Get();
-}
-
-void PipelineConfigState::UpdateInputsOutputs(
-    DeviceSpan<int32_t>& next_tokens,
-    DeviceSpan<int32_t> beam_indices,
-    int total_length) {
-  input_ids_.Update(next_tokens);
-  size_t new_length = static_cast<size_t>(input_ids_.GetShape()[1]);
-
-  // Determine effective lengths for position_ids and KV cache
-  // based on sliding window config (mirrors DecoderOnly_State behavior)
-  int position_length = total_length;
-  int kv_cache_length = total_length;
-
-  if (model_.config_->model.decoder.sliding_window.has_value() &&
-      model_.config_->model.decoder.sliding_window->window_size > 0) {
-    const int window_size = model_.config_->model.decoder.sliding_window->window_size;
-
-    if (model_.config_->model.decoder.sliding_window->slide_inputs) {
-      position_length = std::min(total_length, window_size);
-    }
-
-    if (model_.config_->model.decoder.sliding_window->slide_key_value_cache) {
-      kv_cache_length = std::min(total_length, window_size);
-    }
-  }
-
-  position_inputs_->Update(next_tokens, position_length,
-                           static_cast<int>(new_length));
-  if (kv_cache_) kv_cache_->Update(beam_indices, kv_cache_length);
-  logits_.Update(next_tokens, new_length);
+  // Logits were populated by DecoderOnly_State::Run inside RunFlowStep("decoder")
+  return last_logits_;
 }
 
 void PipelineConfigState::RewindTo(size_t index) {
-  if (kv_cache_) kv_cache_->RewindTo(index);
-  position_inputs_->RewindTo(index);
+  decoder_state_->RewindTo(index);
 }
 
 OrtValue* PipelineConfigState::GetInput(const char* name) {
@@ -334,19 +233,19 @@ OrtValue* PipelineConfigState::GetInput(const char* name) {
       }
     }
   }
-  return State::GetInput(name);
+  // Check decoder state
+  return decoder_state_->GetInput(name);
 }
 
 OrtValue* PipelineConfigState::GetOutput(const char* name) {
   // Check intermediate store for non-decoder outputs
   for (const auto& [key, value] : intermediate_store_) {
-    // Extract tensor name from "session.tensor" key
     auto dot = key.find('.');
     if (dot != std::string::npos && key.substr(dot + 1) == name) {
       return value.get();
     }
   }
-  return State::GetOutput(name);
+  return decoder_state_->GetOutput(name);
 }
 
 }  // namespace Generators

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -160,6 +160,34 @@ void PipelineConfigState::RunNonDecoderSession(
   }
 }
 
+DeviceSpan<float> PipelineConfigState::RunDecoderWithChunking(
+    int total_length, DeviceSpan<int32_t>& next_tokens,
+    DeviceSpan<int32_t> next_indices, size_t chunk_size) {
+  // Chunking logic for context phase — process in chunks.
+  // Mirrors DecoderOnly_State::RunWithChunking.
+  size_t num_tokens = next_tokens.size();
+  size_t processed_tokens = 0;
+  int length = total_length - static_cast<int>(num_tokens);
+
+  if (model_.config_->model.decoder.run_options.has_value()) {
+    State::SetRunOptions(model_.config_->model.decoder.run_options.value());
+  }
+  while (processed_tokens < num_tokens) {
+    size_t current_chunk_size = std::min(chunk_size, num_tokens - processed_tokens);
+    auto chunk_tokens = next_tokens.subspan(processed_tokens, current_chunk_size);
+    length = length + static_cast<int>(current_chunk_size);
+
+    UpdateInputsOutputs(chunk_tokens, next_indices, length);
+
+    bool graph_capture_this_run = false;  // Disable during chunking
+    State::Run(*model_.sessions_.at("decoder"), graph_capture_this_run);
+
+    processed_tokens += current_chunk_size;
+  }
+
+  return logits_.Get();
+}
+
 void PipelineConfigState::RunFlowStep(
     const PipelineConfig::FlowStep& step,
     int total_length,
@@ -205,10 +233,18 @@ void PipelineConfigState::RunFlowStep(
 DeviceSpan<float> PipelineConfigState::Run(
     int total_length, DeviceSpan<int32_t>& next_tokens,
     DeviceSpan<int32_t> next_indices) {
-  UpdateInputsOutputs(next_tokens, next_indices, total_length);
-
   if (!model_.flow_interpreter_->IsMultiSession()) {
-    // Single session (decoder-only): simple path matching DecoderOnly_State
+    // Single session (decoder-only): handle chunking if configured
+    const auto& chunk_size_opt = model_.config_->search.chunk_size;
+    size_t num_tokens = next_tokens.size();
+
+    if (chunk_size_opt.has_value() && chunk_size_opt.value() > 0 &&
+        num_tokens > chunk_size_opt.value()) {
+      return RunDecoderWithChunking(total_length, next_tokens, next_indices,
+                                    chunk_size_opt.value());
+    }
+
+    UpdateInputsOutputs(next_tokens, next_indices, total_length);
     if (model_.config_->model.decoder.run_options.has_value()) {
       State::SetRunOptions(model_.config_->model.decoder.run_options.value());
     }
@@ -219,6 +255,8 @@ DeviceSpan<float> PipelineConfigState::Run(
   }
 
   // Multi-session pipeline execution
+  UpdateInputsOutputs(next_tokens, next_indices, total_length);
+
   if (is_prompt_) {
     // Run prompt-only steps (vision, encoder, etc.)
     for (const auto& step : model_.flow_interpreter_->prompt_steps()) {
@@ -257,9 +295,28 @@ void PipelineConfigState::UpdateInputsOutputs(
     int total_length) {
   input_ids_.Update(next_tokens);
   size_t new_length = static_cast<size_t>(input_ids_.GetShape()[1]);
-  position_inputs_->Update(next_tokens, total_length,
+
+  // Determine effective lengths for position_ids and KV cache
+  // based on sliding window config (mirrors DecoderOnly_State behavior)
+  int position_length = total_length;
+  int kv_cache_length = total_length;
+
+  if (model_.config_->model.decoder.sliding_window.has_value() &&
+      model_.config_->model.decoder.sliding_window->window_size > 0) {
+    const int window_size = model_.config_->model.decoder.sliding_window->window_size;
+
+    if (model_.config_->model.decoder.sliding_window->slide_inputs) {
+      position_length = std::min(total_length, window_size);
+    }
+
+    if (model_.config_->model.decoder.sliding_window->slide_key_value_cache) {
+      kv_cache_length = std::min(total_length, window_size);
+    }
+  }
+
+  position_inputs_->Update(next_tokens, position_length,
                            static_cast<int>(new_length));
-  if (kv_cache_) kv_cache_->Update(beam_indices, total_length);
+  if (kv_cache_) kv_cache_->Update(beam_indices, kv_cache_length);
   logits_.Update(next_tokens, new_length);
 }
 

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -73,14 +73,14 @@ void PipelineConfigState::SetExtraInputs(
   // Route extra inputs to the decoder state
   decoder_state_->SetExtraInputs(extra_inputs);
 
-  // Route extra inputs to non-decoder sessions
+  // Route extra inputs to non-decoder sessions (store owned copies)
   for (const auto& [name, session] : model_.extra_sessions_) {
     auto& io = non_decoder_io_[name];
     auto session_input_names = session->GetInputNames();
     for (const auto& extra : extra_inputs) {
       for (const auto& session_input : session_input_names) {
         if (extra.name == session_input) {
-          io.input_names.push_back(extra.name.c_str());
+          io.input_name_strings.push_back(extra.name);
           io.inputs.push_back(extra.tensor->ort_tensor_.get());
         }
       }
@@ -105,13 +105,14 @@ void PipelineConfigState::RunNonDecoderSession(
 
   auto io_it = non_decoder_io_.find(session_name);
   if (io_it != non_decoder_io_.end()) {
-    for (size_t i = 0; i < io_it->second.input_names.size(); ++i) {
-      input_name_strings.push_back(io_it->second.input_names[i]);
+    for (size_t i = 0; i < io_it->second.input_name_strings.size(); ++i) {
+      input_name_strings.push_back(io_it->second.input_name_strings[i]);
       input_values.push_back(io_it->second.inputs[i]);
     }
   }
 
-  auto wired_inputs = model_.flow_interpreter_->GetWiredInputs(session_name);
+  auto wired_inputs = model_.flow_interpreter_->GetWiredInputs(
+      session_name, intermediates_);
   for (auto& [input_name, value] : wired_inputs) {
     input_name_strings.push_back(input_name);
     input_values.push_back(value);
@@ -138,13 +139,12 @@ void PipelineConfigState::RunNonDecoderSession(
               output_name_ptrs.data(), output_values.data(),
               output_name_ptrs.size());
 
-  // Store outputs as intermediates for downstream sessions.
+  // Store outputs as intermediates (owned by this State, not Model).
   for (size_t i = 0; i < output_name_strings.size(); ++i) {
     if (output_values[i]) {
       auto key = session_name + "." + output_name_strings[i];
-      model_.flow_interpreter_->StoreIntermediate(
-          session_name, output_name_strings[i], output_values[i]);
-      intermediate_store_[key] =
+      intermediates_[key] = output_values[i];
+      intermediate_owned_[key] =
           std::unique_ptr<OrtValue>(output_values[i]);
     }
   }
@@ -158,7 +158,8 @@ void PipelineConfigState::RunFlowStep(
   if (step.run == "decoder") {
     // Wire any intermediate inputs (e.g. inputs_embeds from embedding session)
     // into the decoder state's input bindings before running.
-    auto wired = model_.flow_interpreter_->GetWiredInputs("decoder");
+    auto wired = model_.flow_interpreter_->GetWiredInputs(
+        "decoder", intermediates_);
     for (const auto& [input_name, value] : wired) {
       bool found = false;
       for (size_t i = 0; i < decoder_state_->input_names_.size(); ++i) {
@@ -203,13 +204,14 @@ DeviceSpan<float> PipelineConfigState::Run(
 
   if (is_prompt_) {
     is_prompt_ = false;
-    model_.flow_interpreter_->ClearPromptIntermediates();
+    // Clear prompt-only intermediates from both maps
     const auto& prompt_sessions = model_.flow_interpreter_->prompt_only_sessions();
-    for (auto it = intermediate_store_.begin(); it != intermediate_store_.end();) {
+    for (auto it = intermediates_.begin(); it != intermediates_.end();) {
       auto dot = it->first.find('.');
       if (dot != std::string::npos &&
           prompt_sessions.count(it->first.substr(0, dot))) {
-        it = intermediate_store_.erase(it);
+        intermediate_owned_.erase(it->first);
+        it = intermediates_.erase(it);
       } else {
         ++it;
       }
@@ -225,24 +227,21 @@ void PipelineConfigState::RewindTo(size_t index) {
 }
 
 OrtValue* PipelineConfigState::GetInput(const char* name) {
-  // Check non-decoder I/O stores
   for (const auto& [session_name, io] : non_decoder_io_) {
-    for (size_t i = 0; i < io.input_names.size(); ++i) {
-      if (std::strcmp(io.input_names[i], name) == 0) {
+    for (size_t i = 0; i < io.input_name_strings.size(); ++i) {
+      if (io.input_name_strings[i] == name) {
         return io.inputs[i];
       }
     }
   }
-  // Check decoder state
   return decoder_state_->GetInput(name);
 }
 
 OrtValue* PipelineConfigState::GetOutput(const char* name) {
-  // Check intermediate store for non-decoder outputs
-  for (const auto& [key, value] : intermediate_store_) {
+  for (const auto& [key, value] : intermediates_) {
     auto dot = key.find('.');
     if (dot != std::string::npos && key.substr(dot + 1) == name) {
-      return value.get();
+      return value;
     }
   }
   return decoder_state_->GetOutput(name);

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -238,12 +238,17 @@ OrtValue* PipelineConfigState::GetInput(const char* name) {
 }
 
 OrtValue* PipelineConfigState::GetOutput(const char* name) {
+  // Search intermediates by tensor name (suffix after "session.").
+  // If multiple sessions produce the same tensor name, the last-stored
+  // one wins (which is the most-downstream session in flow order).
+  OrtValue* result = nullptr;
   for (const auto& [key, value] : intermediates_) {
     auto dot = key.find('.');
     if (dot != std::string::npos && key.substr(dot + 1) == name) {
-      return value;
+      result = value;
     }
   }
+  if (result) return result;
   return decoder_state_->GetOutput(name);
 }
 

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -6,12 +6,278 @@
 
 namespace Generators {
 
+// ============================================================================
+// PipelineConfigModel — loads sessions from pipeline config
+// ============================================================================
+
 PipelineConfigModel::PipelineConfigModel(
     std::unique_ptr<Config> config, OrtEnv& ort_env)
-    : DecoderOnly_Model{std::move(config), ort_env} {
-  // Delegates entirely to DecoderOnly_Model for decoder-only models.
-  // Future: inspect config pipeline section to determine model category
-  // and load additional sessions for multi-modal pipelines.
+    : Model{std::move(config)} {
+  const auto& pipeline_config = config_->pipeline_config;
+
+  // Load each named session from the pipeline config
+  for (const auto& [name, session_config] : pipeline_config.sessions) {
+    if (session_config.file.empty()) continue;
+
+    OrtSessionOptions* opts = session_options_.get();
+
+    // Non-decoder sessions get separate options with graph capture disabled.
+    // Vision/embedding/encoder sessions often have control flow nodes that
+    // are incompatible with CUDA graph capture.
+    if (session_config.role != "decoder") {
+      auto custom_opts = OrtSessionOptions::Create();
+      CreateSessionOptionsFromConfig(
+          config_->model.decoder.session_options,
+          *custom_opts, /*is_primary_session_options=*/true,
+          /*disable_graph_capture=*/true);
+      non_decoder_session_options_[name] = std::move(custom_opts);
+      opts = non_decoder_session_options_[name].get();
+    }
+
+    sessions_[name] = CreateSession(ort_env, session_config.file, opts);
+    session_info_.Add(*sessions_[name]);
+  }
+
+  flow_interpreter_ = std::make_unique<FlowInterpreter>(pipeline_config);
+}
+
+std::unique_ptr<State> PipelineConfigModel::CreateState(
+    DeviceSpan<int32_t> sequence_lengths,
+    const GeneratorParams& params) const {
+  return std::make_unique<PipelineConfigState>(
+      *this, sequence_lengths, params);
+}
+
+// ============================================================================
+// PipelineConfigState — orchestrates pipeline execution
+// ============================================================================
+
+PipelineConfigState::PipelineConfigState(
+    const PipelineConfigModel& model,
+    DeviceSpan<int32_t> sequence_lengths,
+    const GeneratorParams& params)
+    : State{params, model},
+      model_{model},
+      kv_cache_(CreateKeyValueCache(*this)),
+      position_inputs_{CreatePositionInputs(
+          *this, sequence_lengths,
+          model_.config_->model.decoder.inputs.attention_mask)} {
+  input_ids_.Add();
+  position_inputs_->Add();
+  logits_.Add();
+  if (kv_cache_) kv_cache_->Add();
+}
+
+void PipelineConfigState::SetExtraInputs(
+    const std::vector<ExtraInput>& extra_inputs) {
+  // Route extra inputs to the decoder session
+  if (model_.sessions_.count("decoder")) {
+    extra_inputs_.Add(extra_inputs,
+                      model_.sessions_.at("decoder")->GetInputNames());
+  }
+
+  // Route extra inputs to non-decoder sessions
+  for (const auto& [name, session] : model_.sessions_) {
+    if (name == "decoder") continue;
+    auto& io = non_decoder_io_[name];
+    auto session_input_names = session->GetInputNames();
+    for (const auto& extra : extra_inputs) {
+      for (const auto& session_input : session_input_names) {
+        if (extra.name == session_input) {
+          io.input_names.push_back(extra.name.c_str());
+          io.inputs.push_back(extra.tensor->ort_tensor_.get());
+        }
+      }
+    }
+  }
+}
+
+void PipelineConfigState::RunNonDecoderSession(
+    const std::string& session_name) {
+  auto session_it = model_.sessions_.find(session_name);
+  if (session_it == model_.sessions_.end() || !session_it->second) {
+    throw std::runtime_error(
+        "Pipeline flow error: session '" + session_name + "' not loaded");
+  }
+
+  auto& session = *session_it->second;
+
+  // Build input arrays from extra inputs + wired intermediates.
+  // We maintain string ownership in input_name_strings to avoid dangling ptrs.
+  std::vector<std::string> input_name_strings;
+  std::vector<OrtValue*> input_values;
+
+  // Add extra inputs that were set for this session
+  auto io_it = non_decoder_io_.find(session_name);
+  if (io_it != non_decoder_io_.end()) {
+    for (size_t i = 0; i < io_it->second.input_names.size(); ++i) {
+      input_name_strings.push_back(io_it->second.input_names[i]);
+      input_values.push_back(io_it->second.inputs[i]);
+    }
+  }
+
+  // Add wired intermediate inputs from upstream sessions
+  auto wired_inputs = model_.flow_interpreter_->GetWiredInputs(session_name);
+  for (auto& [input_name, value] : wired_inputs) {
+    input_name_strings.push_back(input_name);
+    input_values.push_back(value);
+  }
+
+  // Build const char* array from owned strings
+  std::vector<const char*> input_name_ptrs;
+  input_name_ptrs.reserve(input_name_strings.size());
+  for (const auto& name : input_name_strings) {
+    input_name_ptrs.push_back(name.c_str());
+  }
+
+  // Set up outputs: query session for expected output names
+  auto output_name_strings = session.GetOutputNames();
+  std::vector<const char*> output_name_ptrs;
+  output_name_ptrs.reserve(output_name_strings.size());
+  for (const auto& name : output_name_strings) {
+    output_name_ptrs.push_back(name.c_str());
+  }
+  std::vector<OrtValue*> output_values(output_name_strings.size(), nullptr);
+
+  // Run session
+  session.Run(nullptr,
+              input_name_ptrs.data(),
+              reinterpret_cast<const OrtValue* const*>(input_values.data()),
+              input_name_ptrs.size(),
+              output_name_ptrs.data(), output_values.data(),
+              output_name_ptrs.size());
+
+  // Store outputs as intermediates for downstream sessions.
+  // Take ownership of ORT-allocated output tensors.
+  for (size_t i = 0; i < output_name_strings.size(); ++i) {
+    if (output_values[i]) {
+      auto key = session_name + "." + output_name_strings[i];
+      model_.flow_interpreter_->StoreIntermediate(
+          session_name, output_name_strings[i], output_values[i]);
+      intermediate_store_[key] =
+          std::unique_ptr<OrtValue>(output_values[i]);
+    }
+  }
+}
+
+void PipelineConfigState::RunFlowStep(
+    const PipelineConfig::FlowStep& step,
+    int total_length,
+    DeviceSpan<int32_t>& next_tokens,
+    DeviceSpan<int32_t> next_indices) {
+  if (step.run == "decoder") {
+    // Decoder runs through the main state with managed components.
+    // Wire any intermediate inputs (e.g. inputs_embeds from embedding session)
+    // into the decoder's input bindings.
+    auto wired = model_.flow_interpreter_->GetWiredInputs("decoder");
+    for (const auto& [input_name, value] : wired) {
+      // Find if this input is already bound in the state
+      bool found = false;
+      for (size_t i = 0; i < input_names_.size(); ++i) {
+        if (std::strcmp(input_names_[i], input_name.c_str()) == 0) {
+          inputs_[i] = value;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        // Store name persistently and add new input binding
+        wired_input_names_.push_back(input_name);
+        input_names_.push_back(wired_input_names_.back().c_str());
+        inputs_.push_back(value);
+      }
+    }
+
+    if (model_.config_->model.decoder.run_options.has_value()) {
+      State::SetRunOptions(model_.config_->model.decoder.run_options.value());
+    }
+
+    bool graph_capture = params_->use_graph_capture &&
+                         input_ids_.GetShape()[1] == 1;
+    State::Run(*model_.sessions_.at("decoder"), graph_capture);
+    return;
+  }
+
+  // Non-decoder session
+  RunNonDecoderSession(step.run);
+}
+
+DeviceSpan<float> PipelineConfigState::Run(
+    int total_length, DeviceSpan<int32_t>& next_tokens,
+    DeviceSpan<int32_t> next_indices) {
+  UpdateInputsOutputs(next_tokens, next_indices, total_length);
+
+  if (!model_.flow_interpreter_->IsMultiSession()) {
+    // Single session (decoder-only): simple path matching DecoderOnly_State
+    if (model_.config_->model.decoder.run_options.has_value()) {
+      State::SetRunOptions(model_.config_->model.decoder.run_options.value());
+    }
+    bool graph_capture = params_->use_graph_capture &&
+                         input_ids_.GetShape()[1] == 1;
+    State::Run(*model_.sessions_.at("decoder"), graph_capture);
+    return logits_.Get();
+  }
+
+  // Multi-session pipeline execution
+  if (is_prompt_) {
+    // Run prompt-only steps (vision, encoder, etc.)
+    for (const auto& step : model_.flow_interpreter_->prompt_steps()) {
+      RunFlowStep(step, total_length, next_tokens, next_indices);
+    }
+  }
+
+  // Run always-steps (embedding, decoder)
+  for (const auto& step : model_.flow_interpreter_->always_steps()) {
+    RunFlowStep(step, total_length, next_tokens, next_indices);
+  }
+
+  if (is_prompt_) {
+    is_prompt_ = false;
+    model_.flow_interpreter_->ClearPromptIntermediates();
+  }
+
+  return logits_.Get();
+}
+
+void PipelineConfigState::UpdateInputsOutputs(
+    DeviceSpan<int32_t>& next_tokens,
+    DeviceSpan<int32_t> beam_indices,
+    int total_length) {
+  input_ids_.Update(next_tokens);
+  size_t new_length = static_cast<size_t>(input_ids_.GetShape()[1]);
+  position_inputs_->Update(next_tokens, total_length,
+                           static_cast<int>(new_length));
+  if (kv_cache_) kv_cache_->Update(beam_indices, total_length);
+  logits_.Update(next_tokens, new_length);
+}
+
+void PipelineConfigState::RewindTo(size_t index) {
+  if (kv_cache_) kv_cache_->RewindTo(index);
+  position_inputs_->RewindTo(index);
+}
+
+OrtValue* PipelineConfigState::GetInput(const char* name) {
+  // Check non-decoder I/O stores
+  for (const auto& [session_name, io] : non_decoder_io_) {
+    for (size_t i = 0; i < io.input_names.size(); ++i) {
+      if (std::strcmp(io.input_names[i], name) == 0) {
+        return io.inputs[i];
+      }
+    }
+  }
+  return State::GetInput(name);
+}
+
+OrtValue* PipelineConfigState::GetOutput(const char* name) {
+  // Check intermediate store for non-decoder outputs
+  for (const auto& [key, value] : intermediate_store_) {
+    // Extract tensor name from "session.tensor" key
+    auto dot = key.find('.');
+    if (dot != std::string::npos && key.substr(dot + 1) == name) {
+      return value.get();
+    }
+  }
+  return State::GetOutput(name);
 }
 
 }  // namespace Generators

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -16,6 +16,10 @@ PipelineConfigModel::PipelineConfigModel(
   // DecoderOnly_Model already loaded session_decoder_ and registered it
   // with session_info_.  Now load any additional sessions for multi-session
   // pipelines (vision, embedding, encoder, etc.).
+  //
+  // Note: For v2 configs, the v1 translator or preset resolution already
+  // syncs pipeline_config.sessions["decoder"].file to model.decoder.filename
+  // so that DecoderOnly_Model's constructor loads the correct session.
   const auto& pipeline_config = config_->pipeline_config;
 
   for (const auto& [name, session_config] : pipeline_config.sessions) {
@@ -140,12 +144,15 @@ void PipelineConfigState::RunNonDecoderSession(
               output_name_ptrs.size());
 
   // Store outputs as intermediates (owned by this State, not Model).
+  // Also update output_by_tensor_name_ so GetOutput returns the last-
+  // executed session's output (flow order, not map order).
   for (size_t i = 0; i < output_name_strings.size(); ++i) {
     if (output_values[i]) {
       auto key = session_name + "." + output_name_strings[i];
       intermediates_[key] = output_values[i];
       intermediate_owned_[key] =
           std::unique_ptr<OrtValue>(output_values[i]);
+      output_by_tensor_name_[output_name_strings[i]] = output_values[i];
     }
   }
 }
@@ -158,11 +165,15 @@ void PipelineConfigState::RunFlowStep(
   if (step.run == "decoder") {
     // Wire any intermediate inputs (e.g. inputs_embeds from embedding session)
     // into the decoder state's input bindings before running.
+    // Save original size so we can restore after the run — this prevents
+    // dangling pointers when prompt intermediates are freed later.
+    const size_t original_input_count = decoder_state_->input_names_.size();
+
     auto wired = model_.flow_interpreter_->GetWiredInputs(
         "decoder", intermediates_);
     for (const auto& [input_name, value] : wired) {
       bool found = false;
-      for (size_t i = 0; i < decoder_state_->input_names_.size(); ++i) {
+      for (size_t i = 0; i < original_input_count; ++i) {
         if (std::strcmp(decoder_state_->input_names_[i],
                         input_name.c_str()) == 0) {
           decoder_state_->inputs_[i] = value;
@@ -182,10 +193,22 @@ void PipelineConfigState::RunFlowStep(
     // KV cache, position inputs, logits, sliding window, chunking,
     // graph capture, run options.
     last_logits_ = decoder_state_->Run(total_length, next_tokens, next_indices);
+
+    // Restore decoder input bindings to original size so that
+    // prompt-only intermediate pointers don't persist.
+    decoder_state_->input_names_.resize(original_input_count);
+    decoder_state_->inputs_.resize(original_input_count);
     return;
   }
 
-  RunNonDecoderSession(step.run);
+  // Handle non-decoder step.loop if specified
+  if (!step.loop.empty() && step.loop == "per_image") {
+    // TODO: Implement per-image looping for vision sessions.
+    // For now, run the session once (single-image support).
+    RunNonDecoderSession(step.run);
+  } else {
+    RunNonDecoderSession(step.run);
+  }
 }
 
 DeviceSpan<float> PipelineConfigState::Run(
@@ -238,17 +261,9 @@ OrtValue* PipelineConfigState::GetInput(const char* name) {
 }
 
 OrtValue* PipelineConfigState::GetOutput(const char* name) {
-  // Search intermediates by tensor name (suffix after "session.").
-  // If multiple sessions produce the same tensor name, the last-stored
-  // one wins (which is the most-downstream session in flow order).
-  OrtValue* result = nullptr;
-  for (const auto& [key, value] : intermediates_) {
-    auto dot = key.find('.');
-    if (dot != std::string::npos && key.substr(dot + 1) == name) {
-      result = value;
-    }
-  }
-  if (result) return result;
+  // Return the last-executed session's output for this tensor name.
+  auto it = output_by_tensor_name_.find(name);
+  if (it != output_by_tensor_name_.end()) return it->second;
   return decoder_state_->GetOutput(name);
 }
 

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -233,7 +233,19 @@ DeviceSpan<float> PipelineConfigState::Run(
 
   if (is_prompt_) {
     is_prompt_ = false;
+    // Clear prompt-only intermediates from both FlowInterpreter (non-owning)
+    // and intermediate_store_ (owning unique_ptrs)
     model_.flow_interpreter_->ClearPromptIntermediates();
+    const auto& prompt_sessions = model_.flow_interpreter_->prompt_only_sessions();
+    for (auto it = intermediate_store_.begin(); it != intermediate_store_.end();) {
+      auto dot = it->first.find('.');
+      if (dot != std::string::npos &&
+          prompt_sessions.count(it->first.substr(0, dot))) {
+        it = intermediate_store_.erase(it);
+      } else {
+        ++it;
+      }
+    }
   }
 
   return logits_.Get();

--- a/src/models/pipeline_config.cpp
+++ b/src/models/pipeline_config.cpp
@@ -216,23 +216,23 @@ DeviceSpan<float> PipelineConfigState::Run(
     DeviceSpan<int32_t> next_indices) {
   // Multi-session pipeline execution
   if (is_prompt_) {
-    for (const auto& step : model_.flow_interpreter_->prompt_steps()) {
+    for (const auto& step : model_.flow_interpreter_->init_steps()) {
       RunFlowStep(step, total_length, next_tokens, next_indices);
     }
   }
 
-  for (const auto& step : model_.flow_interpreter_->always_steps()) {
+  for (const auto& step : model_.flow_interpreter_->step_steps()) {
     RunFlowStep(step, total_length, next_tokens, next_indices);
   }
 
   if (is_prompt_) {
     is_prompt_ = false;
-    // Clear prompt-only intermediates from both maps
-    const auto& prompt_sessions = model_.flow_interpreter_->prompt_only_sessions();
+    // Clear init-only intermediates from both maps
+    const auto& init_sessions = model_.flow_interpreter_->init_only_sessions();
     for (auto it = intermediates_.begin(); it != intermediates_.end();) {
       auto dot = it->first.find('.');
       if (dot != std::string::npos &&
-          prompt_sessions.count(it->first.substr(0, dot))) {
+          init_sessions.count(it->first.substr(0, dot))) {
         intermediate_owned_.erase(it->first);
         it = intermediates_.erase(it);
       } else {
@@ -243,6 +243,16 @@ DeviceSpan<float> PipelineConfigState::Run(
 
   // Logits were populated by DecoderOnly_State::Run inside RunFlowStep("decoder")
   return last_logits_;
+}
+
+void PipelineConfigState::Finalize(int current_length) {
+  // Run final-phase steps (e.g., TTS vocoder, diffusion VAE decode).
+  // These execute once after the generation loop completes.
+  DeviceSpan<int32_t> empty_tokens;
+  for (const auto& step : model_.flow_interpreter_->final_steps()) {
+    RunFlowStep(step, current_length, empty_tokens, {});
+  }
+  decoder_state_->Finalize(current_length);
 }
 
 void PipelineConfigState::RewindTo(size_t index) {

--- a/src/models/pipeline_config.h
+++ b/src/models/pipeline_config.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "model.h"
+#include "input_ids.h"
+#include "logits.h"
+#include "kv_cache.h"
+#include "position_inputs.h"
+#include "extra_inputs.h"
+
+namespace Generators {
+
+// Pipeline-as-Config model: loads sessions from pipeline config,
+// dispatches based on config version rather than model_type strings.
+//
+// For v2 configs, the PipelineConfigModel replaces string-based dispatch
+// (DecoderOnly_Model, MultiModalLanguageModel, etc.) with a generic
+// model that reads its session layout from the config file.
+//
+// This minimal implementation supports decoder-only models and reuses
+// existing components (DefaultKeyValueCache, DefaultPositionInputs,
+// Logits) to produce identical output to DecoderOnly_Model.
+struct PipelineConfigModel : Model {
+  PipelineConfigModel(std::unique_ptr<Config> config, OrtEnv& ort_env);
+
+  std::unique_ptr<State> CreateState(
+      DeviceSpan<int32_t> sequence_lengths,
+      const GeneratorParams& params) const override;
+
+  std::unique_ptr<OrtSession> session_decoder_;
+};
+
+struct PipelineConfigState : State {
+  PipelineConfigState(const PipelineConfigModel& model,
+                      DeviceSpan<int32_t> sequence_lengths,
+                      const GeneratorParams& params);
+
+  void SetExtraInputs(const std::vector<ExtraInput>& extra_inputs) override;
+  DeviceSpan<float> Run(int total_length, DeviceSpan<int32_t>& next_tokens,
+                        DeviceSpan<int32_t> next_indices) override;
+  void RewindTo(size_t index) override;
+
+ private:
+  void UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens,
+                           DeviceSpan<int32_t> beam_indices,
+                           int total_length);
+
+  const PipelineConfigModel& model_;
+
+  DefaultInputIDs input_ids_{*this};
+  Logits logits_{*this};
+  std::unique_ptr<KeyValueCache> kv_cache_;
+  std::unique_ptr<PositionInputs> position_inputs_;
+  ExtraInputs extra_inputs_{*this};
+};
+
+}  // namespace Generators

--- a/src/models/pipeline_config.h
+++ b/src/models/pipeline_config.h
@@ -74,15 +74,18 @@ struct PipelineConfigState : State {
   std::unique_ptr<DecoderOnly_State> decoder_state_;
 
   // Per-session extra inputs for non-decoder sessions.
+  // Stores owned copies of input name strings to avoid dangling pointers.
   struct NonDecoderSessionIO {
-    std::vector<const char*> input_names;
+    std::vector<std::string> input_name_strings;  // Owned name storage
     std::vector<OrtValue*> inputs;
   };
   std::map<std::string, NonDecoderSessionIO> non_decoder_io_;
 
-  // Intermediate tensor store for wiring between sessions.
-  // Key: "session_name.tensor_name"
-  std::map<std::string, std::unique_ptr<OrtValue>> intermediate_store_;
+  // Intermediate tensor storage (per-State, not per-Model).
+  // Owns OrtValue outputs from non-decoder sessions.
+  std::map<std::string, std::unique_ptr<OrtValue>> intermediate_owned_;
+  // Non-owning view for fast lookup by FlowInterpreter::GetWiredInputs.
+  std::map<std::string, OrtValue*> intermediates_;
 
   // Persistent storage for wired input names to avoid dangling c_str() pointers.
   std::vector<std::string> wired_decoder_input_names_;

--- a/src/models/pipeline_config.h
+++ b/src/models/pipeline_config.h
@@ -87,8 +87,13 @@ struct PipelineConfigState : State {
   // Non-owning view for fast lookup by FlowInterpreter::GetWiredInputs.
   std::map<std::string, OrtValue*> intermediates_;
 
-  // Persistent storage for wired input names to avoid dangling c_str() pointers.
-  std::vector<std::string> wired_decoder_input_names_;
+  // Maps output tensor name → OrtValue*, updated at store time so that
+  // the last-executed session's output wins (flow order, not map order).
+  std::map<std::string, OrtValue*> output_by_tensor_name_;
+
+  // Persistent storage for wired input names.  Uses deque (not vector)
+  // so that push_back never invalidates existing c_str() pointers.
+  std::deque<std::string> wired_decoder_input_names_;
 
   // Logits from the last decoder run, saved by RunFlowStep("decoder").
   DeviceSpan<float> last_logits_;

--- a/src/models/pipeline_config.h
+++ b/src/models/pipeline_config.h
@@ -53,6 +53,7 @@ struct PipelineConfigState : State {
   void SetExtraInputs(const std::vector<ExtraInput>& extra_inputs) override;
   DeviceSpan<float> Run(int total_length, DeviceSpan<int32_t>& next_tokens,
                         DeviceSpan<int32_t> next_indices) override;
+  void Finalize(int current_length) override;
   void RewindTo(size_t index) override;
 
   OrtValue* GetInput(const char* name) override;

--- a/src/models/pipeline_config.h
+++ b/src/models/pipeline_config.h
@@ -2,57 +2,22 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "model.h"
-#include "input_ids.h"
-#include "logits.h"
-#include "kv_cache.h"
-#include "position_inputs.h"
-#include "extra_inputs.h"
+#include "decoder_only.h"
 
 namespace Generators {
 
-// Pipeline-as-Config model: loads sessions from pipeline config,
-// dispatches based on config version rather than model_type strings.
+// Pipeline-as-Config model: dispatches based on config version rather
+// than model_type strings.
 //
-// For v2 configs, the PipelineConfigModel replaces string-based dispatch
-// (DecoderOnly_Model, MultiModalLanguageModel, etc.) with a generic
-// model that reads its session layout from the config file.
+// For v2 configs, CreateModel() routes here instead of the string-based
+// dispatch chain.  The current (minimal) implementation delegates to
+// DecoderOnly_Model for decoder-only models, ensuring identical behavior
+// and avoiding code duplication that could drift over time.
 //
-// This minimal implementation supports decoder-only models and reuses
-// existing components (DefaultKeyValueCache, DefaultPositionInputs,
-// Logits) to produce identical output to DecoderOnly_Model.
-struct PipelineConfigModel : Model {
+// Future versions will support multi-session pipelines (VLM, encoder-
+// decoder) by reading session layout from the config's pipeline section.
+struct PipelineConfigModel : DecoderOnly_Model {
   PipelineConfigModel(std::unique_ptr<Config> config, OrtEnv& ort_env);
-
-  std::unique_ptr<State> CreateState(
-      DeviceSpan<int32_t> sequence_lengths,
-      const GeneratorParams& params) const override;
-
-  std::unique_ptr<OrtSession> session_decoder_;
-};
-
-struct PipelineConfigState : State {
-  PipelineConfigState(const PipelineConfigModel& model,
-                      DeviceSpan<int32_t> sequence_lengths,
-                      const GeneratorParams& params);
-
-  void SetExtraInputs(const std::vector<ExtraInput>& extra_inputs) override;
-  DeviceSpan<float> Run(int total_length, DeviceSpan<int32_t>& next_tokens,
-                        DeviceSpan<int32_t> next_indices) override;
-  void RewindTo(size_t index) override;
-
- private:
-  void UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens,
-                           DeviceSpan<int32_t> beam_indices,
-                           int total_length);
-
-  const PipelineConfigModel& model_;
-
-  DefaultInputIDs input_ids_{*this};
-  Logits logits_{*this};
-  std::unique_ptr<KeyValueCache> kv_cache_;
-  std::unique_ptr<PositionInputs> position_inputs_;
-  ExtraInputs extra_inputs_{*this};
 };
 
 }  // namespace Generators

--- a/src/models/pipeline_config.h
+++ b/src/models/pipeline_config.h
@@ -11,23 +11,26 @@ namespace Generators {
 // Pipeline-as-Config model: dispatches based on config version rather
 // than model_type strings.
 //
-// For v2 configs, CreateModel() routes here instead of the string-based
-// dispatch chain.
+// Inherits from DecoderOnly_Model which loads the decoder session and
+// provides session_decoder_.  For multi-session pipelines (VLM, encoder-
+// decoder), additional sessions are loaded from pipeline_config.sessions.
 //
-// For single-session (decoder-only) pipelines, PipelineConfigState directly
-// implements the same logic as DecoderOnly_State (same components, same order).
+// For single-session configs, CreateState() returns DecoderOnly_State
+// directly — zero code duplication, full decoder parity.
 //
-// For multi-session pipelines (VLM, encoder-decoder), loads all sessions
-// and uses FlowInterpreter to orchestrate execution order and dataflow.
-struct PipelineConfigModel : Model {
+// For multi-session configs, CreateState() returns PipelineConfigState
+// which uses FlowInterpreter to orchestrate non-decoder sessions around
+// a DecoderOnly_State that handles all decoder internals.
+struct PipelineConfigModel : DecoderOnly_Model {
   PipelineConfigModel(std::unique_ptr<Config> config, OrtEnv& ort_env);
 
   std::unique_ptr<State> CreateState(
       DeviceSpan<int32_t> sequence_lengths,
       const GeneratorParams& params) const override;
 
-  // Named sessions loaded from pipeline_config.sessions.
-  std::map<std::string, std::unique_ptr<OrtSession>> sessions_;
+  // Additional sessions for multi-session pipelines (vision, embedding, etc.)
+  // The decoder session is inherited from DecoderOnly_Model::session_decoder_.
+  std::map<std::string, std::unique_ptr<OrtSession>> extra_sessions_;
 
   // Per-session options for non-decoder sessions (graph capture disabled).
   std::map<std::string, std::unique_ptr<OrtSessionOptions>> non_decoder_session_options_;
@@ -36,16 +39,12 @@ struct PipelineConfigModel : Model {
   std::unique_ptr<FlowInterpreter> flow_interpreter_;
 };
 
-// State for Pipeline-as-Config model execution.
+// State for multi-session Pipeline-as-Config model execution.
 //
-// Single-session mode (decoder-only):
-//   Behaves identically to DecoderOnly_State — same components, same flow.
-//
-// Multi-session mode (VLM/encoder-decoder):
-//   Non-decoder sessions (vision, embedding, encoder) are driven by
-//   FlowInterpreter which manages execution order and intermediate wiring.
-//   The decoder session uses existing components (KV cache, position inputs,
-//   logits) for full parity with DecoderOnly_State.
+// The decoder session is fully delegated to DecoderOnly_State (KV cache,
+// position inputs, logits, sliding window, chunking — all handled).
+// Non-decoder sessions (vision, embedding, encoder) are orchestrated by
+// FlowInterpreter which manages execution order and dataflow wiring.
 struct PipelineConfigState : State {
   PipelineConfigState(const PipelineConfigModel& model,
                       DeviceSpan<int32_t> sequence_lengths,
@@ -60,50 +59,36 @@ struct PipelineConfigState : State {
   OrtValue* GetOutput(const char* name) override;
 
  private:
-  void UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens,
-                           DeviceSpan<int32_t> beam_indices,
-                           int total_length);
+  // Run a non-decoder session: set up I/O, execute, capture outputs.
+  void RunNonDecoderSession(const std::string& session_name);
 
+  // Run a flow step (decoder delegates to decoder_state_, others to RunNonDecoderSession).
   void RunFlowStep(const PipelineConfig::FlowStep& step,
                    int total_length,
                    DeviceSpan<int32_t>& next_tokens,
                    DeviceSpan<int32_t> next_indices);
 
-  // Run a non-decoder session: set up I/O, execute, capture outputs.
-  void RunNonDecoderSession(const std::string& session_name);
-
-  // Chunked context processing for decoder (mirrors DecoderOnly_State).
-  DeviceSpan<float> RunDecoderWithChunking(int total_length,
-                                           DeviceSpan<int32_t>& next_tokens,
-                                           DeviceSpan<int32_t> next_indices,
-                                           size_t chunk_size);
-
   const PipelineConfigModel& model_;
 
-  // Decoder session components (reuse existing proven implementations)
-  DefaultInputIDs input_ids_{*this};
-  Logits logits_{*this};
-  std::unique_ptr<KeyValueCache> kv_cache_;
-  std::unique_ptr<PositionInputs> position_inputs_;
-  ExtraInputs extra_inputs_{*this};
+  // Decoder session is fully delegated to DecoderOnly_State.
+  std::unique_ptr<DecoderOnly_State> decoder_state_;
 
   // Per-session extra inputs for non-decoder sessions.
   struct NonDecoderSessionIO {
     std::vector<const char*> input_names;
     std::vector<OrtValue*> inputs;
-    std::vector<const char*> output_names;
-    std::vector<OrtValue*> outputs;
   };
   std::map<std::string, NonDecoderSessionIO> non_decoder_io_;
 
   // Intermediate tensor store for wiring between sessions.
-  // Stores outputs from non-decoder sessions so they can be
-  // passed as inputs to downstream sessions.
   // Key: "session_name.tensor_name"
   std::map<std::string, std::unique_ptr<OrtValue>> intermediate_store_;
 
   // Persistent storage for wired input names to avoid dangling c_str() pointers.
-  std::vector<std::string> wired_input_names_;
+  std::vector<std::string> wired_decoder_input_names_;
+
+  // Logits from the last decoder run, saved by RunFlowStep("decoder").
+  DeviceSpan<float> last_logits_;
 
   bool is_prompt_{true};
 };

--- a/src/models/pipeline_config.h
+++ b/src/models/pipeline_config.h
@@ -3,6 +3,8 @@
 
 #pragma once
 #include "decoder_only.h"
+#include "extra_inputs.h"
+#include "flow_interpreter.h"
 
 namespace Generators {
 
@@ -10,14 +12,94 @@ namespace Generators {
 // than model_type strings.
 //
 // For v2 configs, CreateModel() routes here instead of the string-based
-// dispatch chain.  The current (minimal) implementation delegates to
-// DecoderOnly_Model for decoder-only models, ensuring identical behavior
-// and avoiding code duplication that could drift over time.
+// dispatch chain.
 //
-// Future versions will support multi-session pipelines (VLM, encoder-
-// decoder) by reading session layout from the config's pipeline section.
-struct PipelineConfigModel : DecoderOnly_Model {
+// For single-session (decoder-only) pipelines, PipelineConfigState directly
+// implements the same logic as DecoderOnly_State (same components, same order).
+//
+// For multi-session pipelines (VLM, encoder-decoder), loads all sessions
+// and uses FlowInterpreter to orchestrate execution order and dataflow.
+struct PipelineConfigModel : Model {
   PipelineConfigModel(std::unique_ptr<Config> config, OrtEnv& ort_env);
+
+  std::unique_ptr<State> CreateState(
+      DeviceSpan<int32_t> sequence_lengths,
+      const GeneratorParams& params) const override;
+
+  // Named sessions loaded from pipeline_config.sessions.
+  std::map<std::string, std::unique_ptr<OrtSession>> sessions_;
+
+  // Per-session options for non-decoder sessions (graph capture disabled).
+  std::map<std::string, std::unique_ptr<OrtSessionOptions>> non_decoder_session_options_;
+
+  // Flow interpreter constructed from pipeline_config.
+  std::unique_ptr<FlowInterpreter> flow_interpreter_;
+};
+
+// State for Pipeline-as-Config model execution.
+//
+// Single-session mode (decoder-only):
+//   Behaves identically to DecoderOnly_State — same components, same flow.
+//
+// Multi-session mode (VLM/encoder-decoder):
+//   Non-decoder sessions (vision, embedding, encoder) are driven by
+//   FlowInterpreter which manages execution order and intermediate wiring.
+//   The decoder session uses existing components (KV cache, position inputs,
+//   logits) for full parity with DecoderOnly_State.
+struct PipelineConfigState : State {
+  PipelineConfigState(const PipelineConfigModel& model,
+                      DeviceSpan<int32_t> sequence_lengths,
+                      const GeneratorParams& params);
+
+  void SetExtraInputs(const std::vector<ExtraInput>& extra_inputs) override;
+  DeviceSpan<float> Run(int total_length, DeviceSpan<int32_t>& next_tokens,
+                        DeviceSpan<int32_t> next_indices) override;
+  void RewindTo(size_t index) override;
+
+  OrtValue* GetInput(const char* name) override;
+  OrtValue* GetOutput(const char* name) override;
+
+ private:
+  void UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens,
+                           DeviceSpan<int32_t> beam_indices,
+                           int total_length);
+
+  void RunFlowStep(const PipelineConfig::FlowStep& step,
+                   int total_length,
+                   DeviceSpan<int32_t>& next_tokens,
+                   DeviceSpan<int32_t> next_indices);
+
+  // Run a non-decoder session: set up I/O, execute, capture outputs.
+  void RunNonDecoderSession(const std::string& session_name);
+
+  const PipelineConfigModel& model_;
+
+  // Decoder session components (reuse existing proven implementations)
+  DefaultInputIDs input_ids_{*this};
+  Logits logits_{*this};
+  std::unique_ptr<KeyValueCache> kv_cache_;
+  std::unique_ptr<PositionInputs> position_inputs_;
+  ExtraInputs extra_inputs_{*this};
+
+  // Per-session extra inputs for non-decoder sessions.
+  struct NonDecoderSessionIO {
+    std::vector<const char*> input_names;
+    std::vector<OrtValue*> inputs;
+    std::vector<const char*> output_names;
+    std::vector<OrtValue*> outputs;
+  };
+  std::map<std::string, NonDecoderSessionIO> non_decoder_io_;
+
+  // Intermediate tensor store for wiring between sessions.
+  // Stores outputs from non-decoder sessions so they can be
+  // passed as inputs to downstream sessions.
+  // Key: "session_name.tensor_name"
+  std::map<std::string, std::unique_ptr<OrtValue>> intermediate_store_;
+
+  // Persistent storage for wired input names to avoid dangling c_str() pointers.
+  std::vector<std::string> wired_input_names_;
+
+  bool is_prompt_{true};
 };
 
 }  // namespace Generators

--- a/src/models/pipeline_config.h
+++ b/src/models/pipeline_config.h
@@ -72,6 +72,12 @@ struct PipelineConfigState : State {
   // Run a non-decoder session: set up I/O, execute, capture outputs.
   void RunNonDecoderSession(const std::string& session_name);
 
+  // Chunked context processing for decoder (mirrors DecoderOnly_State).
+  DeviceSpan<float> RunDecoderWithChunking(int total_length,
+                                           DeviceSpan<int32_t>& next_tokens,
+                                           DeviceSpan<int32_t> next_indices,
+                                           size_t chunk_size);
+
   const PipelineConfigModel& model_;
 
   // Decoder session components (reuse existing proven implementations)

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -1,7 +1,6 @@
 #include "../generators.h"
 #include "model.h"
 #include "position_inputs.h"
-#include "model_type.h"
 #include <vector>
 #include <numeric>
 #include <cmath>  // For std::round
@@ -426,7 +425,7 @@ void DefaultPositionInputs::RewindMask(size_t index) {
 //     CpuSpan/CopyCpuToDevice.
 bool DefaultPositionInputs::ShouldUseStaticMaskHandling() const {
   return state_.params_->use_graph_capture ||
-         (state_.params_->IsPastPresentShareBufferEnabled(model_.config_->model.type) &&
+         (state_.params_->IsPastPresentShareBufferEnabled(*model_.config_) &&
           model_.p_device_->GetType() == DeviceType::NvTensorRtRtx);
 }
 
@@ -926,8 +925,9 @@ void Qwen2VLPositionInputs::RewindTo(size_t index) {
 }
 
 std::unique_ptr<PositionInputs> CreatePositionInputs(State& state, DeviceSpan<int32_t> sequence_lengths, const std::string& attention_mask_name) {
-  // Check for Qwen-VL family models which require 3D mRoPE position IDs
-  if (ModelType::IsQwenVLFamily(state.model_.config_->model.type)) {
+  // Config-driven position strategy (v2 pipeline config, also populated for v1 via translator)
+  const auto& strategy = state.model_.config_->pipeline_config.state.position_ids.strategy;
+  if (strategy.has_value() && strategy.value() == "mrope_3d") {
     return std::make_unique<Qwen2VLPositionInputs>(state.model_, state, sequence_lengths);
   }
   if (state.model_.config_->model.decoder.sliding_window.has_value() && state.model_.config_->model.decoder.sliding_window->slide_inputs) {

--- a/src/pipeline_config_schema.cpp
+++ b/src/pipeline_config_schema.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "generators.h"
+#include "pipeline_config_schema.h"
+#include <stdexcept>
+
+namespace Generators {
+
+void ValidatePipelineConfig(const PipelineConfig& config) {
+  // Validate flow steps reference existing sessions
+  for (const auto& step : config.flow) {
+    if (config.sessions.find(step.run) == config.sessions.end()) {
+      throw std::runtime_error(
+          "Pipeline config error: flow step references unknown session '" + step.run + "'");
+    }
+    if (step.when != "always" && step.when != "prompt" && step.when != "once") {
+      throw std::runtime_error(
+          "Pipeline config error: invalid 'when' value '" + step.when +
+          "' for flow step '" + step.run + "'. Expected 'always', 'prompt', or 'once'.");
+    }
+    if (!step.loop.empty() && step.loop != "per_image" && step.loop != "batched") {
+      throw std::runtime_error(
+          "Pipeline config error: invalid 'loop' value '" + step.loop +
+          "' for flow step '" + step.run + "'. Expected '', 'per_image', or 'batched'.");
+    }
+  }
+
+  // Validate dataflow wires reference existing sessions
+  for (const auto& wire : config.dataflow) {
+    if (config.sessions.find(wire.from_session) == config.sessions.end()) {
+      throw std::runtime_error(
+          "Pipeline config error: dataflow from_session '" + wire.from_session + "' not found");
+    }
+    if (config.sessions.find(wire.to_session) == config.sessions.end()) {
+      throw std::runtime_error(
+          "Pipeline config error: dataflow to_session '" + wire.to_session + "' not found");
+    }
+    if (wire.from_output.empty()) {
+      throw std::runtime_error(
+          "Pipeline config error: dataflow from_output is empty for wire from '" +
+          wire.from_session + "'");
+    }
+    if (wire.to_input.empty()) {
+      throw std::runtime_error(
+          "Pipeline config error: dataflow to_input is empty for wire to '" +
+          wire.to_session + "'");
+    }
+  }
+}
+
+}  // namespace Generators

--- a/src/pipeline_config_schema.cpp
+++ b/src/pipeline_config_schema.cpp
@@ -7,6 +7,16 @@
 
 namespace Generators {
 
+void NormalizePipelineConfig(PipelineConfig& config) {
+  for (auto& step : config.flow) {
+    if (step.when == "prompt" || step.when == "once") {
+      step.when = "init";
+    } else if (step.when == "always") {
+      step.when = "step";
+    }
+  }
+}
+
 void ValidatePipelineConfig(const PipelineConfig& config) {
   // Validate flow steps reference existing sessions
   for (const auto& step : config.flow) {
@@ -14,16 +24,30 @@ void ValidatePipelineConfig(const PipelineConfig& config) {
       throw std::runtime_error(
           "Pipeline config error: flow step references unknown session '" + step.run + "'");
     }
-    if (step.when != "always" && step.when != "prompt" && step.when != "once") {
+    if (step.when != "init" && step.when != "step" && step.when != "final" &&
+        step.when != "prompt" && step.when != "always" && step.when != "once") {
       throw std::runtime_error(
           "Pipeline config error: invalid 'when' value '" + step.when +
-          "' for flow step '" + step.run + "'. Expected 'always', 'prompt', or 'once'.");
+          "' for flow step '" + step.run + "'. Expected 'init', 'step', or 'final'.");
     }
     if (!step.loop.empty() && step.loop != "per_image" && step.loop != "batched") {
       throw std::runtime_error(
           "Pipeline config error: invalid 'loop' value '" + step.loop +
           "' for flow step '" + step.run + "'. Expected '', 'per_image', or 'batched'.");
     }
+  }
+
+  // Validate generation_loop (resolve default if unset)
+  const auto& loop = config.generation_loop.value_or("autoregressive");
+  if (loop == "autoregressive" || loop == "single_pass") {
+    // Valid values — no-op
+  } else if (loop == "denoising") {
+    throw std::runtime_error(
+        "Pipeline config error: generation_loop 'denoising' is not yet implemented.");
+  } else {
+    throw std::runtime_error(
+        "Pipeline config error: unknown generation_loop value '" + loop +
+        "'. Expected 'autoregressive', 'single_pass', or 'denoising'.");
   }
 
   // Validate dataflow wires reference existing sessions

--- a/src/pipeline_config_schema.h
+++ b/src/pipeline_config_schema.h
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Pipeline-as-Config v2 schema definitions.
+//
+// These structs represent the v2 config format where pipeline behavior
+// is declared in config JSON rather than hardcoded per model_type.
+// A v2 genai_config.json looks like:
+//
+//   {
+//     "version": 2,
+//     "pipeline": {
+//       "extends": "autoregressive-decoder",
+//       "sessions": { "decoder": { "file": "model.onnx" } },
+//       "flow": [ { "run": "decoder", "when": "always" } ],
+//       "state": { "kv_cache": { "format": "auto" } }
+//     },
+//     "model": { ... },
+//     "search": { ... }
+//   }
+
+#pragma once
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace Generators {
+
+struct PipelineConfig {
+  // A session corresponds to one ONNX model file.
+  struct Session {
+    std::string file;   // Filename relative to config directory
+    std::string role;   // Semantic role: "decoder", "encoder", "vision", "embedding", "speech"
+    // Per-session ORT options (optional; inherits global defaults if absent)
+  };
+
+  // A flow step describes when to run a session during generation.
+  struct FlowStep {
+    std::string run;    // Session name (key into sessions map)
+    std::string when{"always"};  // "always" = every step, "prompt" = first step only, "once" = before generation
+    std::string loop;   // "" = run once, "per_image" = loop over images, "batched" = batch all inputs
+  };
+
+  // A dataflow wire connects an output tensor from one session to an
+  // input tensor of another session.  Uses structured fields (not dot
+  // notation) to avoid ambiguity with tensor names that contain dots.
+  struct DataflowWire {
+    std::string from_session;  // Source session name
+    std::string from_output;   // Output tensor name in source session
+    std::string to_session;    // Destination session name
+    std::string to_input;      // Input tensor name in destination session
+  };
+
+  // State configuration controls how KV cache and position IDs are managed.
+  struct StateConfig {
+    struct KVCache {
+      std::string format{"auto"};  // "auto", "default", "cross", "windowed"
+      std::optional<std::string> past_key_pattern;
+      std::optional<std::string> present_key_pattern;
+      std::optional<std::string> past_value_pattern;
+      std::optional<std::string> present_value_pattern;
+    } kv_cache;
+
+    struct PositionIds {
+      std::string strategy{"auto"};  // "auto", "default", "mrope_3d"
+    } position_ids;
+  } state;
+
+  std::optional<std::string> extends;  // Preset name to inherit from
+  std::map<std::string, Session> sessions;
+  std::vector<FlowStep> flow;
+  std::vector<DataflowWire> dataflow;
+};
+
+// Validate a PipelineConfig for internal consistency:
+// - All flow steps reference existing sessions
+// - All dataflow wires reference existing sessions
+// - Required sessions present based on flow
+// Throws std::runtime_error with descriptive message on failure.
+void ValidatePipelineConfig(const PipelineConfig& config);
+
+}  // namespace Generators

--- a/src/pipeline_config_schema.h
+++ b/src/pipeline_config_schema.h
@@ -55,7 +55,7 @@ struct PipelineConfig {
   // State configuration controls how KV cache and position IDs are managed.
   struct StateConfig {
     struct KVCache {
-      std::string format{"auto"};  // "auto", "default", "cross", "windowed"
+      std::optional<std::string> format;  // "auto", "default", "cross", "windowed"; nullopt = use preset default
       std::optional<std::string> past_key_pattern;
       std::optional<std::string> present_key_pattern;
       std::optional<std::string> past_value_pattern;
@@ -63,7 +63,7 @@ struct PipelineConfig {
     } kv_cache;
 
     struct PositionIds {
-      std::string strategy{"auto"};  // "auto", "default", "mrope_3d"
+      std::optional<std::string> strategy;  // "auto", "default", "mrope_3d"; nullopt = use preset default
     } position_ids;
   } state;
 

--- a/src/pipeline_config_schema.h
+++ b/src/pipeline_config_schema.h
@@ -12,7 +12,7 @@
 //     "pipeline": {
 //       "extends": "autoregressive-decoder",
 //       "sessions": { "decoder": { "file": "model.onnx" } },
-//       "flow": [ { "run": "decoder", "when": "always" } ],
+//       "flow": [ { "run": "decoder", "when": "step" } ],
 //       "state": { "kv_cache": { "format": "auto" } }
 //     },
 //     "model": { ... },
@@ -38,7 +38,7 @@ struct PipelineConfig {
   // A flow step describes when to run a session during generation.
   struct FlowStep {
     std::string run;    // Session name (key into sessions map)
-    std::string when{"always"};  // "always" = every step, "prompt" = first step only, "once" = before generation
+    std::string when{"step"};  // "init", "step", "final"; aliases: "prompt"→"init", "always"→"step", "once"→"init"
     std::string loop;   // "" = run once, "per_image" = loop over images, "batched" = batch all inputs
   };
 
@@ -71,12 +71,18 @@ struct PipelineConfig {
   std::map<std::string, Session> sessions;
   std::vector<FlowStep> flow;
   std::vector<DataflowWire> dataflow;
+  std::optional<std::string> generation_loop;  // "autoregressive", "single_pass", "denoising"; nullopt = use preset default
 };
+
+// Normalize backward-compat aliases in a PipelineConfig:
+// "prompt"→"init", "always"→"step", "once"→"init"
+void NormalizePipelineConfig(PipelineConfig& config);
 
 // Validate a PipelineConfig for internal consistency:
 // - All flow steps reference existing sessions
 // - All dataflow wires reference existing sessions
 // - Required sessions present based on flow
+// - Valid generation_loop value
 // Throws std::runtime_error with descriptive message on failure.
 void ValidatePipelineConfig(const PipelineConfig& config);
 

--- a/src/pipeline_presets.cpp
+++ b/src/pipeline_presets.cpp
@@ -150,8 +150,8 @@ void ApplyOverrides(PipelineConfig& base, const PipelineConfig& overrides) {
     base.dataflow = overrides.dataflow;
   }
 
-  // State: override individual fields if set
-  if (overrides.state.kv_cache.format != "auto") {
+  // State: override individual fields only when explicitly set (has_value)
+  if (overrides.state.kv_cache.format.has_value()) {
     base.state.kv_cache.format = overrides.state.kv_cache.format;
   }
   if (overrides.state.kv_cache.past_key_pattern.has_value()) {
@@ -166,7 +166,7 @@ void ApplyOverrides(PipelineConfig& base, const PipelineConfig& overrides) {
   if (overrides.state.kv_cache.present_value_pattern.has_value()) {
     base.state.kv_cache.present_value_pattern = overrides.state.kv_cache.present_value_pattern;
   }
-  if (overrides.state.position_ids.strategy != "auto") {
+  if (overrides.state.position_ids.strategy.has_value()) {
     base.state.position_ids.strategy = overrides.state.position_ids.strategy;
   }
 }

--- a/src/pipeline_presets.cpp
+++ b/src/pipeline_presets.cpp
@@ -21,7 +21,7 @@ PipelineConfig MakeAutoRegressiveDecoder() {
   // Run decoder every step
   config.flow.push_back(PipelineConfig::FlowStep{
       .run = "decoder",
-      .when = "always",
+      .when = "step",
   });
 
   // Default KV cache + position ID state
@@ -48,19 +48,19 @@ PipelineConfig MakeVisionLanguage() {
       .role = "decoder",
   };
 
-  // Flow: vision runs once on prompt, embedding on prompt, decoder always
+  // Flow: vision runs once on init, embedding on init, decoder every step
   config.flow.push_back(PipelineConfig::FlowStep{
       .run = "vision",
-      .when = "prompt",
+      .when = "init",
       .loop = "per_image",
   });
   config.flow.push_back(PipelineConfig::FlowStep{
       .run = "embedding",
-      .when = "prompt",
+      .when = "init",
   });
   config.flow.push_back(PipelineConfig::FlowStep{
       .run = "decoder",
-      .when = "always",
+      .when = "step",
   });
 
   // Wire vision output → embedding input
@@ -97,14 +97,14 @@ PipelineConfig MakeEncoderDecoder() {
       .role = "decoder",
   };
 
-  // Encoder runs once on prompt, decoder runs every step
+  // Encoder runs once on init, decoder runs every step
   config.flow.push_back(PipelineConfig::FlowStep{
       .run = "encoder",
-      .when = "once",
+      .when = "init",
   });
   config.flow.push_back(PipelineConfig::FlowStep{
       .run = "decoder",
-      .when = "always",
+      .when = "step",
   });
 
   // Wire encoder output → decoder cross-attention input
@@ -168,6 +168,11 @@ void ApplyOverrides(PipelineConfig& base, const PipelineConfig& overrides) {
   }
   if (overrides.state.position_ids.strategy.has_value()) {
     base.state.position_ids.strategy = overrides.state.position_ids.strategy;
+  }
+
+  // Generation loop: override if explicitly set
+  if (overrides.generation_loop.has_value()) {
+    base.generation_loop = overrides.generation_loop;
   }
 }
 

--- a/src/pipeline_presets.cpp
+++ b/src/pipeline_presets.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "generators.h"
+#include "pipeline_presets.h"
+#include <stdexcept>
+
+namespace Generators {
+
+namespace {
+
+PipelineConfig MakeAutoRegressiveDecoder() {
+  PipelineConfig config;
+
+  // Single decoder session
+  config.sessions["decoder"] = PipelineConfig::Session{
+      .file = "model.onnx",
+      .role = "decoder",
+  };
+
+  // Run decoder every step
+  config.flow.push_back(PipelineConfig::FlowStep{
+      .run = "decoder",
+      .when = "always",
+  });
+
+  // Default KV cache + position ID state
+  config.state.kv_cache.format = "auto";
+  config.state.position_ids.strategy = "auto";
+
+  return config;
+}
+
+PipelineConfig MakeVisionLanguage() {
+  PipelineConfig config;
+
+  // Three sessions: vision encoder, embedding projector, text decoder
+  config.sessions["vision"] = PipelineConfig::Session{
+      .file = "vision_encoder.onnx",
+      .role = "vision",
+  };
+  config.sessions["embedding"] = PipelineConfig::Session{
+      .file = "embedding.onnx",
+      .role = "embedding",
+  };
+  config.sessions["decoder"] = PipelineConfig::Session{
+      .file = "decoder.onnx",
+      .role = "decoder",
+  };
+
+  // Flow: vision runs once on prompt, embedding on prompt, decoder always
+  config.flow.push_back(PipelineConfig::FlowStep{
+      .run = "vision",
+      .when = "prompt",
+      .loop = "per_image",
+  });
+  config.flow.push_back(PipelineConfig::FlowStep{
+      .run = "embedding",
+      .when = "prompt",
+  });
+  config.flow.push_back(PipelineConfig::FlowStep{
+      .run = "decoder",
+      .when = "always",
+  });
+
+  // Wire vision output → embedding input
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "vision",
+      .from_output = "image_features",
+      .to_session = "embedding",
+      .to_input = "image_features",
+  });
+
+  // Wire embedding output → decoder input
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "embedding",
+      .from_output = "inputs_embeds",
+      .to_session = "decoder",
+      .to_input = "inputs_embeds",
+  });
+
+  config.state.kv_cache.format = "auto";
+  config.state.position_ids.strategy = "auto";
+
+  return config;
+}
+
+PipelineConfig MakeEncoderDecoder() {
+  PipelineConfig config;
+
+  config.sessions["encoder"] = PipelineConfig::Session{
+      .file = "encoder.onnx",
+      .role = "encoder",
+  };
+  config.sessions["decoder"] = PipelineConfig::Session{
+      .file = "decoder.onnx",
+      .role = "decoder",
+  };
+
+  // Encoder runs once on prompt, decoder runs every step
+  config.flow.push_back(PipelineConfig::FlowStep{
+      .run = "encoder",
+      .when = "once",
+  });
+  config.flow.push_back(PipelineConfig::FlowStep{
+      .run = "decoder",
+      .when = "always",
+  });
+
+  // Wire encoder output → decoder cross-attention input
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "encoder",
+      .from_output = "encoder_hidden_states",
+      .to_session = "decoder",
+      .to_input = "encoder_hidden_states",
+  });
+
+  config.state.kv_cache.format = "auto";
+  config.state.position_ids.strategy = "auto";
+
+  return config;
+}
+
+}  // namespace
+
+PipelineConfig GetPreset(const std::string& name) {
+  if (name == "autoregressive-decoder") return MakeAutoRegressiveDecoder();
+  if (name == "vision-language") return MakeVisionLanguage();
+  if (name == "encoder-decoder") return MakeEncoderDecoder();
+
+  throw std::runtime_error(
+      "Unknown pipeline preset: '" + name +
+      "'. Known presets: 'autoregressive-decoder', 'vision-language', 'encoder-decoder'.");
+}
+
+void ApplyOverrides(PipelineConfig& base, const PipelineConfig& overrides) {
+  // Sessions: merge — override entries replace base entries with same key,
+  // new keys are added
+  for (const auto& [key, session] : overrides.sessions) {
+    base.sessions[key] = session;
+  }
+
+  // Flow: override replaces base entirely if non-empty
+  if (!overrides.flow.empty()) {
+    base.flow = overrides.flow;
+  }
+
+  // Dataflow: override replaces base entirely if non-empty
+  if (!overrides.dataflow.empty()) {
+    base.dataflow = overrides.dataflow;
+  }
+
+  // State: override individual fields if set
+  if (overrides.state.kv_cache.format != "auto") {
+    base.state.kv_cache.format = overrides.state.kv_cache.format;
+  }
+  if (overrides.state.kv_cache.past_key_pattern.has_value()) {
+    base.state.kv_cache.past_key_pattern = overrides.state.kv_cache.past_key_pattern;
+  }
+  if (overrides.state.kv_cache.present_key_pattern.has_value()) {
+    base.state.kv_cache.present_key_pattern = overrides.state.kv_cache.present_key_pattern;
+  }
+  if (overrides.state.kv_cache.past_value_pattern.has_value()) {
+    base.state.kv_cache.past_value_pattern = overrides.state.kv_cache.past_value_pattern;
+  }
+  if (overrides.state.kv_cache.present_value_pattern.has_value()) {
+    base.state.kv_cache.present_value_pattern = overrides.state.kv_cache.present_value_pattern;
+  }
+  if (overrides.state.position_ids.strategy != "auto") {
+    base.state.position_ids.strategy = overrides.state.position_ids.strategy;
+  }
+}
+
+}  // namespace Generators

--- a/src/pipeline_presets.h
+++ b/src/pipeline_presets.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Built-in pipeline presets.
+//
+// Presets provide default PipelineConfig values for common architectures.
+// A v2 config can specify `"extends": "autoregressive-decoder"` to inherit
+// the preset's sessions, flow, and state, then override specific fields.
+
+#pragma once
+#include "pipeline_config_schema.h"
+#include <string>
+
+namespace Generators {
+
+// Resolve a named preset into a PipelineConfig with default values.
+// Known presets:
+//   "autoregressive-decoder"  — single decoder session, KV cache, always-run flow
+//   "vision-language"         — vision + embedding + decoder sessions
+//   "encoder-decoder"         — encoder + decoder sessions with cross-attention
+//
+// Throws std::runtime_error for unknown preset names.
+PipelineConfig GetPreset(const std::string& name);
+
+// Apply overrides from |overrides| onto |base|.
+// - Scalar fields: override replaces base if set
+// - Maps (sessions): merge — override entries replace base entries with same key
+// - Vectors (flow, dataflow): override replaces base entirely if non-empty
+void ApplyOverrides(PipelineConfig& base, const PipelineConfig& overrides);
+
+}  // namespace Generators

--- a/src/v1_translator.cpp
+++ b/src/v1_translator.cpp
@@ -9,6 +9,26 @@
 
 namespace Generators {
 
+namespace {
+// Propagate KV cache name patterns from v1 decoder inputs/outputs to pipeline state.
+void PropagateKVCachePatterns(PipelineConfig& config, const Config& v1) {
+  const auto& inputs = v1.model.decoder.inputs;
+  const auto& outputs = v1.model.decoder.outputs;
+  if (!inputs.past_key_names.empty()) {
+    config.state.kv_cache.past_key_pattern = inputs.past_key_names;
+  }
+  if (!inputs.past_value_names.empty()) {
+    config.state.kv_cache.past_value_pattern = inputs.past_value_names;
+  }
+  if (!outputs.present_key_names.empty()) {
+    config.state.kv_cache.present_key_pattern = outputs.present_key_names;
+  }
+  if (!outputs.present_value_names.empty()) {
+    config.state.kv_cache.present_value_pattern = outputs.present_value_names;
+  }
+}
+}  // namespace
+
 PipelineConfig TranslateV1Config(const Config& v1) {
   const auto& type = v1.model.type;
 
@@ -23,21 +43,7 @@ PipelineConfig TranslateV1Config(const Config& v1) {
       config.sessions["decoder"].file = v1.model.decoder.filename;
     }
 
-    // Propagate KV cache name patterns from v1 decoder inputs/outputs
-    const auto& inputs = v1.model.decoder.inputs;
-    const auto& outputs = v1.model.decoder.outputs;
-    if (!inputs.past_key_names.empty()) {
-      config.state.kv_cache.past_key_pattern = inputs.past_key_names;
-    }
-    if (!inputs.past_value_names.empty()) {
-      config.state.kv_cache.past_value_pattern = inputs.past_value_names;
-    }
-    if (!outputs.present_key_names.empty()) {
-      config.state.kv_cache.present_key_pattern = outputs.present_key_names;
-    }
-    if (!outputs.present_value_names.empty()) {
-      config.state.kv_cache.present_value_pattern = outputs.present_value_names;
-    }
+    PropagateKVCachePatterns(config, v1);
 
   } else if (ModelType::IsVLM(type) || ModelType::IsMMM(type)) {
     // Vision-language model: vision + embedding + decoder sessions
@@ -69,21 +75,7 @@ PipelineConfig TranslateV1Config(const Config& v1) {
       }
     }
 
-    // Propagate KV cache patterns from decoder
-    const auto& inputs = v1.model.decoder.inputs;
-    const auto& outputs = v1.model.decoder.outputs;
-    if (!inputs.past_key_names.empty()) {
-      config.state.kv_cache.past_key_pattern = inputs.past_key_names;
-    }
-    if (!inputs.past_value_names.empty()) {
-      config.state.kv_cache.past_value_pattern = inputs.past_value_names;
-    }
-    if (!outputs.present_key_names.empty()) {
-      config.state.kv_cache.present_key_pattern = outputs.present_key_names;
-    }
-    if (!outputs.present_value_names.empty()) {
-      config.state.kv_cache.present_value_pattern = outputs.present_value_names;
-    }
+    PropagateKVCachePatterns(config, v1);
 
     // Position strategy for Qwen2.5-VL family (3D mRoPE)
     if (ModelType::IsQwen25VL(type)) {

--- a/src/v1_translator.cpp
+++ b/src/v1_translator.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "generators.h"
+#include "v1_translator.h"
+#include "pipeline_presets.h"
+#include "config.h"
+#include "models/model_type.h"
+
+namespace Generators {
+
+PipelineConfig TranslateV1Config(const Config& v1) {
+  const auto& type = v1.model.type;
+
+  PipelineConfig config;
+
+  if (ModelType::IsLLM(type) || ModelType::IsPipe(type)) {
+    // Autoregressive decoder: single session
+    config = GetPreset("autoregressive-decoder");
+
+    // Override session filename from v1 config
+    if (!v1.model.decoder.filename.empty()) {
+      config.sessions["decoder"].file = v1.model.decoder.filename;
+    }
+
+    // Propagate KV cache name patterns from v1 decoder inputs/outputs
+    const auto& inputs = v1.model.decoder.inputs;
+    const auto& outputs = v1.model.decoder.outputs;
+    if (!inputs.past_key_names.empty()) {
+      config.state.kv_cache.past_key_pattern = inputs.past_key_names;
+    }
+    if (!inputs.past_value_names.empty()) {
+      config.state.kv_cache.past_value_pattern = inputs.past_value_names;
+    }
+    if (!outputs.present_key_names.empty()) {
+      config.state.kv_cache.present_key_pattern = outputs.present_key_names;
+    }
+    if (!outputs.present_value_names.empty()) {
+      config.state.kv_cache.present_value_pattern = outputs.present_value_names;
+    }
+
+  } else if (ModelType::IsVLM(type) || ModelType::IsMMM(type)) {
+    // Vision-language model: vision + embedding + decoder sessions
+    config = GetPreset("vision-language");
+
+    if (!v1.model.decoder.filename.empty()) {
+      config.sessions["decoder"].file = v1.model.decoder.filename;
+    }
+    if (!v1.model.vision.filename.empty()) {
+      config.sessions["vision"].file = v1.model.vision.filename;
+    }
+    if (!v1.model.embedding.filename.empty()) {
+      config.sessions["embedding"].file = v1.model.embedding.filename;
+    }
+
+    // VLM-specific: propagate vision I/O name overrides via dataflow
+    // (dataflow wires use tensor names from the v1 config)
+    if (!config.dataflow.empty()) {
+      const auto& vision_outputs = v1.model.vision.outputs;
+      if (!vision_outputs.image_features.empty()) {
+        config.dataflow[0].from_output = vision_outputs.image_features;
+      }
+      const auto& embed_inputs = v1.model.embedding.inputs;
+      if (!embed_inputs.image_features.empty()) {
+        config.dataflow[0].to_input = embed_inputs.image_features;
+      }
+    }
+
+    // Propagate KV cache patterns from decoder
+    const auto& inputs = v1.model.decoder.inputs;
+    const auto& outputs = v1.model.decoder.outputs;
+    if (!inputs.past_key_names.empty()) {
+      config.state.kv_cache.past_key_pattern = inputs.past_key_names;
+    }
+    if (!inputs.past_value_names.empty()) {
+      config.state.kv_cache.past_value_pattern = inputs.past_value_names;
+    }
+    if (!outputs.present_key_names.empty()) {
+      config.state.kv_cache.present_key_pattern = outputs.present_key_names;
+    }
+    if (!outputs.present_value_names.empty()) {
+      config.state.kv_cache.present_value_pattern = outputs.present_value_names;
+    }
+
+    // Position strategy for Qwen2.5-VL family (3D mRoPE)
+    if (ModelType::IsQwen25VL(type)) {
+      config.state.position_ids.strategy = "mrope_3d";
+    }
+
+  } else if (ModelType::IsALM(type)) {
+    // Audio-language model (Whisper): encoder-decoder
+    config = GetPreset("encoder-decoder");
+
+    if (!v1.model.encoder.filename.empty()) {
+      config.sessions["encoder"].file = v1.model.encoder.filename;
+    }
+    if (!v1.model.decoder.filename.empty()) {
+      config.sessions["decoder"].file = v1.model.decoder.filename;
+    }
+
+  } else if (type == "marian-ssru") {
+    // Marian encoder-decoder
+    config = GetPreset("encoder-decoder");
+
+    if (!v1.model.encoder.filename.empty()) {
+      config.sessions["encoder"].file = v1.model.encoder.filename;
+    }
+    if (!v1.model.decoder.filename.empty()) {
+      config.sessions["decoder"].file = v1.model.decoder.filename;
+    }
+
+  } else {
+    // Unknown model type — create minimal config with just the decoder
+    // so that pipeline_config is always populated, even if incomplete.
+    config = GetPreset("autoregressive-decoder");
+    if (!v1.model.decoder.filename.empty()) {
+      config.sessions["decoder"].file = v1.model.decoder.filename;
+    }
+  }
+
+  return config;
+}
+
+}  // namespace Generators

--- a/src/v1_translator.cpp
+++ b/src/v1_translator.cpp
@@ -54,15 +54,18 @@ PipelineConfig TranslateV1Config(const Config& v1) {
     }
 
     // VLM-specific: propagate vision I/O name overrides via dataflow
-    // (dataflow wires use tensor names from the v1 config)
-    if (!config.dataflow.empty()) {
-      const auto& vision_outputs = v1.model.vision.outputs;
-      if (!vision_outputs.image_features.empty()) {
-        config.dataflow[0].from_output = vision_outputs.image_features;
-      }
-      const auto& embed_inputs = v1.model.embedding.inputs;
-      if (!embed_inputs.image_features.empty()) {
-        config.dataflow[0].to_input = embed_inputs.image_features;
+    // Find the vision→embedding wire by session names (not hardcoded index)
+    const auto& vision_outputs = v1.model.vision.outputs;
+    const auto& embed_inputs = v1.model.embedding.inputs;
+    for (auto& wire : config.dataflow) {
+      if (wire.from_session == "vision" && wire.to_session == "embedding") {
+        if (!vision_outputs.image_features.empty()) {
+          wire.from_output = vision_outputs.image_features;
+        }
+        if (!embed_inputs.image_features.empty()) {
+          wire.to_input = embed_inputs.image_features;
+        }
+        break;
       }
     }
 

--- a/src/v1_translator.cpp
+++ b/src/v1_translator.cpp
@@ -78,7 +78,7 @@ PipelineConfig TranslateV1Config(const Config& v1) {
     PropagateKVCachePatterns(config, v1);
 
     // Position strategy for Qwen2.5-VL family (3D mRoPE)
-    if (ModelType::IsQwen25VL(type)) {
+    if (ModelType::IsQwenVLFamily(type)) {
       config.state.position_ids.strategy = "mrope_3d";
     }
 

--- a/src/v1_translator.h
+++ b/src/v1_translator.h
@@ -27,8 +27,8 @@ struct Config;  // Forward declaration
 // are populated from the v1 Config's decoder/vision/embedding/speech
 // sub-structures.
 //
-// Throws std::runtime_error if the model_type is not supported for
-// translation (e.g. unknown or highly custom model types).
+// Unknown model types fall back to the "autoregressive-decoder" preset,
+// since the majority of models are decoder-only LLMs.
 PipelineConfig TranslateV1Config(const Config& v1_config);
 
 }  // namespace Generators

--- a/src/v1_translator.h
+++ b/src/v1_translator.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// V1 → V2 config translator.
+//
+// Translates a legacy v1 Config (model_type-based) into a PipelineConfig
+// so that downstream code can use a single representation.  This enables
+// incremental migration: existing v1 configs still work, and new code
+// can read from PipelineConfig regardless of config version.
+
+#pragma once
+#include "pipeline_config_schema.h"
+
+namespace Generators {
+
+struct Config;  // Forward declaration
+
+// Translate a v1 Config into a PipelineConfig.
+//
+// Maps known model categories to presets:
+//   LLM model types  → "autoregressive-decoder" preset
+//   VLM model types  → "vision-language" preset
+//   ALM model types  → "encoder-decoder" preset (Whisper)
+//   Encoder-decoder  → "encoder-decoder" preset
+//
+// Session filenames, input/output name patterns, and state config
+// are populated from the v1 Config's decoder/vision/embedding/speech
+// sub-structures.
+//
+// Throws std::runtime_error if the model_type is not supported for
+// translation (e.g. unknown or highly custom model types).
+PipelineConfig TranslateV1Config(const Config& v1_config);
+
+}  // namespace Generators

--- a/test/flow_interpreter_test.cpp
+++ b/test/flow_interpreter_test.cpp
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Unit tests for PR 3: FlowInterpreter and multi-session pipeline support.
+
+#include "generators.h"
+#include "pipeline_config_schema.h"
+#include "pipeline_presets.h"
+#include "models/flow_interpreter.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace Generators::test {
+
+// ============================================================================
+// FlowInterpreter — flow partitioning tests
+// ============================================================================
+
+TEST(FlowInterpreter, DecoderOnlyIsNotMultiSession) {
+  auto config = GetPreset("autoregressive-decoder");
+  FlowInterpreter interpreter(config);
+
+  EXPECT_FALSE(interpreter.IsMultiSession());
+  EXPECT_TRUE(interpreter.prompt_steps().empty());
+  ASSERT_EQ(interpreter.always_steps().size(), 1u);
+  EXPECT_EQ(interpreter.always_steps()[0].run, "decoder");
+}
+
+TEST(FlowInterpreter, VLMIsMultiSession) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  EXPECT_TRUE(interpreter.IsMultiSession());
+}
+
+TEST(FlowInterpreter, VLMPromptStepsPartitioned) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  // Vision runs on prompt only, embedding runs on prompt only
+  ASSERT_EQ(interpreter.prompt_steps().size(), 2u);
+  EXPECT_EQ(interpreter.prompt_steps()[0].run, "vision");
+  EXPECT_EQ(interpreter.prompt_steps()[0].when, "prompt");
+  EXPECT_EQ(interpreter.prompt_steps()[1].run, "embedding");
+  EXPECT_EQ(interpreter.prompt_steps()[1].when, "prompt");
+}
+
+TEST(FlowInterpreter, VLMAlwaysStepsPartitioned) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  // Decoder runs always
+  ASSERT_EQ(interpreter.always_steps().size(), 1u);
+  EXPECT_EQ(interpreter.always_steps()[0].run, "decoder");
+  EXPECT_EQ(interpreter.always_steps()[0].when, "always");
+}
+
+TEST(FlowInterpreter, EncoderDecoderPartitioning) {
+  auto config = GetPreset("encoder-decoder");
+  FlowInterpreter interpreter(config);
+
+  EXPECT_TRUE(interpreter.IsMultiSession());
+
+  // Encoder runs once (goes to prompt_steps)
+  ASSERT_EQ(interpreter.prompt_steps().size(), 1u);
+  EXPECT_EQ(interpreter.prompt_steps()[0].run, "encoder");
+  EXPECT_EQ(interpreter.prompt_steps()[0].when, "once");
+
+  // Decoder runs always
+  ASSERT_EQ(interpreter.always_steps().size(), 1u);
+  EXPECT_EQ(interpreter.always_steps()[0].run, "decoder");
+}
+
+// ============================================================================
+// FlowInterpreter — intermediate tensor storage
+// ============================================================================
+
+TEST(FlowInterpreter, StoreAndRetrieveIntermediate) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  // Create a dummy OrtValue pointer (we just need address tracking)
+  int dummy_value = 42;
+  auto* fake_ort_value = reinterpret_cast<OrtValue*>(&dummy_value);
+
+  interpreter.StoreIntermediate("vision", "image_features", fake_ort_value);
+
+  EXPECT_EQ(interpreter.GetIntermediate("vision", "image_features"),
+            fake_ort_value);
+  EXPECT_EQ(interpreter.GetIntermediate("vision", "nonexistent"), nullptr);
+  EXPECT_EQ(interpreter.GetIntermediate("other", "image_features"), nullptr);
+}
+
+TEST(FlowInterpreter, ClearAllRemovesEverything) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  int dummy1 = 1, dummy2 = 2;
+  interpreter.StoreIntermediate("vision", "image_features",
+                                reinterpret_cast<OrtValue*>(&dummy1));
+  interpreter.StoreIntermediate("embedding", "inputs_embeds",
+                                reinterpret_cast<OrtValue*>(&dummy2));
+
+  interpreter.ClearAll();
+
+  EXPECT_EQ(interpreter.GetIntermediate("vision", "image_features"), nullptr);
+  EXPECT_EQ(interpreter.GetIntermediate("embedding", "inputs_embeds"), nullptr);
+}
+
+TEST(FlowInterpreter, ClearPromptIntermediatesSelectiveClean) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  int dummy_vision = 1, dummy_decoder = 2;
+  interpreter.StoreIntermediate("vision", "image_features",
+                                reinterpret_cast<OrtValue*>(&dummy_vision));
+  interpreter.StoreIntermediate("decoder", "some_output",
+                                reinterpret_cast<OrtValue*>(&dummy_decoder));
+
+  // Vision is prompt-only (appears in prompt_steps but not always_steps),
+  // so its intermediates should be cleared.  Decoder is always-run, so
+  // its intermediates should survive.
+  interpreter.ClearPromptIntermediates();
+
+  EXPECT_EQ(interpreter.GetIntermediate("vision", "image_features"), nullptr);
+  EXPECT_EQ(interpreter.GetIntermediate("decoder", "some_output"),
+            reinterpret_cast<OrtValue*>(&dummy_decoder));
+}
+
+// ============================================================================
+// FlowInterpreter — dataflow wiring
+// ============================================================================
+
+TEST(FlowInterpreter, GetWiredInputsFromDataflow) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  // Store a vision output
+  int dummy = 42;
+  auto* fake_value = reinterpret_cast<OrtValue*>(&dummy);
+  interpreter.StoreIntermediate("vision", "image_features", fake_value);
+
+  // The VLM preset has a wire: vision.image_features -> embedding.image_features
+  auto wired = interpreter.GetWiredInputs("embedding");
+  ASSERT_GE(wired.size(), 1u);
+
+  bool found = false;
+  for (const auto& [name, value] : wired) {
+    if (name == "image_features" && value == fake_value) {
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found) << "Expected wired input 'image_features' for embedding session";
+}
+
+TEST(FlowInterpreter, GetWiredInputsForDecoderFromEmbedding) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  // Store an embedding output
+  int dummy = 99;
+  auto* fake_value = reinterpret_cast<OrtValue*>(&dummy);
+  interpreter.StoreIntermediate("embedding", "inputs_embeds", fake_value);
+
+  // The VLM preset has a wire: embedding.inputs_embeds -> decoder.inputs_embeds
+  auto wired = interpreter.GetWiredInputs("decoder");
+  ASSERT_GE(wired.size(), 1u);
+
+  bool found = false;
+  for (const auto& [name, value] : wired) {
+    if (name == "inputs_embeds" && value == fake_value) {
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found) << "Expected wired input 'inputs_embeds' for decoder session";
+}
+
+TEST(FlowInterpreter, GetWiredInputsReturnsEmptyWhenNoIntermediates) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  // No intermediates stored yet — wired inputs should be empty
+  auto wired = interpreter.GetWiredInputs("embedding");
+  EXPECT_TRUE(wired.empty());
+}
+
+TEST(FlowInterpreter, GetWiredInputsForSessionWithNoWires) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  // Vision has no incoming wires in the VLM preset
+  auto wired = interpreter.GetWiredInputs("vision");
+  EXPECT_TRUE(wired.empty());
+}
+
+// ============================================================================
+// FlowInterpreter — custom pipeline config
+// ============================================================================
+
+TEST(FlowInterpreter, CustomFlowWithMixedWhenValues) {
+  PipelineConfig config;
+  config.sessions["encoder"] = {.file = "encoder.onnx", .role = "encoder"};
+  config.sessions["projector"] = {.file = "proj.onnx", .role = "embedding"};
+  config.sessions["decoder"] = {.file = "model.onnx", .role = "decoder"};
+
+  config.flow.push_back({.run = "encoder", .when = "once"});
+  config.flow.push_back({.run = "projector", .when = "prompt"});
+  config.flow.push_back({.run = "decoder", .when = "always"});
+
+  FlowInterpreter interpreter(config);
+
+  EXPECT_TRUE(interpreter.IsMultiSession());
+
+  // "once" and "prompt" go to prompt_steps
+  ASSERT_EQ(interpreter.prompt_steps().size(), 2u);
+  EXPECT_EQ(interpreter.prompt_steps()[0].run, "encoder");
+  EXPECT_EQ(interpreter.prompt_steps()[1].run, "projector");
+
+  // "always" goes to always_steps
+  ASSERT_EQ(interpreter.always_steps().size(), 1u);
+  EXPECT_EQ(interpreter.always_steps()[0].run, "decoder");
+}
+
+TEST(FlowInterpreter, DataflowAccessors) {
+  PipelineConfig config;
+  config.sessions["a"] = {.file = "a.onnx", .role = "encoder"};
+  config.sessions["b"] = {.file = "b.onnx", .role = "decoder"};
+  config.flow.push_back({.run = "a", .when = "once"});
+  config.flow.push_back({.run = "b", .when = "always"});
+  config.dataflow.push_back({
+      .from_session = "a",
+      .from_output = "hidden",
+      .to_session = "b",
+      .to_input = "encoder_out",
+  });
+
+  FlowInterpreter interpreter(config);
+
+  ASSERT_EQ(interpreter.dataflow().size(), 1u);
+  EXPECT_EQ(interpreter.dataflow()[0].from_session, "a");
+  EXPECT_EQ(interpreter.dataflow()[0].from_output, "hidden");
+  EXPECT_EQ(interpreter.dataflow()[0].to_session, "b");
+  EXPECT_EQ(interpreter.dataflow()[0].to_input, "encoder_out");
+}
+
+}  // namespace Generators::test

--- a/test/flow_interpreter_test.cpp
+++ b/test/flow_interpreter_test.cpp
@@ -9,6 +9,7 @@
 #include "models/flow_interpreter.h"
 
 #include <gtest/gtest.h>
+#include <map>
 #include <string>
 
 namespace Generators::test {
@@ -73,76 +74,38 @@ TEST(FlowInterpreter, EncoderDecoderPartitioning) {
 }
 
 // ============================================================================
-// FlowInterpreter — intermediate tensor storage
+// FlowInterpreter — dataflow wiring (stateless — intermediates passed in)
 // ============================================================================
 
-TEST(FlowInterpreter, StoreAndRetrieveIntermediate) {
+TEST(FlowInterpreter, StoreAndRetrieveViaMap) {
   auto config = GetPreset("vision-language");
   FlowInterpreter interpreter(config);
 
-  // Create a dummy OrtValue pointer (we just need address tracking)
+  // Intermediates are now owned by the State, not the interpreter.
+  // Tests pass an external map to GetWiredInputs.
+  std::map<std::string, OrtValue*> intermediates;
   int dummy_value = 42;
   auto* fake_ort_value = reinterpret_cast<OrtValue*>(&dummy_value);
 
-  interpreter.StoreIntermediate("vision", "image_features", fake_ort_value);
+  intermediates["vision.image_features"] = fake_ort_value;
 
-  EXPECT_EQ(interpreter.GetIntermediate("vision", "image_features"),
-            fake_ort_value);
-  EXPECT_EQ(interpreter.GetIntermediate("vision", "nonexistent"), nullptr);
-  EXPECT_EQ(interpreter.GetIntermediate("other", "image_features"), nullptr);
+  auto wired = interpreter.GetWiredInputs("embedding", intermediates);
+  ASSERT_GE(wired.size(), 1u);
+  EXPECT_EQ(wired[0].first, "image_features");
+  EXPECT_EQ(wired[0].second, fake_ort_value);
 }
-
-TEST(FlowInterpreter, ClearAllRemovesEverything) {
-  auto config = GetPreset("vision-language");
-  FlowInterpreter interpreter(config);
-
-  int dummy1 = 1, dummy2 = 2;
-  interpreter.StoreIntermediate("vision", "image_features",
-                                reinterpret_cast<OrtValue*>(&dummy1));
-  interpreter.StoreIntermediate("embedding", "inputs_embeds",
-                                reinterpret_cast<OrtValue*>(&dummy2));
-
-  interpreter.ClearAll();
-
-  EXPECT_EQ(interpreter.GetIntermediate("vision", "image_features"), nullptr);
-  EXPECT_EQ(interpreter.GetIntermediate("embedding", "inputs_embeds"), nullptr);
-}
-
-TEST(FlowInterpreter, ClearPromptIntermediatesSelectiveClean) {
-  auto config = GetPreset("vision-language");
-  FlowInterpreter interpreter(config);
-
-  int dummy_vision = 1, dummy_decoder = 2;
-  interpreter.StoreIntermediate("vision", "image_features",
-                                reinterpret_cast<OrtValue*>(&dummy_vision));
-  interpreter.StoreIntermediate("decoder", "some_output",
-                                reinterpret_cast<OrtValue*>(&dummy_decoder));
-
-  // Vision is prompt-only (appears in prompt_steps but not always_steps),
-  // so its intermediates should be cleared.  Decoder is always-run, so
-  // its intermediates should survive.
-  interpreter.ClearPromptIntermediates();
-
-  EXPECT_EQ(interpreter.GetIntermediate("vision", "image_features"), nullptr);
-  EXPECT_EQ(interpreter.GetIntermediate("decoder", "some_output"),
-            reinterpret_cast<OrtValue*>(&dummy_decoder));
-}
-
-// ============================================================================
-// FlowInterpreter — dataflow wiring
-// ============================================================================
 
 TEST(FlowInterpreter, GetWiredInputsFromDataflow) {
   auto config = GetPreset("vision-language");
   FlowInterpreter interpreter(config);
 
-  // Store a vision output
+  std::map<std::string, OrtValue*> intermediates;
   int dummy = 42;
   auto* fake_value = reinterpret_cast<OrtValue*>(&dummy);
-  interpreter.StoreIntermediate("vision", "image_features", fake_value);
+  intermediates["vision.image_features"] = fake_value;
 
   // The VLM preset has a wire: vision.image_features -> embedding.image_features
-  auto wired = interpreter.GetWiredInputs("embedding");
+  auto wired = interpreter.GetWiredInputs("embedding", intermediates);
   ASSERT_GE(wired.size(), 1u);
 
   bool found = false;
@@ -158,13 +121,13 @@ TEST(FlowInterpreter, GetWiredInputsForDecoderFromEmbedding) {
   auto config = GetPreset("vision-language");
   FlowInterpreter interpreter(config);
 
-  // Store an embedding output
+  std::map<std::string, OrtValue*> intermediates;
   int dummy = 99;
   auto* fake_value = reinterpret_cast<OrtValue*>(&dummy);
-  interpreter.StoreIntermediate("embedding", "inputs_embeds", fake_value);
+  intermediates["embedding.inputs_embeds"] = fake_value;
 
   // The VLM preset has a wire: embedding.inputs_embeds -> decoder.inputs_embeds
-  auto wired = interpreter.GetWiredInputs("decoder");
+  auto wired = interpreter.GetWiredInputs("decoder", intermediates);
   ASSERT_GE(wired.size(), 1u);
 
   bool found = false;
@@ -180,8 +143,8 @@ TEST(FlowInterpreter, GetWiredInputsReturnsEmptyWhenNoIntermediates) {
   auto config = GetPreset("vision-language");
   FlowInterpreter interpreter(config);
 
-  // No intermediates stored yet — wired inputs should be empty
-  auto wired = interpreter.GetWiredInputs("embedding");
+  std::map<std::string, OrtValue*> intermediates;  // empty
+  auto wired = interpreter.GetWiredInputs("embedding", intermediates);
   EXPECT_TRUE(wired.empty());
 }
 
@@ -189,9 +152,23 @@ TEST(FlowInterpreter, GetWiredInputsForSessionWithNoWires) {
   auto config = GetPreset("vision-language");
   FlowInterpreter interpreter(config);
 
+  std::map<std::string, OrtValue*> intermediates;
+  intermediates["something.tensor"] = reinterpret_cast<OrtValue*>(0x1234);
+
   // Vision has no incoming wires in the VLM preset
-  auto wired = interpreter.GetWiredInputs("vision");
+  auto wired = interpreter.GetWiredInputs("vision", intermediates);
   EXPECT_TRUE(wired.empty());
+}
+
+TEST(FlowInterpreter, PromptOnlySessionsIdentified) {
+  auto config = GetPreset("vision-language");
+  FlowInterpreter interpreter(config);
+
+  // Vision and embedding are prompt-only (not in always_steps)
+  const auto& prompt_only = interpreter.prompt_only_sessions();
+  EXPECT_TRUE(prompt_only.count("vision"));
+  EXPECT_TRUE(prompt_only.count("embedding"));
+  EXPECT_FALSE(prompt_only.count("decoder"));
 }
 
 // ============================================================================

--- a/test/flow_interpreter_test.cpp
+++ b/test/flow_interpreter_test.cpp
@@ -23,9 +23,9 @@ TEST(FlowInterpreter, DecoderOnlyIsNotMultiSession) {
   FlowInterpreter interpreter(config);
 
   EXPECT_FALSE(interpreter.IsMultiSession());
-  EXPECT_TRUE(interpreter.prompt_steps().empty());
-  ASSERT_EQ(interpreter.always_steps().size(), 1u);
-  EXPECT_EQ(interpreter.always_steps()[0].run, "decoder");
+  EXPECT_TRUE(interpreter.init_steps().empty());
+  ASSERT_EQ(interpreter.step_steps().size(), 1u);
+  EXPECT_EQ(interpreter.step_steps()[0].run, "decoder");
 }
 
 TEST(FlowInterpreter, VLMIsMultiSession) {
@@ -35,26 +35,26 @@ TEST(FlowInterpreter, VLMIsMultiSession) {
   EXPECT_TRUE(interpreter.IsMultiSession());
 }
 
-TEST(FlowInterpreter, VLMPromptStepsPartitioned) {
+TEST(FlowInterpreter, VLMInitStepsPartitioned) {
   auto config = GetPreset("vision-language");
   FlowInterpreter interpreter(config);
 
-  // Vision runs on prompt only, embedding runs on prompt only
-  ASSERT_EQ(interpreter.prompt_steps().size(), 2u);
-  EXPECT_EQ(interpreter.prompt_steps()[0].run, "vision");
-  EXPECT_EQ(interpreter.prompt_steps()[0].when, "prompt");
-  EXPECT_EQ(interpreter.prompt_steps()[1].run, "embedding");
-  EXPECT_EQ(interpreter.prompt_steps()[1].when, "prompt");
+  // Vision runs on init only, embedding runs on init only
+  ASSERT_EQ(interpreter.init_steps().size(), 2u);
+  EXPECT_EQ(interpreter.init_steps()[0].run, "vision");
+  EXPECT_EQ(interpreter.init_steps()[0].when, "init");
+  EXPECT_EQ(interpreter.init_steps()[1].run, "embedding");
+  EXPECT_EQ(interpreter.init_steps()[1].when, "init");
 }
 
-TEST(FlowInterpreter, VLMAlwaysStepsPartitioned) {
+TEST(FlowInterpreter, VLMStepStepsPartitioned) {
   auto config = GetPreset("vision-language");
   FlowInterpreter interpreter(config);
 
-  // Decoder runs always
-  ASSERT_EQ(interpreter.always_steps().size(), 1u);
-  EXPECT_EQ(interpreter.always_steps()[0].run, "decoder");
-  EXPECT_EQ(interpreter.always_steps()[0].when, "always");
+  // Decoder runs every step
+  ASSERT_EQ(interpreter.step_steps().size(), 1u);
+  EXPECT_EQ(interpreter.step_steps()[0].run, "decoder");
+  EXPECT_EQ(interpreter.step_steps()[0].when, "step");
 }
 
 TEST(FlowInterpreter, EncoderDecoderPartitioning) {
@@ -63,14 +63,14 @@ TEST(FlowInterpreter, EncoderDecoderPartitioning) {
 
   EXPECT_TRUE(interpreter.IsMultiSession());
 
-  // Encoder runs once (goes to prompt_steps)
-  ASSERT_EQ(interpreter.prompt_steps().size(), 1u);
-  EXPECT_EQ(interpreter.prompt_steps()[0].run, "encoder");
-  EXPECT_EQ(interpreter.prompt_steps()[0].when, "once");
+  // Encoder runs once (goes to init_steps)
+  ASSERT_EQ(interpreter.init_steps().size(), 1u);
+  EXPECT_EQ(interpreter.init_steps()[0].run, "encoder");
+  EXPECT_EQ(interpreter.init_steps()[0].when, "init");
 
-  // Decoder runs always
-  ASSERT_EQ(interpreter.always_steps().size(), 1u);
-  EXPECT_EQ(interpreter.always_steps()[0].run, "decoder");
+  // Decoder runs every step
+  ASSERT_EQ(interpreter.step_steps().size(), 1u);
+  EXPECT_EQ(interpreter.step_steps()[0].run, "decoder");
 }
 
 // ============================================================================
@@ -164,11 +164,11 @@ TEST(FlowInterpreter, PromptOnlySessionsIdentified) {
   auto config = GetPreset("vision-language");
   FlowInterpreter interpreter(config);
 
-  // Vision and embedding are prompt-only (not in always_steps)
-  const auto& prompt_only = interpreter.prompt_only_sessions();
-  EXPECT_TRUE(prompt_only.count("vision"));
-  EXPECT_TRUE(prompt_only.count("embedding"));
-  EXPECT_FALSE(prompt_only.count("decoder"));
+  // Vision and embedding are init-only (not in step_steps)
+  const auto& init_only = interpreter.init_only_sessions();
+  EXPECT_TRUE(init_only.count("vision"));
+  EXPECT_TRUE(init_only.count("embedding"));
+  EXPECT_FALSE(init_only.count("decoder"));
 }
 
 // ============================================================================
@@ -181,30 +181,30 @@ TEST(FlowInterpreter, CustomFlowWithMixedWhenValues) {
   config.sessions["projector"] = {.file = "proj.onnx", .role = "embedding"};
   config.sessions["decoder"] = {.file = "model.onnx", .role = "decoder"};
 
-  config.flow.push_back({.run = "encoder", .when = "once"});
-  config.flow.push_back({.run = "projector", .when = "prompt"});
-  config.flow.push_back({.run = "decoder", .when = "always"});
+  config.flow.push_back({.run = "encoder", .when = "init"});
+  config.flow.push_back({.run = "projector", .when = "init"});
+  config.flow.push_back({.run = "decoder", .when = "step"});
 
   FlowInterpreter interpreter(config);
 
   EXPECT_TRUE(interpreter.IsMultiSession());
 
-  // "once" and "prompt" go to prompt_steps
-  ASSERT_EQ(interpreter.prompt_steps().size(), 2u);
-  EXPECT_EQ(interpreter.prompt_steps()[0].run, "encoder");
-  EXPECT_EQ(interpreter.prompt_steps()[1].run, "projector");
+  // "init" goes to init_steps
+  ASSERT_EQ(interpreter.init_steps().size(), 2u);
+  EXPECT_EQ(interpreter.init_steps()[0].run, "encoder");
+  EXPECT_EQ(interpreter.init_steps()[1].run, "projector");
 
-  // "always" goes to always_steps
-  ASSERT_EQ(interpreter.always_steps().size(), 1u);
-  EXPECT_EQ(interpreter.always_steps()[0].run, "decoder");
+  // "step" goes to step_steps
+  ASSERT_EQ(interpreter.step_steps().size(), 1u);
+  EXPECT_EQ(interpreter.step_steps()[0].run, "decoder");
 }
 
 TEST(FlowInterpreter, DataflowAccessors) {
   PipelineConfig config;
   config.sessions["a"] = {.file = "a.onnx", .role = "encoder"};
   config.sessions["b"] = {.file = "b.onnx", .role = "decoder"};
-  config.flow.push_back({.run = "a", .when = "once"});
-  config.flow.push_back({.run = "b", .when = "always"});
+  config.flow.push_back({.run = "a", .when = "init"});
+  config.flow.push_back({.run = "b", .when = "step"});
   config.dataflow.push_back({
       .from_session = "a",
       .from_output = "hidden",

--- a/test/pipeline_config_schema_test.cpp
+++ b/test/pipeline_config_schema_test.cpp
@@ -27,7 +27,7 @@ TEST(PipelinePresets, AutoRegressiveDecoder) {
 
   ASSERT_EQ(config.flow.size(), 1u);
   EXPECT_EQ(config.flow[0].run, "decoder");
-  EXPECT_EQ(config.flow[0].when, "always");
+  EXPECT_EQ(config.flow[0].when, "step");
 
   EXPECT_EQ(config.state.kv_cache.format.value_or(""), "auto");
   EXPECT_EQ(config.state.position_ids.strategy.value_or(""), "auto");
@@ -46,12 +46,12 @@ TEST(PipelinePresets, VisionLanguage) {
 
   ASSERT_EQ(config.flow.size(), 3u);
   EXPECT_EQ(config.flow[0].run, "vision");
-  EXPECT_EQ(config.flow[0].when, "prompt");
+  EXPECT_EQ(config.flow[0].when, "init");
   EXPECT_EQ(config.flow[0].loop, "per_image");
   EXPECT_EQ(config.flow[1].run, "embedding");
-  EXPECT_EQ(config.flow[1].when, "prompt");
+  EXPECT_EQ(config.flow[1].when, "init");
   EXPECT_EQ(config.flow[2].run, "decoder");
-  EXPECT_EQ(config.flow[2].when, "always");
+  EXPECT_EQ(config.flow[2].when, "step");
 
   ASSERT_GE(config.dataflow.size(), 2u);
   EXPECT_EQ(config.dataflow[0].from_session, "vision");
@@ -68,9 +68,9 @@ TEST(PipelinePresets, EncoderDecoder) {
 
   ASSERT_EQ(config.flow.size(), 2u);
   EXPECT_EQ(config.flow[0].run, "encoder");
-  EXPECT_EQ(config.flow[0].when, "once");
+  EXPECT_EQ(config.flow[0].when, "init");
   EXPECT_EQ(config.flow[1].run, "decoder");
-  EXPECT_EQ(config.flow[1].when, "always");
+  EXPECT_EQ(config.flow[1].when, "step");
 
   ASSERT_EQ(config.dataflow.size(), 1u);
   EXPECT_EQ(config.dataflow[0].from_session, "encoder");
@@ -106,7 +106,7 @@ TEST(PipelinePresets, OverrideFlowReplacesEntirely) {
   PipelineConfig overrides;
   overrides.flow.push_back(PipelineConfig::FlowStep{
       .run = "decoder",
-      .when = "always",
+      .when = "step",
   });
 
   ApplyOverrides(base, overrides);
@@ -197,7 +197,7 @@ TEST(PipelineValidation, InvalidLoopValueThrows) {
   config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
   config.flow.push_back(PipelineConfig::FlowStep{
       .run = "decoder",
-      .when = "always",
+      .when = "step",
       .loop = "invalid_loop",
   });
 
@@ -261,7 +261,7 @@ TEST(V1Translator, LLMTranslatesToAutoRegressiveDecoder) {
   ASSERT_GE(pipeline.flow.size(), 1u);
   bool has_decoder_flow = false;
   for (const auto& step : pipeline.flow) {
-    if (step.run == "decoder" && step.when == "always") {
+    if (step.run == "decoder" && step.when == "step") {
       has_decoder_flow = true;
     }
   }
@@ -355,7 +355,7 @@ TEST(V1Translator, MarianSSRUTranslatesToEncoderDecoder) {
   // Should have encoder→decoder flow
   ASSERT_GE(pipeline.flow.size(), 2u);
   EXPECT_EQ(pipeline.flow[0].run, "encoder");
-  EXPECT_EQ(pipeline.flow[0].when, "once");
+  EXPECT_EQ(pipeline.flow[0].when, "init");
 }
 
 TEST(V1Translator, AllLLMTypesTranslateComprehensive) {
@@ -394,11 +394,11 @@ TEST(PipelineEdgeCases, ComplexMultiSessionDataflow) {
   config.sessions["embedding"] = PipelineConfig::Session{.file = "embed.onnx", .role = "embedding"};
   config.sessions["decoder"] = PipelineConfig::Session{.file = "decoder.onnx", .role = "decoder"};
 
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "preprocessor", .when = "once"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "vision", .when = "prompt", .loop = "per_image"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "projector", .when = "prompt"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "embedding", .when = "prompt"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "preprocessor", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "vision", .when = "init", .loop = "per_image"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "projector", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "embedding", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "step"});
 
   // Chain wiring: each session feeds the next
   config.dataflow.push_back(PipelineConfig::DataflowWire{
@@ -426,46 +426,46 @@ TEST(PipelineEdgeCases, StandaloneSessionNoDataflow) {
   config.sessions["standalone"] = PipelineConfig::Session{.file = "standalone.onnx", .role = "custom"};
   config.sessions["decoder"] = PipelineConfig::Session{.file = "decoder.onnx", .role = "decoder"};
 
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "standalone", .when = "once"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "standalone", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "step"});
   // No dataflow wires — standalone session has its own inputs/outputs
 
   EXPECT_NO_THROW(ValidatePipelineConfig(config));
   EXPECT_TRUE(config.dataflow.empty());
 }
 
-TEST(PipelineEdgeCases, FlowWithOnlyOnceSteps) {
-  // All flow steps are 'once' — no 'always' or 'prompt' steps
+TEST(PipelineEdgeCases, FlowWithOnlyInitSteps) {
+  // All flow steps are 'init' — no 'step' or 'final' steps
   PipelineConfig config;
   config.sessions["init_a"] = PipelineConfig::Session{.file = "a.onnx"};
   config.sessions["init_b"] = PipelineConfig::Session{.file = "b.onnx"};
 
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "init_a", .when = "once"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "init_b", .when = "once"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "init_a", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "init_b", .when = "init"});
 
   EXPECT_NO_THROW(ValidatePipelineConfig(config));
 }
 
-TEST(PipelineEdgeCases, FlowWithOnlyPromptSteps) {
-  // All flow steps are 'prompt' — no 'always' or 'once' steps
+TEST(PipelineEdgeCases, FlowWithOnlyInitSteps2) {
+  // All flow steps are 'init' — using different sessions
   PipelineConfig config;
   config.sessions["encoder"] = PipelineConfig::Session{.file = "enc.onnx"};
   config.sessions["projector"] = PipelineConfig::Session{.file = "proj.onnx"};
 
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "encoder", .when = "prompt"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "projector", .when = "prompt"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "encoder", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "projector", .when = "init"});
 
   EXPECT_NO_THROW(ValidatePipelineConfig(config));
 }
 
-TEST(PipelineEdgeCases, FlowWithOnlyAlwaysSteps) {
+TEST(PipelineEdgeCases, FlowWithOnlyStepSteps) {
   // Multiple sessions all running every step
   PipelineConfig config;
   config.sessions["decoder_a"] = PipelineConfig::Session{.file = "a.onnx"};
   config.sessions["decoder_b"] = PipelineConfig::Session{.file = "b.onnx"};
 
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder_a", .when = "always"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder_b", .when = "always"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder_a", .when = "step"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder_b", .when = "step"});
 
   EXPECT_NO_THROW(ValidatePipelineConfig(config));
 }
@@ -516,7 +516,7 @@ TEST(PipelineEdgeCases, LargeFlowManySessions) {
     };
     config.flow.push_back(PipelineConfig::FlowStep{
         .run = name,
-        .when = i == 9 ? "always" : "prompt",
+        .when = i == 9 ? "step" : "init",
     });
     // Wire each session to the next
     if (i > 0) {
@@ -544,10 +544,10 @@ TEST(PipelineEdgeCases, DiamondDataflowTopology) {
   config.sessions["c"] = PipelineConfig::Session{.file = "c.onnx"};
   config.sessions["d"] = PipelineConfig::Session{.file = "d.onnx", .role = "decoder"};
 
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "a", .when = "once"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "b", .when = "prompt"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "c", .when = "prompt"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "d", .when = "always"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "a", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "b", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "c", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "d", .when = "step"});
 
   config.dataflow.push_back(PipelineConfig::DataflowWire{
       .from_session = "a", .from_output = "out1",
@@ -584,7 +584,7 @@ TEST(PipelineEdgeCases, SessionWithEmptyFile) {
   // (runtime will fail when loading, but schema validation shouldn't reject it)
   PipelineConfig config;
   config.sessions["decoder"] = PipelineConfig::Session{.file = "", .role = "decoder"};
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "step"});
 
   EXPECT_NO_THROW(ValidatePipelineConfig(config));
 }
@@ -593,8 +593,8 @@ TEST(PipelineEdgeCases, DuplicateSessionInFlow) {
   // Same session referenced multiple times in flow (valid — runs multiple times)
   PipelineConfig config;
   config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "prompt"});
-  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "step"});
 
   EXPECT_NO_THROW(ValidatePipelineConfig(config));
 }
@@ -605,7 +605,7 @@ TEST(PipelineEdgeCases, EmptyLoopStringIsValid) {
   config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
   config.flow.push_back(PipelineConfig::FlowStep{
       .run = "decoder",
-      .when = "always",
+      .when = "step",
       .loop = "",
   });
 
@@ -667,6 +667,197 @@ TEST(V1Translator, FaraGetsSpecialPositionStrategy) {
   auto pipeline = TranslateV1Config(v1);
 
   EXPECT_EQ(pipeline.state.position_ids.strategy.value_or(""), "mrope_3d");
+}
+
+// ============================================================================
+// Init/Step/Final vocabulary and normalization tests
+// ============================================================================
+
+TEST(PipelineValidation, InitStepFinalVocabulary) {
+  // Valid: init, step, final
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx", .role = "decoder"};
+  config.flow = {PipelineConfig::FlowStep{.run = "decoder", .when = "step"}};
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+
+  config.sessions["vision"] = PipelineConfig::Session{.file = "vision.onnx", .role = "vision"};
+  config.flow = {PipelineConfig::FlowStep{.run = "vision", .when = "init"},
+                 PipelineConfig::FlowStep{.run = "decoder", .when = "step"}};
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+
+  config.sessions["vocoder"] = PipelineConfig::Session{.file = "vocoder.onnx", .role = "vocoder"};
+  config.flow = {PipelineConfig::FlowStep{.run = "decoder", .when = "step"},
+                 PipelineConfig::FlowStep{.run = "vocoder", .when = "final"}};
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+TEST(PipelineValidation, BackwardCompatAliases) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx", .role = "decoder"};
+
+  // "always" → "step"
+  config.flow = {PipelineConfig::FlowStep{.run = "decoder", .when = "always"}};
+  NormalizePipelineConfig(config);
+  EXPECT_EQ(config.flow[0].when, "step");
+
+  // "prompt" → "init"
+  config.flow = {PipelineConfig::FlowStep{.run = "decoder", .when = "prompt"}};
+  NormalizePipelineConfig(config);
+  EXPECT_EQ(config.flow[0].when, "init");
+
+  // "once" → "init"
+  config.flow = {PipelineConfig::FlowStep{.run = "decoder", .when = "once"}};
+  NormalizePipelineConfig(config);
+  EXPECT_EQ(config.flow[0].when, "init");
+}
+
+TEST(PipelineValidation, GenerationLoopValues) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx", .role = "decoder"};
+  config.flow = {PipelineConfig::FlowStep{.run = "decoder", .when = "step"}};
+
+  config.generation_loop = "autoregressive";
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+
+  config.generation_loop = "single_pass";
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+
+  config.generation_loop = "denoising";
+  EXPECT_THROW(ValidatePipelineConfig(config), std::runtime_error);
+
+  config.generation_loop = "unknown_loop";
+  EXPECT_THROW(ValidatePipelineConfig(config), std::runtime_error);
+}
+
+TEST(PipelineValidation, InvalidWhenValueThrowsNewVocab) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx", .role = "decoder"};
+  config.flow = {PipelineConfig::FlowStep{.run = "decoder", .when = "invalid_when"}};
+  EXPECT_THROW(ValidatePipelineConfig(config), std::runtime_error);
+}
+
+TEST(PipelineValidation, DefaultWhenIsStep) {
+  // Default-constructed FlowStep should have when == "step"
+  PipelineConfig::FlowStep step;
+  step.run = "decoder";
+  EXPECT_EQ(step.when, "step");
+}
+
+TEST(PipelinePresets, ExtendsWithOverride) {
+  auto base = GetPreset("autoregressive-decoder");
+  PipelineConfig overrides;
+  overrides.sessions["decoder"] = PipelineConfig::Session{.file = "custom.onnx", .role = "decoder"};
+  ApplyOverrides(base, overrides);
+  EXPECT_EQ(base.sessions.at("decoder").file, "custom.onnx");
+}
+
+TEST(PipelineValidation, DefaultGenerationLoop) {
+  // Default-constructed PipelineConfig has no generation_loop set (nullopt).
+  // Validation resolves to "autoregressive" via value_or().
+  PipelineConfig config;
+  EXPECT_FALSE(config.generation_loop.has_value());
+  EXPECT_EQ(config.generation_loop.value_or("autoregressive"), "autoregressive");
+}
+
+// ============================================================================
+// Alias normalization tests
+// ============================================================================
+
+TEST(PipelineNormalization, PromptNormalizesToInit) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "prompt"});
+
+  NormalizePipelineConfig(config);
+  EXPECT_EQ(config.flow[0].when, "init");
+}
+
+TEST(PipelineNormalization, OnceNormalizesToInit) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "once"});
+
+  NormalizePipelineConfig(config);
+  EXPECT_EQ(config.flow[0].when, "init");
+}
+
+TEST(PipelineNormalization, AlwaysNormalizesToStep) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});
+
+  NormalizePipelineConfig(config);
+  EXPECT_EQ(config.flow[0].when, "step");
+}
+
+TEST(PipelineNormalization, NativeValuesUnchanged) {
+  PipelineConfig config;
+  config.sessions["a"] = PipelineConfig::Session{.file = "a.onnx"};
+  config.sessions["b"] = PipelineConfig::Session{.file = "b.onnx"};
+  config.sessions["c"] = PipelineConfig::Session{.file = "c.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "a", .when = "init"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "b", .when = "step"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "c", .when = "final"});
+
+  NormalizePipelineConfig(config);
+  EXPECT_EQ(config.flow[0].when, "init");
+  EXPECT_EQ(config.flow[1].when, "step");
+  EXPECT_EQ(config.flow[2].when, "final");
+}
+
+TEST(PipelineNormalization, MixedAliasesAndNative) {
+  // A config mixing old aliases and new native values
+  PipelineConfig config;
+  config.sessions["vision"] = PipelineConfig::Session{.file = "v.onnx"};
+  config.sessions["embed"] = PipelineConfig::Session{.file = "e.onnx"};
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "d.onnx"};
+  config.sessions["cleanup"] = PipelineConfig::Session{.file = "c.onnx"};
+
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "vision", .when = "prompt"});   // alias → init
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "embed", .when = "init"});      // native
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});  // alias → step
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "cleanup", .when = "final"});   // native
+
+  NormalizePipelineConfig(config);
+  EXPECT_EQ(config.flow[0].when, "init");
+  EXPECT_EQ(config.flow[1].when, "init");
+  EXPECT_EQ(config.flow[2].when, "step");
+  EXPECT_EQ(config.flow[3].when, "final");
+}
+
+TEST(PipelineNormalization, NormalizedConfigPassesValidation) {
+  // End-to-end: config with aliases → normalize → validate
+  PipelineConfig config;
+  config.sessions["enc"] = PipelineConfig::Session{.file = "enc.onnx"};
+  config.sessions["dec"] = PipelineConfig::Session{.file = "dec.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "enc", .when = "once"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "dec", .when = "always"});
+
+  NormalizePipelineConfig(config);
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+TEST(PipelinePresets, OverrideGenerationLoop) {
+  auto base = GetPreset("autoregressive-decoder");
+  // Preset has no explicit generation_loop (nullopt → defaults to "autoregressive")
+  EXPECT_EQ(base.generation_loop.value_or("autoregressive"), "autoregressive");
+
+  PipelineConfig overrides;
+  overrides.generation_loop = "single_pass";
+
+  ApplyOverrides(base, overrides);
+  EXPECT_EQ(base.generation_loop.value(), "single_pass");
+}
+
+TEST(PipelinePresets, DefaultGenerationLoopDoesNotOverride) {
+  auto base = GetPreset("autoregressive-decoder");
+  base.generation_loop = "denoising";  // Simulate a preset with non-default
+
+  PipelineConfig overrides;
+  // overrides.generation_loop is nullopt — should not clobber
+
+  ApplyOverrides(base, overrides);
+  EXPECT_EQ(base.generation_loop.value(), "denoising");  // Preserved
 }
 
 }  // namespace Generators::test

--- a/test/pipeline_config_schema_test.cpp
+++ b/test/pipeline_config_schema_test.cpp
@@ -381,4 +381,292 @@ TEST(V1Translator, AllVLMTypesTranslate) {
   }
 }
 
+// ============================================================================
+// Edge case tests: complex dataflow, standalone sessions, flow variants
+// ============================================================================
+
+TEST(PipelineEdgeCases, ComplexMultiSessionDataflow) {
+  // 5-session pipeline with chain: preprocessor → vision → projector → embedding → decoder
+  PipelineConfig config;
+  config.sessions["preprocessor"] = PipelineConfig::Session{.file = "preproc.onnx", .role = "preprocessor"};
+  config.sessions["vision"] = PipelineConfig::Session{.file = "vision.onnx", .role = "vision"};
+  config.sessions["projector"] = PipelineConfig::Session{.file = "projector.onnx", .role = "projector"};
+  config.sessions["embedding"] = PipelineConfig::Session{.file = "embed.onnx", .role = "embedding"};
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "decoder.onnx", .role = "decoder"};
+
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "preprocessor", .when = "once"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "vision", .when = "prompt", .loop = "per_image"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "projector", .when = "prompt"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "embedding", .when = "prompt"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});
+
+  // Chain wiring: each session feeds the next
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "preprocessor", .from_output = "processed",
+      .to_session = "vision", .to_input = "pixel_values"});
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "vision", .from_output = "features",
+      .to_session = "projector", .to_input = "vision_features"});
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "projector", .from_output = "projected",
+      .to_session = "embedding", .to_input = "image_features"});
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "embedding", .from_output = "inputs_embeds",
+      .to_session = "decoder", .to_input = "inputs_embeds"});
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+  EXPECT_EQ(config.sessions.size(), 5u);
+  EXPECT_EQ(config.flow.size(), 5u);
+  EXPECT_EQ(config.dataflow.size(), 4u);
+}
+
+TEST(PipelineEdgeCases, StandaloneSessionNoDataflow) {
+  // A session with no dataflow wires (standalone, e.g. audio preprocessor)
+  PipelineConfig config;
+  config.sessions["standalone"] = PipelineConfig::Session{.file = "standalone.onnx", .role = "custom"};
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "decoder.onnx", .role = "decoder"};
+
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "standalone", .when = "once"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});
+  // No dataflow wires — standalone session has its own inputs/outputs
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+  EXPECT_TRUE(config.dataflow.empty());
+}
+
+TEST(PipelineEdgeCases, FlowWithOnlyOnceSteps) {
+  // All flow steps are 'once' — no 'always' or 'prompt' steps
+  PipelineConfig config;
+  config.sessions["init_a"] = PipelineConfig::Session{.file = "a.onnx"};
+  config.sessions["init_b"] = PipelineConfig::Session{.file = "b.onnx"};
+
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "init_a", .when = "once"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "init_b", .when = "once"});
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+TEST(PipelineEdgeCases, FlowWithOnlyPromptSteps) {
+  // All flow steps are 'prompt' — no 'always' or 'once' steps
+  PipelineConfig config;
+  config.sessions["encoder"] = PipelineConfig::Session{.file = "enc.onnx"};
+  config.sessions["projector"] = PipelineConfig::Session{.file = "proj.onnx"};
+
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "encoder", .when = "prompt"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "projector", .when = "prompt"});
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+TEST(PipelineEdgeCases, FlowWithOnlyAlwaysSteps) {
+  // Multiple sessions all running every step
+  PipelineConfig config;
+  config.sessions["decoder_a"] = PipelineConfig::Session{.file = "a.onnx"};
+  config.sessions["decoder_b"] = PipelineConfig::Session{.file = "b.onnx"};
+
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder_a", .when = "always"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder_b", .when = "always"});
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+TEST(PipelineEdgeCases, PresetOverrideConflictingValues) {
+  // Override a preset with conflicting session roles and state values
+  auto base = GetPreset("vision-language");
+
+  PipelineConfig overrides;
+  // Override decoder with a different file AND add a conflicting session
+  overrides.sessions["decoder"] = PipelineConfig::Session{
+      .file = "custom_decoder.onnx",
+      .role = "custom_decoder",  // Different role than preset
+  };
+  overrides.sessions["vision"] = PipelineConfig::Session{
+      .file = "custom_vision.onnx",
+      .role = "custom_vision",
+  };
+  // Override state with specific patterns
+  overrides.state.kv_cache.format = "cross";
+  overrides.state.kv_cache.past_key_pattern = "custom_past.%d.key";
+  overrides.state.position_ids.strategy = "mrope_3d";
+
+  ApplyOverrides(base, overrides);
+
+  // Sessions should be replaced by overrides
+  EXPECT_EQ(base.sessions.at("decoder").file, "custom_decoder.onnx");
+  EXPECT_EQ(base.sessions.at("decoder").role, "custom_decoder");
+  EXPECT_EQ(base.sessions.at("vision").file, "custom_vision.onnx");
+  // Embedding should be preserved from preset
+  EXPECT_TRUE(base.sessions.count("embedding"));
+  // State fields should reflect overrides
+  EXPECT_EQ(base.state.kv_cache.format.value_or(""), "cross");
+  EXPECT_EQ(base.state.kv_cache.past_key_pattern.value_or(""), "custom_past.%d.key");
+  EXPECT_EQ(base.state.position_ids.strategy.value_or(""), "mrope_3d");
+  // Non-overridden state fields from preset should be preserved
+  EXPECT_FALSE(base.state.kv_cache.past_value_pattern.has_value());
+}
+
+TEST(PipelineEdgeCases, LargeFlowManySessions) {
+  // Stress test: 10 sessions in a chain
+  PipelineConfig config;
+  for (int i = 0; i < 10; ++i) {
+    std::string name = "session_" + std::to_string(i);
+    config.sessions[name] = PipelineConfig::Session{
+        .file = name + ".onnx",
+        .role = i == 9 ? "decoder" : "processor",
+    };
+    config.flow.push_back(PipelineConfig::FlowStep{
+        .run = name,
+        .when = i == 9 ? "always" : "prompt",
+    });
+    // Wire each session to the next
+    if (i > 0) {
+      std::string prev = "session_" + std::to_string(i - 1);
+      config.dataflow.push_back(PipelineConfig::DataflowWire{
+          .from_session = prev,
+          .from_output = "output_" + std::to_string(i - 1),
+          .to_session = name,
+          .to_input = "input_" + std::to_string(i),
+      });
+    }
+  }
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+  EXPECT_EQ(config.sessions.size(), 10u);
+  EXPECT_EQ(config.flow.size(), 10u);
+  EXPECT_EQ(config.dataflow.size(), 9u);
+}
+
+TEST(PipelineEdgeCases, DiamondDataflowTopology) {
+  // Diamond: A → B, A → C, B → D, C → D
+  PipelineConfig config;
+  config.sessions["a"] = PipelineConfig::Session{.file = "a.onnx"};
+  config.sessions["b"] = PipelineConfig::Session{.file = "b.onnx"};
+  config.sessions["c"] = PipelineConfig::Session{.file = "c.onnx"};
+  config.sessions["d"] = PipelineConfig::Session{.file = "d.onnx", .role = "decoder"};
+
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "a", .when = "once"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "b", .when = "prompt"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "c", .when = "prompt"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "d", .when = "always"});
+
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "a", .from_output = "out1",
+      .to_session = "b", .to_input = "in1"});
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "a", .from_output = "out2",
+      .to_session = "c", .to_input = "in1"});
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "b", .from_output = "features_b",
+      .to_session = "d", .to_input = "features_b"});
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "c", .from_output = "features_c",
+      .to_session = "d", .to_input = "features_c"});
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+  EXPECT_EQ(config.dataflow.size(), 4u);
+}
+
+TEST(PipelineEdgeCases, DataflowUnknownToSessionThrows) {
+  PipelineConfig config;
+  config.sessions["a"] = PipelineConfig::Session{.file = "a.onnx"};
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "a",
+      .from_output = "out",
+      .to_session = "nonexistent",
+      .to_input = "in",
+  });
+
+  EXPECT_THROW(ValidatePipelineConfig(config), std::runtime_error);
+}
+
+TEST(PipelineEdgeCases, SessionWithEmptyFile) {
+  // A session with an empty file string is valid at schema level
+  // (runtime will fail when loading, but schema validation shouldn't reject it)
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "", .role = "decoder"};
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+TEST(PipelineEdgeCases, DuplicateSessionInFlow) {
+  // Same session referenced multiple times in flow (valid — runs multiple times)
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "prompt"});
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "decoder", .when = "always"});
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+TEST(PipelineEdgeCases, EmptyLoopStringIsValid) {
+  // Empty loop string means "no looping" — should be valid
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{
+      .run = "decoder",
+      .when = "always",
+      .loop = "",
+  });
+
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+TEST(PipelineEdgeCases, OverrideDataflowReplacesEntirely) {
+  auto base = GetPreset("vision-language");
+  ASSERT_EQ(base.dataflow.size(), 2u);
+
+  PipelineConfig overrides;
+  overrides.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "vision",
+      .from_output = "custom_features",
+      .to_session = "decoder",
+      .to_input = "custom_input",
+  });
+
+  ApplyOverrides(base, overrides);
+  ASSERT_EQ(base.dataflow.size(), 1u);  // Replaced, not appended
+  EXPECT_EQ(base.dataflow[0].from_output, "custom_features");
+}
+
+TEST(PipelineEdgeCases, OverrideKVCachePatterns) {
+  auto base = GetPreset("autoregressive-decoder");
+  EXPECT_FALSE(base.state.kv_cache.past_key_pattern.has_value());
+
+  PipelineConfig overrides;
+  overrides.state.kv_cache.past_key_pattern = "custom_past.%d.key";
+  overrides.state.kv_cache.present_key_pattern = "custom_present.%d.key";
+  overrides.state.kv_cache.past_value_pattern = "custom_past.%d.value";
+  overrides.state.kv_cache.present_value_pattern = "custom_present.%d.value";
+
+  ApplyOverrides(base, overrides);
+  EXPECT_EQ(base.state.kv_cache.past_key_pattern.value_or(""), "custom_past.%d.key");
+  EXPECT_EQ(base.state.kv_cache.present_key_pattern.value_or(""), "custom_present.%d.key");
+  EXPECT_EQ(base.state.kv_cache.past_value_pattern.value_or(""), "custom_past.%d.value");
+  EXPECT_EQ(base.state.kv_cache.present_value_pattern.value_or(""), "custom_present.%d.value");
+}
+
+TEST(V1Translator, VLMKVCachePatternsPropagate) {
+  // VLM configs should also propagate KV cache patterns
+  auto v1 = MakeMinimalV1Config("phi3v");
+  v1.model.vision.filename = "vision.onnx";
+  v1.model.embedding.filename = "embed.onnx";
+  v1.model.decoder.inputs.past_key_names = "past_key_values.%d.key";
+  v1.model.decoder.outputs.present_key_names = "present.%d.key";
+  auto pipeline = TranslateV1Config(v1);
+
+  EXPECT_EQ(pipeline.state.kv_cache.past_key_pattern.value_or(""), "past_key_values.%d.key");
+  EXPECT_EQ(pipeline.state.kv_cache.present_key_pattern.value_or(""), "present.%d.key");
+}
+
+TEST(V1Translator, FaraGetsSpecialPositionStrategy) {
+  // fara is also Qwen25VL family — should get mrope_3d
+  auto v1 = MakeMinimalV1Config("fara");
+  v1.model.vision.filename = "vision.onnx";
+  v1.model.embedding.filename = "embed.onnx";
+  auto pipeline = TranslateV1Config(v1);
+
+  EXPECT_EQ(pipeline.state.position_ids.strategy.value_or(""), "mrope_3d");
+}
+
 }  // namespace Generators::test

--- a/test/pipeline_config_schema_test.cpp
+++ b/test/pipeline_config_schema_test.cpp
@@ -1,0 +1,310 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Unit tests for Pipeline-as-Config v2 schema, presets, and v1 translator.
+
+#include "generators.h"
+#include "pipeline_config_schema.h"
+#include "pipeline_presets.h"
+#include "v1_translator.h"
+#include "config.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace Generators::test {
+
+// ============================================================================
+// Preset tests
+// ============================================================================
+
+TEST(PipelinePresets, AutoRegressiveDecoder) {
+  auto config = GetPreset("autoregressive-decoder");
+  ASSERT_EQ(config.sessions.size(), 1u);
+  ASSERT_TRUE(config.sessions.count("decoder"));
+  EXPECT_EQ(config.sessions.at("decoder").file, "model.onnx");
+  EXPECT_EQ(config.sessions.at("decoder").role, "decoder");
+
+  ASSERT_EQ(config.flow.size(), 1u);
+  EXPECT_EQ(config.flow[0].run, "decoder");
+  EXPECT_EQ(config.flow[0].when, "always");
+
+  EXPECT_EQ(config.state.kv_cache.format, "auto");
+  EXPECT_EQ(config.state.position_ids.strategy, "auto");
+}
+
+TEST(PipelinePresets, VisionLanguage) {
+  auto config = GetPreset("vision-language");
+  ASSERT_EQ(config.sessions.size(), 3u);
+  EXPECT_TRUE(config.sessions.count("vision"));
+  EXPECT_TRUE(config.sessions.count("embedding"));
+  EXPECT_TRUE(config.sessions.count("decoder"));
+
+  EXPECT_EQ(config.sessions.at("vision").role, "vision");
+  EXPECT_EQ(config.sessions.at("embedding").role, "embedding");
+  EXPECT_EQ(config.sessions.at("decoder").role, "decoder");
+
+  ASSERT_EQ(config.flow.size(), 3u);
+  EXPECT_EQ(config.flow[0].run, "vision");
+  EXPECT_EQ(config.flow[0].when, "prompt");
+  EXPECT_EQ(config.flow[0].loop, "per_image");
+  EXPECT_EQ(config.flow[1].run, "embedding");
+  EXPECT_EQ(config.flow[1].when, "prompt");
+  EXPECT_EQ(config.flow[2].run, "decoder");
+  EXPECT_EQ(config.flow[2].when, "always");
+
+  ASSERT_GE(config.dataflow.size(), 2u);
+  EXPECT_EQ(config.dataflow[0].from_session, "vision");
+  EXPECT_EQ(config.dataflow[0].to_session, "embedding");
+  EXPECT_EQ(config.dataflow[1].from_session, "embedding");
+  EXPECT_EQ(config.dataflow[1].to_session, "decoder");
+}
+
+TEST(PipelinePresets, EncoderDecoder) {
+  auto config = GetPreset("encoder-decoder");
+  ASSERT_EQ(config.sessions.size(), 2u);
+  EXPECT_TRUE(config.sessions.count("encoder"));
+  EXPECT_TRUE(config.sessions.count("decoder"));
+
+  ASSERT_EQ(config.flow.size(), 2u);
+  EXPECT_EQ(config.flow[0].run, "encoder");
+  EXPECT_EQ(config.flow[0].when, "once");
+  EXPECT_EQ(config.flow[1].run, "decoder");
+  EXPECT_EQ(config.flow[1].when, "always");
+
+  ASSERT_EQ(config.dataflow.size(), 1u);
+  EXPECT_EQ(config.dataflow[0].from_session, "encoder");
+  EXPECT_EQ(config.dataflow[0].to_session, "decoder");
+}
+
+TEST(PipelinePresets, UnknownPresetThrows) {
+  EXPECT_THROW(GetPreset("nonexistent-preset"), std::runtime_error);
+}
+
+// ============================================================================
+// ApplyOverrides tests
+// ============================================================================
+
+TEST(PipelinePresets, OverrideSessionMerge) {
+  auto base = GetPreset("autoregressive-decoder");
+  PipelineConfig overrides;
+  overrides.sessions["decoder"] = PipelineConfig::Session{
+      .file = "custom_model.onnx",
+      .role = "decoder",
+  };
+
+  ApplyOverrides(base, overrides);
+  EXPECT_EQ(base.sessions.at("decoder").file, "custom_model.onnx");
+  // Flow should be unchanged (override flow is empty)
+  ASSERT_EQ(base.flow.size(), 1u);
+}
+
+TEST(PipelinePresets, OverrideFlowReplacesEntirely) {
+  auto base = GetPreset("vision-language");
+  ASSERT_EQ(base.flow.size(), 3u);
+
+  PipelineConfig overrides;
+  overrides.flow.push_back(PipelineConfig::FlowStep{
+      .run = "decoder",
+      .when = "always",
+  });
+
+  ApplyOverrides(base, overrides);
+  ASSERT_EQ(base.flow.size(), 1u);  // Replaced, not appended
+  EXPECT_EQ(base.flow[0].run, "decoder");
+}
+
+TEST(PipelinePresets, OverrideAddsNewSession) {
+  auto base = GetPreset("autoregressive-decoder");
+  ASSERT_EQ(base.sessions.size(), 1u);
+
+  PipelineConfig overrides;
+  overrides.sessions["custom"] = PipelineConfig::Session{
+      .file = "custom.onnx",
+      .role = "custom",
+  };
+
+  ApplyOverrides(base, overrides);
+  ASSERT_EQ(base.sessions.size(), 2u);
+  EXPECT_TRUE(base.sessions.count("custom"));
+}
+
+TEST(PipelinePresets, OverrideStateFields) {
+  auto base = GetPreset("autoregressive-decoder");
+  PipelineConfig overrides;
+  overrides.state.kv_cache.format = "windowed";
+  overrides.state.position_ids.strategy = "mrope_3d";
+
+  ApplyOverrides(base, overrides);
+  EXPECT_EQ(base.state.kv_cache.format, "windowed");
+  EXPECT_EQ(base.state.position_ids.strategy, "mrope_3d");
+}
+
+// ============================================================================
+// Validation tests
+// ============================================================================
+
+TEST(PipelineValidation, ValidConfigPasses) {
+  auto config = GetPreset("autoregressive-decoder");
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+TEST(PipelineValidation, UnknownSessionInFlowThrows) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{.run = "nonexistent"});
+
+  EXPECT_THROW(ValidatePipelineConfig(config), std::runtime_error);
+}
+
+TEST(PipelineValidation, InvalidWhenValueThrows) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{
+      .run = "decoder",
+      .when = "invalid_when",
+  });
+
+  EXPECT_THROW(ValidatePipelineConfig(config), std::runtime_error);
+}
+
+TEST(PipelineValidation, InvalidLoopValueThrows) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
+  config.flow.push_back(PipelineConfig::FlowStep{
+      .run = "decoder",
+      .when = "always",
+      .loop = "invalid_loop",
+  });
+
+  EXPECT_THROW(ValidatePipelineConfig(config), std::runtime_error);
+}
+
+TEST(PipelineValidation, DataflowUnknownFromSessionThrows) {
+  PipelineConfig config;
+  config.sessions["decoder"] = PipelineConfig::Session{.file = "model.onnx"};
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "unknown",
+      .from_output = "out",
+      .to_session = "decoder",
+      .to_input = "in",
+  });
+
+  EXPECT_THROW(ValidatePipelineConfig(config), std::runtime_error);
+}
+
+TEST(PipelineValidation, DataflowEmptyTensorNameThrows) {
+  PipelineConfig config;
+  config.sessions["a"] = PipelineConfig::Session{.file = "a.onnx"};
+  config.sessions["b"] = PipelineConfig::Session{.file = "b.onnx"};
+  config.dataflow.push_back(PipelineConfig::DataflowWire{
+      .from_session = "a",
+      .from_output = "",  // Empty — should fail
+      .to_session = "b",
+      .to_input = "input",
+  });
+
+  EXPECT_THROW(ValidatePipelineConfig(config), std::runtime_error);
+}
+
+TEST(PipelineValidation, EmptyConfigPasses) {
+  PipelineConfig config;
+  EXPECT_NO_THROW(ValidatePipelineConfig(config));
+}
+
+// ============================================================================
+// V1 translator tests
+// ============================================================================
+
+// Helper: create a minimal v1 Config with a model type
+namespace {
+Config MakeMinimalV1Config(const std::string& model_type) {
+  Config config;
+  config.version = 1;
+  config.model.type = model_type;
+  config.model.decoder.filename = "decoder_model.onnx";
+  return config;
+}
+}  // namespace
+
+TEST(V1Translator, LLMTranslatesToAutoRegressiveDecoder) {
+  auto v1 = MakeMinimalV1Config("llama");
+  auto pipeline = TranslateV1Config(v1);
+
+  ASSERT_TRUE(pipeline.sessions.count("decoder"));
+  EXPECT_EQ(pipeline.sessions.at("decoder").file, "decoder_model.onnx");
+
+  ASSERT_GE(pipeline.flow.size(), 1u);
+  bool has_decoder_flow = false;
+  for (const auto& step : pipeline.flow) {
+    if (step.run == "decoder" && step.when == "always") {
+      has_decoder_flow = true;
+    }
+  }
+  EXPECT_TRUE(has_decoder_flow);
+}
+
+TEST(V1Translator, AllLLMTypesTranslate) {
+  // Verify all known LLM types translate without throwing
+  for (const auto& type : {"chatglm", "decoder", "gemma", "llama", "phi", "qwen2", "qwen3", "smollm3"}) {
+    auto v1 = MakeMinimalV1Config(type);
+    EXPECT_NO_THROW(TranslateV1Config(v1)) << "Failed for type: " << type;
+  }
+}
+
+TEST(V1Translator, VLMTranslatesToVisionLanguage) {
+  auto v1 = MakeMinimalV1Config("phi3v");
+  v1.model.vision.filename = "vision.onnx";
+  v1.model.embedding.filename = "embed.onnx";
+  auto pipeline = TranslateV1Config(v1);
+
+  ASSERT_TRUE(pipeline.sessions.count("vision"));
+  ASSERT_TRUE(pipeline.sessions.count("embedding"));
+  ASSERT_TRUE(pipeline.sessions.count("decoder"));
+
+  EXPECT_EQ(pipeline.sessions.at("vision").file, "vision.onnx");
+  EXPECT_EQ(pipeline.sessions.at("embedding").file, "embed.onnx");
+  EXPECT_EQ(pipeline.sessions.at("decoder").file, "decoder_model.onnx");
+}
+
+TEST(V1Translator, QwenVLGetsSpecialPositionStrategy) {
+  auto v1 = MakeMinimalV1Config("qwen2_5_vl");
+  v1.model.vision.filename = "vision.onnx";
+  v1.model.embedding.filename = "embed.onnx";
+  auto pipeline = TranslateV1Config(v1);
+
+  EXPECT_EQ(pipeline.state.position_ids.strategy, "mrope_3d");
+}
+
+TEST(V1Translator, WhisperTranslatesToEncoderDecoder) {
+  auto v1 = MakeMinimalV1Config("whisper");
+  v1.model.encoder.filename = "encoder.onnx";
+  auto pipeline = TranslateV1Config(v1);
+
+  ASSERT_TRUE(pipeline.sessions.count("encoder"));
+  ASSERT_TRUE(pipeline.sessions.count("decoder"));
+  EXPECT_EQ(pipeline.sessions.at("encoder").file, "encoder.onnx");
+}
+
+TEST(V1Translator, KVCachePatternsPropagate) {
+  auto v1 = MakeMinimalV1Config("llama");
+  v1.model.decoder.inputs.past_key_names = "past_key_values.%d.key";
+  v1.model.decoder.inputs.past_value_names = "past_key_values.%d.value";
+  v1.model.decoder.outputs.present_key_names = "present.%d.key";
+  v1.model.decoder.outputs.present_value_names = "present.%d.value";
+  auto pipeline = TranslateV1Config(v1);
+
+  EXPECT_EQ(pipeline.state.kv_cache.past_key_pattern.value_or(""), "past_key_values.%d.key");
+  EXPECT_EQ(pipeline.state.kv_cache.present_key_pattern.value_or(""), "present.%d.key");
+}
+
+TEST(V1Translator, UnknownTypeStillTranslates) {
+  // Unknown model types should still translate (fallback to decoder preset)
+  auto v1 = MakeMinimalV1Config("totally_unknown_type");
+  EXPECT_NO_THROW(TranslateV1Config(v1));
+
+  auto pipeline = TranslateV1Config(v1);
+  EXPECT_TRUE(pipeline.sessions.count("decoder"));
+}
+
+}  // namespace Generators::test

--- a/test/pipeline_config_schema_test.cpp
+++ b/test/pipeline_config_schema_test.cpp
@@ -29,8 +29,8 @@ TEST(PipelinePresets, AutoRegressiveDecoder) {
   EXPECT_EQ(config.flow[0].run, "decoder");
   EXPECT_EQ(config.flow[0].when, "always");
 
-  EXPECT_EQ(config.state.kv_cache.format, "auto");
-  EXPECT_EQ(config.state.position_ids.strategy, "auto");
+  EXPECT_EQ(config.state.kv_cache.format.value_or(""), "auto");
+  EXPECT_EQ(config.state.position_ids.strategy.value_or(""), "auto");
 }
 
 TEST(PipelinePresets, VisionLanguage) {
@@ -136,8 +136,32 @@ TEST(PipelinePresets, OverrideStateFields) {
   overrides.state.position_ids.strategy = "mrope_3d";
 
   ApplyOverrides(base, overrides);
-  EXPECT_EQ(base.state.kv_cache.format, "windowed");
-  EXPECT_EQ(base.state.position_ids.strategy, "mrope_3d");
+  EXPECT_EQ(base.state.kv_cache.format.value_or(""), "windowed");
+  EXPECT_EQ(base.state.position_ids.strategy.value_or(""), "mrope_3d");
+}
+
+TEST(PipelinePresets, OverrideAutoValueApplies) {
+  // Regression test: explicitly setting "auto" should override a non-auto preset value
+  auto base = GetPreset("autoregressive-decoder");
+  base.state.kv_cache.format = "windowed";  // Simulate a preset with non-auto default
+
+  PipelineConfig overrides;
+  overrides.state.kv_cache.format = "auto";  // Explicitly set back to auto
+
+  ApplyOverrides(base, overrides);
+  EXPECT_EQ(base.state.kv_cache.format.value_or(""), "auto");
+}
+
+TEST(PipelinePresets, UnsetOverrideDoesNotClobber) {
+  // When an override field is not set (nullopt), the base value should be preserved
+  auto base = GetPreset("autoregressive-decoder");
+  base.state.kv_cache.format = "windowed";
+
+  PipelineConfig overrides;
+  // overrides.state.kv_cache.format is nullopt (not set)
+
+  ApplyOverrides(base, overrides);
+  EXPECT_EQ(base.state.kv_cache.format.value_or(""), "windowed");  // Preserved
 }
 
 // ============================================================================
@@ -273,7 +297,7 @@ TEST(V1Translator, QwenVLGetsSpecialPositionStrategy) {
   v1.model.embedding.filename = "embed.onnx";
   auto pipeline = TranslateV1Config(v1);
 
-  EXPECT_EQ(pipeline.state.position_ids.strategy, "mrope_3d");
+  EXPECT_EQ(pipeline.state.position_ids.strategy.value_or(""), "mrope_3d");
 }
 
 TEST(V1Translator, WhisperTranslatesToEncoderDecoder) {

--- a/test/pipeline_config_schema_test.cpp
+++ b/test/pipeline_config_schema_test.cpp
@@ -331,4 +331,54 @@ TEST(V1Translator, UnknownTypeStillTranslates) {
   EXPECT_TRUE(pipeline.sessions.count("decoder"));
 }
 
+TEST(V1Translator, Phi4MMTranslatesToVisionLanguage) {
+  auto v1 = MakeMinimalV1Config("phi4mm");
+  v1.model.vision.filename = "vision.onnx";
+  v1.model.embedding.filename = "embed.onnx";
+  auto pipeline = TranslateV1Config(v1);
+
+  ASSERT_TRUE(pipeline.sessions.count("vision"));
+  ASSERT_TRUE(pipeline.sessions.count("embedding"));
+  ASSERT_TRUE(pipeline.sessions.count("decoder"));
+  EXPECT_EQ(pipeline.sessions.at("vision").file, "vision.onnx");
+}
+
+TEST(V1Translator, MarianSSRUTranslatesToEncoderDecoder) {
+  auto v1 = MakeMinimalV1Config("marian-ssru");
+  v1.model.encoder.filename = "encoder.onnx";
+  auto pipeline = TranslateV1Config(v1);
+
+  ASSERT_TRUE(pipeline.sessions.count("encoder"));
+  ASSERT_TRUE(pipeline.sessions.count("decoder"));
+  EXPECT_EQ(pipeline.sessions.at("encoder").file, "encoder.onnx");
+
+  // Should have encoder→decoder flow
+  ASSERT_GE(pipeline.flow.size(), 2u);
+  EXPECT_EQ(pipeline.flow[0].run, "encoder");
+  EXPECT_EQ(pipeline.flow[0].when, "once");
+}
+
+TEST(V1Translator, AllLLMTypesTranslateComprehensive) {
+  // All 21 LLM types from model_type.h should translate without throwing
+  for (const auto& type : {"chatglm", "decoder", "ernie4_5", "gemma", "gemma2",
+                            "gemma3_text", "gpt2", "gptoss", "granite", "internlm2",
+                            "llama", "mistral", "nemotron", "olmo", "phi", "phimoe",
+                            "phi3", "phi3small", "qwen2", "qwen3", "smollm3"}) {
+    auto v1 = MakeMinimalV1Config(type);
+    EXPECT_NO_THROW(TranslateV1Config(v1)) << "Failed for type: " << type;
+    auto pipeline = TranslateV1Config(v1);
+    EXPECT_TRUE(pipeline.sessions.count("decoder")) << "No decoder for type: " << type;
+  }
+}
+
+TEST(V1Translator, AllVLMTypesTranslate) {
+  for (const auto& type : {"fara", "gemma3", "phi3v", "qwen2_5_vl"}) {
+    auto v1 = MakeMinimalV1Config(type);
+    EXPECT_NO_THROW(TranslateV1Config(v1)) << "Failed for type: " << type;
+    auto pipeline = TranslateV1Config(v1);
+    EXPECT_TRUE(pipeline.sessions.count("vision")) << "No vision for type: " << type;
+    EXPECT_TRUE(pipeline.sessions.count("embedding")) << "No embedding for type: " << type;
+  }
+}
+
 }  // namespace Generators::test


### PR DESCRIPTION
## Summary

Introduces a Pipeline-as-Config architecture that enables new model support through JSON configuration instead of C++ source changes.

## Motivation

Currently, every new model architecture requires adding a string to the model_type whitelist and potentially new C++ model/state classes. This creates a bottleneck: the ORT GenAI team must make source changes for every new HuggingFace model.

With Pipeline-as-Config, the runtime becomes a generic pipeline executor. New models are supported by generating ONNX graphs + a v2 pipeline config — zero C++ changes needed.

## Design Principle

**"Detect, don't declare"** — the runtime infers model capabilities from config structure and ONNX session I/O, not from hardcoded model_type strings.

## What This PR Adds

### 1. Config v2 Schema (pipeline_config_schema.h/cpp)
- Pipeline config with sessions, flow, dataflow, state sections
- `extends` mechanism for preset inheritance
- Built-in presets: autoregressive-decoder, vision-language, encoder-decoder

### 2. PipelineConfigModel (pipeline_config.h/cpp)
- Decoder-only: inherits DecoderOnly_Model (zero code duplication)
- Multi-session: FlowInterpreter orchestrates vision/embedding/decoder sessions
- Decoder session delegates to DecoderOnly_State via composition

### 3. v1-to-v2 Translator (v1_translator.h/cpp)
- Auto-translates existing genai_config.json to v2 pipeline format at load time
- Full backward compatibility — all existing models continue to work unchanged

### 4. Config-driven dispatch (model.cpp)
- Replaces model_type string checks with pipeline config fields
- position_ids.strategy instead of IsQwen25VL()
- Encoder session presence instead of model_type=="whisper"

## Config Examples

Minimal decoder-only LLM (4 lines):
```json
{"version": 2, "pipeline": {"extends": "autoregressive-decoder", "sessions": {"decoder": {"file": "model.onnx"}}}, "tokens": {"eos": [2]}}
```

## Testing

- 78+ tests pass (all existing + new pipeline tests)
- All existing model types tested via v1-to-v2 translator
- Backward compatible — v1 configs unchanged

## Competitive Advantage

This makes ORT GenAI the only inference runtime where adding a new model — including multimodal, multi-session models — requires zero code in any language. Just ONNX graphs + JSON config.
