### PR TITLE
Expose mutable sampling parameters on live Generator

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -552,6 +552,8 @@ void Generator::SetRuntimeOption(const char* key, const char* value) {
 }
 
 void Generator::SetSearchNumber(const char* name, double value) {
+  if (!search_)
+    throw std::runtime_error("SetSearchNumber is not supported for this model type");
   std::string_view n{name};
   if (n == "temperature") {
     temperature_override_ = static_cast<float>(value);
@@ -560,6 +562,8 @@ void Generator::SetSearchNumber(const char* name, double value) {
   } else if (n == "top_p") {
     top_p_override_ = static_cast<float>(value);
   } else if (n == "repetition_penalty") {
+    if (value <= 0.0 || !std::isfinite(value))
+      throw std::runtime_error("repetition_penalty must be a positive finite value");
     repetition_penalty_override_ = static_cast<float>(value);
   } else if (n == "min_length") {
     min_length_override_ = static_cast<int>(value);
@@ -570,6 +574,8 @@ void Generator::SetSearchNumber(const char* name, double value) {
 }
 
 void Generator::SetSearchBool(const char* name, bool value) {
+  if (!search_)
+    throw std::runtime_error("SetSearchBool is not supported for this model type");
   std::string_view n{name};
   if (n == "do_sample") {
     do_sample_override_ = value;
@@ -688,10 +694,14 @@ void Generator::GenerateNextToken() {
 
   if (g_log.enabled && g_log.generate_next_token) {
     auto& stream = Log("generate_next_token");
-    stream << SGR::Fg_Green << "do_sample: " << SGR::Reset << search.do_sample << ' '
-           << SGR::Fg_Green << "top_k: " << SGR::Reset << search.top_k << ' '
-           << SGR::Fg_Green << "top_p: " << SGR::Reset << search.top_p << ' '
-           << SGR::Fg_Green << "temperature: " << SGR::Reset << search.temperature << ' '
+    bool effective_do_sample = do_sample_override_.value_or(search.do_sample);
+    int effective_top_k = top_k_override_.value_or(search.top_k);
+    float effective_top_p = top_p_override_.value_or(search.top_p);
+    float effective_temperature = temperature_override_.value_or(search.temperature);
+    stream << SGR::Fg_Green << "do_sample: " << SGR::Reset << effective_do_sample << ' '
+           << SGR::Fg_Green << "top_k: " << SGR::Reset << effective_top_k << ' '
+           << SGR::Fg_Green << "top_p: " << SGR::Reset << effective_top_p << ' '
+           << SGR::Fg_Green << "temperature: " << SGR::Reset << effective_temperature << ' '
            << SGR::Fg_Cyan << "sequence length: " << SGR::Reset << search_->GetSequenceLength()
            << std::endl;
   }

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -551,6 +551,60 @@ void Generator::SetRuntimeOption(const char* key, const char* value) {
   state_->SetRunOption(key, value);
 }
 
+void Generator::SetSearchNumber(const char* name, double value) {
+  std::string_view n{name};
+  if (n == "temperature") {
+    temperature_override_ = static_cast<float>(value);
+  } else if (n == "top_k") {
+    top_k_override_ = static_cast<int>(value);
+  } else if (n == "top_p") {
+    top_p_override_ = static_cast<float>(value);
+  } else if (n == "repetition_penalty") {
+    repetition_penalty_override_ = static_cast<float>(value);
+  } else if (n == "min_length") {
+    min_length_override_ = static_cast<int>(value);
+  } else {
+    throw std::runtime_error("Unknown search number: " + std::string(name));
+  }
+  UpdateSamplingMethod();
+}
+
+void Generator::SetSearchBool(const char* name, bool value) {
+  std::string_view n{name};
+  if (n == "do_sample") {
+    do_sample_override_ = value;
+  } else {
+    throw std::runtime_error("Unknown search bool: " + std::string(name));
+  }
+  UpdateSamplingMethod();
+}
+
+void Generator::UpdateSamplingMethod() {
+  const auto& search = search_->params_->search;
+  bool do_sample = do_sample_override_.value_or(search.do_sample);
+  int top_k = top_k_override_.value_or(search.top_k);
+  float top_p = top_p_override_.value_or(search.top_p);
+  float temperature = temperature_override_.value_or(search.temperature);
+
+  if (!do_sample || top_k == 1 || temperature == 0) {
+    sampling_method_ = SamplingMethod::kGreedy;
+  } else {
+    if (search.num_beams != 1)
+      throw std::runtime_error("TopK and TopP cannot be used with a beam search");
+    if (top_p < 0.0f || top_p > 1.0f)
+      throw std::runtime_error("top_p must be between 0.0 and 1.0");
+    if (top_k < 0)
+      throw std::runtime_error("top_k must be 0 or greater");
+    if (top_p > 0.0f && top_p < 1.0f && top_k > 1) {
+      sampling_method_ = SamplingMethod::kTopKTopP;
+    } else if (top_k > 1) {
+      sampling_method_ = SamplingMethod::kTopK;
+    } else {
+      sampling_method_ = SamplingMethod::kTopP;
+    }
+  }
+}
+
 size_t Generator::TokenCount() const {
   if (is_nemotron_speech_model_)
     return static_cast<NemotronSpeechState*>(state_.get())->TokenCount();
@@ -627,8 +681,10 @@ void Generator::GenerateNextToken() {
   }
   computed_logits_ = false;
   auto& search = search_->params_->search;
-  search_->ApplyMinLength(search.min_length);
-  search_->ApplyRepetitionPenalty(search.repetition_penalty);
+  int min_length = min_length_override_.value_or(search.min_length);
+  float repetition_penalty = repetition_penalty_override_.value_or(search.repetition_penalty);
+  search_->ApplyMinLength(min_length);
+  search_->ApplyRepetitionPenalty(repetition_penalty);
 
   if (g_log.enabled && g_log.generate_next_token) {
     auto& stream = Log("generate_next_token");
@@ -641,18 +697,21 @@ void Generator::GenerateNextToken() {
   }
 
   last_action_ = Action::generated;
+  int top_k = top_k_override_.value_or(search.top_k);
+  float top_p = top_p_override_.value_or(search.top_p);
+  float temperature = temperature_override_.value_or(search.temperature);
   switch (sampling_method_) {
     case SamplingMethod::kGreedy:
       search_->SelectTop();
       return;
     case SamplingMethod::kTopKTopP:
-      search_->SampleTopKTopP(search.top_k, search.top_p, search.temperature);
+      search_->SampleTopKTopP(top_k, top_p, temperature);
       return;
     case SamplingMethod::kTopK:
-      search_->SampleTopK(search.top_k, search.temperature);
+      search_->SampleTopK(top_k, temperature);
       return;
     case SamplingMethod::kTopP:
-      search_->SampleTopP(search.top_p, search.temperature);
+      search_->SampleTopP(top_p, temperature);
       return;
     default:
       throw std::runtime_error("Unknown sampling method");

--- a/src/generators.h
+++ b/src/generators.h
@@ -107,6 +107,8 @@ struct Generator : LeakChecked<Generator> {
   DeviceSpan<float> GetLogits();
   void SetLogits(DeviceSpan<float> logits);
   void SetRuntimeOption(const char* key, const char* value);
+  void SetSearchNumber(const char* name, double value);
+  void SetSearchBool(const char* name, bool value);
   bool IsSessionTerminated() const;
 
   DeviceSpan<int32_t> GetSequence(size_t index) const;
@@ -141,6 +143,15 @@ struct Generator : LeakChecked<Generator> {
   SamplingMethod sampling_method_{SamplingMethod::kGreedy};
   void InitializeSamplingMethod(const GeneratorParams& params);
   void InitializePhi3RopeThreshold(const GeneratorParams& params);
+  void UpdateSamplingMethod();
+
+  // Mutable sampling parameter overrides (set via SetSearchNumber/SetSearchBool)
+  std::optional<float> temperature_override_;
+  std::optional<int> top_k_override_;
+  std::optional<float> top_p_override_;
+  std::optional<float> repetition_penalty_override_;
+  std::optional<int> min_length_override_;
+  std::optional<bool> do_sample_override_;
 };
 
 struct OrtGlobals {

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -512,6 +512,14 @@ struct OgaGenerator : OgaAbstract {
     OgaCheckResult(OgaGenerator_SetRuntimeOption(this, key, value));
   }
 
+  void SetSearchNumber(const char* name, double value) {
+    OgaCheckResult(OgaGenerator_SetSearchNumber(this, name, value));
+  }
+
+  void SetSearchBool(const char* name, bool value) {
+    OgaCheckResult(OgaGenerator_SetSearchBool(this, name, value));
+  }
+
   size_t GetSequenceCount(size_t index) const {
     return OgaGenerator_GetSequenceCount(this, index);
   }

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -509,6 +509,20 @@ OgaResult* OGA_API_CALL OgaGenerator_SetRuntimeOption(OgaGenerator* generator, c
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaGenerator_SetSearchNumber(OgaGenerator* generator, const char* name, double value) {
+  OGA_TRY
+  generator->SetSearchNumber(name, value);
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OGA_API_CALL OgaGenerator_SetSearchBool(OgaGenerator* generator, const char* name, bool value) {
+  OGA_TRY
+  generator->SetSearchBool(name, value);
+  return nullptr;
+  OGA_CATCH
+}
+
 namespace {
 
 /**

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -553,6 +553,26 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_GetNextTokens(const OgaGenerator
 OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_SetRuntimeOption(OgaGenerator* generator, const char* key, const char* value);
 
 /**
+ * \brief Set a numeric search parameter on a live generator without discarding the KV-cache.
+ *        Supported names: temperature, top_k, top_p, repetition_penalty, min_length.
+ * \param[in] generator The generator to update.
+ * \param[in] name The search parameter name.
+ * \param[in] value The new value.
+ * \return OgaResult containing the error message if setting failed.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_SetSearchNumber(OgaGenerator* generator, const char* name, double value);
+
+/**
+ * \brief Set a boolean search parameter on a live generator without discarding the KV-cache.
+ *        Supported names: do_sample.
+ * \param[in] generator The generator to update.
+ * \param[in] name The search parameter name.
+ * \param[in] value The new value.
+ * \return OgaResult containing the error message if setting failed.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_SetSearchBool(OgaGenerator* generator, const char* name, bool value);
+
+/**
  * \brief Rewinds the generator to the given length. This is useful when the user wants to rewind the generator to a specific length
  *        and continue generating from that point.
  * \param[in] generator The generator to rewind to the given length.

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -290,6 +290,20 @@ struct PyGenerator {
     generator_->SetRuntimeOption(key.c_str(), value.c_str());
   }
 
+  void SetSearchOptions(const pybind11::kwargs& dict) {
+    for (auto& entry : dict) {
+      auto name = entry.first.cast<std::string>();
+      if (pybind11::isinstance<pybind11::float_>(entry.second)) {
+        generator_->SetSearchNumber(name.c_str(), entry.second.cast<double>());
+      } else if (pybind11::isinstance<pybind11::bool_>(entry.second)) {
+        generator_->SetSearchBool(name.c_str(), entry.second.cast<bool>());
+      } else if (pybind11::isinstance<pybind11::int_>(entry.second)) {
+        generator_->SetSearchNumber(name.c_str(), entry.second.cast<int>());
+      } else
+        throw std::runtime_error("Unknown search option type, can be float/bool/int:" + name);
+    }
+  }
+
  private:
   std::unique_ptr<OgaGenerator> generator_;
 };
@@ -496,7 +510,8 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def("get_next_tokens", &PyGenerator::GetNextTokens)
       .def("get_sequence", &PyGenerator::GetSequence)
       .def("set_active_adapter", &PyGenerator::SetActiveAdapter)
-      .def("set_runtime_option", &PyGenerator::SetRuntimeOption);
+      .def("set_runtime_option", &PyGenerator::SetRuntimeOption)
+      .def("set_search_options", &PyGenerator::SetSearchOptions);
 
   pybind11::class_<OgaImages>(m, "Images")
       .def_static("open", [](pybind11::args image_paths) {

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -409,3 +409,68 @@ Print all primes between 1 and n
   std::cout << tokenizer->Decode(result) << "\r\n";
 }
 #endif
+
+// Test that changing sampling parameters mid-generation preserves KV-cache correctness.
+// Generate tokens with greedy, switch to sampling mid-way, verify:
+// 1. Tokens before the switch match a pure-greedy baseline (KV-cache intact)
+// 2. No crash or corruption after switching
+TEST(ModelTests, MutableSamplingPreservesKVCache) {
+  auto model = OgaModel::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+
+  std::vector<int32_t> input_ids{0, 0, 0, 52, 195, 731};
+  const int max_length = 20;
+  const int switch_at = 10;  // switch after generating this many tokens (including input)
+
+  // Baseline: pure greedy run
+  auto params_baseline = OgaGeneratorParams::Create(*model);
+  params_baseline->SetSearchOption("max_length", max_length);
+  params_baseline->SetSearchOptionBool("do_sample", false);
+
+  auto gen_baseline = OgaGenerator::Create(*model, *params_baseline);
+  gen_baseline->AppendTokens(input_ids);
+  while (!gen_baseline->IsDone()) {
+    gen_baseline->GenerateNextToken();
+  }
+  auto baseline_seq = gen_baseline->GetSequence(0);
+
+  // Test run: greedy for first (switch_at - input_len) tokens, then switch to sampling
+  auto params_test = OgaGeneratorParams::Create(*model);
+  params_test->SetSearchOption("max_length", max_length);
+  params_test->SetSearchOptionBool("do_sample", false);
+
+  auto gen_test = OgaGenerator::Create(*model, *params_test);
+  gen_test->AppendTokens(input_ids);
+
+  int seq_len = static_cast<int>(input_ids.size());
+  // Generate greedy up to switch point
+  while (seq_len < switch_at && !gen_test->IsDone()) {
+    gen_test->GenerateNextToken();
+    seq_len++;
+  }
+
+  // Verify tokens up to switch point match baseline (KV-cache is correct)
+  auto test_seq_at_switch = gen_test->GetSequence(0);
+  for (int i = 0; i < switch_at && i < static_cast<int>(test_seq_at_switch.size()); i++) {
+    EXPECT_EQ(test_seq_at_switch[i], baseline_seq[i])
+        << "Token mismatch at position " << i << " before sampling switch";
+  }
+
+  // Switch to sampling
+  gen_test->SetSearchBool("do_sample", true);
+  gen_test->SetSearchNumber("top_k", 5);
+  gen_test->SetSearchNumber("temperature", 1.0);
+
+  // Continue generating — should not crash, and tokens should be valid
+  while (!gen_test->IsDone()) {
+    gen_test->GenerateNextToken();
+  }
+
+  auto test_seq_final = gen_test->GetSequence(0);
+  EXPECT_EQ(static_cast<int>(test_seq_final.size()), max_length);
+
+  // Tokens before switch should still match baseline (unchanged by later sampling)
+  for (int i = 0; i < switch_at; i++) {
+    EXPECT_EQ(test_seq_final[i], baseline_seq[i])
+        << "Token at position " << i << " corrupted after sampling switch";
+  }
+}

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -424,6 +424,7 @@ TEST(ModelTests, MutableSamplingPreservesKVCache) {
   // Baseline: pure greedy run
   auto params_baseline = OgaGeneratorParams::Create(*model);
   params_baseline->SetSearchOption("max_length", max_length);
+  params_baseline->SetSearchOption("min_length", max_length);
   params_baseline->SetSearchOptionBool("do_sample", false);
 
   auto gen_baseline = OgaGenerator::Create(*model, *params_baseline);
@@ -436,6 +437,7 @@ TEST(ModelTests, MutableSamplingPreservesKVCache) {
   // Test run: greedy for first (switch_at - input_len) tokens, then switch to sampling
   auto params_test = OgaGeneratorParams::Create(*model);
   params_test->SetSearchOption("max_length", max_length);
+  params_test->SetSearchOption("min_length", max_length);
   params_test->SetSearchOptionBool("do_sample", false);
 
   auto gen_test = OgaGenerator::Create(*model, *params_test);

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -460,6 +460,142 @@ TEST(SamplingTests, RepetitionPenaltyCorrectnessCpu) {
       << " Unpenalized per-token avg=" << unpenalized_avg;
 }
 
+// Test switching from greedy to top-k sampling via Generator::SetSearchNumber/SetSearchBool.
+// Greedy always picks the highest logit; after switching to top_k=2, only the top 2 tokens are candidates.
+TEST(SamplingTests, MutableSamplingGreedyToTopK) {
+  std::vector<float> logits_cpu{2.0f, 1.5f, 1.25f, 0.25f, 0.25f};
+
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->Overlay(R"({ "model": { "vocab_size" : 5 } })");
+  auto model = OgaModel::Create(*config);
+
+  // Create generator with greedy, then switch to top_k sampling before generating
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 10);
+  params->SetSearchOptionBool("do_sample", false);
+
+  auto generator = OgaGenerator::Create(*model, *params);
+
+  // Switch to top-k sampling before first generation
+  generator->SetSearchBool("do_sample", true);
+  generator->SetSearchNumber("top_k", 2);
+  generator->SetSearchNumber("temperature", 1.0);
+
+  generator->SetLogits(*OgaTensor::Create(logits_cpu.data(), std::array<int64_t, 2>{1LL, 5LL}));
+  generator->GenerateNextToken();
+  auto next_tokens = generator->GetNextTokens();
+  // With top_k=2, only tokens 0 (2.0) and 1 (1.5) are candidates
+  EXPECT_TRUE(next_tokens[0] == 0 || next_tokens[0] == 1)
+      << "Token " << next_tokens[0] << " is outside top_k=2 candidates";
+}
+
+// Test switching from sampling back to greedy via SetSearchBool("do_sample", false).
+TEST(SamplingTests, MutableSamplingSamplingToGreedy) {
+  std::vector<float> logits_cpu{0.25f, 2.0f, 1.5f, 1.25f, 0.25f};
+
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->Overlay(R"({ "model": { "vocab_size" : 5 } })");
+  auto model = OgaModel::Create(*config);
+
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 10);
+  params->SetSearchOptionBool("do_sample", true);
+  params->SetSearchOption("top_k", 4);
+
+  auto generator = OgaGenerator::Create(*model, *params);
+
+  // Switch to greedy before generating
+  generator->SetSearchBool("do_sample", false);
+
+  generator->SetLogits(*OgaTensor::Create(logits_cpu.data(), std::array<int64_t, 2>{1LL, 5LL}));
+  generator->GenerateNextToken();
+  auto next_tokens = generator->GetNextTokens();
+  EXPECT_EQ(next_tokens[0], 1) << "Greedy should always pick token 1 (highest logit = 2.0)";
+}
+
+// Test changing temperature on a live generator.
+// With temperature=0, sampling degenerates to greedy.
+TEST(SamplingTests, MutableSamplingTemperatureZero) {
+  std::vector<float> logits_cpu{0.25f, 0.25f, 2.0f, 1.5f, 0.25f};
+
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->Overlay(R"({ "model": { "vocab_size" : 5 } })");
+  auto model = OgaModel::Create(*config);
+
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 10);
+  params->SetSearchOptionBool("do_sample", true);
+  params->SetSearchOption("top_k", 4);
+
+  auto generator = OgaGenerator::Create(*model, *params);
+  generator->SetSearchNumber("temperature", 0.0);
+
+  generator->SetLogits(*OgaTensor::Create(logits_cpu.data(), std::array<int64_t, 2>{1LL, 5LL}));
+  generator->GenerateNextToken();
+  auto next_tokens = generator->GetNextTokens();
+  EXPECT_EQ(next_tokens[0], 2) << "temperature=0 should always pick token 2 (highest logit)";
+}
+
+// Test that changing top_k=1 on a live generator forces greedy selection.
+TEST(SamplingTests, MutableSamplingTopKChange) {
+  std::vector<float> logits_cpu{5.0f, 4.0f, 3.0f, 2.0f, 1.0f};
+
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->Overlay(R"({ "model": { "vocab_size" : 5 } })");
+  auto model = OgaModel::Create(*config);
+
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 10);
+  params->SetSearchOptionBool("do_sample", true);
+  params->SetSearchOption("top_k", 5);
+
+  auto generator = OgaGenerator::Create(*model, *params);
+  generator->SetSearchNumber("top_k", 1);
+
+  generator->SetLogits(*OgaTensor::Create(logits_cpu.data(), std::array<int64_t, 2>{1LL, 5LL}));
+  generator->GenerateNextToken();
+  auto next_tokens = generator->GetNextTokens();
+  EXPECT_EQ(next_tokens[0], 0) << "top_k=1 should always pick the highest logit token";
+}
+
+// Test that SetSearchNumber rejects unknown parameter names.
+TEST(SamplingTests, MutableSamplingInvalidName) {
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto model = OgaModel::Create(*config);
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 10);
+
+  auto generator = OgaGenerator::Create(*model, *params);
+  EXPECT_THROW(generator->SetSearchNumber("nonexistent_param", 1.0), std::runtime_error);
+  EXPECT_THROW(generator->SetSearchBool("nonexistent_param", true), std::runtime_error);
+}
+
+// Test that overrides don't affect other generators created from the same params.
+TEST(SamplingTests, MutableSamplingIsolation) {
+  std::vector<float> logits_cpu{2.0f, 1.5f, 1.25f, 0.25f, 0.25f};
+
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->Overlay(R"({ "model": { "vocab_size" : 5 } })");
+  auto model = OgaModel::Create(*config);
+
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 10);
+  params->SetSearchOptionBool("do_sample", false);  // greedy
+
+  // Generator 1: override to sampling
+  auto gen1 = OgaGenerator::Create(*model, *params);
+  gen1->SetSearchBool("do_sample", true);
+  gen1->SetSearchNumber("top_k", 3);
+
+  // Generator 2: should still be greedy (params unchanged)
+  auto gen2 = OgaGenerator::Create(*model, *params);
+
+  gen2->SetLogits(*OgaTensor::Create(logits_cpu.data(), std::array<int64_t, 2>{1LL, 5LL}));
+  gen2->GenerateNextToken();
+  auto next_tokens = gen2->GetNextTokens();
+  EXPECT_EQ(next_tokens[0], 0) << "Generator 2 should still be greedy (token 0 has highest logit)";
+}
+
 #if USE_CUDA
 TEST(SamplingTests, BatchedSamplingTopPCuda) {
   std::vector<int32_t> input_ids{0, 1, 2, 3};


### PR DESCRIPTION
## Summary

- Add  and  C API functions to change sampling parameters (temperature, top_k, top_p, repetition_penalty, do_sample) on a live generator without destroying/recreating it
- Generator stores optional overrides that take precedence over the original  values
-  is recomputed when relevant parameters change
- Python binding exposes  with kwargs

## Motivation

Sampling parameters (temperature, top_k, top_p, do_sample, repetition_penalty) only affect logit post-processing and are independent of the KV-cache. Previously, changing any parameter required destroying the generator and recreating it, discarding the entire KV-cache. This is wasteful for scenarios like Edge's Prompt API where mid-conversation parameter changes are needed.

## Test plan

- [x] 6 unit tests in  covering greedy-to-sampling switch, sampling-to-greedy, temperature change, top_k change, invalid name error, and isolation between generators
- [x] 1 model test in  verifying KV-cache preservation after mid-generation parameter switch
- [x] Python e2e test: multi-turn conversation with parameter changes between turns produces coherent, contextually-aware responses
- [x] All 7 C++ tests pass, Python test passes with phi4 model