### PR TITLE
Add JSON DOM and RFC 7386 merge_patch to src/json

### DIFF
--- a/src/json.cpp
+++ b/src/json.cpp
@@ -3,7 +3,11 @@
 
 #include <cmath>
 #include <charconv>
+#include <cstdio>
+#include <limits>
+#include <list>
 #include <sstream>
+#include <type_traits>
 
 namespace JSON {
 static constexpr const char* value_names[] = {"string", "number", "bool", "null"};
@@ -80,7 +84,7 @@ bool JSON::Skip(char c) {
 template <size_t TCount>
 bool JSON::Skip(const char (&sz)[TCount]) {
   size_t const count = TCount - 1;  // Remove the null terminator from the string literal
-  if (current_ + count >= end_ || std::strncmp(current_, sz, count) != 0) {
+  if (current_ + count > end_ || std::strncmp(current_, sz, count) != 0) {
     return false;
   }
 
@@ -280,6 +284,226 @@ std::string JSON::Parse_String() {
     string.push_back(c);
   }
   return string;
+}
+
+// ---------------------------------------------------------------------------
+// JSON DOM (Document) — built on top of the streaming Parse() above.
+// ---------------------------------------------------------------------------
+namespace {
+
+Document FromValue(Value v) {
+  if (auto* sv = std::get_if<std::string_view>(&v)) {
+    return Document(std::string(*sv));
+  }
+  if (auto* d = std::get_if<double>(&v)) {
+    return Document(*d);
+  }
+  if (auto* b = std::get_if<bool>(&v)) {
+    return Document(*b);
+  }
+  return Document(nullptr);
+}
+
+// Builder used for any nested Object / Array. The streaming parser hands us
+// reference-stable Element pointers to drive each nested level; we own the
+// per-level builders in std::list so emplace_back doesn't invalidate the
+// references we've already returned to the parser.
+struct DocumentBuilder : Element {
+  Document& target_;
+  std::list<DocumentBuilder> children_;
+
+  explicit DocumentBuilder(Document& t) : target_(t) {}
+
+  Document& InsertChild(std::string_view name) {
+    if (auto* obj = std::get_if<Object>(&target_.value)) {
+      // operator[] default-constructs a Document if the key is absent,
+      // which is what the caller will fill in next. If the key is already
+      // present (parser saw a duplicate key), the new value wins — same
+      // behaviour as the streaming Element parser.
+      return (*obj)[std::string(name)];
+    }
+    if (auto* arr = std::get_if<Array>(&target_.value)) {
+      arr->emplace_back();
+      return arr->back();
+    }
+    // Should not happen — parser only nests inside containers — but if it
+    // does, just clobber the slot.
+    return target_;
+  }
+
+  void OnValue(std::string_view name, Value v) override {
+    InsertChild(name) = FromValue(v);
+  }
+
+  Element& OnObject(std::string_view name) override {
+    Document& slot = InsertChild(name);
+    slot = Document(Object{});
+    children_.emplace_back(slot);
+    return children_.back();
+  }
+
+  Element& OnArray(std::string_view name) override {
+    Document& slot = InsertChild(name);
+    slot = Document(Array{});
+    children_.emplace_back(slot);
+    return children_.back();
+  }
+};
+
+// Top-level builder. The streaming parser invokes one of OnValue / OnObject /
+// OnArray with an empty name to seed the root value.
+struct RootDocumentBuilder : Element {
+  Document& root_;
+  std::list<DocumentBuilder> children_;
+
+  explicit RootDocumentBuilder(Document& root) : root_(root) {}
+
+  void OnValue(std::string_view, Value v) override {
+    root_ = FromValue(v);
+  }
+
+  Element& OnObject(std::string_view) override {
+    root_ = Document(Object{});
+    children_.emplace_back(root_);
+    return children_.back();
+  }
+
+  Element& OnArray(std::string_view) override {
+    root_ = Document(Array{});
+    children_.emplace_back(root_);
+    return children_.back();
+  }
+};
+
+void EscapeString(const std::string& s, std::ostringstream& oss) {
+  oss << '"';
+  for (char c : s) {
+    switch (c) {
+      case '"':
+        oss << "\\\"";
+        break;
+      case '\\':
+        oss << "\\\\";
+        break;
+      case '\b':
+        oss << "\\b";
+        break;
+      case '\f':
+        oss << "\\f";
+        break;
+      case '\n':
+        oss << "\\n";
+        break;
+      case '\r':
+        oss << "\\r";
+        break;
+      case '\t':
+        oss << "\\t";
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          char buf[8];
+          std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(c));
+          oss << buf;
+        } else {
+          oss << c;
+        }
+    }
+  }
+  oss << '"';
+}
+
+void SerializeImpl(const Document& doc, std::ostringstream& oss) {
+  std::visit(
+      [&](auto&& v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::nullptr_t>) {
+          oss << "null";
+        } else if constexpr (std::is_same_v<T, bool>) {
+          oss << (v ? "true" : "false");
+        } else if constexpr (std::is_same_v<T, double>) {
+          // Emit integral values without a decimal point so a base config
+          // round-trips byte-for-byte through a no-op merge in the common
+          // case (e.g. token ids, head_size, hidden_size).
+          if (std::isfinite(v) && v == static_cast<double>(static_cast<long long>(v)) &&
+              v >= static_cast<double>(std::numeric_limits<long long>::min()) &&
+              v <= static_cast<double>(std::numeric_limits<long long>::max())) {
+            oss << static_cast<long long>(v);
+          } else {
+            // Use enough precision to round-trip a double exactly.
+            std::ostringstream tmp;
+            tmp.precision(17);
+            tmp << v;
+            oss << tmp.str();
+          }
+        } else if constexpr (std::is_same_v<T, std::string>) {
+          EscapeString(v, oss);
+        } else if constexpr (std::is_same_v<T, Array>) {
+          oss << '[';
+          bool first = true;
+          for (const auto& e : v) {
+            if (!first) oss << ',';
+            first = false;
+            SerializeImpl(e, oss);
+          }
+          oss << ']';
+        } else if constexpr (std::is_same_v<T, Object>) {
+          oss << '{';
+          bool first = true;
+          for (const auto& [k, val] : v) {
+            if (!first) oss << ',';
+            first = false;
+            EscapeString(k, oss);
+            oss << ':';
+            SerializeImpl(val, oss);
+          }
+          oss << '}';
+        }
+      },
+      doc.value);
+}
+
+}  // namespace
+
+Document ParseDocument(std::string_view text) {
+  Document root;
+  RootDocumentBuilder builder(root);
+  Parse(builder, text);
+  return root;
+}
+
+std::string SerializeDocument(const Document& doc) {
+  std::ostringstream oss;
+  SerializeImpl(doc, oss);
+  return oss.str();
+}
+
+void MergePatch(Document& target, const Document& patch) {
+  // RFC 7386: if the patch is not an object, the target is replaced wholesale.
+  if (!patch.IsObject()) {
+    target = patch;
+    return;
+  }
+  // If the target is anything other than an object, RFC 7386 says treat it as
+  // an empty object before applying the patch.
+  if (!target.IsObject()) {
+    target = Document(Object{});
+  }
+  Object& target_obj = target.AsObject();
+  const Object& patch_obj = patch.AsObject();
+  for (const auto& [key, patch_val] : patch_obj) {
+    if (patch_val.IsNull()) {
+      target_obj.erase(key);
+    } else {
+      auto it = target_obj.find(key);
+      if (it == target_obj.end()) {
+        // Insert a deep copy.
+        target_obj.emplace(key, patch_val);
+      } else {
+        MergePatch(it->second, patch_val);
+      }
+    }
+  }
 }
 
 }  // namespace JSON

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -232,6 +232,13 @@ double JSON::Parse_Number() {
     throw std::runtime_error("Expecting number");
   }
   current_ = end;
+  // strtod returns ±HUGE_VAL on overflow without otherwise signalling failure;
+  // surface that as a parse error rather than admitting Inf into the DOM
+  // (the serializer rejects non-finite doubles, so this would otherwise be
+  // a deferred crash on a later round-trip).
+  if (!std::isfinite(value)) {
+    throw std::runtime_error("Number out of range");
+  }
 #endif
   return value;
 }
@@ -422,12 +429,25 @@ void SerializeImpl(const Document& doc, std::ostringstream& oss) {
         } else if constexpr (std::is_same_v<T, bool>) {
           oss << (v ? "true" : "false");
         } else if constexpr (std::is_same_v<T, double>) {
+          // JSON has no representation for non-finite numbers (RFC 8259 §6
+          // restricts the grammar to the finite reals). Refuse to emit them
+          // rather than producing nan/inf token soup.
+          if (!std::isfinite(v)) {
+            throw std::runtime_error("JSON serialize: non-finite number");
+          }
           // Emit integral values without a decimal point so a base config
           // round-trips byte-for-byte through a no-op merge in the common
-          // case (e.g. token ids, head_size, hidden_size).
-          if (std::isfinite(v) && v == static_cast<double>(static_cast<long long>(v)) &&
-              v >= static_cast<double>(std::numeric_limits<long long>::min()) &&
-              v <= static_cast<double>(std::numeric_limits<long long>::max())) {
+          // case (e.g. token ids, head_size, hidden_size). Bounds-check
+          // before the cast — converting an out-of-range double to long long
+          // is undefined behavior — and then use modf to test integrality
+          // without going through the cast at all. The upper bound uses a
+          // strict `<` because static_cast<double>(LLONG_MAX) rounds up to
+          // 2^63 (LLONG_MAX = 2^63-1 is not exactly representable as
+          // double); admitting v = 2^63 would still overflow the cast.
+          double integral_part = 0.0;
+          if (v >= static_cast<double>(std::numeric_limits<long long>::min()) &&
+              v < static_cast<double>(std::numeric_limits<long long>::max()) &&
+              std::modf(v, &integral_part) == 0.0) {
             oss << static_cast<long long>(v);
           } else {
             // Use enough precision to round-trip a double exactly.

--- a/src/json.h
+++ b/src/json.h
@@ -7,6 +7,16 @@
 // For the elements inside of an array, the names will be empty strings
 // The root element also has no names.
 //
+#pragma once
+
+#include <exception>
+#include <map>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
 namespace JSON {
 struct unknown_value_error : std::exception {};  // Throw this from any Element callback to throw a std::runtime error reporting the unknown value name
 struct type_mismatch {                           // When a file has one type, but we're expecting another type. "seen" & "expected" are indices into the Value std::variant below
@@ -36,4 +46,66 @@ struct Element {
 
 void Parse(Element& element, std::string_view document);
 void TranslateException(std::string_view name);  // Translate JSON exceptions into std::runtime_exception with a useful message
+
+// ---------------------------------------------------------------------------
+// Lightweight JSON DOM
+//
+// Built on top of the streaming parser above. Use this for cases where we need
+// to manipulate JSON values (e.g. apply a JSON Merge Patch) before consuming
+// them. For simple "read into a struct" config loading, prefer the streaming
+// Element interface directly — it is lower overhead.
+// ---------------------------------------------------------------------------
+struct Document;
+using Object = std::map<std::string, Document>;
+using Array = std::vector<Document>;
+using DocumentValue = std::variant<std::nullptr_t, bool, double, std::string, Array, Object>;
+
+struct Document {
+  DocumentValue value;
+
+  Document() : value(nullptr) {}
+  /* implicit */ Document(std::nullptr_t) : value(nullptr) {}
+  /* implicit */ Document(bool v) : value(v) {}
+  /* implicit */ Document(double v) : value(v) {}
+  /* implicit */ Document(int v) : value(static_cast<double>(v)) {}
+  /* implicit */ Document(std::string v) : value(std::move(v)) {}
+  /* implicit */ Document(const char* v) : value(std::string(v)) {}
+  /* implicit */ Document(Array v) : value(std::move(v)) {}
+  /* implicit */ Document(Object v) : value(std::move(v)) {}
+
+  bool IsNull() const { return std::holds_alternative<std::nullptr_t>(value); }
+  bool IsBool() const { return std::holds_alternative<bool>(value); }
+  bool IsNumber() const { return std::holds_alternative<double>(value); }
+  bool IsString() const { return std::holds_alternative<std::string>(value); }
+  bool IsArray() const { return std::holds_alternative<Array>(value); }
+  bool IsObject() const { return std::holds_alternative<Object>(value); }
+
+  bool AsBool() const { return std::get<bool>(value); }
+  double AsNumber() const { return std::get<double>(value); }
+  const std::string& AsString() const { return std::get<std::string>(value); }
+  const Array& AsArray() const { return std::get<Array>(value); }
+  Array& AsArray() { return std::get<Array>(value); }
+  const Object& AsObject() const { return std::get<Object>(value); }
+  Object& AsObject() { return std::get<Object>(value); }
+};
+
+// Parse a JSON document into a DOM. Throws std::runtime_error on parse error.
+Document ParseDocument(std::string_view text);
+
+// Serialize a DOM back to a JSON string. Object keys are serialized in
+// std::map-defined (lexicographic) order. Numbers that are integral within the
+// double range are emitted without a decimal point.
+std::string SerializeDocument(const Document& doc);
+
+// Apply RFC 7386 (https://datatracker.ietf.org/doc/html/rfc7386) JSON Merge
+// Patch in-place to |target|:
+//   - If |patch| is not an object, |target| is replaced wholesale.
+//   - For each key in |patch|:
+//       * If the value is null, the key is removed from |target|.
+//       * Else, MergePatch is applied recursively to target[key] and
+//         patch[key]. If target[key] is missing, the patch value is inserted.
+//   - Keys in |target| not mentioned in |patch| are left unchanged.
+//   - Arrays and scalars in |patch| always replace wholesale; there is no
+//     element-level array merge.
+void MergePatch(Document& target, const Document& patch);
 }  // namespace JSON

--- a/test/json_merge_patch_test.cpp
+++ b/test/json_merge_patch_test.cpp
@@ -5,6 +5,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+#include <limits>
+
 namespace Generators::test {
 
 namespace {
@@ -57,6 +60,44 @@ TEST(JsonDomTest, IntegralDoublesEmittedWithoutDecimal) {
   // ids / hidden_size etc. round-trip byte-stable through a no-op merge.
   JSON::Document d(static_cast<double>(199999));
   EXPECT_EQ(JSON::SerializeDocument(d), "199999");
+}
+
+TEST(JsonDomTest, OutOfLongLongRangeIntegralUsesScientific) {
+  // 1e19 is integral but overflows long long. The serializer must NOT take
+  // the integer fast path here — that would invoke UB via static_cast<long
+  // long>(v) on an out-of-range double. Falls through to the precision-17
+  // path; result is finite, parseable, and round-trips back to a finite
+  // number through ParseDocument.
+  JSON::Document d(1e19);
+  const std::string serialized = JSON::SerializeDocument(d);
+  // We don't pin the exact textual form (precision-17 may emit either
+  // 1e+19 or 10000000000000000000), but it must be valid JSON that
+  // re-parses to a finite double.
+  const auto reparsed = JSON::ParseDocument(serialized);
+  ASSERT_TRUE(reparsed.IsNumber());
+  EXPECT_TRUE(std::isfinite(reparsed.AsNumber()));
+}
+
+TEST(JsonDomTest, SerializeRejectsNonFiniteNumbers) {
+  // JSON has no nan/inf. The serializer must throw rather than emit a token
+  // that is not valid JSON.
+  EXPECT_THROW(JSON::SerializeDocument(JSON::Document(
+                   std::numeric_limits<double>::infinity())),
+               std::exception);
+  EXPECT_THROW(JSON::SerializeDocument(JSON::Document(
+                   -std::numeric_limits<double>::infinity())),
+               std::exception);
+  EXPECT_THROW(JSON::SerializeDocument(JSON::Document(
+                   std::numeric_limits<double>::quiet_NaN())),
+               std::exception);
+}
+
+TEST(JsonDomTest, ParseRejectsNumberOverflow) {
+  // 1e500 overflows double. Both parser branches (from_chars and the
+  // strtod fallback) must surface this as a hard parse error rather than
+  // producing ±Inf and admitting it into the DOM.
+  EXPECT_THROW(JSON::ParseDocument("1e500"), std::exception);
+  EXPECT_THROW(JSON::ParseDocument("-1e500"), std::exception);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/json_merge_patch_test.cpp
+++ b/test/json_merge_patch_test.cpp
@@ -1,0 +1,262 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "json.h"
+
+#include <gtest/gtest.h>
+
+namespace Generators::test {
+
+namespace {
+
+// Round-trip helper: parse text into a Document and serialize it back.
+std::string RoundTrip(std::string_view text) {
+  return JSON::SerializeDocument(JSON::ParseDocument(text));
+}
+
+// Apply RFC 7386 merge patch via the public API and serialize the result.
+std::string MergeAndSerialize(std::string_view target, std::string_view patch) {
+  JSON::Document t = JSON::ParseDocument(target);
+  JSON::Document p = JSON::ParseDocument(patch);
+  JSON::MergePatch(t, p);
+  return JSON::SerializeDocument(t);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// DOM parse / serialize round-trip basics.
+// ---------------------------------------------------------------------------
+
+TEST(JsonDomTest, RoundTripScalars) {
+  EXPECT_EQ(RoundTrip("null"), "null");
+  EXPECT_EQ(RoundTrip("true"), "true");
+  EXPECT_EQ(RoundTrip("false"), "false");
+  EXPECT_EQ(RoundTrip("42"), "42");
+  EXPECT_EQ(RoundTrip("-7"), "-7");
+  EXPECT_EQ(RoundTrip("\"hello\""), "\"hello\"");
+}
+
+TEST(JsonDomTest, RoundTripObjectAndArray) {
+  // Object keys are serialized in sorted order (std::map). Both inputs below
+  // therefore round-trip to the same canonical string.
+  EXPECT_EQ(RoundTrip("{\"a\":1,\"b\":\"x\"}"), "{\"a\":1,\"b\":\"x\"}");
+  EXPECT_EQ(RoundTrip("{\"b\":\"x\",\"a\":1}"), "{\"a\":1,\"b\":\"x\"}");
+  EXPECT_EQ(RoundTrip("[1,2,3]"), "[1,2,3]");
+  EXPECT_EQ(RoundTrip("{\"a\":[1,{\"b\":2}]}"), "{\"a\":[1,{\"b\":2}]}");
+}
+
+TEST(JsonDomTest, RoundTripEmpty) {
+  EXPECT_EQ(RoundTrip("{}"), "{}");
+  EXPECT_EQ(RoundTrip("[]"), "[]");
+  EXPECT_EQ(RoundTrip("{\"a\":[],\"b\":{}}"), "{\"a\":[],\"b\":{}}");
+}
+
+TEST(JsonDomTest, IntegralDoublesEmittedWithoutDecimal) {
+  // Integral-valued doubles round-trip without a decimal point so that token
+  // ids / hidden_size etc. round-trip byte-stable through a no-op merge.
+  JSON::Document d(static_cast<double>(199999));
+  EXPECT_EQ(JSON::SerializeDocument(d), "199999");
+}
+
+// ---------------------------------------------------------------------------
+// RFC 7386 conformance examples.
+// https://datatracker.ietf.org/doc/html/rfc7386 §3
+// ---------------------------------------------------------------------------
+
+TEST(JsonMergePatchTest, RfcExample_ReplaceScalar) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":"b"})", R"({"a":"c"})"),
+            R"({"a":"c"})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_AddKey) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":"b"})", R"({"b":"c"})"),
+            R"({"a":"b","b":"c"})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_DeleteKey) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":"b"})", R"({"a":null})"),
+            R"({})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_DeleteOneOfMany) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":"b","b":"c"})", R"({"a":null})"),
+            R"({"b":"c"})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_ReplaceArrayWithScalar) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":["b"]})", R"({"a":"c"})"),
+            R"({"a":"c"})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_ReplaceScalarWithArray) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":"c"})", R"({"a":["b"]})"),
+            R"({"a":["b"]})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_RecurseObjectAndDelete) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":{"b":"c"}})",
+                              R"({"a":{"b":"d","c":null}})"),
+            R"({"a":{"b":"d"}})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_ArrayOfObjectReplacesWholesale) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":[{"b":"c"}]})", R"({"a":[1]})"),
+            R"({"a":[1]})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_ArrayPatchReplacesArray) {
+  EXPECT_EQ(MergeAndSerialize(R"(["a","b"])", R"(["c","d"])"),
+            R"(["c","d"])");
+}
+
+TEST(JsonMergePatchTest, RfcExample_ArrayPatchReplacesObject) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":"b"})", R"(["c"])"),
+            R"(["c"])");
+}
+
+TEST(JsonMergePatchTest, RfcExample_NullPatchReplacesObject) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":"foo"})", R"(null)"),
+            R"(null)");
+}
+
+TEST(JsonMergePatchTest, RfcExample_StringPatchReplacesObject) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":"foo"})", R"("bar")"),
+            R"("bar")");
+}
+
+TEST(JsonMergePatchTest, RfcExample_NullInTargetSurvivesAddition) {
+  // Pre-existing null in the target is not removed by an unrelated patch.
+  EXPECT_EQ(MergeAndSerialize(R"({"e":null})", R"({"a":1})"),
+            R"({"a":1,"e":null})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_MergeIntoArrayResetsToObject) {
+  // RFC: when the target is not an object and the patch is an object, the
+  // target is treated as an empty object.
+  EXPECT_EQ(MergeAndSerialize(R"([1,2])", R"({"a":"b","c":null})"),
+            R"({"a":"b"})");
+}
+
+TEST(JsonMergePatchTest, RfcExample_DeepNestedAdd) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":{"b":{"c":1}}})",
+                              R"({"a":{"b":{"d":2}}})"),
+            R"({"a":{"b":{"c":1,"d":2}}})");
+}
+
+// ---------------------------------------------------------------------------
+// GenAI-relevant scenarios — sanity-check the shapes the package overlay
+// design will rely on (per Appendix A of the v4 design).
+// ---------------------------------------------------------------------------
+
+TEST(JsonMergePatchTest, GenAi_OverrideContextLengthAndIONames) {
+  constexpr const char* base = R"({
+    "model": {
+      "type": "phi3",
+      "context_length": 131072,
+      "decoder": {
+        "inputs": {"position_ids": "position_ids"}
+      }
+    }
+  })";
+  constexpr const char* overlay = R"({
+    "model": {
+      "context_length": 4096,
+      "decoder": {
+        "inputs": {"position_ids": "pos_ids_qnn"}
+      }
+    }
+  })";
+  JSON::Document t = JSON::ParseDocument(base);
+  JSON::Document p = JSON::ParseDocument(overlay);
+  JSON::MergePatch(t, p);
+  EXPECT_EQ(t.AsObject().at("model").AsObject().at("context_length").AsNumber(),
+            4096);
+  EXPECT_EQ(t.AsObject()
+                .at("model")
+                .AsObject()
+                .at("decoder")
+                .AsObject()
+                .at("inputs")
+                .AsObject()
+                .at("position_ids")
+                .AsString(),
+            "pos_ids_qnn");
+  // type stayed put.
+  EXPECT_EQ(t.AsObject().at("model").AsObject().at("type").AsString(), "phi3");
+}
+
+TEST(JsonMergePatchTest, GenAi_PipelineArrayReplacedWholesale) {
+  // Pipeline arrays are replaced wholesale (RFC 7386). This is the documented
+  // contract for v4 multi-file QNN-style variants.
+  constexpr const char* base = R"({
+    "model": {"decoder": {"pipeline": [{"old_stage": {"filename": "old.onnx"}}]}}
+  })";
+  constexpr const char* overlay = R"({
+    "model": {"decoder": {"pipeline": [
+      {"embedding": {"filename": "emb.onnx"}},
+      {"prompt": {"filename": "ctx.onnx"}}
+    ]}}
+  })";
+  JSON::Document t = JSON::ParseDocument(base);
+  JSON::Document p = JSON::ParseDocument(overlay);
+  JSON::MergePatch(t, p);
+  const auto& pipeline = t.AsObject()
+                             .at("model")
+                             .AsObject()
+                             .at("decoder")
+                             .AsObject()
+                             .at("pipeline")
+                             .AsArray();
+  ASSERT_EQ(pipeline.size(), 2u);
+  EXPECT_TRUE(pipeline[0].AsObject().count("embedding"));
+  EXPECT_TRUE(pipeline[1].AsObject().count("prompt"));
+}
+
+TEST(JsonMergePatchTest, GenAi_NullDeletesOptionalField) {
+  // Producers should be able to suppress a base field by setting it to null
+  // in the overlay (e.g. drop a default eos_token_id list).
+  constexpr const char* base = R"({"model": {"eos_token_id": [1, 2]}})";
+  constexpr const char* overlay = R"({"model": {"eos_token_id": null}})";
+  EXPECT_EQ(MergeAndSerialize(base, overlay), R"({"model":{}})");
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases beyond the RFC examples.
+// ---------------------------------------------------------------------------
+
+TEST(JsonMergePatchTest, EmptyPatchObjectIsNoOp) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":1})", R"({})"), R"({"a":1})");
+}
+
+TEST(JsonMergePatchTest, EmptyPatchObjectOntoScalarBecomesEmptyObject) {
+  // Per RFC: when target is non-object and patch is object, target is treated
+  // as an empty object before applying the patch.
+  EXPECT_EQ(MergeAndSerialize(R"(42)", R"({})"), R"({})");
+}
+
+TEST(JsonMergePatchTest, DeleteOfMissingKeyIsNoOp) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":1})", R"({"missing":null})"),
+            R"({"a":1})");
+}
+
+TEST(JsonMergePatchTest, ObjectOverlayOntoScalarLeafForcesObjectSemantics) {
+  EXPECT_EQ(MergeAndSerialize(R"({"a":"old"})", R"({"a":{"b":1}})"),
+            R"({"a":{"b":1}})");
+}
+
+TEST(JsonDomTest, TrailingWhitespaceParses) {
+  EXPECT_EQ(JSON::SerializeDocument(JSON::ParseDocument("  {\"a\":1}  ")),
+            R"({"a":1})");
+}
+
+TEST(JsonDomTest, BareLiteralAtEndOfInputParses) {
+  // Regression: the streaming parser used to silently drop a top-level
+  // true / false / null literal when it appeared at the very end of the
+  // input buffer (Skip() bounds check was off-by-one).
+  EXPECT_EQ(JSON::SerializeDocument(JSON::ParseDocument("true")), "true");
+  EXPECT_EQ(JSON::SerializeDocument(JSON::ParseDocument("false")), "false");
+  EXPECT_EQ(JSON::SerializeDocument(JSON::ParseDocument("null")), "null");
+}
+
+}  // namespace Generators::test


### PR DESCRIPTION
Adds a lightweight in-memory JSON DOM (Document / Object / Array) on top of the existing streaming parser, plus serializer and RFC 7386 JSON Merge Patch. This is the foundation for v4 model-package per-variant overlays, which carry a JSON Merge Patch in consumer_metadata.genai_config_overlay and need to be merged into the package-shipped base genai_config.json before the existing streaming-parser-driven Config loader sees it.

The new APIs are additive — every existing JSON::Element-based config loader is unaffected. The DOM is intentionally minimal (no fancy number representations, no object-key insertion order, no schema validation); its only consumers are Config-time overlay merging and the unit tests.

Also fixes a pre-existing off-by-one in the streaming parser's Skip(literal) bounds check that silently dropped a top-level true / false / null literal when it sat at the very end of the input buffer. The bug never surfaced in real genai_config.json files because every keyword there is followed by a comma, brace or bracket, but the new DOM round-trip tests exercise it directly.

Tests: test/json_merge_patch_test.cpp covers the full RFC 7386 example table plus GenAI-relevant shapes (overlay overrides context_length and I/O names; pipeline arrays replace wholesale; null deletes optional fields) and a small set of edge cases beyond the RFC.