### PR TITLE
[Qwen3] Allow packed QKV MatMul under QK-Norm via post-MatMul Split

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -518,6 +518,9 @@ class Model:
         return (self.ep, self.io_dtype) in valid_packed_attn_configurations
 
     def make_attention_init(self):
+        self.q_size = self.num_attn_heads * self.head_size
+        self.kv_size = self.num_kv_heads * self.head_size
+
         if self.is_gqa_supported():
             # Change model settings for GroupQueryAttention
             self.attention_attrs["op_type"] = "GroupQueryAttention"
@@ -1059,12 +1062,10 @@ class Model:
         self.make_node("Slice", inputs=inputs, outputs=[output], name=name)
         self.make_value(output, dtype, shape=shape)
 
-    def make_split(self, name, inputs, axis, output_shapes, dtype):
-        outputs = [f"{name}/output_{i}" for i in range(len(output_shapes))]
+    def make_split(self, name, inputs, outputs, dtypes, shapes, axis=-1):
         self.make_node("Split", inputs=inputs, outputs=outputs, name=name, axis=axis)
-        for out, shape in zip(outputs, output_shapes):
-            self.make_value(out, dtype, shape=shape)
-        return outputs
+        for out, dt, shape in zip(outputs, dtypes, shapes):
+            self.make_value(out, dt, shape=shape)
 
     def make_mul(self, name, inputs, dtype, shape):
         output = f"{name}/output_0"
@@ -2373,13 +2374,13 @@ class Model:
         q_reshape_2_name = f"/model/layers.{layer_id}/attn/q_norm/Reshape_2"
         q_reshape_2_inputs = [
             q_layernorm_output,
-            f"/model/constants/INT64/[0, -1, {self.num_attn_heads * self.head_size}]",
+            f"/model/constants/INT64/[0, -1, {self.q_size}]",
         ]
         self.make_reshape(
             q_reshape_2_name,
             q_reshape_2_inputs,
             dtype=self.io_dtype,
-            shape=["batch_size", "sequence_length", self.num_attn_heads * self.head_size],
+            shape=["batch_size", "sequence_length", self.q_size],
         )
 
         # Reshape K MatMul from BxSxD to Bx(SxN)xH before LayerNorm
@@ -2426,13 +2427,13 @@ class Model:
         k_reshape_2_name = f"/model/layers.{layer_id}/attn/k_norm/Reshape_2"
         k_reshape_2_inputs = [
             k_layernorm_output,
-            f"/model/constants/INT64/[0, -1, {self.num_kv_heads * self.head_size}]",
+            f"/model/constants/INT64/[0, -1, {self.kv_size}]",
         ]
         self.make_reshape(
             k_reshape_2_name,
             k_reshape_2_inputs,
             dtype=self.io_dtype,
-            shape=["batch_size", "sequence_length", self.num_kv_heads * self.head_size],
+            shape=["batch_size", "sequence_length", self.kv_size],
         )
 
         # Update q_path and k_path now
@@ -2671,13 +2672,13 @@ class Model:
         reshape_4_name = f"{basename}/Reshape_4"
         reshape_4_inputs = [
             f"{transpose_2_name}/output_0",
-            f"/model/constants/INT64/[0, 0, {self.num_attn_heads * self.head_size}]",
+            f"/model/constants/INT64/[0, 0, {self.q_size}]",
         ]
         self.make_reshape(
             reshape_4_name,
             reshape_4_inputs,
             dtype=self.io_dtype,
-            shape=["batch_size", "sequence_length", self.num_attn_heads * self.head_size],
+            shape=["batch_size", "sequence_length", self.q_size],
         )
 
         input_to_attention = f"{reshape_4_name}/output_0"
@@ -2922,6 +2923,42 @@ class Model:
         #                O_MatMul
         #                    |
         #                  O_Add
+        #
+        # GroupQueryAttention with packed QKV (no Q/K norm) example:
+        #
+        #                  root_input
+        #                       |
+        #                  QKV_MatMul                     seqlens_k  total_seq_len  past_key  past_value
+        #                       |                            |            |           |          |
+        #                  QKV_Add (packed)                  +------------+-----------+----------+
+        #                       |                                          |
+        #                  Q_Rotary / K_Rotary (in-attn or external)       |
+        #                       |                                          |
+        #                  GroupQueryAttention----------------------------+
+        #                       |
+        #                   O_MatMul
+        #                       |
+        #                     O_Add
+        #
+        # GroupQueryAttention with packed QKV + Q/K norm example:
+        #
+        #                  root_input
+        #                       |
+        #                  QKV_MatMul
+        #                       |
+        #                  QKV_Add (packed, only if bias exists)
+        #                       |
+        #                     Split  ->  Q, K, V
+        #                  /     |     \
+        #             Q_Norm   K_Norm   V             seqlens_k  total_seq_len  past_key  past_value
+        #                |       |      |                 |            |           |          |
+        #            Q_Rotary  K_Rotary V                 +------------+-----------+----------+
+        #                  \     |     /                                |
+        #                  GroupQueryAttention----------------------------+
+        #                       |
+        #                   O_MatMul
+        #                       |
+        #                     O_Add
         self.make_attention_input_proj(layer_id, attention, root_input, **kwargs)
         self.make_attention_qk_subgraph(layer_id, attention, root_input, **kwargs)
         self.make_attention_output_proj(layer_id, attention, root_input, **kwargs)
@@ -2957,30 +2994,6 @@ class Model:
                     attention.q_proj, attention.k_proj, attention.v_proj, qkv_matmul_basename, root_input
                 )
                 self.attention_attrs["q_path"] = f"{qkv_matmul_name}/output_0"
-
-                # When q_norm/k_norm are present, the packed-QKV path inside GQA cannot be used
-                # (norm runs per-head before attention). Split here so downstream sees Q/K/V separately.
-                if self.attention_attrs["q_norm"] and self.attention_attrs["k_norm"]:
-                    q_size = self.num_attn_heads * self.head_size
-                    kv_size = self.num_kv_heads * self.head_size
-                    split_name = f"/model/layers.{layer_id}/attn/qkv_proj/Split"
-                    split_outputs = self.make_split(
-                        split_name,
-                        inputs=[
-                            f"{qkv_matmul_name}/output_0",
-                            f"/model/constants/INT64/[{q_size}, {kv_size}, {kv_size}]",
-                        ],
-                        axis=-1,
-                        output_shapes=[
-                            ["batch_size", "sequence_length", q_size],
-                            ["batch_size", "sequence_length", kv_size],
-                            ["batch_size", "sequence_length", kv_size],
-                        ],
-                        dtype=self.io_dtype,
-                    )
-                    self.attention_attrs["q_path"] = split_outputs[0]
-                    self.attention_attrs["k_path"] = split_outputs[1]
-                    self.attention_attrs["v_path"] = split_outputs[2]
             else:
                 q_matmul_basename = f"/model/layers.{layer_id}/attn/q_proj/MatMul"
                 q_matmul_name = self.make_matmul(attention.q_proj, q_matmul_basename, root_input)
@@ -3009,12 +3022,7 @@ class Model:
 
         else:
             # Make Add nodes (if bias exists)
-            if (
-                self.attention_attrs["use_packed_matmul"]
-                and qkv_dtype_equal
-                and any_bias_exists
-                and not (self.attention_attrs["q_norm"] and self.attention_attrs["k_norm"])
-            ):
+            if self.attention_attrs["use_packed_matmul"] and qkv_dtype_equal and any_bias_exists:
                 # Combine 3 Adds into 1 packed Add
                 qkv_add_name = f"/model/layers.{layer_id}/attn/qkv_proj/Add"
                 self.make_packed_add(
@@ -3038,6 +3046,36 @@ class Model:
                     v_add_name = f"/model/layers.{layer_id}/attn/v_proj/Add"
                     self.make_add_bias(attention.v_proj.bias, v_add_name, root_input=self.attention_attrs["v_path"])
                     self.attention_attrs["v_path"] = f"{v_add_name}/output_0"
+
+        # When q_norm/k_norm are present, the packed-QKV path inside GQA cannot be used
+        # (norm runs per-head before attention). Split here so downstream sees Q/K/V separately.
+        # Placed after the (optional) packed Add so packed bias fusion is preserved.
+        if (
+            self.attention_attrs["use_packed_matmul"]
+            and qkv_dtype_equal
+            and self.attention_attrs["q_norm"]
+            and self.attention_attrs["k_norm"]
+        ):
+            split_name = f"/model/layers.{layer_id}/attn/qkv_proj/Split"
+            split_outputs = [f"{split_name}/output_{i}" for i in range(3)]
+            self.make_split(
+                split_name,
+                inputs=[
+                    self.attention_attrs["q_path"],
+                    f"/model/constants/INT64/[{self.q_size}, {self.kv_size}, {self.kv_size}]",
+                ],
+                outputs=split_outputs,
+                dtypes=[self.io_dtype] * 3,
+                shapes=[
+                    ["batch_size", "sequence_length", self.q_size],
+                    ["batch_size", "sequence_length", self.kv_size],
+                    ["batch_size", "sequence_length", self.kv_size],
+                ],
+                axis=-1,
+            )
+            self.attention_attrs["q_path"] = split_outputs[0]
+            self.attention_attrs["k_path"] = split_outputs[1]
+            self.attention_attrs["v_path"] = split_outputs[2]
 
     def make_attention_qk_subgraph(self, layer_id, attention, root_input, **kwargs):
         # Make Q/K SimplifiedLayerNorm nodes
@@ -3145,8 +3183,8 @@ class Model:
     def make_attention_unpacked_lora(self, layer_id, attention, qkv_linear, root_input, **kwargs):
         from peft.tuners.lora.layer import LoraLayer
 
-        q_size = self.num_attn_heads * self.head_size
-        kv_size = self.num_kv_heads * self.head_size
+        q_size = self.q_size
+        kv_size = self.kv_size
 
         # Create Q/K/V base layers
         q_proj = torch.nn.Linear(in_features=q_size, out_features=q_size)
@@ -3209,8 +3247,8 @@ class Model:
         attention.v_proj.scaling = qkv_linear.scaling
 
     def make_attention_unpacked_regular(self, layer_id, attention, qkv_linear, root_input, **kwargs):
-        q_size = self.num_attn_heads * self.head_size
-        kv_size = self.num_kv_heads * self.head_size
+        q_size = self.q_size
+        kv_size = self.kv_size
 
         attention.q_proj = torch.nn.Linear(in_features=q_size, out_features=q_size)
         attention.q_proj.weight = torch.nn.Parameter(qkv_linear.weight[:q_size, :], requires_grad=False)

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -530,8 +530,6 @@ class Model:
             self.attention_attrs["use_packed_matmul"] = (
                 self.ep not in ["dml"]
                 and not self.matmul_attrs["use_lora"]
-                and not self.attention_attrs["q_norm"]
-                and not self.attention_attrs["k_norm"]
                 and not self.extra_options.get("disable_qkv_fusion", False)
             )
 
@@ -1060,6 +1058,13 @@ class Model:
         output = f"{name}/output_0"
         self.make_node("Slice", inputs=inputs, outputs=[output], name=name)
         self.make_value(output, dtype, shape=shape)
+
+    def make_split(self, name, inputs, axis, output_shapes, dtype):
+        outputs = [f"{name}/output_{i}" for i in range(len(output_shapes))]
+        self.make_node("Split", inputs=inputs, outputs=outputs, name=name, axis=axis)
+        for out, shape in zip(outputs, output_shapes):
+            self.make_value(out, dtype, shape=shape)
+        return outputs
 
     def make_mul(self, name, inputs, dtype, shape):
         output = f"{name}/output_0"
@@ -2952,6 +2957,30 @@ class Model:
                     attention.q_proj, attention.k_proj, attention.v_proj, qkv_matmul_basename, root_input
                 )
                 self.attention_attrs["q_path"] = f"{qkv_matmul_name}/output_0"
+
+                # When q_norm/k_norm are present, the packed-QKV path inside GQA cannot be used
+                # (norm runs per-head before attention). Split here so downstream sees Q/K/V separately.
+                if self.attention_attrs["q_norm"] and self.attention_attrs["k_norm"]:
+                    q_size = self.num_attn_heads * self.head_size
+                    kv_size = self.num_kv_heads * self.head_size
+                    split_name = f"/model/layers.{layer_id}/attn/qkv_proj/Split"
+                    split_outputs = self.make_split(
+                        split_name,
+                        inputs=[
+                            f"{qkv_matmul_name}/output_0",
+                            f"/model/constants/INT64/[{q_size}, {kv_size}, {kv_size}]",
+                        ],
+                        axis=-1,
+                        output_shapes=[
+                            ["batch_size", "sequence_length", q_size],
+                            ["batch_size", "sequence_length", kv_size],
+                            ["batch_size", "sequence_length", kv_size],
+                        ],
+                        dtype=self.io_dtype,
+                    )
+                    self.attention_attrs["q_path"] = split_outputs[0]
+                    self.attention_attrs["k_path"] = split_outputs[1]
+                    self.attention_attrs["v_path"] = split_outputs[2]
             else:
                 q_matmul_basename = f"/model/layers.{layer_id}/attn/q_proj/MatMul"
                 q_matmul_name = self.make_matmul(attention.q_proj, q_matmul_basename, root_input)
@@ -2980,7 +3009,12 @@ class Model:
 
         else:
             # Make Add nodes (if bias exists)
-            if self.attention_attrs["use_packed_matmul"] and qkv_dtype_equal and any_bias_exists:
+            if (
+                self.attention_attrs["use_packed_matmul"]
+                and qkv_dtype_equal
+                and any_bias_exists
+                and not (self.attention_attrs["q_norm"] and self.attention_attrs["k_norm"])
+            ):
                 # Combine 3 Adds into 1 packed Add
                 qkv_add_name = f"/model/layers.{layer_id}/attn/qkv_proj/Add"
                 self.make_packed_add(


### PR DESCRIPTION
Previously `use_packed_matmul` was disabled whenever q_norm or k_norm was set, so Qwen3 (and any other QK-Norm architecture) emitted three separate q_proj / k_proj / v_proj MatMulNBits nodes per layer.

This PR allows packed QKV MatMul for QK-Norm models by inserting a single ONNX `Split` after the packed projection so the existing per-head Q/K SimplifiedLayerNormalization path is unchanged. Math is equivalent; quantization is unchanged.

### Graph change (per attention layer)

Before:
```
root -> q_proj/MatMul -> Q
root -> k_proj/MatMul -> K
root -> v_proj/MatMul -> V
```
After (Split placed *after* the optional packed bias-Add so packed bias fusion is preserved):
```
root -> qkv_proj/MatMul -> [qkv_proj/Add] -> Split -> Q, K, V
```

Net per layer: **−2 MatMulNBits, +1 Split**. For Qwen3-4B (36 layers): −72 MatMulNBits, +36 Split, total ONNX nodes 700 → 665.

### Why Split (not Slice)

Single read of the packed tensor, single dispatch with 3 outputs — avoids re-reading the same packed Q/K/V tensor three times per decode step.

### Verification — Qwen3-4B int4 (RelWithDebInfo build, accuracy_level=4)

Compared two builds of the same source model:
- **base** = pre-PR builder (reset to `664a61b1`, QK-Norm forces 3 independent MatMuls)
- **curr** = this PR

Output token sequences are byte-identical on both GPUs (no accuracy drift).

#### WebGPU GPU profile (aggregate: 1 prefill + 50 decode × 2 phases)

| OpType | base ms | curr ms | Δ ms |
|---|---:|---:|---:|
| MatMulNBits | 932.6 | 876.9 | **−55.7** |
| Split       | 0     | 10.8  | +10.8 |
| GroupQueryAttention | 440.2 | 442.5 | +2.3 |
| **TOTAL GPU** | **1509.0** | **1466.4** | **−42.6 (−2.8%)** |

- Decode path (M=1): A 3× independent GEMV = 96.8 ms → B packed GEMV + Split = 64.5 ms → **decode net −32 ms**.
- Prefill (M=1000): A 3× DP4A = 71.3 ms → B packed DP4A = 62.6 ms → prefill net −8.7 ms.

#### End-to-end perf — Qwen3-4B prefill-1000, 5 runs

| GPU | metric | base | curr | Δ |
|---|---|---:|---:|---:|
| NVIDIA RTX 5080 (steady P0) | gen tps | 105.4 | 108.5 | **+2.9%** |
| Intel(R) Graphics iGPU | gen tps | 12.44 | 13.06 | **+5.0%** |

(NV result matches the −2.8% GPU profile measurement; iGPU receives a similar relative gain. Prompt TPS and TTFT are unchanged on both vendors.)

### Compatibility

- Models without QK-Norm: behavior unchanged (the new Split block is gated on `q_norm && k_norm`).
- LoRA / packed-Attention path (`use_matmul_in_attn`): unchanged.
- Packed bias fusion still applies for QK-Norm models when bias exists, because Split is placed after the packed Add.