### PR TITLE
Slice packed qkv output for GroupQueryAttention

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -2921,6 +2921,59 @@ class Model:
         self.make_attention_qk_subgraph(layer_id, attention, root_input, **kwargs)
         self.make_attention_output_proj(layer_id, attention, root_input, **kwargs)
 
+    def make_packed_qkv_slices(self, layer_id, packed_input):
+        # Slice the packed qkv_proj output along the last dim into Q, K, V.
+        # GroupQueryAttention takes separate Q/K/V inputs, so the packed buffer
+        # must be split here; otherwise q_path would carry the full packed tensor
+        # and k_path/v_path would retain stale values from a prior unpacked layer.
+        q_size = self.num_attn_heads * self.head_size
+        k_size = self.num_kv_heads * self.head_size
+        v_size = self.num_kv_heads * self.head_size
+        seq_dim = "sequence_length"
+        axes_const = "/model/constants/INT64/[-1]"
+
+        q_slice_name = f"/model/layers.{layer_id}/attn/q_proj/Slice"
+        self.make_slice(
+            q_slice_name,
+            [
+                packed_input,
+                "/model/constants/INT64/[0]",
+                f"/model/constants/INT64/[{q_size}]",
+                axes_const,
+            ],
+            dtype=self.io_dtype,
+            shape=["batch_size", seq_dim, q_size],
+        )
+        self.attention_attrs["q_path"] = f"{q_slice_name}/output_0"
+
+        k_slice_name = f"/model/layers.{layer_id}/attn/k_proj/Slice"
+        self.make_slice(
+            k_slice_name,
+            [
+                packed_input,
+                f"/model/constants/INT64/[{q_size}]",
+                f"/model/constants/INT64/[{q_size + k_size}]",
+                axes_const,
+            ],
+            dtype=self.io_dtype,
+            shape=["batch_size", seq_dim, k_size],
+        )
+        self.attention_attrs["k_path"] = f"{k_slice_name}/output_0"
+
+        v_slice_name = f"/model/layers.{layer_id}/attn/v_proj/Slice"
+        self.make_slice(
+            v_slice_name,
+            [
+                packed_input,
+                f"/model/constants/INT64/[{q_size + k_size}]",
+                f"/model/constants/INT64/[{q_size + k_size + v_size}]",
+                axes_const,
+            ],
+            dtype=self.io_dtype,
+            shape=["batch_size", seq_dim, v_size],
+        )
+        self.attention_attrs["v_path"] = f"{v_slice_name}/output_0"
+
     def make_attention_input_proj(self, layer_id, attention, root_input, **kwargs):
         # Unpack attention weights if needed
         self.make_attention_unpacked(layer_id, attention, root_input, **kwargs)
@@ -3004,6 +3057,11 @@ class Model:
                     v_add_name = f"/model/layers.{layer_id}/attn/v_proj/Add"
                     self.make_add_bias(attention.v_proj.bias, v_add_name, root_input=self.attention_attrs["v_path"])
                     self.attention_attrs["v_path"] = f"{v_add_name}/output_0"
+
+        # If a packed qkv MatMul (+ optional packed Add) produced a single fused buffer,
+        # split it back into Q/K/V so downstream ops (GQA/MHA) see correct per-projection inputs.
+        if self.attention_attrs["use_packed_matmul"] and qkv_dtype_equal:
+            self.make_packed_qkv_slices(layer_id, self.attention_attrs["q_path"])
 
     def make_attention_qk_subgraph(self, layer_id, attention, root_input, **kwargs):
         # Make Q/K SimplifiedLayerNorm nodes

--- a/test/python/test_packed_qkv_slices.py
+++ b/test/python/test_packed_qkv_slices.py
@@ -1,0 +1,238 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""
+Regression test for the packed-qkv slicing fix in PR #2160.
+
+When the model builder routes Q/K/V through a packed `qkv_proj/MatMul`
+(GroupQueryAttention with `use_packed_matmul`), it must emit three Slice
+nodes that extract Q, K, V from the packed buffer along the last dim and
+update `attention_attrs["q_path"|"k_path"|"v_path"]` accordingly. Without
+this, GQA was fed the full packed tensor as Q while K/V stayed pointing
+at the prior unpacked layer's outputs, producing shape-inference errors
+at `o_proj/MatMulNBits` for WebGPU-converted models.
+
+Run with:
+    python -m pytest test/python/test_packed_qkv_slices.py -v --test_models <any-value>
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import onnx_ir as ir
+
+# Import Model from the source tree so tests run against the working copy.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src", "python", "py"))
+
+from models.builders.base import Model
+
+
+# DeepSeek-R1-Distill-Qwen-1.5B GQA dims (matches FIX_GUIDE.md):
+#   num_heads=12, kv_num_heads=2, head_dim=128
+#   Q = 12 * 128 = 1536, K = V = 2 * 128 = 256, total = 2048
+DEEPSEEK_DIMS = dict(num_attn_heads=12, num_kv_heads=2, head_size=128)
+
+# Llama-3.2-1B GQA dims:
+#   num_heads=32, kv_num_heads=8, head_dim=64
+#   Q = 32 * 64 = 2048, K = V = 8 * 64 = 512, total = 3072
+LLAMA_DIMS = dict(num_attn_heads=32, num_kv_heads=8, head_size=64)
+
+
+def _make_minimal_model(dims: dict) -> Model:
+    """Build a `Model` instance with just enough state for graph-construction helpers.
+
+    Bypasses `__init__` so we don't need a real HF config; sets only the attributes
+    that `make_packed_qkv_slices` / `make_slice` / `make_node` / `make_value` read.
+    """
+    model = object.__new__(Model)
+    model.num_attn_heads = dims["num_attn_heads"]
+    model.num_kv_heads = dims["num_kv_heads"]
+    model.head_size = dims["head_size"]
+    model.io_dtype = ir.DataType.FLOAT16
+    model.graph = ir.Graph(
+        inputs=(), outputs=(), nodes=(),
+        opset_imports={"": 21, "com.microsoft": 1},
+        name="main_graph",
+    )
+    model.model = ir.Model(model.graph, ir_version=10, producer_name="test")
+    model.values = {}
+    model.node_names = set()
+    model.attention_attrs = {
+        "q_path": "",
+        "k_path": "",
+        "v_path": "",
+        "use_packed_matmul": True,
+    }
+    return model
+
+
+def _slice_nodes_by_proj(graph: ir.Graph, layer_id: int) -> dict[str, ir.Node]:
+    """Return Slice nodes emitted by `make_packed_qkv_slices` for a given layer."""
+    expected = {
+        f"/model/layers.{layer_id}/attn/q_proj/Slice": "q",
+        f"/model/layers.{layer_id}/attn/k_proj/Slice": "k",
+        f"/model/layers.{layer_id}/attn/v_proj/Slice": "v",
+    }
+    out: dict[str, ir.Node] = {}
+    for node in graph:
+        if node.op_type == "Slice" and node.name in expected:
+            out[expected[node.name]] = node
+    return out
+
+
+def _input_names(node: ir.Node) -> list[str]:
+    return [inp.name for inp in node.inputs]
+
+
+class TestPackedQKVSlices:
+    """Verify packed-qkv slicing emits the right graph and routes Q/K/V correctly."""
+
+    def test_emits_three_slice_nodes(self):
+        """One Slice node per projection on the current layer."""
+        model = _make_minimal_model(DEEPSEEK_DIMS)
+        layer_id = 0
+        packed = f"/model/layers.{layer_id}/attn/qkv_proj/MatMul/output_0"
+
+        model.make_packed_qkv_slices(layer_id, packed)
+
+        nodes = _slice_nodes_by_proj(model.graph, layer_id)
+        assert set(nodes) == {"q", "k", "v"}, f"Missing Slice nodes: {set(nodes)}"
+
+    def test_q_path_points_to_q_slice_not_packed_buffer(self):
+        """Q must point to the new Slice output, not the full packed MatMul output."""
+        model = _make_minimal_model(DEEPSEEK_DIMS)
+        packed = "/model/layers.0/attn/qkv_proj/Add/output_0"
+
+        model.make_packed_qkv_slices(0, packed)
+
+        assert model.attention_attrs["q_path"] == "/model/layers.0/attn/q_proj/Slice/output_0"
+        assert model.attention_attrs["k_path"] == "/model/layers.0/attn/k_proj/Slice/output_0"
+        assert model.attention_attrs["v_path"] == "/model/layers.0/attn/v_proj/Slice/output_0"
+        # Crucially q_path no longer carries the full packed buffer.
+        assert model.attention_attrs["q_path"] != packed
+
+    def test_slice_indices_match_deepseek_layout(self):
+        """DeepSeek-R1-Distill-Qwen-1.5B: Q[0:1536], K[1536:1792], V[1792:2048] on axis -1."""
+        model = _make_minimal_model(DEEPSEEK_DIMS)
+        packed = "/model/layers.0/attn/qkv_proj/MatMul/output_0"
+
+        model.make_packed_qkv_slices(0, packed)
+        nodes = _slice_nodes_by_proj(model.graph, 0)
+
+        q_inputs = _input_names(nodes["q"])
+        k_inputs = _input_names(nodes["k"])
+        v_inputs = _input_names(nodes["v"])
+
+        # Slice(data, starts, ends, axes)
+        assert q_inputs[0] == packed
+        assert q_inputs[1] == "/model/constants/INT64/[0]"
+        assert q_inputs[2] == "/model/constants/INT64/[1536]"
+        assert q_inputs[3] == "/model/constants/INT64/[-1]"
+
+        assert k_inputs[0] == packed
+        assert k_inputs[1] == "/model/constants/INT64/[1536]"
+        assert k_inputs[2] == "/model/constants/INT64/[1792]"
+        assert k_inputs[3] == "/model/constants/INT64/[-1]"
+
+        assert v_inputs[0] == packed
+        assert v_inputs[1] == "/model/constants/INT64/[1792]"
+        assert v_inputs[2] == "/model/constants/INT64/[2048]"
+        assert v_inputs[3] == "/model/constants/INT64/[-1]"
+
+    def test_slice_indices_match_llama_layout(self):
+        """Llama-3.2-1B: Q[0:2048], K[2048:2560], V[2560:3072] on axis -1."""
+        model = _make_minimal_model(LLAMA_DIMS)
+        packed = "/model/layers.5/attn/qkv_proj/MatMul/output_0"
+
+        model.make_packed_qkv_slices(5, packed)
+        nodes = _slice_nodes_by_proj(model.graph, 5)
+
+        q_inputs = _input_names(nodes["q"])
+        k_inputs = _input_names(nodes["k"])
+        v_inputs = _input_names(nodes["v"])
+
+        assert q_inputs[1:4] == [
+            "/model/constants/INT64/[0]",
+            "/model/constants/INT64/[2048]",
+            "/model/constants/INT64/[-1]",
+        ]
+        assert k_inputs[1:4] == [
+            "/model/constants/INT64/[2048]",
+            "/model/constants/INT64/[2560]",
+            "/model/constants/INT64/[-1]",
+        ]
+        assert v_inputs[1:4] == [
+            "/model/constants/INT64/[2560]",
+            "/model/constants/INT64/[3072]",
+            "/model/constants/INT64/[-1]",
+        ]
+
+    def test_axes_passed_as_input_not_attribute(self):
+        """`axes` must be an input tensor (opset-21), not a node attribute.
+
+        Older ONNX consumers reject `Slice` with `axes` as an attribute; this is
+        called out in FIX_GUIDE.md as a common mistake.
+        """
+        model = _make_minimal_model(DEEPSEEK_DIMS)
+        model.make_packed_qkv_slices(0, "/packed")
+        for node in _slice_nodes_by_proj(model.graph, 0).values():
+            assert len(node.inputs) == 4, "Slice must have exactly 4 inputs (data, starts, ends, axes)"
+            assert "axes" not in dict(node.attributes), "axes must not be a Slice attribute"
+
+    def test_breaks_cross_layer_reference(self):
+        """K/V from a prior unpacked layer must not leak into a later packed layer.
+
+        Simulates: layer 0 takes the unpacked branch and sets k_path/v_path to
+        per-layer-0 MatMul outputs; layer 1 then takes the packed branch. After
+        slicing, layer 1's k_path/v_path must reference layer 1 — not layer 0.
+        """
+        model = _make_minimal_model(DEEPSEEK_DIMS)
+
+        # Layer 0 (unpacked): paths point at layer-0 MatMuls.
+        model.attention_attrs["q_path"] = "/model/layers.0/attn/q_proj/MatMul/output_0"
+        model.attention_attrs["k_path"] = "/model/layers.0/attn/k_proj/MatMul/output_0"
+        model.attention_attrs["v_path"] = "/model/layers.0/attn/v_proj/MatMul/output_0"
+
+        # Layer 1 (packed): emit slices over the packed layer-1 buffer.
+        layer1_packed = "/model/layers.1/attn/qkv_proj/MatMul/output_0"
+        model.make_packed_qkv_slices(1, layer1_packed)
+
+        # The previously-broken behavior would leave k_path/v_path pointing at layer 0.
+        for path_key in ("q_path", "k_path", "v_path"):
+            assert "layers.0" not in model.attention_attrs[path_key], (
+                f"{path_key} still references layer 0: {model.attention_attrs[path_key]}"
+            )
+            assert "layers.1" in model.attention_attrs[path_key]
+
+    def test_slice_outputs_registered_with_io_dtype(self):
+        """Slice outputs must carry `io_dtype` (FLOAT16) so downstream nodes type-check."""
+        model = _make_minimal_model(DEEPSEEK_DIMS)
+        model.make_packed_qkv_slices(0, "/packed")
+
+        for path_key in ("q_path", "k_path", "v_path"):
+            out_name = model.attention_attrs[path_key]
+            value = model.values[out_name]
+            assert value.dtype == ir.DataType.FLOAT16, (
+                f"{path_key} ({out_name}) has dtype {value.dtype}, expected FLOAT16"
+            )
+
+    def test_slice_output_shapes(self):
+        """Each Slice output should advertise the correct per-projection last dim."""
+        model = _make_minimal_model(DEEPSEEK_DIMS)
+        model.make_packed_qkv_slices(0, "/packed")
+
+        expected_last_dim = {
+            "q_path": DEEPSEEK_DIMS["num_attn_heads"] * DEEPSEEK_DIMS["head_size"],  # 1536
+            "k_path": DEEPSEEK_DIMS["num_kv_heads"] * DEEPSEEK_DIMS["head_size"],    # 256
+            "v_path": DEEPSEEK_DIMS["num_kv_heads"] * DEEPSEEK_DIMS["head_size"],    # 256
+        }
+        for path_key, last_dim in expected_last_dim.items():
+            out_name = model.attention_attrs[path_key]
+            shape = list(model.values[out_name].shape)
+            assert shape[-1] == last_dim, (
+                f"{path_key} last dim is {shape[-1]}, expected {last_dim} (full shape: {shape})"
+            )


### PR DESCRIPTION
## Summary

- In `make_attention_input_proj`, the packed-qkv branch only updated `q_path` (to the full packed buffer) and left `k_path`/`v_path` untouched. Since `attention_attrs` is mutated in place across layers, `GroupQueryAttention` received the whole packed tensor as Q and stale K/V from a prior unpacked layer, producing the `MatMulNBits` shape-inference errors at `o_proj` documented for WebGPU-converted DeepSeek-R1-Distill-Qwen-1.5B and Llama-3.2-1B.
- Add `make_packed_qkv_slices` to emit three `Slice` nodes over axis `-1` of the packed buffer (`[0:N_q]`, `[N_q:N_q+N_kv]`, `[N_q+N_kv:total]`) and route `q_path`/`k_path`/`v_path` to those outputs. `axes` is passed as an input tensor (opset-21 compatible) and outputs are registered with `io_dtype` so downstream FLOAT16 nodes type-check.
- Gated on the same `use_packed_matmul and qkv_dtype_equal` condition as the packed MatMul, so the unpacked-per-projection branch and the `Attention`-op (`use_matmul_in_attn`) branch are unaffected.

## Test plan

- [ ] Build DeepSeek-R1-Distill-Qwen-1.5B targeting WebGPU FP16 with the model builder and confirm the previously-affected layers (`0, 6, 8, 12, 25, 26, 27`) no longer have cross-layer K/V references (per the detection snippet in `olive-recipes/.aitk/docs/others/FIX_GUIDE.md`).
- [ ] Build Llama-3.2-1B targeting WebGPU FP16 and confirm layers `2, 5, 6, 8, 10, 13` are clean.
- [ ] Load each model with `onnxruntime_genai` and run a short generation — no shape-inference errors at `o_proj/MatMulNBits`.
- [ ] Regression: build a CUDA FP16 INT4 model that takes the same packed branch and confirm parity with prior outputs.
- [ ] Regression: build a model that takes the unpacked branch (e.g., q/k_norm enabled or `disable_qkv_fusion=true`) and confirm the graph is unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)