### PR TITLE
Apply linear rope_scaling in model builder for Neutts/nano

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -470,7 +470,6 @@ class Model:
             config.rope_scaling.get("rope_type", config.rope_scaling.get("type")) == "linear"
             and "factor" in config.rope_scaling
         ):
-            print("Linear RoPE scaling is used in this model.")
             # Hugging Face: modeling_rope_utils._compute_linear_scaling_rope_parameters — inv_freq /= factor
             # Equivalent to inv_freq = 1 / (factor * theta ** (i / dim)) in make_rotary_embedding_caches_from_scratch.
             factor = float(config.rope_scaling["factor"])

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -466,6 +466,18 @@ class Model:
                 "ntk_beta": beta_fast,
             }
 
+        elif (
+            config.rope_scaling.get("rope_type", config.rope_scaling.get("type")) == "linear"
+            and "factor" in config.rope_scaling
+        ):
+            print("Linear RoPE scaling is used in this model.")
+            # Hugging Face: modeling_rope_utils._compute_linear_scaling_rope_parameters — inv_freq /= factor
+            # Equivalent to inv_freq = 1 / (factor * theta ** (i / dim)) in make_rotary_embedding_caches_from_scratch.
+            factor = float(config.rope_scaling["factor"])
+            if factor <= 0:
+                raise ValueError(f"rope_scaling.factor must be positive for linear RoPE scaling, got {factor}")
+            self.rope_attrs["rescale_factors"] = factor
+
         elif "mrope_section" in config.rope_scaling:
             # For models that use MRoPE (e.g. Qwen 2.5 VL, Qwen 3 VL)
             self.rope_attrs["mrope"] = {

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -3,9 +3,6 @@
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
 #
-# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
-# Portions of this file consist of AI generated content.
-#
 # Modifications Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Portions of this file consist of AI generated content.
 # --------------------------------------------------------------------------

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -3,7 +3,10 @@
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
 #
-# Copyright (C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Portions of this file consist of AI generated content.
+#
+# Modifications Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Portions of this file consist of AI generated content.
 # --------------------------------------------------------------------------
 from __future__ import annotations


### PR DESCRIPTION
## Model builder support for TTS models from neuphonic

This is used in NeuTTS model: [neuphonic/neutts-nano](https://huggingface.co/neuphonic/neutts-nano)

Linear RoPE configs (rope_type/type "linear" with factor) were ignored in make_rope_init, so inv_freq matched unscaled RoPE and diverged from Transformers (_compute_linear_scaling_rope_parameters: inv_freq /= factor). Set rope_attrs["rescale_factors"] to the config factor so make_rotary_embedding_caches_from_scratch matches HF (e.g. neutts-nano). Reject non-positive factors with a clear error.