### PR TITLE
[v4-pkg W2-stub] Add ModelPackageContext stub directory walker

### DIFF
--- a/src/models/model_package.cpp
+++ b/src/models/model_package.cpp
@@ -1,0 +1,715 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../json.h"
+#include "model_package.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <system_error>
+#include <unordered_set>
+
+namespace Generators {
+
+namespace {
+
+// ---- fs::path <-> std::filesystem::path bridge -------------------------------
+//
+// The codebase's `fs::path` (src/filesystem.h) is the public surface; it
+// treats narrow strings as UTF-8 and uses `MultiByteToWideChar(CP_UTF8, ...)`
+// on Windows. `std::filesystem::path`'s narrow ctor on Windows interprets
+// its input as the *active code page*. To keep encoding correct for non-ASCII
+// paths we must round-trip through the wide form on Windows; on Unix the
+// native narrow encoding IS UTF-8 and the simple ctor is correct.
+
+std::filesystem::path ToStd(const fs::path& p) {
+#ifdef _WIN32
+  return std::filesystem::path(p.c_str());
+#else
+  return std::filesystem::path(p.string());
+#endif
+}
+
+fs::path FromStd(const std::filesystem::path& p) {
+#ifdef _WIN32
+  const std::wstring w = p.wstring();
+  if (w.empty()) return fs::path{};
+  const int needed = WideCharToMultiByte(
+      CP_UTF8, 0, w.data(), static_cast<int>(w.size()),
+      nullptr, 0, nullptr, nullptr);
+  std::string utf8(static_cast<std::size_t>(needed), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, w.data(), static_cast<int>(w.size()),
+                      utf8.data(), needed, nullptr, nullptr);
+  return fs::path(utf8);
+#else
+  return fs::path(p.string());
+#endif
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+std::string ReadFile(const std::filesystem::path& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("model package: failed to open " + path.string());
+  }
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+// Reject path fragments that came from package JSON if they could escape
+// the package root or hit an absolute / drive-qualified path. Names like
+// "decoder", "cpu", "abc123def" are allowed. Names like "..", "../foo",
+// "/etc/passwd", "C:\\windows", "a/b" are rejected.
+void ValidatePathFragment(std::string_view fragment, std::string_view kind) {
+  if (fragment.empty()) {
+    throw std::runtime_error(std::string("model package: empty ") + std::string(kind));
+  }
+  if (fragment == "." || fragment == "..") {
+    throw std::runtime_error(
+        std::string("model package: invalid ") + std::string(kind) + " '" +
+        std::string(fragment) + "' (relative-path token)");
+  }
+  for (char c : fragment) {
+    if (c == '/' || c == '\\') {
+      throw std::runtime_error(
+          std::string("model package: invalid ") + std::string(kind) + " '" +
+          std::string(fragment) + "' (contains path separator)");
+    }
+  }
+  // Catch ".." substring even when joined with separators — defence in depth.
+  if (fragment.find("..") != std::string_view::npos) {
+    throw std::runtime_error(
+        std::string("model package: invalid ") + std::string(kind) + " '" +
+        std::string(fragment) + "' (contains '..')");
+  }
+  // Reject Windows drive prefixes and UNC paths even on non-Windows builds —
+  // a package authored on Windows must not embed drive-rooted names.
+  if (fragment.size() >= 2 && fragment[1] == ':') {
+    throw std::runtime_error(
+        std::string("model package: invalid ") + std::string(kind) + " '" +
+        std::string(fragment) + "' (drive-qualified)");
+  }
+}
+
+// ---- variant.json parsing ---------------------------------------------------
+
+JSON::Object DocumentToObject(const JSON::Document& d) {
+  if (d.IsObject()) return d.AsObject();
+  if (d.IsNull()) return {};
+  throw std::runtime_error("variant.json: expected object");
+}
+
+VariantManifest ParseVariantManifestFromText(const std::string& json_text,
+                                             const std::filesystem::path& origin) {
+  JSON::Document doc;
+  try {
+    doc = JSON::ParseDocument(json_text);
+  } catch (const std::exception& e) {
+    throw std::runtime_error("variant.json: parse error in " + origin.string() + ": " + e.what());
+  }
+  if (!doc.IsObject()) {
+    throw std::runtime_error("variant.json: root must be a JSON object (" + origin.string() + ")");
+  }
+  const auto& root = doc.AsObject();
+
+  VariantManifest result;
+  auto files_it = root.find("files");
+  if (files_it == root.end()) {
+    throw std::runtime_error("variant.json: missing required 'files' array (" + origin.string() + ")");
+  }
+  if (!files_it->second.IsArray()) {
+    throw std::runtime_error("variant.json: 'files' must be an array (" + origin.string() + ")");
+  }
+  const auto& files_array = files_it->second.AsArray();
+  result.files.reserve(files_array.size());
+  for (const auto& file_doc : files_array) {
+    if (!file_doc.IsObject()) {
+      throw std::runtime_error("variant.json: each entry of 'files' must be an object (" + origin.string() + ")");
+    }
+    const auto& file_obj = file_doc.AsObject();
+
+    VariantFile vf;
+
+    auto fname_it = file_obj.find("filename");
+    if (fname_it == file_obj.end() || !fname_it->second.IsString()) {
+      throw std::runtime_error("variant.json: each file requires a string 'filename' (" + origin.string() + ")");
+    }
+    vf.filename = fname_it->second.AsString();
+    ValidatePathFragment(vf.filename, "variant file filename");
+
+    if (auto so_it = file_obj.find("session_options"); so_it != file_obj.end()) {
+      vf.session_options = DocumentToObject(so_it->second);
+    }
+    if (auto po_it = file_obj.find("provider_options"); po_it != file_obj.end()) {
+      vf.provider_options = DocumentToObject(po_it->second);
+    }
+    if (auto sf_it = file_obj.find("shared_files"); sf_it != file_obj.end()) {
+      if (!sf_it->second.IsObject()) {
+        throw std::runtime_error("variant.json: 'shared_files' must be an object (" + origin.string() + ")");
+      }
+      for (const auto& [graph_filename, checksum_doc] : sf_it->second.AsObject()) {
+        if (!checksum_doc.IsString()) {
+          throw std::runtime_error("variant.json: 'shared_files' values must be strings (" + origin.string() + ")");
+        }
+        const std::string& checksum = checksum_doc.AsString();
+        ValidatePathFragment(checksum, "shared-weight checksum");
+        vf.shared_files.emplace(graph_filename, checksum);
+      }
+    }
+
+    result.files.push_back(std::move(vf));
+  }
+
+  return result;
+}
+
+std::string ExtractConsumerMetadataFromText(const std::string& json_text,
+                                            const std::filesystem::path& origin) {
+  JSON::Document doc;
+  try {
+    doc = JSON::ParseDocument(json_text);
+  } catch (const std::exception& e) {
+    throw std::runtime_error("variant.json: parse error in " + origin.string() + ": " + e.what());
+  }
+  if (!doc.IsObject()) {
+    throw std::runtime_error("variant.json: root must be a JSON object (" + origin.string() + ")");
+  }
+  const auto& root = doc.AsObject();
+  auto cm_it = root.find("consumer_metadata");
+  if (cm_it == root.end()) {
+    return {};
+  }
+  return JSON::SerializeDocument(cm_it->second);
+}
+
+// ---- metadata.json streaming parser (preserves variant declaration order) ---
+//
+// Spec shape:
+//   {
+//     "variants": {
+//       "<name>": {
+//         "ep_compatibility": [
+//           { "ep": "...", "device": "...?", "compatibility": ["..."] }
+//         ]
+//       }
+//     }
+//   }
+//
+// `JSON::Object` is `std::map`, which doesn't preserve insertion order. The
+// streaming parser DOES — `OnObject(name)` fires per key in source order — so
+// we use the streaming Element interface here even though the rest of the
+// model_package code uses the DOM.
+
+struct CompatStrings_Element : JSON::Element {
+  std::vector<std::string>* out = nullptr;
+  void OnValue(std::string_view /*name*/, JSON::Value value) override {
+    out->push_back(std::string(JSON::Get<std::string_view>(value)));
+  }
+};
+
+struct EpCompatibilityEntry_Element : JSON::Element {
+  EpCompatibilityEntry entry;
+  CompatStrings_Element compat_;
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "ep") {
+      entry.ep = std::string(JSON::Get<std::string_view>(value));
+    } else if (name == "device") {
+      entry.device = std::string(JSON::Get<std::string_view>(value));
+    } else {
+      throw JSON::unknown_value_error{};
+    }
+  }
+
+  JSON::Element& OnArray(std::string_view name) override {
+    if (name == "compatibility") {
+      compat_.out = &entry.compatibility;
+      return compat_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+};
+
+struct EpCompatibilityArray_Element : JSON::Element {
+  std::vector<EpCompatibilityEntry>* out = nullptr;
+  std::vector<std::unique_ptr<EpCompatibilityEntry_Element>> sub_;
+
+  JSON::Element& OnObject(std::string_view /*name*/) override {
+    sub_.emplace_back(std::make_unique<EpCompatibilityEntry_Element>());
+    return *sub_.back();
+  }
+  void OnComplete(bool /*empty*/) override {
+    out->reserve(sub_.size());
+    for (auto& entry : sub_) {
+      if (entry->entry.ep.empty()) {
+        throw std::runtime_error("metadata.json: ep_compatibility entry missing 'ep'");
+      }
+      out->push_back(std::move(entry->entry));
+    }
+  }
+};
+
+struct VariantEntry_Element : JSON::Element {
+  std::vector<EpCompatibilityEntry> ep_compatibility;
+  EpCompatibilityArray_Element compat_array_;
+
+  JSON::Element& OnArray(std::string_view name) override {
+    if (name == "ep_compatibility") {
+      compat_array_.out = &ep_compatibility;
+      return compat_array_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+};
+
+struct ParsedVariantInfo {
+  std::string name;
+  std::vector<EpCompatibilityEntry> ep_compatibility;
+};
+
+struct VariantsObject_Element : JSON::Element {
+  std::vector<ParsedVariantInfo>* out = nullptr;
+  std::vector<std::unique_ptr<VariantEntry_Element>> sub_;
+  std::vector<std::string> names_;
+
+  JSON::Element& OnObject(std::string_view name) override {
+    ValidatePathFragment(name, "variant name");
+    sub_.emplace_back(std::make_unique<VariantEntry_Element>());
+    names_.emplace_back(name);
+    return *sub_.back();
+  }
+  void OnComplete(bool /*empty*/) override {
+    out->reserve(sub_.size());
+    std::unordered_set<std::string> seen;
+    for (std::size_t i = 0; i < sub_.size(); ++i) {
+      const std::string& nm = names_[i];
+      if (!seen.insert(nm).second) {
+        throw std::runtime_error("metadata.json: duplicate variant name '" + nm + "'");
+      }
+      ParsedVariantInfo info;
+      info.name = nm;
+      info.ep_compatibility = std::move(sub_[i]->ep_compatibility);
+      out->push_back(std::move(info));
+    }
+  }
+};
+
+struct MetadataRoot_Element : JSON::Element {
+  std::vector<ParsedVariantInfo>* out = nullptr;
+  VariantsObject_Element variants_;
+
+  JSON::Element& OnObject(std::string_view name) override {
+    if (name == "variants") {
+      variants_.out = out;
+      return variants_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+};
+
+std::vector<ParsedVariantInfo> ParseMetadataJson(const std::string& json_text,
+                                                 const std::filesystem::path& origin) {
+  std::vector<ParsedVariantInfo> variants;
+  MetadataRoot_Element root;
+  root.out = &variants;
+  try {
+    JSON::Parse(root, json_text);
+  } catch (const std::exception& e) {
+    throw std::runtime_error("metadata.json: parse error in " + origin.string() + ": " + e.what());
+  }
+  if (variants.empty()) {
+    throw std::runtime_error("metadata.json: 'variants' map is empty or missing (" + origin.string() + ")");
+  }
+  return variants;
+}
+
+// ---- manifest.json parsing --------------------------------------------------
+
+struct ParsedManifest {
+  std::optional<std::vector<std::string>> components;  // nullopt if not declared
+};
+
+ParsedManifest ParseManifestJson(const std::string& json_text,
+                                 const std::filesystem::path& origin) {
+  JSON::Document doc;
+  try {
+    doc = JSON::ParseDocument(json_text);
+  } catch (const std::exception& e) {
+    throw std::runtime_error("manifest.json: parse error in " + origin.string() + ": " + e.what());
+  }
+  if (!doc.IsObject()) {
+    throw std::runtime_error("manifest.json: root must be a JSON object (" + origin.string() + ")");
+  }
+  const auto& root = doc.AsObject();
+
+  // Reject schema versions we don't recognize. Absent is fine — older
+  // packages simply omit the field.
+  if (auto sv_it = root.find("schema_version"); sv_it != root.end()) {
+    if (!sv_it->second.IsNumber()) {
+      throw std::runtime_error("manifest.json: 'schema_version' must be a number (" + origin.string() + ")");
+    }
+    const double sv = sv_it->second.AsNumber();
+    if (sv != 1.0) {
+      throw std::runtime_error(
+          "manifest.json: unsupported schema_version " + std::to_string(sv) +
+          " (this build supports 1)");
+    }
+  }
+
+  ParsedManifest result;
+  if (auto comps_it = root.find("components"); comps_it != root.end()) {
+    if (!comps_it->second.IsArray()) {
+      throw std::runtime_error("manifest.json: 'components' must be an array of strings (" + origin.string() + ")");
+    }
+    std::vector<std::string> names;
+    std::unordered_set<std::string> seen;
+    names.reserve(comps_it->second.AsArray().size());
+    for (const auto& comp : comps_it->second.AsArray()) {
+      if (!comp.IsString()) {
+        throw std::runtime_error("manifest.json: 'components' must be an array of STRINGS (" + origin.string() + ")");
+      }
+      const std::string& name = comp.AsString();
+      ValidatePathFragment(name, "component name");
+      if (!seen.insert(name).second) {
+        throw std::runtime_error("manifest.json: duplicate component name '" + name + "'");
+      }
+      names.push_back(name);
+    }
+    result.components = std::move(names);
+  }
+  return result;
+}
+
+// ---- stub backend -----------------------------------------------------------
+
+struct StubVariant {
+  std::string name;
+  fs::path folder;  // <package>/<component>/<variant>
+  std::vector<EpCompatibilityEntry> ep_compatibility;
+  std::size_t file_count = 0;        // from variant.json `files[]`
+  std::string consumer_metadata;     // serialized JSON, "" if absent
+};
+
+struct StubComponent {
+  std::string name;
+  fs::path component_dir;            // <package>/<component>
+  std::vector<StubVariant> variants;
+};
+
+struct StubComponentInstance : ComponentInstance {
+  fs::path component_dir;
+  fs::path variant_folder;
+  std::size_t file_count = 0;
+  std::string consumer_metadata_blob;
+
+  fs::path VariantFolderPath() const override { return variant_folder; }
+  std::size_t FileCount() const override { return file_count; }
+  std::string ConsumerMetadata() const override { return consumer_metadata_blob; }
+
+  fs::path ResolveSharedWeight(std::string_view checksum) const override {
+    ValidatePathFragment(checksum, "shared-weight checksum");
+    const std::filesystem::path sw_dir =
+        ToStd(component_dir) / "shared_weights" / std::string(checksum);
+    std::error_code ec;
+    if (!std::filesystem::is_directory(sw_dir, ec) || ec) {
+      throw std::runtime_error(
+          "model package: shared-weight directory not found: " + sw_dir.string() +
+          (ec ? (" (" + ec.message() + ")") : std::string{}));
+    }
+
+    std::vector<std::filesystem::path> blobs;
+    std::filesystem::directory_iterator it(sw_dir, ec);
+    if (ec) {
+      throw std::runtime_error(
+          "model package: cannot iterate " + sw_dir.string() + ": " + ec.message());
+    }
+    for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+      if (ec) {
+        throw std::runtime_error(
+            "model package: error iterating " + sw_dir.string() + ": " + ec.message());
+      }
+      const bool is_regular = it->is_regular_file(ec);
+      if (ec) {
+        throw std::runtime_error(
+            "model package: cannot stat " + it->path().string() + ": " + ec.message());
+      }
+      if (is_regular) {
+        blobs.push_back(it->path());
+      }
+    }
+    if (blobs.empty()) {
+      throw std::runtime_error(
+          "model package: shared-weight directory contains no blob: " + sw_dir.string());
+    }
+    if (blobs.size() > 1) {
+      throw std::runtime_error(
+          "model package: shared-weight directory contains multiple blobs: " + sw_dir.string());
+    }
+    return FromStd(blobs.front());
+  }
+};
+
+struct StubModelPackageContext : ModelPackageContext {
+  fs::path package_root;
+  std::vector<StubComponent> components;
+
+  std::size_t NumComponents() const override { return components.size(); }
+  std::string ComponentName(std::size_t cix) const override { return components.at(cix).name; }
+  std::size_t NumVariants(std::size_t cix) const override { return components.at(cix).variants.size(); }
+  std::string VariantName(std::size_t cix, std::size_t vix) const override {
+    return components.at(cix).variants.at(vix).name;
+  }
+  std::span<const EpCompatibilityEntry> VariantEpCompatibility(
+      std::size_t cix, std::size_t vix) const override {
+    const auto& entries = components.at(cix).variants.at(vix).ep_compatibility;
+    return {entries.data(), entries.size()};
+  }
+
+  std::vector<std::string> EpsCompatibleWith(std::size_t cix) const override {
+    std::vector<std::string> result;
+    std::unordered_set<std::string> seen;
+    for (const auto& variant : components.at(cix).variants) {
+      for (const auto& entry : variant.ep_compatibility) {
+        if (seen.insert(entry.ep).second) {
+          result.push_back(entry.ep);
+        }
+      }
+    }
+    return result;
+  }
+
+  std::unique_ptr<ComponentInstance> SelectComponent(
+      std::size_t cix, const ModelPackageSelectionOptions& options) const override {
+    const StubComponent& component = components.at(cix);
+
+    // Spec: empty captured EP list defaults to [{CPUExecutionProvider}].
+    static const std::vector<EpSelection> kCpuFallback = {{"CPUExecutionProvider", std::nullopt}};
+    const std::vector<EpSelection>& priority =
+        options.ep_priority.empty() ? kCpuFallback : options.ep_priority;
+
+    // Score = (priority index of best matching EP, declaration index of variant).
+    // Smaller score wins.
+    constexpr std::size_t kNoMatch = static_cast<std::size_t>(-1);
+    std::size_t best_priority = kNoMatch;
+    std::size_t best_variant_index = kNoMatch;
+
+    for (std::size_t vix = 0; vix < component.variants.size(); ++vix) {
+      const auto& variant = component.variants[vix];
+      // Find the best (= smallest-index) priority entry that matches any
+      // of this variant's compat entries.
+      std::size_t variant_priority = kNoMatch;
+      for (const auto& compat : variant.ep_compatibility) {
+        for (std::size_t pi = 0; pi < priority.size(); ++pi) {
+          if (priority[pi].ep_name != compat.ep) continue;
+          // If the package pins a device for this entry, the caller's
+          // device must match (or be unset, which is treated as "any").
+          if (compat.device.has_value() && priority[pi].device.has_value() &&
+              *compat.device != *priority[pi].device) {
+            continue;
+          }
+          if (pi < variant_priority) {
+            variant_priority = pi;
+          }
+        }
+      }
+      if (variant_priority == kNoMatch) continue;
+      if (variant_priority < best_priority) {
+        best_priority = variant_priority;
+        best_variant_index = vix;
+      }
+      // Equal priority: tie-break by declaration order, which means we
+      // keep the earlier variant (already in best_variant_index).
+    }
+
+    if (best_variant_index == kNoMatch) return nullptr;
+
+    const auto& chosen = component.variants[best_variant_index];
+    auto inst = std::make_unique<StubComponentInstance>();
+    inst->component_dir = component.component_dir;
+    inst->variant_folder = chosen.folder;
+    inst->file_count = chosen.file_count;
+    inst->consumer_metadata_blob = chosen.consumer_metadata;
+    return inst;
+  }
+
+  fs::path SharedAssetsPath() const override {
+    return package_root.join("configs");
+  }
+};
+
+// ---- Open() detection + loading ---------------------------------------------
+
+// Direct child names a v4 package treats as reserved (i.e. NOT components).
+bool IsReservedChild(const std::string& name) {
+  if (name == "configs") return true;
+  if (!name.empty() && (name[0] == '.' || name[0] == '_')) return true;
+  return false;
+}
+
+// Returns the list of immediate child directories of `root`, lexicographically
+// sorted, that are NOT reserved. Surfaces filesystem iteration errors as
+// exceptions (we cannot tell a transient IO error apart from "no candidates"
+// otherwise).
+std::vector<std::filesystem::path> EnumerateComponentCandidates(
+    const std::filesystem::path& root) {
+  std::vector<std::filesystem::path> result;
+  std::error_code ec;
+  std::filesystem::directory_iterator it(root, ec);
+  if (ec) {
+    throw std::runtime_error(
+        "model package: cannot iterate " + root.string() + ": " + ec.message());
+  }
+  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    if (ec) {
+      throw std::runtime_error(
+          "model package: error iterating " + root.string() + ": " + ec.message());
+    }
+    const bool is_dir = it->is_directory(ec);
+    if (ec) {
+      throw std::runtime_error(
+          "model package: cannot stat " + it->path().string() + ": " + ec.message());
+    }
+    if (!is_dir) continue;
+    const std::string fname = it->path().filename().string();
+    if (IsReservedChild(fname)) continue;
+    result.push_back(it->path());
+  }
+  std::sort(result.begin(), result.end());
+  return result;
+}
+
+// True iff at least one immediate non-reserved child of `root` contains a
+// `metadata.json` file. Used as a fallback v4-detection signal when there is
+// no `manifest.json`.
+bool AnyChildHasMetadata(const std::filesystem::path& root) {
+  std::error_code ec;
+  std::filesystem::directory_iterator it(root, ec);
+  if (ec) return false;  // Treat IO error as "not detected" — exists() check below catches real breakage.
+  for (; it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    if (ec) return false;
+    bool is_dir = it->is_directory(ec);
+    if (ec || !is_dir) continue;
+    const std::string fname = it->path().filename().string();
+    if (IsReservedChild(fname)) continue;
+    if (std::filesystem::exists(it->path() / "metadata.json", ec) && !ec) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool FileExistsStrict(const std::filesystem::path& p) {
+  std::error_code ec;
+  const bool exists = std::filesystem::exists(p, ec);
+  if (ec) {
+    throw std::runtime_error(
+        "model package: cannot stat " + p.string() + ": " + ec.message());
+  }
+  return exists;
+}
+
+}  // namespace
+
+VariantManifest ParseVariantManifest(const fs::path& variant_folder) {
+  const std::filesystem::path origin = ToStd(variant_folder) / "variant.json";
+  if (!FileExistsStrict(origin)) {
+    throw std::runtime_error("model package: missing variant.json at " + origin.string());
+  }
+  return ParseVariantManifestFromText(ReadFile(origin), origin);
+}
+
+std::unique_ptr<ModelPackageContext> ModelPackageContext::Open(const fs::path& path) {
+  const std::filesystem::path root = ToStd(path);
+
+  // Detection.
+  const std::filesystem::path manifest_path = root / "manifest.json";
+  const bool has_manifest = FileExistsStrict(manifest_path);
+  const bool has_component_metadata = !has_manifest && AnyChildHasMetadata(root);
+  if (!has_manifest && !has_component_metadata) {
+    return nullptr;
+  }
+
+  auto ctx = std::make_unique<StubModelPackageContext>();
+  ctx->package_root = path;
+
+  // Determine the component name list.
+  std::vector<std::string> component_names;
+  if (has_manifest) {
+    ParsedManifest manifest = ParseManifestJson(ReadFile(manifest_path), manifest_path);
+    if (manifest.components) {
+      component_names = std::move(*manifest.components);
+    } else {
+      // Manifest present but components absent — discover by directory scan.
+      for (const auto& child : EnumerateComponentCandidates(root)) {
+        component_names.push_back(child.filename().string());
+      }
+    }
+  } else {
+    for (const auto& child : EnumerateComponentCandidates(root)) {
+      component_names.push_back(child.filename().string());
+    }
+  }
+
+  if (component_names.empty()) {
+    throw std::runtime_error(
+        "model package: package recognized at " + path.string() +
+        " but no components were found");
+  }
+
+  // Load each component.
+  for (const auto& component_name : component_names) {
+    StubComponent component;
+    component.name = component_name;
+    component.component_dir = path.join(component_name);
+
+    const std::filesystem::path component_dir = root / component_name;
+    const std::filesystem::path metadata_path = component_dir / "metadata.json";
+    if (!FileExistsStrict(metadata_path)) {
+      throw std::runtime_error(
+          "model package: component '" + component_name +
+          "' is missing required metadata.json at " + metadata_path.string());
+    }
+
+    std::vector<ParsedVariantInfo> variants =
+        ParseMetadataJson(ReadFile(metadata_path), metadata_path);
+
+    // Validate that every metadata-declared variant has a directory with a
+    // variant.json on disk, and parse it to capture file_count + consumer_metadata.
+    for (auto& parsed : variants) {
+      const std::filesystem::path variant_dir = component_dir / parsed.name;
+      const std::filesystem::path variant_json = variant_dir / "variant.json";
+      if (!FileExistsStrict(variant_json)) {
+        throw std::runtime_error(
+            "model package: variant '" + parsed.name + "' of component '" +
+            component_name + "' is missing variant.json at " + variant_json.string());
+      }
+      const std::string variant_text = ReadFile(variant_json);
+      VariantManifest vm = ParseVariantManifestFromText(variant_text, variant_json);
+      std::string consumer = ExtractConsumerMetadataFromText(variant_text, variant_json);
+
+      StubVariant sv;
+      sv.name = std::move(parsed.name);
+      sv.folder = FromStd(variant_dir);
+      sv.ep_compatibility = std::move(parsed.ep_compatibility);
+      sv.file_count = vm.files.size();
+      sv.consumer_metadata = std::move(consumer);
+      component.variants.push_back(std::move(sv));
+    }
+
+    if (component.variants.empty()) {
+      throw std::runtime_error(
+          "model package: component '" + component_name + "' has no variants");
+    }
+
+    ctx->components.push_back(std::move(component));
+  }
+
+  return ctx;
+}
+
+}  // namespace Generators

--- a/src/models/model_package.h
+++ b/src/models/model_package.h
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "../filesystem.h"
+#include "../json.h"
+
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Generators {
+
+// GenAI-internal abstraction over the v4 model-package layout. Constructed
+// at Config-time and consumed by the package-vs-flat-dir branch in
+// `Config::Config(path, overlay)` (see `feature/v4-package-w3-...`).
+//
+// Today the only implementation is a stub directory walker (model_package.cpp)
+// that interprets the on-disk layout described in the ORT v4 model-package
+// proposal. When ORT v4 lands, an alternate implementation will delegate to
+// `OrtModelPackageContext`. Callers see only the abstract surface, so the
+// v4 plumbing change is contained to this file pair.
+//
+// The abstract surface deliberately mirrors the shape of the proposed C API:
+// a context that traverses components and variants, a per-component
+// `SelectComponent` that takes a captured EP-priority list, and a per-instance
+// accessor for the variant folder, file count, opaque consumer metadata blob,
+// and a checksum-keyed shared-weight resolver. Per-file detail (filename,
+// session_options, provider_options, shared_files) is intentionally NOT on
+// `ComponentInstance` — consumers parse `variant.json` directly via
+// `ParseVariantManifest`, matching the v4 contract that ORT does not expose
+// per-file accessors.
+
+// One entry from a variant's `metadata.json` `ep_compatibility` list.
+struct EpCompatibilityEntry {
+  std::string ep;                          // e.g. "CUDAExecutionProvider"
+  std::optional<std::string> device;       // optional discriminator (OpenVINO "GPU" / "NPU")
+  std::vector<std::string> compatibility;  // free-form constraint strings (sm_80, soc_69, ...)
+};
+
+// One entry on the caller's prioritized EP list. Mirrors the captured-EP
+// shape of `OrtModelPackageOptions`: ordered, with optional device
+// discriminator. The ordering is the user's preference; selection treats
+// earlier entries as preferred.
+struct EpSelection {
+  std::string ep_name;
+  std::optional<std::string> device;
+};
+
+// Inputs to `SelectComponent`. An empty `ep_priority` list is treated as
+// `[{CPUExecutionProvider}]` per spec — callers that didn't append any EP
+// to their session-options template should still get CPU variants.
+struct ModelPackageSelectionOptions {
+  std::vector<EpSelection> ep_priority;
+};
+
+struct ComponentInstance {
+  virtual ~ComponentInstance() = default;
+
+  // Path to the variant folder for the selected variant. Per-component ONNX
+  // files, LoRA adapters, custom-ops libraries are loaded from here.
+  virtual fs::path VariantFolderPath() const = 0;
+
+  // Number of files declared in the variant's `variant.json`. Single-file
+  // consumers expect 1; pipeline runners (W6) handle >= 1.
+  virtual std::size_t FileCount() const = 0;
+
+  // Opaque consumer-metadata blob extracted verbatim from the selected
+  // variant's `variant.json`. Returned as a serialized JSON string (the
+  // package format does not interpret it). Empty string if absent. The
+  // GenAI consumer parses this and pulls out `genai_config_overlay`.
+  virtual std::string ConsumerMetadata() const = 0;
+
+  // Resolve a shared-weight checksum (as referenced by a file's
+  // `shared_files` map) to its absolute path on disk. Throws on missing,
+  // path-unsafe, zero-blob, or multi-blob checksum directories — the
+  // package is malformed in any of those cases.
+  virtual fs::path ResolveSharedWeight(std::string_view checksum) const = 0;
+};
+
+struct ModelPackageContext {
+  virtual ~ModelPackageContext() = default;
+
+  // Detect and open. Returns `nullptr` if `path` does not point at a v4
+  // model package. A nullptr return is the caller's signal to fall back
+  // to flat-directory mode — it is NOT an error.
+  //
+  // Detection rule (intentionally conservative to keep flat-dir fallback
+  // reliable): treat as a v4 package iff EITHER
+  //   * `<path>/manifest.json` exists, OR
+  //   * at least one immediate non-hidden child directory of `<path>`,
+  //     other than `configs/`, contains a `metadata.json`.
+  // The bare presence of `<path>/configs/` is NOT a positive signal — a
+  // flat-dir model could plausibly have such a directory.
+  //
+  // Once the package is recognized, malformed content is a hard error
+  // (throws). The two cases are deliberately distinct: a missing package
+  // marker is "not a v4 package, try flat-dir"; a present but malformed
+  // package is "broken, surface the error to the user".
+  static std::unique_ptr<ModelPackageContext> Open(const fs::path& path);
+
+  // Component traversal. Order matches `manifest.json`'s `components`
+  // array when present, otherwise lexicographic order of subdirectories.
+  virtual std::size_t NumComponents() const = 0;
+  virtual std::string ComponentName(std::size_t cix) const = 0;
+
+  // Variant traversal — order is `metadata.json` declaration order (the
+  // spec's tie-break for selection when the EP preference ABI declines).
+  virtual std::size_t NumVariants(std::size_t cix) const = 0;
+  virtual std::string VariantName(std::size_t cix, std::size_t vix) const = 0;
+  virtual std::span<const EpCompatibilityEntry> VariantEpCompatibility(
+      std::size_t cix, std::size_t vix) const = 0;
+
+  // Per-component EP compatibility, computed as the union of EP names
+  // declared in each variant's `ep_compatibility[]` (first-seen order).
+  // Used by Model-level EP defaulting: intersect across all components
+  // to find the EPs that can load the whole package.
+  virtual std::vector<std::string> EpsCompatibleWith(std::size_t cix) const = 0;
+
+  // Pick a variant for a component using the captured EP priority list.
+  //
+  // Algorithm (mirrors the spec's selection algorithm subset that the stub
+  // backend can implement without an EP preference ABI):
+  //   1. Filter variants whose `ep_compatibility[]` has any entry matching
+  //      one of `options.ep_priority` by `ep_name` (and `device` if the
+  //      compat entry pins one).
+  //   2. Score by ordinal position of the matched EP in `ep_priority`
+  //      (lower = better).
+  //   3. Tie-break by `metadata.json` insertion order.
+  //
+  // Returns `nullptr` if no variant of this component is compatible with
+  // any of the requested EPs — this is a recoverable signal callers can
+  // use for diagnostic / fallback purposes (W3 EP defaulting). Throws on
+  // malformed package content.
+  virtual std::unique_ptr<ComponentInstance> SelectComponent(
+      std::size_t cix, const ModelPackageSelectionOptions& options) const = 0;
+
+  // Path to the package's shared-assets bucket: `<package>/configs/`. Houses
+  // the base `genai_config.json`, tokenizer files, processor configs, and
+  // the chat template. See `Config::shared_assets_path`. The directory
+  // is not required to exist; existence-checking is the caller's concern.
+  virtual fs::path SharedAssetsPath() const = 0;
+};
+
+// One entry of a variant's `variant.json` `files[]` array. Used by the
+// multi-file pipeline runner (W6). The session_options / provider_options
+// values are kept as a `JSON::Object` (string-keyed map of typed
+// `JSON::Document`) so callers can preserve number/bool typing when
+// applying them through the SetProviderSessionOptions machinery.
+struct VariantFile {
+  std::string filename;
+  JSON::Object session_options;
+  JSON::Object provider_options;
+  // Map from filename-as-referenced-by-the-onnx-graph to the checksum of a
+  // shared-weight blob. Resolve via `ComponentInstance::ResolveSharedWeight`.
+  std::map<std::string, std::string> shared_files;
+};
+
+struct VariantManifest {
+  std::vector<VariantFile> files;
+};
+
+// Parse `<variant_folder>/variant.json`. Standalone helper because the v4
+// C API does not expose per-file detail through the `cix` handle: consumers
+// parse `variant.json` directly. Throws on missing file or malformed JSON.
+VariantManifest ParseVariantManifest(const fs::path& variant_folder);
+
+}  // namespace Generators

--- a/test/model_package_test.cpp
+++ b/test/model_package_test.cpp
@@ -1,0 +1,789 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for the stub directory-walker implementation of
+// `Generators::ModelPackageContext` and the `ParseVariantManifest` helper.
+// The stub is a complete drop-in for the abstract surface and is used both
+// directly here and as the placeholder backend until ORT v4 lands.
+//
+// Each test materialises a synthetic v4 package layout under
+// `std::filesystem::temp_directory_path() / <unique>` and exercises one slice
+// of the surface. The fixture cleans up after itself.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <string>
+#include <string_view>
+
+#include "json.h"
+#include "models/model_package.h"
+
+namespace Generators::test {
+
+namespace {
+
+class TempDir {
+ public:
+  TempDir() {
+    std::random_device rd;
+    std::uniform_int_distribution<uint64_t> dist;
+    path_ = std::filesystem::temp_directory_path() /
+            ("genai-model-package-test-" + std::to_string(dist(rd)));
+    std::filesystem::create_directories(path_);
+  }
+  ~TempDir() {
+    std::error_code ec;
+    std::filesystem::remove_all(path_, ec);
+  }
+  TempDir(const TempDir&) = delete;
+  TempDir& operator=(const TempDir&) = delete;
+
+  const std::filesystem::path& path() const { return path_; }
+  fs::path fs_path() const { return fs::path(path_.string()); }
+
+ private:
+  std::filesystem::path path_;
+};
+
+void WriteFile(const std::filesystem::path& p, std::string_view contents) {
+  std::filesystem::create_directories(p.parent_path());
+  std::ofstream out(p, std::ios::binary);
+  ASSERT_TRUE(out.is_open()) << "cannot open " << p;
+  out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+}
+
+// Materialise a representative two-component package:
+//   <root>/manifest.json                   {"schema_version":1,"components":["decoder","embedding"]}
+//   <root>/configs/                        (empty: not exercised here directly)
+//   <root>/decoder/metadata.json           cpu, cuda variants (in this order)
+//   <root>/decoder/cpu/variant.json        single file, overlay sets context_length=2048
+//   <root>/decoder/cuda/variant.json       single file, overlay sets context_length=4096
+//   <root>/embedding/metadata.json         single variant cpu, EP compat = [CPU, WebGPU]
+//   <root>/embedding/cpu/variant.json      single file, no consumer_metadata
+void BuildTwoComponentPackage(const std::filesystem::path& root) {
+  WriteFile(root / "manifest.json", R"({
+    "schema_version": 1,
+    "components": ["decoder", "embedding"]
+  })");
+
+  std::filesystem::create_directories(root / "configs");
+
+  WriteFile(root / "decoder" / "metadata.json", R"({
+    "variants": {
+      "cpu": {
+        "ep_compatibility": [{"ep": "CPUExecutionProvider"}]
+      },
+      "cuda": {
+        "ep_compatibility": [
+          {"ep": "CUDAExecutionProvider", "compatibility": ["sm_80", "sm_90"]}
+        ]
+      }
+    }
+  })");
+
+  WriteFile(root / "decoder" / "cpu" / "variant.json", R"({
+    "files": [{"filename": "model.onnx"}],
+    "consumer_metadata": {
+      "genai_config_overlay": {"model": {"context_length": 2048}}
+    }
+  })");
+
+  WriteFile(root / "decoder" / "cuda" / "variant.json", R"({
+    "files": [{"filename": "model.onnx"}],
+    "consumer_metadata": {
+      "genai_config_overlay": {"model": {"context_length": 4096}}
+    }
+  })");
+
+  WriteFile(root / "embedding" / "metadata.json", R"({
+    "variants": {
+      "cpu": {
+        "ep_compatibility": [
+          {"ep": "CPUExecutionProvider"},
+          {"ep": "WebGpuExecutionProvider"}
+        ]
+      }
+    }
+  })");
+
+  WriteFile(root / "embedding" / "cpu" / "variant.json", R"({
+    "files": [{"filename": "embed.onnx"}]
+  })");
+}
+
+// Find first object that contains key 'k' and return the value's number,
+// helper to keep test bodies readable when dispatching on overlay shape.
+double NumberAt(const JSON::Document& d, std::initializer_list<const char*> path) {
+  const JSON::Document* cur = &d;
+  for (const char* key : path) {
+    EXPECT_TRUE(cur->IsObject()) << "expected object at " << key;
+    auto it = cur->AsObject().find(key);
+    EXPECT_NE(it, cur->AsObject().end()) << "missing key " << key;
+    cur = &it->second;
+  }
+  EXPECT_TRUE(cur->IsNumber());
+  return cur->AsNumber();
+}
+
+ModelPackageSelectionOptions OnePriority(std::string ep, std::optional<std::string> device = std::nullopt) {
+  ModelPackageSelectionOptions opts;
+  opts.ep_priority.push_back({std::move(ep), std::move(device)});
+  return opts;
+}
+
+}  // namespace
+
+// ============================================================================
+// Detection
+// ============================================================================
+
+TEST(ModelPackageContextTest, EmptyDirectoryReturnsNullptr) {
+  TempDir dir;
+  EXPECT_EQ(ModelPackageContext::Open(dir.fs_path()), nullptr);
+}
+
+TEST(ModelPackageContextTest, FlatDirReturnsNullptr) {
+  TempDir dir;
+  // A flat-dir model: only genai_config.json + ONNX files at the root, no
+  // subdirs that could contain metadata.json. Detection must say nullptr.
+  WriteFile(dir.path() / "genai_config.json", R"({"model":{"type":"phi3"}})");
+  WriteFile(dir.path() / "model.onnx", "fake");
+  EXPECT_EQ(ModelPackageContext::Open(dir.fs_path()), nullptr);
+}
+
+TEST(ModelPackageContextTest, ConfigsBucketAloneIsNotV4) {
+  // A directory with only a configs/ subdirectory but no manifest and no
+  // component metadata.json should NOT be treated as v4 — configs/ alone
+  // is too weak a marker (a flat-dir model could plausibly contain one).
+  TempDir dir;
+  std::filesystem::create_directories(dir.path() / "configs");
+  WriteFile(dir.path() / "configs" / "genai_config.json", R"({"model":{}})");
+  EXPECT_EQ(ModelPackageContext::Open(dir.fs_path()), nullptr);
+}
+
+TEST(ModelPackageContextTest, NoManifestButComponentMetadataIsRecognized) {
+  // Spec says manifest.json is optional. A package with no manifest but a
+  // component subdirectory containing metadata.json + variant directory
+  // must be recognized.
+  TempDir dir;
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants": {"cpu": {"ep_compatibility": [{"ep": "CPUExecutionProvider"}]}}
+  })");
+  WriteFile(dir.path() / "decoder" / "cpu" / "variant.json",
+            R"({"files":[{"filename":"model.onnx"}]})");
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  EXPECT_EQ(ctx->NumComponents(), 1u);
+  EXPECT_EQ(ctx->ComponentName(0), "decoder");
+}
+
+TEST(ModelPackageContextTest, OpenSucceedsOnCanonicalTwoComponentPackage) {
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  EXPECT_EQ(ctx->NumComponents(), 2u);
+  EXPECT_EQ(ctx->ComponentName(0), "decoder");
+  EXPECT_EQ(ctx->ComponentName(1), "embedding");
+}
+
+// ============================================================================
+// Manifest validation
+// ============================================================================
+
+TEST(ModelPackageContextTest, ManifestNonObjectRootThrows) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"(["not", "an", "object"])");
+  EXPECT_THROW(ModelPackageContext::Open(dir.fs_path()), std::exception);
+}
+
+TEST(ModelPackageContextTest, ManifestRejectsLegacyObjectArrayShape) {
+  // The OLD (pre-spec-update) manifest shape used objects with a `name` key.
+  // The new spec uses a string array; the legacy shape must be rejected so
+  // misordered packages don't silently load.
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":[{"name":"decoder"}]})");
+  EXPECT_THROW(ModelPackageContext::Open(dir.fs_path()), std::exception);
+}
+
+TEST(ModelPackageContextTest, ManifestUnsupportedSchemaVersionThrows) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"schema_version": 99, "components":["x"]})");
+  EXPECT_THROW(ModelPackageContext::Open(dir.fs_path()), std::exception);
+}
+
+TEST(ModelPackageContextTest, ManifestRejectsDuplicateComponents) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder","decoder"]})");
+  EXPECT_THROW(ModelPackageContext::Open(dir.fs_path()), std::exception);
+}
+
+TEST(ModelPackageContextTest, ManifestRejectsPathTraversalInComponentName) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["../escape"]})");
+  EXPECT_THROW(ModelPackageContext::Open(dir.fs_path()), std::exception);
+}
+
+TEST(ModelPackageContextTest, ManifestListedComponentMissingMetadataThrows) {
+  TempDir dir;
+  // manifest declares `decoder`, but there is no `decoder/metadata.json`.
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  std::filesystem::create_directories(dir.path() / "decoder");
+  EXPECT_THROW(ModelPackageContext::Open(dir.fs_path()), std::exception);
+}
+
+TEST(ModelPackageContextTest, ManifestAbsentComponentsScansSubdirs) {
+  // manifest present but has no `components` field → fall back to scanning.
+  // configs/ must be excluded; hidden dirs (.foo) and underscore-prefixed
+  // (_foo) must also be excluded.
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"schema_version":1})");
+  std::filesystem::create_directories(dir.path() / "configs");
+  std::filesystem::create_directories(dir.path() / ".hidden");
+  std::filesystem::create_directories(dir.path() / "_reserved");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants":{"cpu":{"ep_compatibility":[{"ep":"CPUExecutionProvider"}]}}
+  })");
+  WriteFile(dir.path() / "decoder" / "cpu" / "variant.json",
+            R"({"files":[{"filename":"model.onnx"}]})");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  EXPECT_EQ(ctx->NumComponents(), 1u);
+  EXPECT_EQ(ctx->ComponentName(0), "decoder");
+}
+
+// ============================================================================
+// Variant traversal & metadata.json declaration order
+// ============================================================================
+
+TEST(ModelPackageContextTest, VariantTraversalPreservesMetadataDeclarationOrder) {
+  // Even if the on-disk filesystem order would differ (here it's identical
+  // alphabetically: cpu < cuda), what matters is that metadata.json is the
+  // authoritative source — declaration order is what the EP-preference
+  // tie-break leans on. We assert the order matches what we wrote.
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+
+  EXPECT_EQ(ctx->NumVariants(0), 2u);
+  EXPECT_EQ(ctx->VariantName(0, 0), "cpu");
+  EXPECT_EQ(ctx->VariantName(0, 1), "cuda");
+}
+
+TEST(ModelPackageContextTest, VariantOrderCanInvertFilesystemAlpha) {
+  // Author the metadata.json with `zeta` BEFORE `alpha` — filesystem alpha
+  // sort would put alpha first, but metadata.json wins.
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants": {
+      "zeta":  {"ep_compatibility": [{"ep": "CPUExecutionProvider"}]},
+      "alpha": {"ep_compatibility": [{"ep": "CPUExecutionProvider"}]}
+    }
+  })");
+  WriteFile(dir.path() / "decoder" / "zeta"  / "variant.json", R"({"files":[{"filename":"m.onnx"}]})");
+  WriteFile(dir.path() / "decoder" / "alpha" / "variant.json", R"({"files":[{"filename":"m.onnx"}]})");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(ctx->NumVariants(0), 2u);
+  EXPECT_EQ(ctx->VariantName(0, 0), "zeta");
+  EXPECT_EQ(ctx->VariantName(0, 1), "alpha");
+}
+
+TEST(ModelPackageContextTest, VariantEpCompatibilityCarriesDeviceAndCompatStrings) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants": {
+      "openvino-npu": {
+        "ep_compatibility": [
+          {"ep": "OpenVINOExecutionProvider", "device": "NPU"}
+        ]
+      },
+      "qnn": {
+        "ep_compatibility": [
+          {"ep": "QNNExecutionProvider", "compatibility": ["soc_60", "soc_69"]}
+        ]
+      }
+    }
+  })");
+  WriteFile(dir.path() / "decoder" / "openvino-npu" / "variant.json",
+            R"({"files":[{"filename":"m.onnx"}]})");
+  WriteFile(dir.path() / "decoder" / "qnn" / "variant.json",
+            R"({"files":[{"filename":"m.onnx"}]})");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_EQ(ctx->NumVariants(0), 2u);
+
+  const auto ov = ctx->VariantEpCompatibility(0, 0);
+  ASSERT_EQ(ov.size(), 1u);
+  EXPECT_EQ(ov[0].ep, "OpenVINOExecutionProvider");
+  ASSERT_TRUE(ov[0].device.has_value());
+  EXPECT_EQ(*ov[0].device, "NPU");
+  EXPECT_TRUE(ov[0].compatibility.empty());
+
+  const auto qnn = ctx->VariantEpCompatibility(0, 1);
+  ASSERT_EQ(qnn.size(), 1u);
+  EXPECT_EQ(qnn[0].ep, "QNNExecutionProvider");
+  EXPECT_FALSE(qnn[0].device.has_value());
+  ASSERT_EQ(qnn[0].compatibility.size(), 2u);
+  EXPECT_EQ(qnn[0].compatibility[0], "soc_60");
+  EXPECT_EQ(qnn[0].compatibility[1], "soc_69");
+}
+
+// ============================================================================
+// EP defaulting traversal helper
+// ============================================================================
+
+TEST(ModelPackageContextTest, EpsCompatibleWithUnionsAcrossVariants) {
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+
+  // decoder: cpu (CPU) + cuda (CUDA) → {CPU, CUDA} in first-seen order.
+  const auto decoder_eps = ctx->EpsCompatibleWith(0);
+  ASSERT_EQ(decoder_eps.size(), 2u);
+  EXPECT_EQ(decoder_eps[0], "CPUExecutionProvider");
+  EXPECT_EQ(decoder_eps[1], "CUDAExecutionProvider");
+
+  // embedding: one variant declaring CPU + WebGpu → both, in declared order.
+  const auto embedding_eps = ctx->EpsCompatibleWith(1);
+  ASSERT_EQ(embedding_eps.size(), 2u);
+  EXPECT_EQ(embedding_eps[0], "CPUExecutionProvider");
+  EXPECT_EQ(embedding_eps[1], "WebGpuExecutionProvider");
+}
+
+TEST(ModelPackageContextTest, EpsCompatibleWithDedupesAcrossVariants) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants": {
+      "v1": {"ep_compatibility": [{"ep": "CPUExecutionProvider"}]},
+      "v2": {"ep_compatibility": [{"ep": "CPUExecutionProvider"}]}
+    }
+  })");
+  WriteFile(dir.path() / "decoder" / "v1" / "variant.json", R"({"files":[{"filename":"m.onnx"}]})");
+  WriteFile(dir.path() / "decoder" / "v2" / "variant.json", R"({"files":[{"filename":"m.onnx"}]})");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  const auto eps = ctx->EpsCompatibleWith(0);
+  ASSERT_EQ(eps.size(), 1u);
+  EXPECT_EQ(eps[0], "CPUExecutionProvider");
+}
+
+// ============================================================================
+// Variant selection
+// ============================================================================
+
+TEST(ModelPackageContextTest, SelectComponentReturnsNullptrForUnmatchedEp) {
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  EXPECT_EQ(ctx->SelectComponent(0, OnePriority("DmlExecutionProvider")), nullptr);
+}
+
+TEST(ModelPackageContextTest, SelectComponentPicksMatchingVariant) {
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+
+  auto cuda = ctx->SelectComponent(0, OnePriority("CUDAExecutionProvider"));
+  ASSERT_NE(cuda, nullptr);
+  EXPECT_EQ(cuda->VariantFolderPath().string(),
+            (dir.path() / "decoder" / "cuda").string());
+
+  auto cpu = ctx->SelectComponent(0, OnePriority("CPUExecutionProvider"));
+  ASSERT_NE(cpu, nullptr);
+  EXPECT_EQ(cpu->VariantFolderPath().string(),
+            (dir.path() / "decoder" / "cpu").string());
+}
+
+TEST(ModelPackageContextTest, SelectComponentRespectsEpPriorityOrder) {
+  // decoder has cpu and cuda variants. Pass priority [CUDA, CPU] — cuda wins;
+  // pass priority [CPU, CUDA] — cpu wins. Proves that a variant matching a
+  // higher-priority EP outranks a variant matching a lower one regardless of
+  // metadata declaration order.
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+
+  ModelPackageSelectionOptions cuda_first;
+  cuda_first.ep_priority = {{"CUDAExecutionProvider", std::nullopt},
+                            {"CPUExecutionProvider", std::nullopt}};
+  auto a = ctx->SelectComponent(0, cuda_first);
+  ASSERT_NE(a, nullptr);
+  EXPECT_EQ(a->VariantFolderPath().string(),
+            (dir.path() / "decoder" / "cuda").string());
+
+  ModelPackageSelectionOptions cpu_first;
+  cpu_first.ep_priority = {{"CPUExecutionProvider", std::nullopt},
+                           {"CUDAExecutionProvider", std::nullopt}};
+  auto b = ctx->SelectComponent(0, cpu_first);
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->VariantFolderPath().string(),
+            (dir.path() / "decoder" / "cpu").string());
+}
+
+TEST(ModelPackageContextTest, SelectComponentEmptyPriorityDefaultsToCpu) {
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+
+  // Spec: empty captured EP list is treated as [CPUExecutionProvider].
+  ModelPackageSelectionOptions empty;
+  auto inst = ctx->SelectComponent(0, empty);
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(inst->VariantFolderPath().string(),
+            (dir.path() / "decoder" / "cpu").string());
+}
+
+TEST(ModelPackageContextTest, SelectComponentDeviceAwareMatch) {
+  // Component has two variants pinning OpenVINO/GPU and OpenVINO/NPU. The
+  // device discriminator in the caller's priority entry must select the
+  // correct variant; passing OpenVINO without a device must NOT match a
+  // device-pinned variant.
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants": {
+      "openvino-gpu": {"ep_compatibility": [
+        {"ep": "OpenVINOExecutionProvider", "device": "GPU"}]},
+      "openvino-npu": {"ep_compatibility": [
+        {"ep": "OpenVINOExecutionProvider", "device": "NPU"}]}
+    }
+  })");
+  WriteFile(dir.path() / "decoder" / "openvino-gpu" / "variant.json",
+            R"({"files":[{"filename":"m.onnx"}]})");
+  WriteFile(dir.path() / "decoder" / "openvino-npu" / "variant.json",
+            R"({"files":[{"filename":"m.onnx"}]})");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+
+  auto gpu = ctx->SelectComponent(0, OnePriority("OpenVINOExecutionProvider", "GPU"));
+  ASSERT_NE(gpu, nullptr);
+  EXPECT_EQ(gpu->VariantFolderPath().string(),
+            (dir.path() / "decoder" / "openvino-gpu").string());
+
+  auto npu = ctx->SelectComponent(0, OnePriority("OpenVINOExecutionProvider", "NPU"));
+  ASSERT_NE(npu, nullptr);
+  EXPECT_EQ(npu->VariantFolderPath().string(),
+            (dir.path() / "decoder" / "openvino-npu").string());
+}
+
+TEST(ModelPackageContextTest, SelectComponentTieBreaksByMetadataOrder) {
+  // Two variants both compatible with CPU. Metadata declares `second`
+  // before `first` — a CPU priority must select `second`.
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants": {
+      "second": {"ep_compatibility": [{"ep": "CPUExecutionProvider"}]},
+      "first":  {"ep_compatibility": [{"ep": "CPUExecutionProvider"}]}
+    }
+  })");
+  WriteFile(dir.path() / "decoder" / "second" / "variant.json", R"({"files":[{"filename":"m.onnx"}]})");
+  WriteFile(dir.path() / "decoder" / "first"  / "variant.json", R"({"files":[{"filename":"m.onnx"}]})");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  auto inst = ctx->SelectComponent(0, OnePriority("CPUExecutionProvider"));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(inst->VariantFolderPath().string(),
+            (dir.path() / "decoder" / "second").string());
+}
+
+// ============================================================================
+// ConsumerMetadata
+// ============================================================================
+
+TEST(ModelPackageContextTest, ConsumerMetadataIsReturnedVerbatim) {
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+
+  auto cpu = ctx->SelectComponent(0, OnePriority("CPUExecutionProvider"));
+  ASSERT_NE(cpu, nullptr);
+
+  const std::string blob = cpu->ConsumerMetadata();
+  ASSERT_FALSE(blob.empty());
+  // Round-trip through DOM and assert structural equivalence — the
+  // serializer canonicalises whitespace, so byte equality would be brittle.
+  const auto parsed = JSON::ParseDocument(blob);
+  ASSERT_TRUE(parsed.IsObject());
+  EXPECT_DOUBLE_EQ(NumberAt(parsed, {"genai_config_overlay", "model", "context_length"}), 2048.0);
+}
+
+TEST(ModelPackageContextTest, ConsumerMetadataAbsentReturnsEmpty) {
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  auto inst = ctx->SelectComponent(1, OnePriority("CPUExecutionProvider"));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(inst->ConsumerMetadata(), "");
+}
+
+// ============================================================================
+// Shared assets
+// ============================================================================
+
+TEST(ModelPackageContextTest, SharedAssetsPathPointsAtConfigsBucket) {
+  TempDir dir;
+  BuildTwoComponentPackage(dir.path());
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  EXPECT_EQ(ctx->SharedAssetsPath().string(),
+            (dir.path() / "configs").string());
+}
+
+// ============================================================================
+// FileCount
+// ============================================================================
+
+TEST(ModelPackageContextTest, FileCountReflectsVariantJsonFilesArray) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants": {"qnn": {"ep_compatibility":[{"ep":"QNNExecutionProvider"}]}}
+  })");
+  // Multi-file QNN-style variant.
+  WriteFile(dir.path() / "decoder" / "qnn" / "variant.json", R"({
+    "files": [
+      {"filename": "embedding.onnx"},
+      {"filename": "prompt.onnx"},
+      {"filename": "token_gen.onnx"},
+      {"filename": "lm_head.onnx"}
+    ]
+  })");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  auto inst = ctx->SelectComponent(0, OnePriority("QNNExecutionProvider"));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(inst->FileCount(), 4u);
+}
+
+// ============================================================================
+// ResolveSharedWeight
+// ============================================================================
+
+TEST(ModelPackageContextTest, ResolveSharedWeightReturnsBlobPath) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants":{"cpu":{"ep_compatibility":[{"ep":"CPUExecutionProvider"}]}}
+  })");
+  WriteFile(dir.path() / "decoder" / "cpu" / "variant.json", R"({
+    "files":[{"filename":"m.onnx",
+              "shared_files":{"m.onnx.data":"abc123"}}]
+  })");
+  // The blob name inside the checksum directory is producer-chosen.
+  WriteFile(dir.path() / "decoder" / "shared_weights" / "abc123" / "weights.data",
+            "fake-weights");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  auto inst = ctx->SelectComponent(0, OnePriority("CPUExecutionProvider"));
+  ASSERT_NE(inst, nullptr);
+
+  const auto resolved = inst->ResolveSharedWeight("abc123");
+  EXPECT_EQ(resolved.string(),
+            (dir.path() / "decoder" / "shared_weights" / "abc123" / "weights.data").string());
+}
+
+TEST(ModelPackageContextTest, ResolveSharedWeightThrowsOnMissingChecksum) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants":{"cpu":{"ep_compatibility":[{"ep":"CPUExecutionProvider"}]}}
+  })");
+  WriteFile(dir.path() / "decoder" / "cpu" / "variant.json",
+            R"({"files":[{"filename":"m.onnx"}]})");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  auto inst = ctx->SelectComponent(0, OnePriority("CPUExecutionProvider"));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_THROW(inst->ResolveSharedWeight("doesnotexist"), std::exception);
+}
+
+TEST(ModelPackageContextTest, ResolveSharedWeightThrowsOnEmptyDirectory) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants":{"cpu":{"ep_compatibility":[{"ep":"CPUExecutionProvider"}]}}
+  })");
+  WriteFile(dir.path() / "decoder" / "cpu" / "variant.json",
+            R"({"files":[{"filename":"m.onnx"}]})");
+  std::filesystem::create_directories(dir.path() / "decoder" / "shared_weights" / "empty");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  auto inst = ctx->SelectComponent(0, OnePriority("CPUExecutionProvider"));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_THROW(inst->ResolveSharedWeight("empty"), std::exception);
+}
+
+TEST(ModelPackageContextTest, ResolveSharedWeightThrowsOnMultipleBlobs) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants":{"cpu":{"ep_compatibility":[{"ep":"CPUExecutionProvider"}]}}
+  })");
+  WriteFile(dir.path() / "decoder" / "cpu" / "variant.json",
+            R"({"files":[{"filename":"m.onnx"}]})");
+  WriteFile(dir.path() / "decoder" / "shared_weights" / "abc" / "a.bin", "1");
+  WriteFile(dir.path() / "decoder" / "shared_weights" / "abc" / "b.bin", "2");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  auto inst = ctx->SelectComponent(0, OnePriority("CPUExecutionProvider"));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_THROW(inst->ResolveSharedWeight("abc"), std::exception);
+}
+
+TEST(ModelPackageContextTest, ResolveSharedWeightRejectsPathTraversalChecksum) {
+  TempDir dir;
+  WriteFile(dir.path() / "manifest.json", R"({"components":["decoder"]})");
+  WriteFile(dir.path() / "decoder" / "metadata.json", R"({
+    "variants":{"cpu":{"ep_compatibility":[{"ep":"CPUExecutionProvider"}]}}
+  })");
+  WriteFile(dir.path() / "decoder" / "cpu" / "variant.json",
+            R"({"files":[{"filename":"m.onnx"}]})");
+
+  auto ctx = ModelPackageContext::Open(dir.fs_path());
+  ASSERT_NE(ctx, nullptr);
+  auto inst = ctx->SelectComponent(0, OnePriority("CPUExecutionProvider"));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_THROW(inst->ResolveSharedWeight("../escape"), std::exception);
+}
+
+// ============================================================================
+// ParseVariantManifest helper (W6's pipeline runner uses this)
+// ============================================================================
+
+TEST(ParseVariantManifestTest, ParsesFilesArrayInOrder) {
+  TempDir dir;
+  // Author the files in a specific order; we expect that order to round-trip.
+  WriteFile(dir.path() / "variant.json", R"({
+    "files": [
+      {"filename": "stage1.onnx"},
+      {"filename": "stage2.onnx"},
+      {"filename": "stage3.onnx"}
+    ]
+  })");
+
+  const auto vm = ParseVariantManifest(fs::path(dir.path().string()));
+  ASSERT_EQ(vm.files.size(), 3u);
+  EXPECT_EQ(vm.files[0].filename, "stage1.onnx");
+  EXPECT_EQ(vm.files[1].filename, "stage2.onnx");
+  EXPECT_EQ(vm.files[2].filename, "stage3.onnx");
+}
+
+TEST(ParseVariantManifestTest, ParsesPerFileSessionOptionsAsTypedJson) {
+  TempDir dir;
+  WriteFile(dir.path() / "variant.json", R"({
+    "files": [{
+      "filename": "m.onnx",
+      "session_options": {
+        "intra_op_num_threads": 4,
+        "graph_optimization_level": "ORT_ENABLE_ALL",
+        "use_deterministic_compute": true
+      },
+      "provider_options": {
+        "htp_performance_mode": "burst"
+      }
+    }]
+  })");
+
+  const auto vm = ParseVariantManifest(fs::path(dir.path().string()));
+  ASSERT_EQ(vm.files.size(), 1u);
+  const auto& f = vm.files[0];
+
+  // Number value preserved as JSON double.
+  auto so_threads = f.session_options.find("intra_op_num_threads");
+  ASSERT_NE(so_threads, f.session_options.end());
+  ASSERT_TRUE(so_threads->second.IsNumber());
+  EXPECT_DOUBLE_EQ(so_threads->second.AsNumber(), 4.0);
+
+  // String value preserved as JSON string.
+  auto so_opt = f.session_options.find("graph_optimization_level");
+  ASSERT_NE(so_opt, f.session_options.end());
+  ASSERT_TRUE(so_opt->second.IsString());
+  EXPECT_EQ(so_opt->second.AsString(), "ORT_ENABLE_ALL");
+
+  // Boolean value preserved as JSON bool.
+  auto so_det = f.session_options.find("use_deterministic_compute");
+  ASSERT_NE(so_det, f.session_options.end());
+  ASSERT_TRUE(so_det->second.IsBool());
+  EXPECT_TRUE(so_det->second.AsBool());
+
+  auto po_perf = f.provider_options.find("htp_performance_mode");
+  ASSERT_NE(po_perf, f.provider_options.end());
+  ASSERT_TRUE(po_perf->second.IsString());
+  EXPECT_EQ(po_perf->second.AsString(), "burst");
+}
+
+TEST(ParseVariantManifestTest, ParsesSharedFilesMap) {
+  TempDir dir;
+  WriteFile(dir.path() / "variant.json", R"({
+    "files": [{
+      "filename": "m.onnx",
+      "shared_files": {
+        "m.onnx.data": "abc123",
+        "extra.bin": "def456"
+      }
+    }]
+  })");
+
+  const auto vm = ParseVariantManifest(fs::path(dir.path().string()));
+  ASSERT_EQ(vm.files.size(), 1u);
+  const auto& sf = vm.files[0].shared_files;
+  ASSERT_EQ(sf.size(), 2u);
+  EXPECT_EQ(sf.at("m.onnx.data"), "abc123");
+  EXPECT_EQ(sf.at("extra.bin"),   "def456");
+}
+
+TEST(ParseVariantManifestTest, RejectsMissingFiles) {
+  TempDir dir;
+  WriteFile(dir.path() / "variant.json", R"({"consumer_metadata":{}})");
+  EXPECT_THROW(ParseVariantManifest(fs::path(dir.path().string())), std::exception);
+}
+
+TEST(ParseVariantManifestTest, RejectsPathTraversalInFilename) {
+  TempDir dir;
+  WriteFile(dir.path() / "variant.json", R"({"files":[{"filename":"../escape.onnx"}]})");
+  EXPECT_THROW(ParseVariantManifest(fs::path(dir.path().string())), std::exception);
+}
+
+TEST(ParseVariantManifestTest, RejectsPathTraversalInSharedFilesChecksum) {
+  TempDir dir;
+  WriteFile(dir.path() / "variant.json", R"({
+    "files":[{"filename":"m.onnx","shared_files":{"x.bin":"../escape"}}]
+  })");
+  EXPECT_THROW(ParseVariantManifest(fs::path(dir.path().string())), std::exception);
+}
+
+TEST(ParseVariantManifestTest, RejectsAbsentVariantJson) {
+  TempDir dir;  // empty
+  EXPECT_THROW(ParseVariantManifest(fs::path(dir.path().string())), std::exception);
+}
+
+}  // namespace Generators::test


### PR DESCRIPTION
Stacks on #2125 (W1 JSON DOM + merge_patch). Review/merge after #2125 lands.

## What

Adds an internal abstraction over the ORT v4 model-package layout that will be wired into `Config::Config` in a follow-up PR. The single public surface is the abstract `ModelPackageContext` / `ComponentInstance` pair declared in `src/models/model_package.h`.

Today the only implementation is a stub directory walker that reads the package's `manifest.json` + per-variant `variant.json` files using the JSON DOM from #2125. When ORT v4 lands, an alternate implementation backed by `OrtModelPackageContext` will slot in alongside the stub; callers see only the abstract surface.

## Public surface

- `Open(path)` — returns `nullptr` if no `manifest.json` (caller falls back to flat-dir mode), throws on a malformed manifest. The contract is: nullptr means "not a v4 package", throw means "broken v4 package".
- `NumComponents` / `ComponentName(cix)` — manifest-order traversal.
- `EpsCompatibleWith(cix)` — union of EP names per-component-variants, consumed by the EP-defaulting algorithm (W5b) which intersects across components.
- `SelectComponent(cix, ep_name)` — returns a `ComponentInstance` for a matching variant, or `nullptr`.
- `SharedAssetsPath` / `VariantFolderPath` / `GenAIConfigOverlay` — paths consumed by tokenizer/processor loaders (W4-real) and by Config's per-variant overlay merge (W3).

## Notes

- Variant directory iteration is sorted before traversal so test and EP-defaulting behaviour is stable across platforms (filesystem iterators expose implementation-defined order).
- The implementation bridges between the codebase's custom `fs::path` (from `src/filesystem.h`, the public surface) and `std::filesystem::path` (needed for directory iteration, which `fs::path` does not support).
- `files[]` and other ORT-internal metadata are deliberately not surfaced here — they are pipeline-runner / W6 territory.

## Dead code

This change is dead code from the rest of the codebase's perspective — `Config` does not yet consult `ModelPackageContext`. Wiring follows in W3 (config detection + base load + overlay merge). Tests verify the abstract contract directly via 12 GTest cases (detection / shared assets / EP compatibility / variant selection / overlay extraction).

This is part of an incremental v4 package integration; see also #2125 (W1) and #2126 (W4-prep) and #2131 (W5c-prep).