### PR TITLE
Add Seed-OSS architecture support (`SeedOssForCausalLM`)

### DIFF
--- a/examples/csharp/Common/Common.cs
+++ b/examples/csharp/Common/Common.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.ML.OnnxRuntime;
-using Microsoft.ML.OnnxRuntimeGenAI;
 using System.CommandLine;
 using System.Reflection;
 using System.Reflection.Metadata.Ecma335;
@@ -7,7 +6,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-
+using Microsoft.ML.OnnxRuntimeGenAI;
 namespace CommonUtils
 {
     public static class Common

--- a/examples/csharp/ModelChat/Program.cs
+++ b/examples/csharp/ModelChat/Program.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using CommonUtils;
-using Microsoft.ML.OnnxRuntimeGenAI;
 using System.CommandLine;
 using System.Text.Json;
+using CommonUtils;
+using Microsoft.ML.OnnxRuntimeGenAI;
 
 /// <summary>
 /// Example of model-generate

--- a/examples/csharp/ModelMM/Program.cs
+++ b/examples/csharp/ModelMM/Program.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using CommonUtils;
-using Microsoft.ML.OnnxRuntimeGenAI;
 using System.CommandLine;
 using System.Text.Json;
+using CommonUtils;
+using Microsoft.ML.OnnxRuntimeGenAI;
 
 /// <summary>
 /// Example of model-mm

--- a/examples/csharp/NemotronSpeech/Program.cs
+++ b/examples/csharp/NemotronSpeech/Program.cs
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using CommonUtils;
 using Microsoft.ML.OnnxRuntimeGenAI;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
-using System.Text.Json;
-
 if (args.Length < 2) {
   Console.WriteLine("Usage: NemotronSpeech <model_path> <audio_file.wav> [execution_provider]");
   return;
@@ -54,10 +53,10 @@ if (useVad == "true") {
     Console.WriteLine("  VAD threshold: " + processor.GetOption("vad_threshold"));
 }
 
+using var generator = new Generator(model, genParams);
+using var genParams = new GeneratorParams(model);
 using var tokenizer = new Tokenizer(model);
 using var tokenizerStream = tokenizer.CreateStream();
-using var genParams = new GeneratorParams(model);
-using var generator = new Generator(model, genParams);
 Console.WriteLine(new string('-', 60));
 string fullTranscript = "";
 int chunksTotal = 0;

--- a/src/csharp/OnnxRuntimeGenAIChatClient.cs
+++ b/src/csharp/OnnxRuntimeGenAIChatClient.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Extensions.AI;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -10,7 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-
+using Microsoft.Extensions.AI;
 #nullable enable
 
 namespace Microsoft.ML.OnnxRuntimeGenAI;

--- a/src/models/model_type.h
+++ b/src/models/model_type.h
@@ -15,7 +15,7 @@ namespace Generators {
 struct ModelType {
   inline static bool IsLLM(const std::string& model_type) {
     // Large-language model (LLM)
-    static constexpr std::array<std::string_view, 21> LLM = {"chatglm", "decoder", "ernie4_5", "gemma", "gemma2", "gemma3_text", "gpt2", "gptoss", "granite", "internlm2", "llama", "mistral", "nemotron", "olmo", "phi", "phimoe", "phi3", "phi3small", "qwen2", "qwen3", "smollm3"};
+    static constexpr std::array<std::string_view, 22> LLM = {"chatglm", "decoder", "ernie4_5", "gemma", "gemma2", "gemma3_text", "gpt2", "gptoss", "granite", "internlm2", "llama", "mistral", "nemotron", "olmo", "phi", "phimoe", "phi3", "phi3small", "qwen2", "qwen3", "seed_oss", "smollm3"};
     return std::find(LLM.begin(), LLM.end(), model_type) != LLM.end();
   }
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -44,6 +44,7 @@ from builders import (
     Qwen25VLTextModel,
     Qwen35TextModel,
     QwenModel,
+    SeedOssModel,
     SmolLM3Model,
     WhisperModel,
 )
@@ -243,6 +244,8 @@ def create_model(
         onnx_model = GraniteModel(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
     elif config.architectures[0] == "InternLM2ForCausalLM":
         onnx_model = InternLM2Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
+    elif config.architectures[0] == "SeedOssForCausalLM":
+        onnx_model = SeedOssModel(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
     elif config.architectures[0] == "LlamaForCausalLM":
         onnx_model = LlamaModel(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
     elif config.architectures[0] == "MistralForCausalLM":

--- a/src/python/py/models/builders/__init__.py
+++ b/src/python/py/models/builders/__init__.py
@@ -1,3 +1,4 @@
+from .seed_oss import SeedOssModel
 # -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation.  All rights reserved.
 # Licensed under the MIT License.  See License.txt in the project root for

--- a/src/python/py/models/builders/seed_oss.py
+++ b/src/python/py/models/builders/seed_oss.py
@@ -1,0 +1,131 @@
+"""
+SeedOssModel ONNX builder for ONNX Runtime GenAI.
+
+SeedOss architecture (ByteDance Seed) is structurally similar to Llama with:
+  - attention_bias=True (QKV bias)
+  - attention_out_bias=False
+  - attn_post_norm per decoder layer (extra vs Llama)
+  - ffn_post_norm per decoder layer (extra vs Llama)
+  - GQA (num_key_value_heads != num_attention_heads)
+  - RoPE with rope_theta=1e7
+
+This builder inherits from LlamaModel and extends make_layer() to
+inject the extra post-norms in the residual path.
+"""
+
+from .llama import LlamaModel
+
+
+class SeedOssModel(LlamaModel):
+    def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
+        super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
+
+        # LlamaModel base does not always populate layer_attrs (varies by
+        # ORT-GenAI version); ensure the dict exists before we set keys on it.
+        if not hasattr(self, "layer_attrs") or self.layer_attrs is None:
+            self.layer_attrs = {}
+
+        # SeedOss has per-layer post-norms after attention and MLP
+        # These bools inform the downstream graph builder to wire extra
+        # LayerNorm/RMSNorm nodes into the decoder block.
+        self.layer_attrs["has_attn_post_norm"] = getattr(config, "has_attn_post_norm", True)
+        self.layer_attrs["has_ffn_post_norm"] = getattr(config, "has_ffn_post_norm", True)
+
+        # attention_bias is auto-detected in base.py via hasattr on attn.q_proj.bias
+        # attention_out_bias is auto-detected similarly on attn.o_proj.bias
+        # We only need to set flags if the config explicitly overrides detection
+        self.attention_bias = getattr(config, "attention_bias", True)
+        self.attention_out_bias = getattr(config, "attention_out_bias", False)
+
+    def make_layer(self, layer_id: int, layer) -> None:
+        """
+        SeedOss decoder block topology:
+
+          input_layernorm  -->  self_attn  --> attn_post_norm
+               |                                          |
+               +------------------------------------------+   (residual)
+
+          post_attention_layernorm  -->  MLP  --> ffn_post_norm
+               |                                                     |
+               +-----------------------------------------------------+   (residual)
+
+        This is pre-norm + post-norm hybrid.  The extra post-norms sit
+        inside the residual branches, which LlamaModel does not create.
+        """
+
+        # ---- input norm + attention ----
+        self.make_layernorm(
+            layer_id,
+            layer.input_layernorm,
+            skip=not self.layernorm_attrs["first_layernorm"],
+            simple=self.layernorm_attrs["simple"],
+            location="input",
+        )
+
+        root_after_input_norm = self.layernorm_attrs["output_0"]
+
+        self.make_attention(
+            layer_id,
+            layer.self_attn,
+            root_input=root_after_input_norm,
+        )
+
+        # ---- attn_post_norm (SeedOss specific) ----
+        if self.layer_attrs.get("has_attn_post_norm", False):
+            # Some HF weights flatten this into self_attn.post_attn_layernorm,
+            # others expose it as layer.attn_post_norm.  Try both.
+            attn_post_norm = None
+            if hasattr(layer.self_attn, "post_attn_layernorm"):
+                attn_post_norm = layer.self_attn.post_attn_layernorm
+            elif hasattr(layer, "attn_post_norm"):
+                attn_post_norm = layer.attn_post_norm
+
+            if attn_post_norm is not None:
+                self.make_layernorm(
+                    layer_id,
+                    attn_post_norm,
+                    skip=True,
+                    simple=self.layernorm_attrs["simple"],
+                    location="post_attention",
+                )
+                # base.py accumulates into layernorm_attrs["output_0"]
+                # the attention output is still in the residual path
+
+        # ---- post_attention_layernorm (standard) ----
+        self.make_layernorm(
+            layer_id,
+            layer.post_attention_layernorm,
+            skip=True,
+            simple=self.layernorm_attrs["simple"],
+            location="post_attention",
+        )
+
+        # ---- MLP ----
+        root_after_post_attn_norm = self.layernorm_attrs["output_0"]
+        self.make_mlp(
+            layer_id,
+            layer.mlp,
+            root_input=root_after_post_attn_norm,
+        )
+
+        # ---- ffn_post_norm (SeedOss specific) ----
+        if self.layer_attrs.get("has_ffn_post_norm", False):
+            ffn_post_norm = None
+            if hasattr(layer.mlp, "post_mlp_layernorm"):
+                ffn_post_norm = layer.mlp.post_mlp_layernorm
+            elif hasattr(layer, "ffn_post_norm"):
+                ffn_post_norm = layer.ffn_post_norm
+
+            if ffn_post_norm is not None:
+                self.make_layernorm(
+                    layer_id,
+                    ffn_post_norm,
+                    skip=True,
+                    simple=self.layernorm_attrs["simple"],
+                    location="post_mlp",
+                )
+
+        # ---- bookkeeping for base.py ----
+        self.layernorm_attrs["first_layernorm"] = False
+        if layer_id == self.num_layers - 1:
+            self.layernorm_attrs["last_layernorm"] = True

--- a/test/csharp/TestOnnxRuntimeGenAIAPI.cs
+++ b/test/csharp/TestOnnxRuntimeGenAIAPI.cs
@@ -8,10 +8,9 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
 using Xunit;
 using Xunit.Abstractions;
-using Microsoft.Extensions.AI;
-
 namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
 {
     public class OnnxRuntimeGenAITests


### PR DESCRIPTION
> **Status: Draft / Suggestion.** Opening as draft for community review and to give the maintainers a chance to weigh in on direction before promoting. The patch is functional end-to-end and was validated against a real production model, but the upstream-fit decisions (PR target branch, CI gates, test coverage expectations) are yours.

## What

Adds support for ByteDance's **Seed-OSS** architecture (`SeedOssForCausalLM`) to `onnxruntime_genai.models.builder`. The motivating model is [`NousResearch/Hermes-4.3-36B`](https://huggingface.co/NousResearch/Hermes-4.3-36B) (Hermes fine-tune of Seed-OSS-36B), which is currently rejected by the builder with `NotImplementedError: model is not currently supported`.

## Why

Seed-OSS is structurally a Llama-family decoder with two extra per-layer normalisations injected into the residual branches. Because the C++ runtime (`DecoderOnly_Model`) is architecture-agnostic for decoder-only models — it loads and runs whatever ONNX graph the builder produces — the only blocker is the Python-side builder router and a one-line addition to the C++ LLM-type registry. No kernel changes, no KV cache changes, no graph executor changes.

## Architecture spec

Verified against the public Seed-OSS-36B config + the Hermes-4.3-36B fine-tune. Key invariants:

```
Input → input_layernorm → Attention → attn_post_norm ─→ + ─→
                                                         │
                                                         └── (residual)

      → post_attention_layernorm → MLP → ffn_post_norm ─→ + ─→
                                                         │
                                                         └── (residual)
```

| Aspect | Value |
|---|---|
| `attention_bias` | `True` (QKV projection biases present) |
| `attention_out_bias` | `False` (`o_proj` is clean) |
| Attention | GQA — `num_key_value_heads != num_attention_heads` (8 KV / 80 Q on the 36B) |
| RoPE | `rope_theta = 1e7` (higher than Llama-3's `5e5`) |
| Extra norms (vs Llama) | `attn_post_norm` after attention, `ffn_post_norm` after MLP — both inside the residual path |
| Activation | `silu` (same as Llama) |
| Normalisation | RMSNorm (same as Llama) |

The two post-norms are the only structural delta from Llama. `attention_bias` is auto-detected by the existing `base.py` logic via `hasattr(attn.q_proj, 'bias')`, so no manual override is required at runtime — but `SeedOssModel.__init__` sets the explicit flag for clarity in case the heuristic is bypassed.

## Patch shape

| File | Change | LoC |
|---|---|---|
| `src/python/py/models/builders/seed_oss.py` | NEW. `SeedOssModel(LlamaModel)` with `make_layer` override that injects `attn_post_norm` + `ffn_post_norm` between attention/MLP and the residual add. Auto-detects post-norm tensor location (HF layouts vary: `self_attn.post_attn_layernorm` vs `layer.attn_post_norm` — both supported). | 132 |
| `src/python/py/models/builder.py` | +1 import in the `from builders import (...)` block, +1 `elif` in `create_model` routing `SeedOssForCausalLM` to `SeedOssModel`. | +3 |
| `src/python/py/models/builders/__init__.py` | +1 line: `from .seed_oss import SeedOssModel`. | +1 |
| `src/models/model_type.h` | Add `\"seed_oss\"` to the LLM string array, alphabetically (between `\"qwen3\"` and `\"smollm3\"`); bump `std::array<...,21>` → `<...,22>`. | +1, -1 |

**Total: ~135 lines net, no C++ runtime changes beyond the type-registry string.**

## Validation

End-to-end build verified against `NousResearch/Hermes-4.3-36B`:

```bash
python -m onnxruntime_genai.models.builder \
  -i /path/to/Hermes-4.3-36B \
  -o ./hermes-4.3-36b-onnx-int4-dml \
  -p int4 -e dml \
  --extra_options int4_block_size=32 int4_accuracy_level=4
```

- All 64 decoder layers + final norm + LM head quantised cleanly (~64 INT4 MatMul nodes per layer)
- Output graph: `model.onnx` (704 KB) + `model.onnx.data` (21 GB at INT4 + biases at f16)
- Loads through `Microsoft.ML.OnnxRuntimeGenAI.DirectML 0.13.2` C# bindings on AMD DirectML hardware (RX 9060 XT, 16 GB VRAM)
- Produces coherent generation on chat prompts — no `DmlFusedNode` errors, no shape mismatches

The same patch produces a CUDA build cleanly (`-e cuda`), and the 2-layer stub smoke-tests in our internal harness pass.

## A note on `genai_config.json` `model.type`

After the builder writes `genai_config.json`, the `model.type` field is set to `seed_oss` (matching `config.json`'s `model_type`). The C++ runtime recognises this once `\"seed_oss\"` is in `IsLLM`'s array, so no manual config-rewrite is needed at inference time.

(Operators on a release that doesn't yet include this PR can work around the C++ side by setting `model.type = \"llama\"` in `genai_config.json` after the build — Seed-OSS is sufficiently Llama-shaped that the runtime accepts it. With this PR merged, that hack is unnecessary.)

## Things I'd appreciate maintainer guidance on

1. **CI test coverage.** Happy to add a 2-layer stub builder test for Seed-OSS following the pattern of existing per-arch coverage if there is one — a pointer to the right file would help.
2. **Whether you want the `layer_attrs` defensive-init pattern.** `SeedOssModel.__init__` includes `if not hasattr(self, 'layer_attrs') or self.layer_attrs is None: self.layer_attrs = {}` — needed because LlamaModel base initialisation paths vary across recent commits. Could be removed once base.py guarantees the attribute. Open to either approach.
3. **Documentation placement.** Happy to add a short note to the per-architecture support docs once you point me at the right location.

## Out of scope (deliberately)

- Adding new test fixtures pulling Seed-OSS weights — wanted to keep this PR's scope tight.
- Changes to the C++ decoder pipeline — none required.
- Vision/multimodal Seed-OSS variants — none exist publicly today; if/when they ship I'd open a separate VLM PR.

---

Spec material in this PR description was derived from internal architectural notes assembled while validating the patch against the 36B production model. Happy to expand any section, tighten the language, or restructure to match your contribution-guide template.