### PR TITLE
Fix WebGPU inference crash in embedding and multi-modal feature allocation

### DIFF
--- a/src/models/embeddings.cpp
+++ b/src/models/embeddings.cpp
@@ -21,7 +21,7 @@ Embeddings::Embeddings(State& state, Embeddings::Mode mode, const std::string& n
   // So only create the transient input and reuse that ortvalue for previous
   // steps in the pipeline.
   if (mode == Embeddings::Mode::Input) {
-    embeddings_ = OrtValue::CreateTensor(model_.p_device_->GetAllocator(), shape_, type_);
+    embeddings_ = OrtValue::CreateTensor(model_.p_device_inputs_->GetAllocator(), shape_, type_);
   }
 }
 
@@ -49,7 +49,7 @@ void Embeddings::UpdateSequenceLength(size_t new_length) {
     shape_[1] = new_length;
 
     if (mode_ == Embeddings::Mode::Input) {
-      embeddings_ = OrtValue::CreateTensor(model_.p_device_->GetAllocator(), shape_, type_);
+      embeddings_ = OrtValue::CreateTensor(model_.p_device_inputs_->GetAllocator(), shape_, type_);
       state_.inputs_[index_] = embeddings_.get();
     }
   }

--- a/src/models/multi_modal_features.cpp
+++ b/src/models/multi_modal_features.cpp
@@ -63,7 +63,7 @@ void MultiModalFeatures::Update(bool is_prompt) {
   // num_feature_tokens will be 0 when no image is provided
   if (!is_prompt && shape_[shape_.size() - 2] > 0) {  // if num_image_tokens > 0
     shape_[shape_.size() - 2] = 0;
-    features_ = OrtValue::CreateTensor(model_.p_device_->GetAllocator(), shape_, type_);
+    features_ = OrtValue::CreateTensor(model_.p_device_inputs_->GetAllocator(), shape_, type_);
     state_.inputs_[index_] = features_.get();
   }
 }
@@ -82,7 +82,7 @@ void MultiModalFeatures::AllocateEmptyFeatures() {
   // Skip if already allocated (avoids redundant allocation when called from
   // both EmbeddingState::SetExtraInputs and the pipeline prompt path)
   if (features_ && state_.inputs_[index_] == features_.get()) return;
-  features_ = OrtValue::CreateTensor(model_.p_device_->GetAllocator(), shape_, type_);
+  features_ = OrtValue::CreateTensor(model_.p_device_inputs_->GetAllocator(), shape_, type_);
   state_.inputs_[index_] = features_.get();
 }
 


### PR DESCRIPTION
## Summary

- Fix heap corruption crash during WebGPU inference by using the correct allocator (`p_device_inputs_`) for tensors that serve as inputs to the embedding/decoder session
- Previously, `embeddings.cpp` and `multi_modal_features.cpp` allocated these tensors on `p_device_` (WebGPU GPU memory), but the embedding session runs on CPU for WebGPU (without graph capture), causing the CPU session to write into GPU memory.
- This is a pair change for this pr https://github.com/microsoft/onnxruntime/pull/28501.

## Changes

**`src/models/embeddings.cpp`** (lines 24, 52):
- Changed `model_.p_device_->GetAllocator()` → `model_.p_device_inputs_->GetAllocator()` for embedding input tensor allocation and reallocation during sequence length updates

**`src/models/multi_modal_features.cpp`** (lines 66, 85):
- Changed `model_.p_device_->GetAllocator()` → `model_.p_device_inputs_->GetAllocator()` for empty feature tensors in `Update()` and `AllocateEmptyFeatures()` — these are inputs to the embedding session
- Vision/speech model output allocations (lines 42, 98) correctly remain on `p_device_`

## Impact

- **WebGPU**: Fixes crash (heap corruption 0xc0000374) during inference
- **CUDA/DML/RyzenAI**: No-op — `p_device_inputs_ == p_device_` on these providers
- **CPU**: No-op — `p_device_inputs_ == p_device_` on CPU

## Test plan

- [x] End-to-end WebGPU inference with Gemma 4 E2B (109 tokens generated correctly)
- [x] CPU inference still works after changes
- [x] Output matches between CPU and WebGPU execution