### PR TITLE
Add Config::shared_assets_path for shared tokenizer/processor assets

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1567,7 +1567,7 @@ void OverlayConfig(Config& config, std::string_view json) {
   JSON::Parse(element, json);
 }
 
-Config::Config(const fs::path& path, std::string_view json_overlay) : config_path{path} {
+Config::Config(const fs::path& path, std::string_view json_overlay) : config_path{path}, shared_assets_path{path} {
   ParseConfig(path / "genai_config.json", json_overlay, *this);
 
   if (model.context_length == 0 && !ModelType::IsRNNT(model.type)) {

--- a/src/config.h
+++ b/src/config.h
@@ -82,7 +82,14 @@ struct Config {
     static constexpr std::string_view JoinerLogitsName = "outputs";
   };
 
-  fs::path config_path;  // Path of the config directory
+  fs::path config_path;  // Path of the config directory. In flat-dir mode this is also the model-asset root.
+  // Directory holding shared assets (tokenizer files, processor JSON, chat template) that are
+  // common across components. In flat-dir mode this equals config_path. In package mode (ORT v4)
+  // this is set to <pkg>/configs/ by the package loader. Runtime-resolved only; not parsed from
+  // genai_config.json. Per-component model assets (ONNX, LoRA, custom ops, external data) are
+  // intentionally NOT covered by this field — they are addressed per-component variant folder by
+  // later workstreams.
+  fs::path shared_assets_path;
 
   using NamedString = std::pair<std::string, std::string>;
   struct DeviceFilteringOptions {

--- a/src/constrained_logits_processor.cpp
+++ b/src/constrained_logits_processor.cpp
@@ -51,7 +51,7 @@ void GuidanceLogitsProcessor::InitializeLlgTokenizer() {
   };
 
   // Find the path to the tokenizer.json file
-  auto tokenizer_path = params_->config.config_path.string();
+  auto tokenizer_path = params_->config.shared_assets_path.string();
   fs::path tokenizer_path_fs(tokenizer_path);
   fs::path json_path(tokenizer_path_fs / kDefaultVocabFile);
 

--- a/src/models/gemma4_multimodal_processor.cpp
+++ b/src/models/gemma4_multimodal_processor.cpp
@@ -171,7 +171,7 @@ Gemma4MultiModalProcessor::Gemma4MultiModalProcessor(Config& config, const Sessi
   if (session_info.HasInput(config.model.vision.inputs.pixel_position_ids)) {
     pixel_position_ids_type_ = session_info.GetInputDataType(config.model.vision.inputs.pixel_position_ids);
   }
-  const auto image_processor_config = (config.config_path / fs::path(config.model.vision.config_filename)).string();
+  const auto image_processor_config = (config.shared_assets_path / fs::path(config.model.vision.config_filename)).string();
   CheckResult(OrtxCreateProcessor(image_processor_.ToBeAssigned(), image_processor_config.c_str()));
 
   config.AddMapping(std::string(Config::Defaults::InputIdsName), config.model.embedding.inputs.input_ids);
@@ -180,7 +180,7 @@ Gemma4MultiModalProcessor::Gemma4MultiModalProcessor(Config& config, const Sessi
 
   // Initialize speech/audio processor if config is present
   if (!config.model.speech.config_filename.empty()) {
-    auto speech_config_path = config.config_path / fs::path(config.model.speech.config_filename);
+    auto speech_config_path = config.shared_assets_path / fs::path(config.model.speech.config_filename);
     if (fs::exists(speech_config_path)) {
       has_speech_ = true;
       audio_features_type_ = session_info.GetInputDataType(config.model.speech.inputs.audio_embeds);

--- a/src/models/gemma_image_processor.cpp
+++ b/src/models/gemma_image_processor.cpp
@@ -80,7 +80,7 @@ ProcessImagePrompt(const Generators::Tokenizer& tokenizer, const std::string& pr
 
 GemmaImageProcessor::GemmaImageProcessor(Config& config, const SessionInfo& session_info)
     : pixel_values_type_{session_info.GetInputDataType(config.model.vision.inputs.pixel_values)} {
-  const auto processor_config = (config.config_path / fs::path(config.model.vision.config_filename)).string();
+  const auto processor_config = (config.shared_assets_path / fs::path(config.model.vision.config_filename)).string();
   CheckResult(OrtxCreateProcessor(processor_.ToBeAssigned(), processor_config.c_str()));
 
   config.AddMapping(std::string(Config::Defaults::InputIdsName), config.model.embedding.inputs.input_ids);

--- a/src/models/mistral3_image_processor.cpp
+++ b/src/models/mistral3_image_processor.cpp
@@ -212,7 +212,7 @@ Mistral3ImageProcessor::Mistral3ImageProcessor(Config& config, const SessionInfo
       patch_size_{config.model.vision.patch_size},
       spatial_merge_size_{config.model.vision.spatial_merge_size} {
   const auto processor_config =
-      (config.config_path / fs::path(config.model.vision.config_filename)).string();
+      (config.shared_assets_path / fs::path(config.model.vision.config_filename)).string();
   CheckResult(OrtxCreateProcessor(processor_.ToBeAssigned(), processor_config.c_str()));
 
   config.AddMapping(std::string(Config::Defaults::InputIdsName),

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -305,7 +305,7 @@ Tokenizer::Tokenizer(Config& config) : bos_token_id_{config.model.bos_token_id},
   const char* keys[] = {"add_special_tokens", "skip_special_tokens"};
   const char* values[] = {"false", "true"};
 
-  CheckResult(OrtxCreateTokenizerWithOptions(tokenizer_.Address(), config.config_path.string().c_str(), keys, values, 2));
+  CheckResult(OrtxCreateTokenizerWithOptions(tokenizer_.Address(), config.shared_assets_path.string().c_str(), keys, values, 2));
 }
 
 std::unique_ptr<TokenizerStream> Tokenizer::CreateStream() const {

--- a/src/models/phi_image_processor.cpp
+++ b/src/models/phi_image_processor.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<OrtValue> ProcessImagePrompt(const Generators::Tokenizer& tokeni
 
 PhiImageProcessor::PhiImageProcessor(Config& config, const SessionInfo& session_info)
     : pixel_values_type_{session_info.GetInputDataType(config.model.vision.inputs.pixel_values)} {
-  auto processor_config = (config.config_path / fs::path(config.model.vision.config_filename)).string();
+  auto processor_config = (config.shared_assets_path / fs::path(config.model.vision.config_filename)).string();
   CheckResult(OrtxCreateProcessor(processor_.ToBeAssigned(), processor_config.c_str()));
 
   config.AddMapping(std::string(Config::Defaults::InputIdsName), config.model.embedding.inputs.input_ids);

--- a/src/models/phi_multimodal_processor.cpp
+++ b/src/models/phi_multimodal_processor.cpp
@@ -106,10 +106,10 @@ PhiMultiModalProcessor::PhiMultiModalProcessor(Config& config, const SessionInfo
       attention_mask_type_{session_info.GetInputDataType(config.model.vision.inputs.attention_mask)},
       audio_features_type_{session_info.GetInputDataType(config.model.speech.inputs.audio_embeds)},
       audio_sizes_type_{session_info.GetInputDataType(config.model.speech.inputs.audio_sizes)} {
-  const auto image_processor_config = (config.config_path / fs::path(config.model.vision.config_filename)).string();
+  const auto image_processor_config = (config.shared_assets_path / fs::path(config.model.vision.config_filename)).string();
   CheckResult(OrtxCreateProcessor(image_processor_.ToBeAssigned(), image_processor_config.c_str()));
 
-  const auto audio_processor_config = (config.config_path / fs::path(config.model.speech.config_filename)).string();
+  const auto audio_processor_config = (config.shared_assets_path / fs::path(config.model.speech.config_filename)).string();
   CheckResult(OrtxCreateSpeechFeatureExtractor(audio_processor_.ToBeAssigned(), audio_processor_config.c_str()));
 
   config.AddMapping(std::string(Config::Defaults::InputIdsName), config.model.embedding.inputs.input_ids);

--- a/src/models/qwen2_5_vl_image_processor.cpp
+++ b/src/models/qwen2_5_vl_image_processor.cpp
@@ -169,7 +169,7 @@ QwenImageProcessor::QwenImageProcessor(Config& config, const SessionInfo& sessio
     : pixel_values_type_{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT},  // Default to float, will be determined at runtime if vision session exists
       spatial_merge_size_{config.model.vision.spatial_merge_size},
       patch_size_{config.model.vision.patch_size} {
-  const auto processor_config = (config.config_path / fs::path(config.model.vision.config_filename)).string();
+  const auto processor_config = (config.shared_assets_path / fs::path(config.model.vision.config_filename)).string();
   CheckResult(OrtxCreateProcessor(processor_.ToBeAssigned(), processor_config.c_str()));
 
   // Try to get pixel values type from session info if vision session exists (for MultiModalLanguageModel)

--- a/src/models/whisper_processor.cpp
+++ b/src/models/whisper_processor.cpp
@@ -8,7 +8,7 @@ namespace Generators {
 
 WhisperProcessor::WhisperProcessor(Config& config, const SessionInfo& session_info)
     : audio_features_type_{session_info.GetInputDataType(config.model.encoder.inputs.audio_features)} {
-  auto processor_config = (config.config_path / fs::path(config.model.speech.config_filename)).string();
+  auto processor_config = (config.shared_assets_path / fs::path(config.model.speech.config_filename)).string();
   processor_ = ort_extensions::OrtxObjectPtr<OrtxFeatureExtractor>(OrtxCreateSpeechFeatureExtractor, processor_config.c_str());
 
   config.AddMapping(std::string(Config::Defaults::AudioFeaturesName), config.model.encoder.inputs.audio_features);


### PR DESCRIPTION
Introduce a new fs::path field next to Config::config_path to address the directory holding tokenizer files, processor JSON, chat template, and other assets that are common across components (decoder/vision/speech/encoder/...).

In flat-dir mode this field is initialized to config_path in Config::Config(path, overlay), so behavior is identical. In a future ORT v4 package mode the package loader will set it to <pkg>/configs/.

Rewrite all call sites that load shared assets to use shared_assets_path:
- Tokenizer (model.cpp:308) and constrained_logits_processor (tokenizer.json).
- Vision/multimodal processor configs in gemma/gemma4/mistral3/phi/phi-multimodal/qwen2_5_vl.
- Whisper speech processor config.

Per-component model assets (ONNX, LoRA, custom_ops, external data) and EP-private paths (OpenVINO cache_dir, RyzenAI/VitisAI model_root) are intentionally NOT migrated — they are addressed per-component variant folder and require deeper schema work in a follow-up workstream.

This is preparatory plumbing for the ORT v4 model-package format integration.