### PR TITLE
Add `kv_cache_fixed_to_max_length` search option (AMD RyzenAI)

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1343,9 +1343,11 @@ void SetSearchNumber(Config::Search& search, std::string_view name, double value
   if (name == "max_length" && search.kv_cache_fixed_to_max_length) {
     const int new_value = static_cast<int>(value);
     if (new_value != search.max_length) {
-      Log("warning", "Ignoring max_length=" + std::to_string(new_value) +
-                         " override: kv_cache_fixed_to_max_length is enabled in genai_config.json (kv-cache pinned to max_length=" +
-                         std::to_string(search.max_length) + ").");
+      if (g_log.enabled && g_log.warning) {
+        Log("warning", "Ignoring max_length=" + std::to_string(new_value) +
+                           " override: kv_cache_fixed_to_max_length is enabled in genai_config.json (kv-cache pinned to max_length=" +
+                           std::to_string(search.max_length) + ").");
+      }
     }
     return;
   }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1264,6 +1264,8 @@ struct Search_Element : JSON::Element {
       v_.early_stopping = JSON::Get<bool>(value);
     } else if (name == "blank_penalty") {
       v_.blank_penalty = static_cast<float>(JSON::Get<double>(value));
+    } else if (name == "kv_cache_fixed_to_max_length") {
+      v_.kv_cache_fixed_to_max_length = JSON::Get<bool>(value);
     } else {
       throw JSON::unknown_value_error{};
     }
@@ -1335,6 +1337,18 @@ struct Engine_Element : JSON::Element {
 };
 
 void SetSearchNumber(Config::Search& search, std::string_view name, double value) {
+  // AMD RyzenAI fixed-buffer mode pins kv-cache size to max_length from genai_config.json,
+  // so runtime overrides that would change max_length must be ignored to preserve the pre-sized buffer.
+  // Same-value sets are silent no-ops; differing values are warned and dropped.
+  if (name == "max_length" && search.kv_cache_fixed_to_max_length) {
+    const int new_value = static_cast<int>(value);
+    if (new_value != search.max_length) {
+      Log("warning", "Ignoring max_length=" + std::to_string(new_value) +
+                         " override: kv_cache_fixed_to_max_length is enabled in genai_config.json (kv-cache pinned to max_length=" +
+                         std::to_string(search.max_length) + ").");
+    }
+    return;
+  }
   try {
     Search_Element(search).OnValue(name, value);
   } catch (...) {

--- a/src/config.h
+++ b/src/config.h
@@ -406,6 +406,7 @@ struct Config {
     int random_seed{-1};               // -1 = Seed with random device, otherwise use value to seed RNG
     std::optional<size_t> chunk_size;  // Chunk size for prefill chunking during context processing. If present, chunking is enabled with the chunk size > 0.
     float blank_penalty{};             // Penalty applied to blank token logits in CTC/RNNT decoding. Default 0 means no penalty.
+    bool kv_cache_fixed_to_max_length{};  // AMD RyzenAI only: kv-cache is allocated as a fixed buffer sized to max_length from genai_config.json. When set, max_length cannot be overridden via SetSearchOption.
   } search;
 
   struct Engine {


### PR DESCRIPTION
  ## Summary

  Adds a new `kv_cache_fixed_to_max_length` boolean to the `search` section of `genai_config.json`. Some AMD RyzenAI models require the kv-cache to be allocated as a fixed buffer sized to `max_length`; this option marks the model as having that constraint so OGA can preserve the
  invariant at runtime.

  ## Behavior

  - When `kv_cache_fixed_to_max_length` is true, runtime overrides of `max_length` via `OgaGeneratorParamsSetSearchNumber` (and equivalents in C#/Python/Java/Objective-C) that would change the value are dropped with a yellow `warning` log entry, preserving the pre-sized buffer.
  - Same-value overrides are silent no-ops.
  - When the option is unset (default), behavior is unchanged.

  ## Why a warning instead of an error

  Throwing on every override would break clients that pass `max_length` through defensively (e.g. `model_benchmark`'s `--max_length` flag, which is set by default to `prompt_length + generation_length`). Logging a warning and ignoring the override keeps existing tools working
  while still surfacing that the value was not applied.

  ## Files changed

  - `src/config.h` — new `bool kv_cache_fixed_to_max_length{}` field at the end of `Config::Search`.
  - `src/config.cpp` — JSON parser branch for the new key (last in the chain, before the unknown-key throw), and a guard at the top of `SetSearchNumber` that warns and drops differing `max_length` overrides.

  ## Test plan

  - [x] `model_benchmark -ml 1024` with `kv_cache_fixed_to_max_length: true` and `max_length: 131072` in `genai_config.json` → warning printed, benchmark runs with `max_length=131072`.
  - [x] `model_benchmark -ml 131072` (matches config) → no warning, benchmark runs.
  - [x] `model_benchmark -ml -1` (no override call) → no warning, benchmark runs.
  - [x] Verified on Windows x64, RelWithDebInfo, CPU EP, with `Llama-3.2-1B-Instruct` (Q4F16).

  Sample warning output:

  ```
  [warning]  Ignoring max_length=1024 override: kv_cache_fixed_to_max_length is enabled in genai_config.json (kv-cache pinned to max_length=131072).
  ```