### PR TITLE
Add per-run profiling config for fine-grained Run() profiling

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -228,6 +228,25 @@ struct RunOptions_Element : JSON::Element {
   Config::RunOptions& v_;
 };
 
+struct RunProfiling_Element : JSON::Element {
+  explicit RunProfiling_Element(Config::Model::RunProfiling& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "enabled") {
+      v_.enabled = JSON::Get<bool>(value);
+    } else if (name == "output_prefix") {
+      v_.output_prefix = JSON::Get<std::string_view>(value);
+    } else if (name == "runs") {
+      v_.runs = JSON::Get<std::string_view>(value);
+    } else {
+      throw JSON::unknown_value_error{};
+    }
+  }
+
+ private:
+  Config::Model::RunProfiling& v_;
+};
+
 struct EncoderInputs_Element : JSON::Element {
   explicit EncoderInputs_Element(Config::Model::Encoder::Inputs& v) : v_{v} {}
 
@@ -622,6 +641,9 @@ struct Decoder_Element : JSON::Element {
       v_.sliding_window = Config::Model::Decoder::SlidingWindow{};
       return sliding_window_;
     }
+    if (name == "run_profiling") {
+      return run_profiling_;
+    }
     // Support object-style pipeline: "pipeline": { "embeddings": { ... }, ... }
     if (name == "pipeline") {
       pipeline_object_ = std::make_unique<PipelineModelObject_Element>(v_.pipeline);
@@ -645,6 +667,7 @@ struct Decoder_Element : JSON::Element {
   Config::Model::Decoder& v_;
   SessionOptions_Element session_options_{v_.session_options};
   std::unique_ptr<RunOptions_Element> run_options_;
+  RunProfiling_Element run_profiling_{v_.run_profiling};
   DecoderInputs_Element inputs_{v_.inputs};
   DecoderOutputs_Element outputs_{v_.outputs};
   Pipeline_Element pipeline_{v_.pipeline};

--- a/src/config.h
+++ b/src/config.h
@@ -295,10 +295,17 @@ struct Config {
       std::optional<RunOptions> run_options;
     } vad;
 
+    struct RunProfiling {
+      bool enabled{false};
+      std::string output_prefix{"onnxruntime_run_profile"};
+      std::string runs{"0"};  // DSL: "N", "A-B", "A-", "*", comma-separated
+    };
+
     struct Decoder {
       std::string filename;
       SessionOptions session_options;
       std::optional<RunOptions> run_options;
+      RunProfiling run_profiling;
 
       int hidden_size{};          // Not currently used, potentially useful for embeddings in the future
       int num_attention_heads{};  // Not currently used, potentially useful if num_key_value_heads isn't set

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -76,6 +76,52 @@ class DirGuard {
   }
 };
 
+bool RunIndexMatches(std::string_view spec, int idx) {
+  size_t pos = 0;
+  while (pos < spec.size()) {
+    size_t comma = spec.find(',', pos);
+    std::string_view tok = spec.substr(pos, (comma == std::string_view::npos ? spec.size() : comma) - pos);
+    pos = (comma == std::string_view::npos) ? spec.size() : comma + 1;
+
+    // Trim spaces
+    while (!tok.empty() && (tok.front() == ' ' || tok.front() == '\t')) tok.remove_prefix(1);
+    while (!tok.empty() && (tok.back() == ' ' || tok.back() == '\t')) tok.remove_suffix(1);
+    if (tok.empty()) continue;
+
+    if (tok == "*") return true;
+
+    size_t dash = tok.find('-');
+    auto parse = [](std::string_view s, int& out) {
+      if (s.empty()) return false;
+      int v = 0;
+      for (char c : s) {
+        if (c < '0' || c > '9') return false;
+        v = v * 10 + (c - '0');
+      }
+      out = v;
+      return true;
+    };
+
+    if (dash == std::string_view::npos) {
+      int n;
+      if (parse(tok, n) && n == idx) return true;
+    } else {
+      std::string_view lhs = tok.substr(0, dash);
+      std::string_view rhs = tok.substr(dash + 1);
+      int a;
+      if (!parse(lhs, a)) throw std::runtime_error("Invalid run_profiling.runs token: " + std::string(tok));
+      if (rhs.empty()) {
+        if (idx >= a) return true;
+      } else {
+        int b;
+        if (!parse(rhs, b)) throw std::runtime_error("Invalid run_profiling.runs token: " + std::string(tok));
+        if (idx >= a && idx <= b) return true;
+      }
+    }
+  }
+  return false;
+}
+
 }  // namespace
 
 State::State(const GeneratorParams& params, const Model& model)
@@ -156,8 +202,24 @@ void State::Run(OrtSession& session, bool graph_capture_this_run) {
     run_options_->AddConfigEntry("disable_synchronize_execution_providers", "1");
   }
 
+#if ORT_API_VERSION >= 25
+  {
+    const auto& rp = model_.config_->model.decoder.run_profiling;
+    if (rp.enabled) {
+      if (RunIndexMatches(rp.runs, run_count_)) {
+        std::string p = rp.output_prefix + std::to_string(run_count_);
+        run_options_->EnableProfiling(fs::path(p).c_str());
+      } else {
+        run_options_->DisableProfiling();
+      }
+    }
+  }
+#endif
+
   session.Run(run_options_.get(), input_names_.data(), inputs_.data(), input_names_.size(),
               output_names_.data(), outputs_.data(), output_names_.size());
+
+  ++run_count_;
 
   extra_outputs_.RegisterOutputs();
 

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -56,6 +56,7 @@ struct State {
  protected:
   void Run(OrtSession& session, bool graph_capture_this_run = false);
   bool first_run_{true};
+  int run_count_{0};
 
   std::unique_ptr<OrtRunOptions> run_options_;
 


### PR DESCRIPTION
Adds model.decoder.run_profiling to genai_config.json so users can profile selected session.Run() calls (e.g. only prefill, or only the N-th decode) without modifying Python code. The existing set_runtime_option('enable_profiling', ...) path already supports per- run profiling but requires API calls per experiment; this surfaces the same capability via config.

Schema:
  "run_profiling": {
    "enabled": true,
    "output_prefix": "onnxruntime_run_profile",
    "runs": "0"
  }

runs DSL: comma-separated tokens, each one of N, A-B, A-, or *.
  "0"      -> prefill only (default)
  "1-"     -> all decode steps
  "0,5"    -> prefill + 5th decode
  "*"      -> every run

Filename: <output_prefix><idx>_<ort_timestamp>.json. Run index is a per-Generator counter (0 = prefill, N = N-th decode). Coexists with session-level enable_profiling; both produce independent files.