### PR TITLE
[v4-pkg W5c-prep] Extract EffectiveSessionOptions helper for non-decoder components

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1567,6 +1567,13 @@ void OverlayConfig(Config& config, std::string_view json) {
   JSON::Parse(element, json);
 }
 
+const Config::SessionOptions& EffectiveSessionOptions(
+    const Config& config,
+    const std::optional<Config::SessionOptions>& component_session_options) {
+  return component_session_options.has_value() ? component_session_options.value()
+                                               : config.model.decoder.session_options;
+}
+
 Config::Config(const fs::path& path, std::string_view json_overlay) : config_path{path} {
   ParseConfig(path / "genai_config.json", json_overlay, *this);
 

--- a/src/config.h
+++ b/src/config.h
@@ -441,4 +441,18 @@ void ClearDecoderProviderOptionsHardwareDeviceType(Config& config, std::string_v
 void ClearDecoderProviderOptionsHardwareDeviceId(Config& config, std::string_view provider_name);
 void ClearDecoderProviderOptionsHardwareVendorId(Config& config, std::string_view provider_name);
 
+// Returns the effective layer-2 session_options view for a non-decoder
+// component, falling back to the decoder's session_options when the component
+// has no explicit override. Replaces the inline ternary
+//   model.<component>.session_options.has_value()
+//       ? model.<component>.session_options.value()
+//       : model.decoder.session_options
+// that previously appeared in marian / whisper / multi_modal session-creation
+// paths. Behavior is identical to the inlined form; isolating it here gives v4
+// model-package mode a single seam where the layer-1 (variant.json) baseline
+// will eventually be merged in front of the layer-2 (genai_config) view.
+const Config::SessionOptions& EffectiveSessionOptions(
+    const Config& config,
+    const std::optional<Config::SessionOptions>& component_session_options);
+
 }  // namespace Generators

--- a/src/models/marian.cpp
+++ b/src/models/marian.cpp
@@ -8,7 +8,7 @@ namespace Generators {
 MarianModel::MarianModel(std::unique_ptr<Config> config, OrtEnv& ort_env)
     : Model{std::move(config)} {
   encoder_session_options_ = OrtSessionOptions::Create();
-  CreateSessionOptionsFromConfig(config_->model.encoder.session_options.has_value() ? config_->model.encoder.session_options.value() : config_->model.decoder.session_options, *encoder_session_options_, true);
+  CreateSessionOptionsFromConfig(EffectiveSessionOptions(*config_, config_->model.encoder.session_options), *encoder_session_options_, true);
 
   session_encoder_ = CreateSession(ort_env, config_->model.encoder.filename, encoder_session_options_.get());
   session_decoder_ = CreateSession(ort_env, config_->model.decoder.filename, session_options_.get());

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -96,18 +96,18 @@ MultiModalLanguageModel::MultiModalLanguageModel(std::unique_ptr<Config> config,
   // The non-decoder models don't support graph capture because of control flow nodes, so disable graph capture for them
   if (vision) {
     vision_session_options_ = OrtSessionOptions::Create();
-    CreateSessionOptionsFromConfig(config_->model.vision.session_options.has_value() ? config_->model.vision.session_options.value() : config_->model.decoder.session_options, *vision_session_options_, true, /*disable_graph_capture=*/true);
+    CreateSessionOptionsFromConfig(EffectiveSessionOptions(*config_, config_->model.vision.session_options), *vision_session_options_, true, /*disable_graph_capture=*/true);
     vision_session_ = CreateSession(ort_env, config_->model.vision.filename, vision_session_options_.get());
   }
 
   if (speech) {
     speech_session_options_ = OrtSessionOptions::Create();
-    CreateSessionOptionsFromConfig(config_->model.speech.session_options.has_value() ? config_->model.speech.session_options.value() : config_->model.decoder.session_options, *speech_session_options_, true, /*disable_graph_capture=*/true);
+    CreateSessionOptionsFromConfig(EffectiveSessionOptions(*config_, config_->model.speech.session_options), *speech_session_options_, true, /*disable_graph_capture=*/true);
     speech_session_ = CreateSession(ort_env, config_->model.speech.filename, speech_session_options_.get());
   }
 
   embedding_session_options_ = OrtSessionOptions::Create();
-  CreateSessionOptionsFromConfig(config_->model.embedding.session_options.has_value() ? config_->model.embedding.session_options.value() : config_->model.decoder.session_options, *embedding_session_options_, true, /*disable_graph_capture=*/true);
+  CreateSessionOptionsFromConfig(EffectiveSessionOptions(*config_, config_->model.embedding.session_options), *embedding_session_options_, true, /*disable_graph_capture=*/true);
 
   embedding_session_ = CreateSession(ort_env, config_->model.embedding.filename, embedding_session_options_.get());
   decoder_session_ = CreateSession(ort_env, config_->model.decoder.filename, session_options_.get());

--- a/src/models/whisper.cpp
+++ b/src/models/whisper.cpp
@@ -8,7 +8,7 @@ namespace Generators {
 WhisperModel::WhisperModel(std::unique_ptr<Config> config, OrtEnv& ort_env)
     : Model{std::move(config)} {
   encoder_session_options_ = OrtSessionOptions::Create();
-  CreateSessionOptionsFromConfig(config_->model.encoder.session_options.has_value() ? config_->model.encoder.session_options.value() : config_->model.decoder.session_options, *encoder_session_options_, true);
+  CreateSessionOptionsFromConfig(EffectiveSessionOptions(*config_, config_->model.encoder.session_options), *encoder_session_options_, true);
 
   session_encoder_ = CreateSession(ort_env, config_->model.encoder.filename, encoder_session_options_.get());
   session_decoder_ = CreateSession(ort_env, config_->model.decoder.filename, session_options_.get());

--- a/test/config_helpers_test.cpp
+++ b/test/config_helpers_test.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for free helpers declared in src/config.h that are used by every
+// non-decoder session-creation path. These helpers are part of the public
+// internal C++ surface for v4 model-package preparation: the v4 path will
+// extend them to merge layer-1 (variant.json) baselines on top of the
+// today-only layer-2 (genai_config) view, and the call sites must keep
+// working unchanged.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <optional>
+
+#include "generators.h"
+#include "config.h"
+
+#include "test_utils.h"
+
+namespace Generators::test {
+
+namespace {
+
+constexpr const char* kTinyGpt2RelativePath = "hf-internal-testing/tiny-random-gpt2-fp32";
+
+std::filesystem::path TinyGpt2Path() {
+  return std::filesystem::path(MODEL_PATH) / kTinyGpt2RelativePath;
+}
+
+}  // namespace
+
+// --- EffectiveSessionOptions ----------------------------------------------
+
+TEST(EffectiveSessionOptionsTest, FallsBackToDecoderWhenComponentIsNullopt) {
+  Config config{TinyGpt2Path(), std::string_view{}};
+  std::optional<Config::SessionOptions> empty;
+
+  const Config::SessionOptions& result = EffectiveSessionOptions(config, empty);
+
+  // Must alias the decoder's session_options storage, not a copy: the address
+  // identity is what lets call sites pass the result straight through to
+  // CreateSessionOptionsFromConfig without lifetime concerns.
+  EXPECT_EQ(&result, &config.model.decoder.session_options);
+}
+
+TEST(EffectiveSessionOptionsTest, ReturnsComponentWhenSet) {
+  Config config{TinyGpt2Path(), std::string_view{}};
+  std::optional<Config::SessionOptions> component;
+  component.emplace();
+  component->log_id = "vision-session";
+
+  const Config::SessionOptions& result = EffectiveSessionOptions(config, component);
+
+  // Reference must alias the optional's stored value, not the decoder, and
+  // not a copy of either.
+  EXPECT_EQ(&result, &component.value());
+  EXPECT_NE(&result, &config.model.decoder.session_options);
+  ASSERT_TRUE(result.log_id.has_value());
+  EXPECT_EQ(result.log_id.value(), "vision-session");
+}
+
+TEST(EffectiveSessionOptionsTest, FallbackPicksUpLiveDecoderState) {
+  // The fallback returns a reference into the live Config, so subsequent
+  // mutations of the decoder block must be observable through the returned
+  // reference. The five v4-prep call sites in marian / whisper / multi_modal
+  // rely on this — they read the result immediately after the call, but the
+  // reference semantics are part of the contract so future refactors don't
+  // accidentally start copying.
+  Config config{TinyGpt2Path(), std::string_view{}};
+  std::optional<Config::SessionOptions> empty;
+
+  const Config::SessionOptions& result = EffectiveSessionOptions(config, empty);
+
+  config.model.decoder.session_options.log_id = "decoder-after-call";
+  ASSERT_TRUE(result.log_id.has_value());
+  EXPECT_EQ(result.log_id.value(), "decoder-after-call");
+}
+
+}  // namespace Generators::test


### PR DESCRIPTION
Part of the ORT v4 model-package integration. **Behavior change is zero** on every flat-directory model. Independent of W1, W4-prep, W9.

## What

Five non-decoder session-creation paths inline the same fallback ternary:

\\\cpp
config_->model.<component>.session_options.has_value()
    ? config_->model.<component>.session_options.value()
    : config_->model.decoder.session_options
\\\

— at `marian.cpp` (encoder), `whisper.cpp` (encoder), and `multi_modal.cpp` × 3 (vision / speech / embedding).

Replaced with a single free helper `EffectiveSessionOptions(config, component_session_options)` declared in `config.h` next to `OverlayConfig` and the other layer-2 free helpers.

## Why

Today the helper is purely cosmetic. In the v4 model-package world the same call sites need a single seam where the **layer-1 baseline** (`variant.json files[].session_options`) gets merged in front of the today-only **layer-2 view** (`genai_config`). Centralising the lookup here means the v4 work touches one function body, not five ternaries scattered across three files.

## Tests

`test/config_helpers_test.cpp` covers the three contract bullets that matter for the call sites:

1. Fallback identity to decoder when component is `nullopt` (must alias decoder storage, not copy)
2. Identity to the component's stored value when set (must alias the optional's storage)
3. Live-aliasing of the decoder fallback (mutations after the call are visible through the returned reference, so future refactors don't accidentally start copying `SessionOptions`)

## Stack

Independent of all other v4-prep branches. Reviewable / mergeable in any order relative to W1 (#2125), W4-prep (#2126), W9 (#2130).