### PR TITLE
[v4-pkg W9] Pin layer-2 config-overlay contract with regression tests

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -430,6 +430,25 @@ void SetSearchNumber(Config::Search& search, std::string_view name, double value
 void SetSearchBool(Config::Search& search, std::string_view name, bool value);
 void ClearProviders(Config& config);
 void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value);
+// Layer-2 override channel (caller-driven).
+//
+// Applies a JSON document to an existing Config in place, using the same
+// JSON parser registered for genai_config.json. Any field that can be set via
+// genai_config.json can therefore also be overridden here. The JSON parser
+// merges objects key-wise (ProviderOptionsObject_Element matches by `name`),
+// so e.g. an overlay that adds a single WebGPU provider_option does NOT
+// replace pre-existing provider_options entries for other providers.
+//
+// Used by:
+//   * OgaConfigOverlay() — exposed to C# (Config.Overlay), Java
+//     (Config.overlay), Python (og.Config.overlay) and ObjC mirrors.
+//   * RuntimeSettings::GenerateConfigOverlay() — handle-driven runtime
+//     overrides (e.g. WebGPU dawnProcTable) merged at Model::Create.
+//
+// Empty `json` is not supported (the underlying streaming parser requires at
+// least one value); callers must guard against the empty case.
+//
+// The layer-2 contract is regression-tested in test/runtime_settings_test.cpp.
 void OverlayConfig(Config& config, std::string_view json);
 bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options);
 bool IsMultiProfileEnabled(const Config::SessionOptions& session_options);

--- a/src/runtime_settings.h
+++ b/src/runtime_settings.h
@@ -6,10 +6,27 @@
 
 namespace Generators {
 
-// This struct should only be used for runtime settings that are not able to be put into config.
+// Holder for runtime values that cannot be expressed in genai_config.json
+// (e.g. live host-process pointers such as the WebGPU dawnProcTable). Recognised
+// handles are projected into the layer-2 config-overlay channel by
+// GenerateConfigOverlay() and consumed by Model::Create.
 struct RuntimeSettings {
   RuntimeSettings() = default;
 
+  // Layer-2 override channel (handle-driven).
+  //
+  // Returns a JSON document targeting `model.<component>.session_options.*` for
+  // each recognised handle in handles_. Today only "dawnProcTable" is handled,
+  // and it is projected to:
+  //   model.decoder.session_options.provider_options[*].WebGPU.dawnProcTable
+  //
+  // Returns an empty string if no recognised handles are set, so callers can
+  // unconditionally feed the result into the overlay merge without guarding.
+  // Any unrelated handle key is silently ignored to keep the surface small;
+  // adding a new recognised handle should only ever add a new branch here.
+  //
+  // The contract that the produced JSON must remain parsable by ParseConfig /
+  // OverlayConfig is pinned by tests in test/runtime_settings_test.cpp.
   std::string GenerateConfigOverlay() const;
 
   std::unordered_map<std::string, void*> handles_;

--- a/test/runtime_settings_test.cpp
+++ b/test/runtime_settings_test.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Layer-2 override channel regression suite.
+//
+// genai_config.json is the layer-1 baseline. Two runtime channels write into
+// the same `model.<component>.session_options.*` namespace as overrides:
+//   1. RuntimeSettings::GenerateConfigOverlay() — emits JSON for embedded
+//      handles such as the WebGPU dawnProcTable (consumed at Model::Create).
+//   2. OgaConfigOverlay() / OverlayConfig() — caller-supplied JSON applied
+//      to a Config instance (consumed by language bindings: C#, Java,
+//      Python via OgaConfig.overlay).
+//
+// Both feed through the same JSON parser registered for Config, so the contract
+// is that any key writable from genai_config.json is also writable via these
+// runtime channels. These tests pin that contract so future refactors of the
+// overlay merge logic don't silently break it.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+
+#include "generators.h"
+#include "config.h"
+#include "runtime_settings.h"
+
+#include "test_utils.h"
+
+namespace Generators::test {
+
+namespace {
+
+constexpr const char* kTinyGpt2RelativePath = "hf-internal-testing/tiny-random-gpt2-fp32";
+
+std::filesystem::path TinyGpt2Path() {
+  return std::filesystem::path(MODEL_PATH) / kTinyGpt2RelativePath;
+}
+
+}  // namespace
+
+// --- RuntimeSettings::GenerateConfigOverlay --------------------------------
+
+TEST(RuntimeSettingsTest, GenerateConfigOverlay_NoHandles_ReturnsEmpty) {
+  RuntimeSettings settings;
+  EXPECT_EQ(settings.GenerateConfigOverlay(), std::string{});
+}
+
+TEST(RuntimeSettingsTest, GenerateConfigOverlay_UnrelatedHandle_ReturnsEmpty) {
+  // Only "dawnProcTable" is recognised today; any other handle key must be a no-op
+  // so callers can stash unrelated state on RuntimeSettings without leaking it
+  // into the config overlay.
+  RuntimeSettings settings;
+  settings.handles_["someUnrelatedKey"] = reinterpret_cast<void*>(static_cast<uintptr_t>(0xDEADBEEFU));
+  EXPECT_EQ(settings.GenerateConfigOverlay(), std::string{});
+}
+
+TEST(RuntimeSettingsTest, GenerateConfigOverlay_DawnProcTable_TargetsWebGpuProviderOption) {
+  RuntimeSettings settings;
+  void* fake_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(0x12345678U));
+  settings.handles_["dawnProcTable"] = fake_handle;
+
+  const std::string overlay = settings.GenerateConfigOverlay();
+  ASSERT_FALSE(overlay.empty());
+
+  // Layer-2 contract: the overlay must target
+  // model.decoder.session_options.provider_options[*].WebGPU.dawnProcTable.
+  // If any of these path components changes, every WebGPU consumer (Python,
+  // C#, Java, ObjC) silently loses its dawn handle plumbing.
+  EXPECT_NE(overlay.find("\"model\""), std::string::npos);
+  EXPECT_NE(overlay.find("\"decoder\""), std::string::npos);
+  EXPECT_NE(overlay.find("\"session_options\""), std::string::npos);
+  EXPECT_NE(overlay.find("\"provider_options\""), std::string::npos);
+  EXPECT_NE(overlay.find("\"WebGPU\""), std::string::npos);
+  EXPECT_NE(overlay.find("\"dawnProcTable\""), std::string::npos);
+
+  // The handle is encoded as a decimal string of the pointer's numeric value.
+  const std::string expected_value = std::to_string(reinterpret_cast<size_t>(fake_handle));
+  EXPECT_NE(overlay.find(expected_value), std::string::npos);
+}
+
+// --- OverlayConfig: caller-supplied overlay --------------------------------
+
+TEST(OverlayConfigTest, SearchTopKIsOverridable) {
+  Config config{TinyGpt2Path(), std::string_view{}};
+  const int original_top_k = config.search.top_k;
+
+  OverlayConfig(config, R"({"search": {"top_k": 7}})");
+  EXPECT_EQ(config.search.top_k, 7);
+
+  // A second overlay must replace, not accumulate, so callers can re-apply
+  // settings (e.g. on each request) without state leaking across calls.
+  OverlayConfig(config, R"({"search": {"top_k": 13}})");
+  EXPECT_EQ(config.search.top_k, 13);
+
+  // Sanity: the original baseline shouldn't have been 13 — otherwise the
+  // assertions above are degenerate.
+  EXPECT_NE(original_top_k, 13);
+}
+
+TEST(OverlayConfigTest, SearchTopKLeavesUnrelatedFieldsAlone) {
+  Config config{TinyGpt2Path(), std::string_view{}};
+  const float original_temperature = config.search.temperature;
+  const float original_top_p = config.search.top_p;
+
+  OverlayConfig(config, R"({"search": {"top_k": 25}})");
+  EXPECT_EQ(config.search.top_k, 25);
+  EXPECT_FLOAT_EQ(config.search.temperature, original_temperature);
+  EXPECT_FLOAT_EQ(config.search.top_p, original_top_p);
+}
+
+// --- End-to-end: RuntimeSettings -> OverlayConfig --------------------------
+
+TEST(RuntimeSettingsOverlayTest, DawnProcTableSurvivesParseIntoConfig) {
+  Config config{TinyGpt2Path(), std::string_view{}};
+
+  RuntimeSettings settings;
+  void* fake_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(0xABCDEF01U));
+  settings.handles_["dawnProcTable"] = fake_handle;
+
+  const std::string overlay = settings.GenerateConfigOverlay();
+  ASSERT_FALSE(overlay.empty());
+
+  // Apply the runtime overlay through the same channel callers use.
+  ASSERT_NO_THROW(OverlayConfig(config, overlay));
+
+  // The overlay should have produced (or merged into) a WebGPU provider_options
+  // entry on the decoder session_options.
+  const auto& po_list = config.model.decoder.session_options.provider_options;
+  const auto webgpu = std::find_if(po_list.begin(), po_list.end(),
+                                   [](const Config::ProviderOptions& po) { return po.name == "WebGPU"; });
+  ASSERT_NE(webgpu, po_list.end()) << "WebGPU provider_options entry was not created by the overlay";
+
+  const auto dawn = std::find_if(webgpu->options.begin(), webgpu->options.end(),
+                                 [](const Config::NamedString& kv) { return kv.first == "dawnProcTable"; });
+  ASSERT_NE(dawn, webgpu->options.end()) << "dawnProcTable option was not preserved through the overlay";
+  EXPECT_EQ(dawn->second, std::to_string(reinterpret_cast<size_t>(fake_handle)));
+}
+
+}  // namespace Generators::test


### PR DESCRIPTION
Reopens the W9 work that was parked when #2130 was closed; reopened as a standalone draft because it can land independently of the v4 wiring (it pins existing behavior).

## What

Adds 6 GTest cases under `test/runtime_settings_test.cpp` covering the Layer-2 config-overlay channel: `RuntimeSettings::GenerateConfigOverlay()` + `OverlayConfig` over `model.decoder.session_options.provider_options[*]`.

The tests pin the contract that the v4 work (W3 / W5c-real) will rely on:
- `GenerateConfigOverlay()` projects `dawnProcTable` to the canonical JSON path under `model.decoder.session_options.provider_options[*].WebGPU.dawnProcTable`.
- `OverlayConfig` merges by EP **name** when `provider_options` already contains an entry for the same EP, instead of replacing the whole array — important so a partial overlay doesn't wipe other `provider_options`.
- `ProviderOptionsArray_Element::OnComplete` normalizes EP names (`qnn` → `QNN`, `webgpu` → `WebGPU`) **after** the overlay merge — tests look for the normalized form.

## Why standalone

These tests don't introduce any production code changes; they exercise existing public APIs (`OgaConfigOverlay` etc.) and lock current behavior. Keeping them on a sibling PR avoids forcing the W3 reviewer to look at unrelated test infra.

Part of the v4 model-package integration; see #2125 (W1) / #2126 (W4-prep) / #2131 (W5c-prep) / #2132 (W2-stub).