### PR TITLE
Gate leaked-object error reporting in Shutdown() to debug builds or when logging is enabled

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -87,11 +87,28 @@ GetOrtGlobals() {
   return globals;
 }
 
-// Used by Shutdown() to display the counts and types of any leaked objects
+// Used by Shutdown() to display the counts and types of any leaked objects.
+// Leak reporting is gated to debug builds or when logging is enabled, since
+// consuming applications often cannot guarantee model teardown before process
+// exit, and there is little they can do in response at that point.
+static bool ShouldReportLeaks() {
+#if !defined(NDEBUG)
+  return true;
+#else
+  return g_log.enabled;
+#endif
+}
+
 template <typename... Types>
 bool LeakTypeList<Types...>::Dump() {
-  ((LeakChecked<Types>::Count() != 0 ? std::cerr << "OGA Error: " << LeakChecked<Types>::Count() << " instances of " << typeid(Types).name() << " were leaked." << std::endl : std::cerr), ...);
-  return ((LeakChecked<Types>::Count() != 0) || ...);
+  const bool report = ShouldReportLeaks();
+  bool any_leaked = false;
+  ((LeakChecked<Types>::Count() != 0
+        ? (any_leaked = true,
+           report ? (std::cerr << "OGA Error: " << LeakChecked<Types>::Count() << " instances of " << typeid(Types).name() << " were leaked." << std::endl, 0) : 0)
+        : 0),
+   ...);
+  return any_leaked && report;
 }
 
 void Shutdown() {


### PR DESCRIPTION
`Generators::Shutdown()` walks the LeakChecked<T> counters and prints messages of the form:

```
OGA Error: N instances of <type> were leaked.
    Please see the documentation for the API being used to ensure proper cleanup.
```

to stderr whenever any tracked object is still alive at process exit.

FoundryLocal offers a model.unload. But if users do not unload the model, they will run into this std::cerr error on their console.

With this pull-request, the leak dump is now gated:

- Debug builds (NDEBUG not defined): leaks are reported as before
- Release builds: leaks are reported only when logging is enabled.