### PR TITLE
Add AMDGPU execution provider

### DIFF
--- a/benchmark/c/options.cpp
+++ b/benchmark/c/options.cpp
@@ -30,7 +30,7 @@ namespace {
     << "    -i,--input_folder <path>\n"
     << "      Path to the ONNX model directory to benchmark, compatible with onnxruntime-genai.\n"
     << "    -e,--execution_provider <provider>\n"
-    << "      Execution provider to use. Valid values are: cpu, cuda, dml, NvTensorRtRtx. Default: " << defaults.execution_provider << "\n"
+    << "      Execution provider to use. Valid values are: cpu, cuda, dml, NvTensorRtRtx, AMDGPU. Default: " << defaults.execution_provider << "\n"
     << "    -b,--batch_size <number>\n"
     << "      Number of sequences to generate in parallel. Default: " << defaults.batch_size << "\n"
     << "    Prompt options:\n"
@@ -98,8 +98,9 @@ std::string ReadFileContent(std::string_view file_path) {
 }
 
 void ValidateExecutionProvider(const std::string& provider) {
-  if (provider != "cpu" && provider != "cuda" && provider != "dml" && provider != "NvTensorRtRtx") {
-    throw std::runtime_error("Invalid execution provider: " + provider + ". Valid values are: cpu, cuda, dml, NvTensorRtRtx");
+  if (provider != "cpu" && provider != "cuda" && provider != "dml" && provider != "NvTensorRtRtx" &&
+      provider != "AMDGPU") {
+    throw std::runtime_error("Invalid execution provider: " + provider + ". Valid values are: cpu, cuda, dml, NvTensorRtRtx, AMDGPU");
   }
 }
 

--- a/cmake/global_variables.cmake
+++ b/cmake/global_variables.cmake
@@ -81,6 +81,8 @@ file(GLOB generator_srcs CONFIGURE_DEPENDS
   "${GENERATORS_ROOT}/cuda/session_options.cpp"
   "${GENERATORS_ROOT}/nvtensorrtrtx/*.h"
   "${GENERATORS_ROOT}/nvtensorrtrtx/*.cpp"
+  "${GENERATORS_ROOT}/amdgpu/*.h"
+  "${GENERATORS_ROOT}/amdgpu/*.cpp"
   "${GENERATORS_ROOT}/vitisai/*.h"
   "${GENERATORS_ROOT}/vitisai/*.cpp"
   "${GENERATORS_ROOT}/dml/session_options.h"

--- a/src/amdgpu/interface.cpp
+++ b/src/amdgpu/interface.cpp
@@ -164,8 +164,8 @@ struct PinnedMemory final : DeviceBuffer {
   }
 
   const char* GetType() const override { return pinned_device_label; }
-  void AllocateCpu() override {}       // p_cpu_ already valid (== p_device_)
-  void CopyDeviceToCpu() override {}   // same memory: nothing to copy
+  void AllocateCpu() override {}      // p_cpu_ already valid (== p_device_)
+  void CopyDeviceToCpu() override {}  // same memory: nothing to copy
   void CopyCpuToDevice() override {}
 
   void CopyFrom(size_t begin_dest, DeviceBuffer& source, size_t begin_source, size_t size_in_bytes) override {
@@ -264,8 +264,7 @@ struct PinnedInputsImpl : DeviceInterface {
   bool UpdateAttentionMask(void* next_mask_data, void* mask_data, int batch_beam_size, int new_kv_length,
                            int total_length, int max_length, bool update_only,
                            ONNXTensorElementDataType type) override {
-    return GetDeviceInterface(DeviceType::CPU)->UpdateAttentionMask(next_mask_data, mask_data, batch_beam_size, new_kv_length,
-                                                  total_length, max_length, update_only, type);
+    return GetDeviceInterface(DeviceType::CPU)->UpdateAttentionMask(next_mask_data, mask_data, batch_beam_size, new_kv_length, total_length, max_length, update_only, type);
   }
 
   InterfaceImpl& base_;

--- a/src/amdgpu/interface.cpp
+++ b/src/amdgpu/interface.cpp
@@ -1,0 +1,294 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// GPU-resident KV cache for the AMDGPU device.
+//
+// p_device_ is an opaque device-buffer handle, so no pointer arithmetic or
+// dereference. All copies go through ORT's CopyTensors. Offset copies fall
+// back to CPU staging via CopyThroughCpu.
+
+#include "../generators.h"
+#include "../search.h"
+#include "interface.h"
+
+#include <stdexcept>
+
+namespace Generators {
+namespace AMDGPU {
+
+const char* device_label = "amdgpu";
+const char* label_cpu = "cpu";
+
+struct GpuMemory final : DeviceBuffer {
+  GpuMemory(size_t size, Ort::Allocator* allocator, const OrtMemoryInfo* memory_info)
+      : owned_{true}, ort_allocator_{allocator}, ort_memory_info_{memory_info} {
+    size_in_bytes_ = size;
+    p_device_ = static_cast<uint8_t*>(ort_allocator_->Alloc(size_in_bytes_));
+  }
+
+  GpuMemory(void* p, size_t size, Ort::Allocator* allocator, const OrtMemoryInfo* memory_info)
+      : owned_{false}, ort_allocator_{allocator}, ort_memory_info_{memory_info} {
+    size_in_bytes_ = size;
+    p_device_ = static_cast<uint8_t*>(p);
+  }
+
+  ~GpuMemory() override {
+    if (owned_)
+      ort_allocator_->Free(p_device_);
+    if (p_cpu_)
+      free(p_cpu_);
+  }
+
+  const char* GetType() const override { return device_label; }
+
+  void AllocateCpu() override {
+    if (!p_cpu_)
+      p_cpu_ = static_cast<uint8_t*>(malloc(size_in_bytes_));
+  }
+
+  void CopyDeviceToCpu() override {
+    if (!ort_allocator_)
+      throw std::runtime_error("AMDGPU allocator not initialized");
+
+    AllocateCpu();
+
+    int64_t shape_val = static_cast<int64_t>(size_in_bytes_);
+    std::span<const int64_t> shape{&shape_val, 1};
+    auto src_tensor = OrtValue::CreateTensor(*ort_memory_info_, p_device_, size_in_bytes_, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+
+    auto cpu_mem_info = OrtMemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
+    auto dst_tensor = OrtValue::CreateTensor(*cpu_mem_info, p_cpu_, size_in_bytes_, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+
+    const std::vector<const OrtValue*> src_ptrs = {src_tensor.get()};
+    const std::vector<OrtValue*> dst_ptrs = {dst_tensor.get()};
+    GetOrtEnv().CopyTensors(src_ptrs, dst_ptrs, nullptr);
+  }
+
+  void CopyCpuToDevice() override {
+    if (!ort_allocator_)
+      throw std::runtime_error("AMDGPU allocator not initialized");
+    assert(p_cpu_);
+
+    int64_t shape_val = static_cast<int64_t>(size_in_bytes_);
+    std::span<const int64_t> shape{&shape_val, 1};
+    auto cpu_mem_info = OrtMemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
+    auto src_tensor = OrtValue::CreateTensor(*cpu_mem_info, p_cpu_, size_in_bytes_, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+
+    auto dst_tensor = OrtValue::CreateTensor(*ort_memory_info_, p_device_, size_in_bytes_, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+
+    const std::vector<const OrtValue*> src_ptrs = {src_tensor.get()};
+    const std::vector<OrtValue*> dst_ptrs = {dst_tensor.get()};
+    GetOrtEnv().CopyTensors(src_ptrs, dst_ptrs, nullptr);
+  }
+
+  void CopyFrom(size_t begin_dest, DeviceBuffer& source, size_t begin_source, size_t size_in_bytes) override {
+    if (!ort_allocator_)
+      throw std::runtime_error("AMDGPU allocator not initialized");
+
+    // Opaque handle, so wrap the whole buffer and let CopyTensors do the copy.
+    if (strcmp(source.GetType(), device_label) == 0 && begin_source == 0 && begin_dest == 0) {
+      // Full-buffer device-to-device copy.
+      int64_t shape_val = static_cast<int64_t>(size_in_bytes);
+      std::span<const int64_t> shape{&shape_val, 1};
+      auto src_tensor = OrtValue::CreateTensor(*ort_memory_info_, source.p_device_, size_in_bytes, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+      auto dst_tensor = OrtValue::CreateTensor(*ort_memory_info_, p_device_, size_in_bytes, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+
+      const std::vector<const OrtValue*> src_ptrs = {src_tensor.get()};
+      const std::vector<OrtValue*> dst_ptrs = {dst_tensor.get()};
+      GetOrtEnv().CopyTensors(src_ptrs, dst_ptrs, nullptr);
+    } else if (strcmp(source.GetType(), label_cpu) == 0 && begin_source == 0 && begin_dest == 0) {
+      // Full-buffer CPU-to-device copy.
+      int64_t shape_val = static_cast<int64_t>(size_in_bytes);
+      std::span<const int64_t> shape{&shape_val, 1};
+      auto cpu_mem_info = OrtMemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
+      auto src_tensor = OrtValue::CreateTensor(*cpu_mem_info, source.p_device_, size_in_bytes, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+      auto dst_tensor = OrtValue::CreateTensor(*ort_memory_info_, p_device_, size_in_bytes, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+
+      const std::vector<const OrtValue*> src_ptrs = {src_tensor.get()};
+      const std::vector<OrtValue*> dst_ptrs = {dst_tensor.get()};
+      GetOrtEnv().CopyTensors(src_ptrs, dst_ptrs, nullptr);
+    } else {
+      // Offset copies can't sub-buffer-view an opaque handle, so stage through CPU.
+      CopyThroughCpu(*this, begin_dest, source, begin_source, size_in_bytes);
+    }
+  }
+
+  void Zero() override {
+    if (!ort_allocator_)
+      throw std::runtime_error("AMDGPU allocator not initialized");
+
+    // TODO: device-side zero to avoid the host staging buffer. Off the decode hot path for now.
+    std::vector<uint8_t> zero_buffer(size_in_bytes_, 0);
+
+    int64_t shape_val = static_cast<int64_t>(size_in_bytes_);
+    std::span<const int64_t> shape{&shape_val, 1};
+    auto cpu_mem_info = OrtMemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
+    auto src_tensor = OrtValue::CreateTensor(*cpu_mem_info, zero_buffer.data(), size_in_bytes_, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+
+    auto dst_tensor = OrtValue::CreateTensor(*ort_memory_info_, p_device_, size_in_bytes_, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+
+    const std::vector<const OrtValue*> src_ptrs = {src_tensor.get()};
+    const std::vector<OrtValue*> dst_ptrs = {dst_tensor.get()};
+    GetOrtEnv().CopyTensors(src_ptrs, dst_ptrs, nullptr);
+  }
+
+  bool owned_;  // If we own the memory, we free it on destruction
+  Ort::Allocator* ort_allocator_;
+  const OrtMemoryInfo* ort_memory_info_;
+};
+
+const char* pinned_device_label = "amdgpu_pinned";
+
+// DeviceBuffer over a host-accessible allocation: one mapped pointer is both CPU-writable
+// and GPU-readable, so p_cpu_ aliases p_device_ and the copy methods are no-ops. Used for
+// decode inputs so the CPU updates them in place with no roundtrip.
+struct PinnedMemory final : DeviceBuffer {
+  PinnedMemory(size_t size, Ort::Allocator* allocator) : owned_{true}, ort_allocator_{allocator} {
+    size_in_bytes_ = size;
+    p_device_ = static_cast<uint8_t*>(ort_allocator_->Alloc(size_in_bytes_));
+    p_cpu_ = p_device_;  // mapped: one pointer for both
+  }
+
+  PinnedMemory(void* p, size_t size, Ort::Allocator* allocator) : owned_{false}, ort_allocator_{allocator} {
+    size_in_bytes_ = size;
+    p_device_ = static_cast<uint8_t*>(p);
+    p_cpu_ = p_device_;
+  }
+
+  ~PinnedMemory() override {
+    if (owned_)
+      ort_allocator_->Free(p_device_);
+    // p_cpu_ aliases p_device_, do not free it separately.
+  }
+
+  const char* GetType() const override { return pinned_device_label; }
+  void AllocateCpu() override {}       // p_cpu_ already valid (== p_device_)
+  void CopyDeviceToCpu() override {}   // same memory: nothing to copy
+  void CopyCpuToDevice() override {}
+
+  void CopyFrom(size_t begin_dest, DeviceBuffer& source, size_t begin_source, size_t size_in_bytes) override {
+    // Pinned memory is CPU-addressable; source may be on any device.
+    CopyThroughCpu(*this, begin_dest, source, begin_source, size_in_bytes);
+  }
+
+  void Zero() override { memset(p_device_, 0, size_in_bytes_); }
+
+  bool owned_;
+  Ort::Allocator* ort_allocator_;
+};
+
+struct InterfaceImpl : DeviceInterface {
+  DeviceType GetType() const override { return DeviceType::AMDGPU; }
+
+  void InitOrt(const OrtApi& api, Ort::Allocator& allocator) override {
+    Ort::api = &api;
+    assert(!ort_allocator_);
+    ort_allocator_ = &allocator;
+    // Cache the memory info so tensors wrapping p_device_ carry the allocator's device attributes.
+    ort_memory_info_ = &ort_allocator_->GetInfo();
+  }
+
+  Ort::Allocator& GetAllocator() override {
+    return *ort_allocator_;
+  }
+
+  void InitHostAccessible(Ort::Allocator& allocator) override {
+    ort_pinned_allocator_ = &allocator;
+  }
+
+  Ort::Allocator* GetHostAccessibleAllocator() override {
+    return ort_pinned_allocator_;
+  }
+
+  Ort::Allocator* PinnedAllocator() const { return ort_pinned_allocator_; }
+
+  std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
+    return std::make_shared<GpuMemory>(size, ort_allocator_, ort_memory_info_);
+  }
+
+  std::shared_ptr<DeviceBuffer> WrapMemoryBase(void* p, size_t size) override {
+    return std::make_shared<GpuMemory>(p, size, ort_allocator_, ort_memory_info_);
+  }
+
+  std::unique_ptr<Search> CreateGreedy(const GeneratorParams& params) override {
+    return GetDeviceInterface(DeviceType::CPU)->CreateGreedy(params);
+  }
+
+  std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override {
+    return GetDeviceInterface(DeviceType::CPU)->CreateBeam(params);
+  }
+
+  void Synchronize() override {}
+
+ private:
+  Ort::Allocator* ort_allocator_{};
+  const OrtMemoryInfo* ort_memory_info_{};
+  // Host-accessible allocator, set by InitHostAccessible when one is available.
+  Ort::Allocator* ort_pinned_allocator_{};
+};
+
+// Inputs-only interface: allocations come from the host-accessible allocator, everything else
+// delegates to the base AMDGPU interface. Updates run on the CPU in place.
+struct PinnedInputsImpl : DeviceInterface {
+  explicit PinnedInputsImpl(InterfaceImpl& base) : base_{base} {}
+
+  DeviceType GetType() const override { return DeviceType::AMDGPU; }
+  void InitOrt(const OrtApi& api, Ort::Allocator& allocator) override { base_.InitOrt(api, allocator); }
+  Ort::Allocator& GetAllocator() override { return *base_.PinnedAllocator(); }
+  Ort::Allocator* GetHostAccessibleAllocator() override { return base_.PinnedAllocator(); }
+
+  std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
+    return std::make_shared<PinnedMemory>(size, base_.PinnedAllocator());
+  }
+  std::shared_ptr<DeviceBuffer> WrapMemoryBase(void* p, size_t size) override {
+    return std::make_shared<PinnedMemory>(p, size, base_.PinnedAllocator());
+  }
+
+  std::unique_ptr<Search> CreateGreedy(const GeneratorParams& params) override { return base_.CreateGreedy(params); }
+  std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override { return base_.CreateBeam(params); }
+  void Synchronize() override { base_.Synchronize(); }
+
+  bool Cast(void* input, void* output, ONNXTensorElementDataType input_type,
+            ONNXTensorElementDataType output_type, size_t element_count) override {
+    return base_.Cast(input, output, input_type, output_type, element_count);
+  }
+
+  // In-place CPU updates on the pinned buffer. Delegate to the CPU interface and report
+  // success so the caller skips its copy-back path.
+  bool UpdatePositionIds(void* position_ids, int batch_beam_size, int total_length,
+                         int new_kv_length, ONNXTensorElementDataType type) override {
+    return GetDeviceInterface(DeviceType::CPU)->UpdatePositionIds(position_ids, batch_beam_size, total_length, new_kv_length, type);
+  }
+  bool UpdateAttentionMask(void* next_mask_data, void* mask_data, int batch_beam_size, int new_kv_length,
+                           int total_length, int max_length, bool update_only,
+                           ONNXTensorElementDataType type) override {
+    return GetDeviceInterface(DeviceType::CPU)->UpdateAttentionMask(next_mask_data, mask_data, batch_beam_size, new_kv_length,
+                                                  total_length, max_length, update_only, type);
+  }
+
+  InterfaceImpl& base_;
+};
+
+}  // namespace AMDGPU
+
+static std::unique_ptr<AMDGPU::InterfaceImpl> g_amdgpu_device;
+static std::unique_ptr<AMDGPU::PinnedInputsImpl> g_amdgpu_pinned_inputs;
+
+DeviceInterface* GetAMDGPUInterface() {
+  if (!g_amdgpu_device)
+    g_amdgpu_device = std::make_unique<AMDGPU::InterfaceImpl>();
+  return g_amdgpu_device.get();
+}
+
+DeviceInterface* GetAMDGPUPinnedInputsInterface() {
+  auto* base = static_cast<AMDGPU::InterfaceImpl*>(GetAMDGPUInterface());
+  if (!base->GetHostAccessibleAllocator())
+    return nullptr;  // no pinned allocator, caller falls back to the device interface
+  if (!g_amdgpu_pinned_inputs)
+    g_amdgpu_pinned_inputs = std::make_unique<AMDGPU::PinnedInputsImpl>(*base);
+  return g_amdgpu_pinned_inputs.get();
+}
+
+}  // namespace Generators

--- a/src/amdgpu/interface.cpp
+++ b/src/amdgpu/interface.cpp
@@ -242,6 +242,9 @@ struct InterfaceImpl : DeviceInterface {
     return ort_pinned_allocator_;
   }
 
+  // Defined below, once PinnedInputsImpl is complete.
+  DeviceInterface* GetHostAccessibleDevice() override;
+
   Ort::Allocator* PinnedAllocator() const { return ort_pinned_allocator_; }
 
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
@@ -323,13 +326,16 @@ DeviceInterface* GetAMDGPUInterface() {
   return g_amdgpu_device.get();
 }
 
-DeviceInterface* GetAMDGPUPinnedInputsInterface() {
-  auto* base = static_cast<AMDGPU::InterfaceImpl*>(GetAMDGPUInterface());
-  if (!base->GetHostAccessibleAllocator())
-    return nullptr;  // no pinned allocator, caller falls back to the device interface
+namespace AMDGPU {
+
+DeviceInterface* InterfaceImpl::GetHostAccessibleDevice() {
+  if (!ort_pinned_allocator_)
+    return nullptr;
   if (!g_amdgpu_pinned_inputs)
-    g_amdgpu_pinned_inputs = std::make_unique<AMDGPU::PinnedInputsImpl>(*base);
+    g_amdgpu_pinned_inputs = std::make_unique<PinnedInputsImpl>(*this);
   return g_amdgpu_pinned_inputs.get();
 }
+
+}  // namespace AMDGPU
 
 }  // namespace Generators

--- a/src/amdgpu/interface.cpp
+++ b/src/amdgpu/interface.cpp
@@ -11,6 +11,7 @@
 
 #include "../generators.h"
 #include "../search.h"
+#include "../models/session_options.h"
 #include "interface.h"
 
 #include <stdexcept>
@@ -20,6 +21,9 @@ namespace AMDGPU {
 
 const char* device_label = "amdgpu";
 const char* label_cpu = "cpu";
+
+// Registration name the EP is discovered under, used to look up its advertised memory-info.
+constexpr const char* kExecutionProviderName = "AMDGPUExecutionProvider";
 
 struct GpuMemory final : DeviceBuffer {
   GpuMemory(size_t size, Ort::Allocator* allocator, const OrtMemoryInfo* memory_info)
@@ -194,16 +198,48 @@ struct InterfaceImpl : DeviceInterface {
     return *ort_allocator_;
   }
 
-  // The MIGraphX backend registers its device memory-info under "Hip", keyed on the device id.
+  // The backend registers its device memory-info under "Hip", keyed on the device id.
   std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
     return OrtMemoryInfo::Create("Hip", OrtAllocatorType::OrtDeviceAllocator,
                                  device_id_, OrtMemType::OrtMemTypeDefault);
   }
 
-  void SetDeviceId(int device_id) { device_id_ = device_id; }
+  // Read the id of the EP device the model will run on, so the allocators bind to it rather than
+  // assuming device 0. Resolves to 0 on a single-GPU machine.
+  int GetDeviceId(const ProviderOptions* user_options) override {
+    auto ep_devices = FindRegisteredEpDevices(kExecutionProviderName);
+    if (user_options)
+      ep_devices = ApplyDeviceFiltering(*user_options, ep_devices);
+    if (!ep_devices.empty()) {
+      if (const OrtMemoryInfo* mi =
+              Ort::api->EpDevice_MemoryInfo(ep_devices.front(), OrtDeviceMemoryType_DEFAULT))
+        Ort::ThrowOnError(Ort::api->MemoryInfoGetId(mi, &device_id_));
+    }
+    return device_id_;
+  }
 
-  void InitHostAccessible(Ort::Allocator& allocator) override {
-    ort_pinned_allocator_ = &allocator;
+  // Pick up the host-accessible allocator advertised on the same device as the compute allocator,
+  // so the pinned decode inputs live on the device that runs the model. If the EP advertises none,
+  // this leaves the allocator null and callers keep the default device-memory path.
+  void InitDeviceAllocators(const ProviderOptions* /*user_options*/, int device_id) override {
+    if (ort_pinned_allocator_)
+      return;
+    try {
+      for (const OrtEpDevice* ep_device : FindRegisteredEpDevices(kExecutionProviderName)) {
+        const OrtMemoryInfo* mi =
+            Ort::api->EpDevice_MemoryInfo(ep_device, OrtDeviceMemoryType_HOST_ACCESSIBLE);
+        if (!mi)
+          continue;
+        int host_device_id = 0;
+        Ort::ThrowOnError(Ort::api->MemoryInfoGetId(mi, &host_device_id));
+        if (host_device_id == device_id) {
+          ort_pinned_allocator_ = GetOrtEnv().GetSharedAllocator(*mi);
+          break;
+        }
+      }
+    } catch (const Ort::Exception&) {
+      ort_pinned_allocator_ = nullptr;
+    }
   }
 
   Ort::Allocator* GetHostAccessibleAllocator() override {
@@ -233,7 +269,7 @@ struct InterfaceImpl : DeviceInterface {
  private:
   Ort::Allocator* ort_allocator_{};
   const OrtMemoryInfo* ort_memory_info_{};
-  // Host-accessible allocator, set by InitHostAccessible when one is available.
+  // Host-accessible allocator, set by InitDeviceAllocators when the EP advertises one.
   Ort::Allocator* ort_pinned_allocator_{};
   int device_id_{};
 };
@@ -289,10 +325,6 @@ DeviceInterface* GetAMDGPUInterface() {
   if (!g_amdgpu_device)
     g_amdgpu_device = std::make_unique<AMDGPU::InterfaceImpl>();
   return g_amdgpu_device.get();
-}
-
-void SetAMDGPUDeviceId(int device_id) {
-  static_cast<AMDGPU::InterfaceImpl*>(GetAMDGPUInterface())->SetDeviceId(device_id);
 }
 
 DeviceInterface* GetAMDGPUPinnedInputsInterface() {

--- a/src/amdgpu/interface.cpp
+++ b/src/amdgpu/interface.cpp
@@ -194,6 +194,14 @@ struct InterfaceImpl : DeviceInterface {
     return *ort_allocator_;
   }
 
+  // The MIGraphX backend registers its device memory-info under "Hip", keyed on the device id.
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return OrtMemoryInfo::Create("Hip", OrtAllocatorType::OrtDeviceAllocator,
+                                 device_id_, OrtMemType::OrtMemTypeDefault);
+  }
+
+  void SetDeviceId(int device_id) { device_id_ = device_id; }
+
   void InitHostAccessible(Ort::Allocator& allocator) override {
     ort_pinned_allocator_ = &allocator;
   }
@@ -227,6 +235,7 @@ struct InterfaceImpl : DeviceInterface {
   const OrtMemoryInfo* ort_memory_info_{};
   // Host-accessible allocator, set by InitHostAccessible when one is available.
   Ort::Allocator* ort_pinned_allocator_{};
+  int device_id_{};
 };
 
 // Inputs-only interface: allocations come from the host-accessible allocator, everything else
@@ -238,6 +247,7 @@ struct PinnedInputsImpl : DeviceInterface {
   void InitOrt(const OrtApi& api, Ort::Allocator& allocator) override { base_.InitOrt(api, allocator); }
   Ort::Allocator& GetAllocator() override { return *base_.PinnedAllocator(); }
   Ort::Allocator* GetHostAccessibleAllocator() override { return base_.PinnedAllocator(); }
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override { return base_.GetMemoryInfo(); }
 
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<PinnedMemory>(size, base_.PinnedAllocator());
@@ -280,6 +290,10 @@ DeviceInterface* GetAMDGPUInterface() {
   if (!g_amdgpu_device)
     g_amdgpu_device = std::make_unique<AMDGPU::InterfaceImpl>();
   return g_amdgpu_device.get();
+}
+
+void SetAMDGPUDeviceId(int device_id) {
+  static_cast<AMDGPU::InterfaceImpl*>(GetAMDGPUInterface())->SetDeviceId(device_id);
 }
 
 DeviceInterface* GetAMDGPUPinnedInputsInterface() {

--- a/src/amdgpu/interface.cpp
+++ b/src/amdgpu/interface.cpp
@@ -164,8 +164,8 @@ struct PinnedMemory final : DeviceBuffer {
   }
 
   const char* GetType() const override { return pinned_device_label; }
-  void AllocateCpu() override {}       // p_cpu_ already valid (== p_device_)
-  void CopyDeviceToCpu() override {}   // same memory: nothing to copy
+  void AllocateCpu() override {}      // p_cpu_ already valid (== p_device_)
+  void CopyDeviceToCpu() override {}  // same memory: nothing to copy
   void CopyCpuToDevice() override {}
 
   void CopyFrom(size_t begin_dest, DeviceBuffer& source, size_t begin_source, size_t size_in_bytes) override {
@@ -274,8 +274,7 @@ struct PinnedInputsImpl : DeviceInterface {
   bool UpdateAttentionMask(void* next_mask_data, void* mask_data, int batch_beam_size, int new_kv_length,
                            int total_length, int max_length, bool update_only,
                            ONNXTensorElementDataType type) override {
-    return GetDeviceInterface(DeviceType::CPU)->UpdateAttentionMask(next_mask_data, mask_data, batch_beam_size, new_kv_length,
-                                                  total_length, max_length, update_only, type);
+    return GetDeviceInterface(DeviceType::CPU)->UpdateAttentionMask(next_mask_data, mask_data, batch_beam_size, new_kv_length, total_length, max_length, update_only, type);
   }
 
   InterfaceImpl& base_;

--- a/src/amdgpu/interface.cpp
+++ b/src/amdgpu/interface.cpp
@@ -22,9 +22,6 @@ namespace AMDGPU {
 const char* device_label = "amdgpu";
 const char* label_cpu = "cpu";
 
-// Registration name the EP is discovered under, used to look up its advertised memory-info.
-constexpr const char* kExecutionProviderName = "AMDGPUExecutionProvider";
-
 struct GpuMemory final : DeviceBuffer {
   GpuMemory(size_t size, Ort::Allocator* allocator, const OrtMemoryInfo* memory_info)
       : owned_{true}, ort_allocator_{allocator}, ort_memory_info_{memory_info} {
@@ -206,7 +203,7 @@ struct InterfaceImpl : DeviceInterface {
   // Read the id of the EP device the model will run on, so the allocators bind to it rather than
   // assuming device 0. Resolves to 0 on a single-GPU machine.
   int GetDeviceId(const ProviderOptions* user_options) override {
-    auto ep_devices = FindRegisteredEpDevices(kExecutionProviderName);
+    auto ep_devices = FindRegisteredEpDevices(kAMDGPUExecutionProviderName);
     if (user_options)
       ep_devices = ApplyDeviceFiltering(*user_options, ep_devices);
     if (!ep_devices.empty()) {
@@ -224,7 +221,7 @@ struct InterfaceImpl : DeviceInterface {
     if (ort_pinned_allocator_)
       return;
     try {
-      for (const OrtEpDevice* ep_device : FindRegisteredEpDevices(kExecutionProviderName)) {
+      for (const OrtEpDevice* ep_device : FindRegisteredEpDevices(kAMDGPUExecutionProviderName)) {
         const OrtMemoryInfo* mi =
             Ort::api->EpDevice_MemoryInfo(ep_device, OrtDeviceMemoryType_HOST_ACCESSIBLE);
         if (!mi)

--- a/src/amdgpu/interface.cpp
+++ b/src/amdgpu/interface.cpp
@@ -198,7 +198,6 @@ struct InterfaceImpl : DeviceInterface {
     return *ort_allocator_;
   }
 
-  // The backend registers its device memory-info under "Hip", keyed on the device id.
   std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
     return OrtMemoryInfo::Create("Hip", OrtAllocatorType::OrtDeviceAllocator,
                                  device_id_, OrtMemType::OrtMemTypeDefault);

--- a/src/amdgpu/interface.h
+++ b/src/amdgpu/interface.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+namespace Generators {
+
+DeviceInterface* GetAMDGPUInterface();
+
+// Inputs-only interface backed by the host-accessible allocator. Decode inputs allocated
+// here are CPU-writable and GPU-readable, so per-step updates happen in place with no
+// roundtrip. KV and scoring keep the default interface. Null if no host-accessible allocator.
+DeviceInterface* GetAMDGPUPinnedInputsInterface();
+
+}  // namespace Generators

--- a/src/amdgpu/interface.h
+++ b/src/amdgpu/interface.h
@@ -9,6 +9,10 @@ namespace Generators {
 
 DeviceInterface* GetAMDGPUInterface();
 
+// Device this interface's allocators bind to. Resolved from the selected EP device before the
+// allocator is created; defaults to 0.
+void SetAMDGPUDeviceId(int device_id);
+
 // Inputs-only interface backed by the host-accessible allocator. Decode inputs allocated
 // here are CPU-writable and GPU-readable, so per-step updates happen in place with no
 // roundtrip. KV and scoring keep the default interface. Null if no host-accessible allocator.

--- a/src/amdgpu/interface.h
+++ b/src/amdgpu/interface.h
@@ -9,10 +9,6 @@ namespace Generators {
 
 DeviceInterface* GetAMDGPUInterface();
 
-// Device this interface's allocators bind to. Resolved from the selected EP device before the
-// allocator is created; defaults to 0.
-void SetAMDGPUDeviceId(int device_id);
-
 // Inputs-only interface backed by the host-accessible allocator. Decode inputs allocated
 // here are CPU-writable and GPU-readable, so per-step updates happen in place with no
 // roundtrip. KV and scoring keep the default interface. Null if no host-accessible allocator.

--- a/src/amdgpu/interface.h
+++ b/src/amdgpu/interface.h
@@ -12,9 +12,4 @@ constexpr const char* kAMDGPUExecutionProviderName = "AMDGPUExecutionProvider";
 
 DeviceInterface* GetAMDGPUInterface();
 
-// Inputs-only interface backed by the host-accessible allocator. Decode inputs allocated
-// here are CPU-writable and GPU-readable, so per-step updates happen in place with no
-// roundtrip. KV and scoring keep the default interface. Null if no host-accessible allocator.
-DeviceInterface* GetAMDGPUPinnedInputsInterface();
-
 }  // namespace Generators

--- a/src/amdgpu/interface.h
+++ b/src/amdgpu/interface.h
@@ -7,6 +7,9 @@
 
 namespace Generators {
 
+// Name the EP library is registered under, and that its OrtEpDevice is discovered by.
+constexpr const char* kAMDGPUExecutionProviderName = "AMDGPUExecutionProvider";
+
 DeviceInterface* GetAMDGPUInterface();
 
 // Inputs-only interface backed by the host-accessible allocator. Decode inputs allocated

--- a/src/amdgpu/session_options.cpp
+++ b/src/amdgpu/session_options.cpp
@@ -37,6 +37,9 @@ DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
                                          bool /*disable_graph_capture*/) {
   SetStaticPaddingConfig(session_options, config);
 
+  // Umbrella-level hint: the model architecture drives the EP's backend routing.
+  session_options.AddConfigEntry("ep.amdgpuexecutionprovider.model_arch", config.model.type.c_str());
+
   AppendExecutionProviderV2(session_options, provider_options,
                             DeviceType::AMDGPU, "AMDGPUExecutionProvider");
 

--- a/src/amdgpu/session_options.cpp
+++ b/src/amdgpu/session_options.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "session_options.h"
+
+#include "../models/session_options.h"
+#include "interface.h"
+
+namespace Generators::AMDGPUExecutionProvider {
+
+namespace {
+
+// Emit static-padding hints so the EP pads the prefill token axis to max_length and
+// compiles it once, instead of recompiling per prompt length.
+void SetStaticPaddingConfig(OrtSessionOptions& session_options, const Config& config) {
+  const auto& decoder = config.model.decoder;
+  const std::string seq_len = std::to_string(config.search.max_length);
+  const std::string pad_inputs =
+      decoder.inputs.input_ids + ":1," + decoder.inputs.position_ids + ":1";
+  const std::string pad_outputs = decoder.outputs.logits + ":1";
+
+  session_options.AddConfigEntry("ep.migraphx.static_pad_seq", "1");
+  session_options.AddConfigEntry("ep.migraphx.static_pad_seq_len", seq_len.c_str());
+  session_options.AddConfigEntry("ep.migraphx.static_pad_inputs", pad_inputs.c_str());
+  session_options.AddConfigEntry("ep.migraphx.static_pad_outputs", pad_outputs.c_str());
+
+  session_options.AddConfigEntry("ep.migraphx.hip_graph_enable", "1");
+}
+
+}  // namespace
+
+DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
+                                         const Config::ProviderOptions& provider_options,
+                                         const Config& config,
+                                         bool /*disable_graph_capture*/) {
+  SetStaticPaddingConfig(session_options, config);
+
+  AppendExecutionProviderV2(session_options, provider_options,
+                            DeviceType::AMDGPU, "AMDGPUExecutionProvider");
+
+  return GetAMDGPUInterface();
+}
+
+}  // namespace Generators::AMDGPUExecutionProvider

--- a/src/amdgpu/session_options.cpp
+++ b/src/amdgpu/session_options.cpp
@@ -5,12 +5,85 @@
 
 #include "session_options.h"
 
+#include <filesystem>
+#include <string>
+
+#include "../models/env_utils.h"
 #include "../models/session_options.h"
 #include "interface.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 
 namespace Generators::AMDGPUExecutionProvider {
 
 namespace {
+
+constexpr const char* kEpPathEnvKey = "AMDGPU_EP_PATH";
+#if defined(_WIN32)
+constexpr const char* kEpFilename = "amdgpu-ep.dll";
+#else
+constexpr const char* kEpFilename = "libamdgpu-ep.so";
+#endif
+
+// A plugin EP is only discoverable once its library is registered on the OrtEnv. Hosts that can
+// supply a path do that themselves; resolve it here for the ones that cannot. No-op if the EP is
+// already registered or the library is not found, so an explicit registration always wins.
+void EnsureUmbrellaEpRegistered() {
+  if (!FindRegisteredEpDevices(kAMDGPUExecutionProviderName).empty())
+    return;
+
+  std::error_code ec;
+  std::filesystem::path ep_path = GetEnv(kEpPathEnvKey);
+
+#if defined(_WIN32)
+  const auto module_of = [](const void* address) -> HMODULE {
+    MEMORY_BASIC_INFORMATION mbi;
+    if (VirtualQuery(address, &mbi, sizeof(mbi)) && mbi.AllocationBase)
+      return reinterpret_cast<HMODULE>(mbi.AllocationBase);
+    return nullptr;
+  };
+
+  const auto find_next_to_module = [&](HMODULE module) -> std::filesystem::path {
+    wchar_t buffer[MAX_PATH + 1] = {0};
+    if (GetModuleFileNameW(module, buffer, MAX_PATH + 1))
+      if (const auto dir = std::filesystem::path{buffer}.remove_filename(); !dir.empty())
+        if (auto path = dir / kEpFilename; std::filesystem::exists(path, ec))
+          return path;
+    return {};
+  };
+
+  if (ep_path.empty())
+    // next to onnxruntime-genai, using a symbol in that module as the address marker
+    if (const auto module = module_of(reinterpret_cast<const void*>(&GetAMDGPUInterface)))
+      ep_path = find_next_to_module(module);
+
+  if (ep_path.empty())
+    // next to onnxruntime
+    if (const auto module = module_of(reinterpret_cast<const void*>(Ort::api->RegisterExecutionProviderLibrary)))
+      ep_path = find_next_to_module(module);
+
+  if (ep_path.empty())
+    // next to the current executable
+    if (const auto module = GetModuleHandleA(nullptr))
+      ep_path = find_next_to_module(module);
+#endif
+
+  if (ep_path.empty())
+    ep_path = std::filesystem::current_path(ec) / kEpFilename;
+
+  if (!std::filesystem::exists(ep_path, ec))
+    return;
+
+  try {
+    Ort::RegisterExecutionProviderLibrary(&GetOrtEnv(), kAMDGPUExecutionProviderName, ep_path.native().c_str());
+  } catch (const Ort::Exception& e) {
+    // Registered but advertising no device: the check above cannot see that, ORT reports it here.
+    if (std::string(e.what()).find("already registered") == std::string::npos)
+      throw;
+  }
+}
 
 // Emit static-padding hints so the EP pads the prefill token axis to max_length and
 // compiles it once, instead of recompiling per prompt length.
@@ -35,6 +108,8 @@ DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
                                          const Config::ProviderOptions& provider_options,
                                          const Config& config,
                                          bool /*disable_graph_capture*/) {
+  EnsureUmbrellaEpRegistered();
+
   SetStaticPaddingConfig(session_options, config);
 
   // Umbrella-level hint: the model architecture drives the EP's backend routing.
@@ -44,7 +119,7 @@ DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
   session_options.AddConfigEntry("ep.directml.enable_host_accessible", "1");
 
   AppendExecutionProviderV2(session_options, provider_options,
-                            DeviceType::AMDGPU, "AMDGPUExecutionProvider");
+                            DeviceType::AMDGPU, kAMDGPUExecutionProviderName);
 
   return GetAMDGPUInterface();
 }

--- a/src/amdgpu/session_options.cpp
+++ b/src/amdgpu/session_options.cpp
@@ -40,6 +40,9 @@ DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
   // Umbrella-level hint: the model architecture drives the EP's backend routing.
   session_options.AddConfigEntry("ep.amdgpuexecutionprovider.model_arch", config.model.type.c_str());
 
+  // DirectML backend: host-accessible decode inputs.
+  session_options.AddConfigEntry("ep.directml.enable_host_accessible", "1");
+
   AppendExecutionProviderV2(session_options, provider_options,
                             DeviceType::AMDGPU, "AMDGPUExecutionProvider");
 

--- a/src/amdgpu/session_options.h
+++ b/src/amdgpu/session_options.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#pragma once
+
+#include "../generators.h"
+
+namespace Generators::AMDGPUExecutionProvider {
+
+DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
+                                         const Config::ProviderOptions& provider_options,
+                                         const Config& config,
+                                         bool disable_graph_capture = false);
+
+}  // namespace Generators::AMDGPUExecutionProvider

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -44,6 +44,10 @@ std::string_view NormalizeProviderName(std::string_view name) {
     return "RyzenAI";
   } else if (lower_name == "nvtensorrtrtx") {
     return "NvTensorRtRtx";
+  } else if (lower_name == "amdgpu" ||
+             lower_name == "amdgpuexecutionprovider") {
+    // Accept canonical and catalog forms, all route to AMDGPU.
+    return "AMDGPU";
   }
   return name;  // Return name unchanged
 }
@@ -1518,6 +1522,8 @@ bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options) {
             }
           }
         }
+        return true;
+      } else if (provider_options->name == "AMDGPU") {
         return true;
       } else if (provider_options->name == "WebGPU") {
         for (const auto& value : provider_options->options) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -45,6 +45,10 @@ std::string_view NormalizeProviderName(std::string_view name) {
     return "RyzenAI";
   } else if (lower_name == "nvtensorrtrtx") {
     return "NvTensorRtRtx";
+  } else if (lower_name == "amdgpu" ||
+             lower_name == "amdgpuexecutionprovider") {
+    // Accept canonical and catalog forms, all route to AMDGPU.
+    return "AMDGPU";
   }
   return name;  // Return name unchanged
 }
@@ -1542,6 +1546,8 @@ bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options) {
             return false;
           }
         }
+        return true;
+      } else if (provider_options->name == "AMDGPU") {
         return true;
       } else if (provider_options->name == "WebGPU") {
         for (const auto& value : provider_options->options) {

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -23,6 +23,7 @@
 #include "webgpu/interface.h"
 #include "openvino/interface.h"
 #include "ryzenai/interface.h"
+#include "amdgpu/interface.h"
 #include "engine/engine.h"
 
 #if defined(_WIN32)
@@ -335,6 +336,9 @@ DeviceInterface* OrtGlobals::GetDeviceInterface(DeviceType type) {
       owned_interfaces_.push_back(CreateRyzenAIInterface(*env_));
       slot = owned_interfaces_.back().get();
       break;
+    case DeviceType::AMDGPU:
+      slot = GetAMDGPUInterface();  // static singleton owned by amdgpu/interface.cpp
+      break;
     case DeviceType::CPU:
     default:
       owned_interfaces_.push_back(CreateCpuInterface());
@@ -363,6 +367,8 @@ std::string to_string(DeviceType device_type) {
       return "NvTensorRtRtx";
     case DeviceType::RyzenAI:
       return "RyzenAI";
+    case DeviceType::AMDGPU:
+      return "AMDGPU";
     default:
       throw std::runtime_error("Unknown device type");
   }
@@ -774,6 +780,7 @@ void Generator::GenerateNextToken() {
     auto next_tokens = search_->GetNextTokens();
     if (last_action_ == Action::rewound)
       search_->AppendTokens(next_tokens);
+
     ComputeLogits(next_tokens);
   }
   if (guidance_logits_processor_) {

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -861,7 +861,6 @@ void Generator::GenerateNextToken() {
     auto next_tokens = search_->GetNextTokens();
     if (last_action_ == Action::rewound)
       search_->AppendTokens(next_tokens);
-
     ComputeLogits(next_tokens);
   }
   if (guidance_logits_processor_) {

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -369,7 +369,7 @@ DeviceInterface* OrtGlobals::GetDeviceInterface(DeviceType type) {
       slot = owned_interfaces_.back().get();
       break;
     case DeviceType::AMDGPU:
-      slot = GetAMDGPUInterface();  // static singleton owned by amdgpu/interface.cpp
+      slot = GetAMDGPUInterface();
       break;
     case DeviceType::CPU:
     default:

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -25,6 +25,7 @@
 #include "webgpu/interface.h"
 #include "openvino/interface.h"
 #include "ryzenai/interface.h"
+#include "amdgpu/interface.h"
 #include "engine/engine.h"
 
 #if defined(_WIN32)
@@ -367,6 +368,9 @@ DeviceInterface* OrtGlobals::GetDeviceInterface(DeviceType type) {
       owned_interfaces_.push_back(CreateRyzenAIInterface(*env_));
       slot = owned_interfaces_.back().get();
       break;
+    case DeviceType::AMDGPU:
+      slot = GetAMDGPUInterface();  // static singleton owned by amdgpu/interface.cpp
+      break;
     case DeviceType::CPU:
     default:
       owned_interfaces_.push_back(CreateCpuInterface());
@@ -395,6 +399,8 @@ std::string to_string(DeviceType device_type) {
       return "NvTensorRtRtx";
     case DeviceType::RyzenAI:
       return "RyzenAI";
+    case DeviceType::AMDGPU:
+      return "AMDGPU";
     default:
       throw std::runtime_error("Unknown device type");
   }
@@ -855,6 +861,7 @@ void Generator::GenerateNextToken() {
     auto next_tokens = search_->GetNextTokens();
     if (last_action_ == Action::rewound)
       search_->AppendTokens(next_tokens);
+
     ComputeLogits(next_tokens);
   }
   if (guidance_logits_processor_) {

--- a/src/generators.h
+++ b/src/generators.h
@@ -175,6 +175,7 @@ struct OrtGlobals {
     // Optional host-accessible allocator for decode inputs, owned by the OrtEnv (do not free).
     // Null if unavailable, in which case inputs stay on the default device allocator.
     Ort::Allocator* host_accessible_allocator_{};
+    int device_id_{};  // Device this allocator is bound to (0 unless a specific device was selected).
   };
   Allocator device_allocators_[static_cast<int>(DeviceType::MAX)];
 

--- a/src/generators.h
+++ b/src/generators.h
@@ -172,6 +172,9 @@ struct OrtGlobals {
     // ~allocator_ runs first.
     std::unique_ptr<OrtSession> session_;
     std::unique_ptr<Ort::Allocator> allocator_;
+    // Optional host-accessible allocator for decode inputs, owned by the OrtEnv (do not free).
+    // Null if unavailable, in which case inputs stay on the default device allocator.
+    Ort::Allocator* host_accessible_allocator_{};
   };
   Allocator device_allocators_[static_cast<int>(DeviceType::MAX)];
 

--- a/src/generators.h
+++ b/src/generators.h
@@ -186,6 +186,7 @@ struct OrtGlobals {
     // Optional host-accessible allocator for decode inputs, owned by the OrtEnv (do not free).
     // Null if unavailable, in which case inputs stay on the default device allocator.
     Ort::Allocator* host_accessible_allocator_{};
+    int device_id_{};  // Device this allocator is bound to (0 unless a specific device was selected).
   };
   Allocator device_allocators_[static_cast<int>(DeviceType::MAX)];
 

--- a/src/generators.h
+++ b/src/generators.h
@@ -183,6 +183,9 @@ struct OrtGlobals {
     // ~allocator_ runs first.
     std::unique_ptr<OrtSession> session_;
     std::unique_ptr<Ort::Allocator> allocator_;
+    // Optional host-accessible allocator for decode inputs, owned by the OrtEnv (do not free).
+    // Null if unavailable, in which case inputs stay on the default device allocator.
+    Ort::Allocator* host_accessible_allocator_{};
   };
   Allocator device_allocators_[static_cast<int>(DeviceType::MAX)];
 

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -432,7 +432,10 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
       }
 
       presents_.push_back(OrtValue::CreateTensor(Allocator(), tensor_shape, type_));
-      if (Device().GetType() != DeviceType::WEBGPU) {
+      // WebGPU has no Zero() implementation; AMDGPU skips it for the same reason (Stage A
+      // DeviceInterface throws on Zero — KV is fresh per-Generator so zeroing is optional).
+      if (Device().GetType() != DeviceType::WEBGPU &&
+          Device().GetType() != DeviceType::AMDGPU) {
         ByteWrapTensor(Device(), *presents_.back()).Zero();
       }
     }

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -432,10 +432,8 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
       }
 
       presents_.push_back(OrtValue::CreateTensor(Allocator(), tensor_shape, type_));
-      // WebGPU has no Zero() implementation; AMDGPU skips it for the same reason (Stage A
-      // DeviceInterface throws on Zero — KV is fresh per-Generator so zeroing is optional).
-      if (Device().GetType() != DeviceType::WEBGPU &&
-          Device().GetType() != DeviceType::AMDGPU) {
+      // WebGPU has no Zero() implementation; every other backend (incl. AMDGPU) zero-inits the KV.
+      if (Device().GetType() != DeviceType::WEBGPU) {
         ByteWrapTensor(Device(), *presents_.back()).Zero();
       }
     }

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -517,10 +517,8 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
       }
 
       presents_.push_back(OrtValue::CreateTensor(Allocator(), tensor_shape, type_));
-      // WebGPU has no Zero() implementation; AMDGPU skips it for the same reason (Stage A
-      // DeviceInterface throws on Zero — KV is fresh per-Generator so zeroing is optional).
-      if (Device().GetType() != DeviceType::WEBGPU &&
-          Device().GetType() != DeviceType::AMDGPU) {
+      // WebGPU has no Zero() implementation; every other backend (incl. AMDGPU) zero-inits the KV.
+      if (Device().GetType() != DeviceType::WEBGPU) {
         ByteWrapTensor(Device(), *presents_.back()).Zero();
       }
     }

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -517,7 +517,10 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
       }
 
       presents_.push_back(OrtValue::CreateTensor(Allocator(), tensor_shape, type_));
-      if (Device().GetType() != DeviceType::WEBGPU) {
+      // WebGPU has no Zero() implementation; AMDGPU skips it for the same reason (Stage A
+      // DeviceInterface throws on Zero — KV is fresh per-Generator so zeroing is optional).
+      if (Device().GetType() != DeviceType::WEBGPU &&
+          Device().GetType() != DeviceType::AMDGPU) {
         ByteWrapTensor(Device(), *presents_.back()).Zero();
       }
     }

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -517,7 +517,7 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
       }
 
       presents_.push_back(OrtValue::CreateTensor(Allocator(), tensor_shape, type_));
-      // WebGPU has no Zero() implementation; every other backend (incl. AMDGPU) zero-inits the KV.
+      // WebGPU has no Zero() implementation; every other backend zero-inits the KV.
       if (Device().GetType() != DeviceType::WEBGPU) {
         ByteWrapTensor(Device(), *presents_.back()).Zero();
       }

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -13,7 +13,13 @@ Logits::Logits(State& state)
     : state_{state},
       shape_{static_cast<int64_t>(state_.params_->BatchBeamSize()), 0, model_.config_->model.vocab_size},
       type_{model_.session_info_.GetOutputDataType(model_.config_->model.decoder.outputs.logits)} {
-  output_raw_ = std::make_unique<Tensor>(model_.p_device_inputs_, type_);
+  // Logits is GPU-written / CPU-read (the sampler). For AMDGPU, p_device_inputs_ points at the
+  // host-accessible allocator (DML WRITE_COMBINE is not CPU-read-coherent), so route logits to the
+  // CPU interface instead; other backends keep logits on their device-inputs interface.
+  p_logits_ = (model_.p_device_->GetType() == DeviceType::AMDGPU)
+                  ? GetDeviceInterface(DeviceType::CPU)
+                  : model_.p_device_inputs_;
+  output_raw_ = std::make_unique<Tensor>(p_logits_, type_);
 
   input_sequence_lengths.resize(state_.params_->search.batch_size);
 
@@ -42,10 +48,10 @@ DeviceSpan<float> Logits::Get() {
     const size_t num_beams = state_.params_->search.num_beams;
 
     // create new OrtValue for logits_of_last_token and use output_last_tokens_ to hold it
-    output_last_tokens_ = OrtValue::CreateTensor(model_.p_device_inputs_->GetAllocator(), shape_last, type_);
+    output_last_tokens_ = OrtValue::CreateTensor(p_logits_->GetAllocator(), shape_last, type_);
 
     if (type_ == Ort::TypeToTensorType<Ort::Float16_t> || type_ == Ort::TypeToTensorType<Ort::BFloat16_t>)
-      logits_of_last_token_fp32_ = OrtValue::CreateTensor<float>(model_.p_device_inputs_->GetAllocator(), shape_);
+      logits_of_last_token_fp32_ = OrtValue::CreateTensor<float>(p_logits_->GetAllocator(), shape_);
 
     logits_of_last_token = output_last_tokens_.get();
 
@@ -53,7 +59,7 @@ DeviceSpan<float> Logits::Get() {
     size_t vocab_index = 0;  // Simpler math to have this index go up by vocab_size for every logit chunk we process
 
     auto logits_raw = output_raw_->GetByteSpan();
-    auto logits_last_tokens = ByteWrapTensor(*model_.p_device_inputs_, *logits_of_last_token);
+    auto logits_last_tokens = ByteWrapTensor(*p_logits_, *logits_of_last_token);
 
     for (int batch_index = 0; batch_index < state_.params_->search.batch_size; batch_index++) {
       // Find the first non pad token from the end
@@ -71,12 +77,12 @@ DeviceSpan<float> Logits::Get() {
 
   // Convert from float16/bfloat16 to float32 if necessary
   if (type_ == Ort::TypeToTensorType<Ort::Float16_t> || type_ == Ort::TypeToTensorType<Ort::BFloat16_t>) {
-    Cast(*logits_of_last_token, logits_of_last_token_fp32_, *model_.p_device_inputs_, Ort::TypeToTensorType<float>);
+    Cast(*logits_of_last_token, logits_of_last_token_fp32_, *p_logits_, Ort::TypeToTensorType<float>);
     logits_of_last_token = logits_of_last_token_fp32_.get();
   }
 
   if (logits_.empty() || logits_of_last_token->GetTensorMutableRawData() != logits_.Span().data())
-    logits_ = WrapTensor<float>(*model_.p_device_inputs_, *logits_of_last_token);
+    logits_ = WrapTensor<float>(*p_logits_, *logits_of_last_token);
 
   return logits_;
 }

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -13,13 +13,7 @@ Logits::Logits(State& state)
     : state_{state},
       shape_{static_cast<int64_t>(state_.params_->BatchBeamSize()), 0, model_.config_->model.vocab_size},
       type_{model_.session_info_.GetOutputDataType(model_.config_->model.decoder.outputs.logits)} {
-  // Logits is GPU-written / CPU-read (the sampler). For AMDGPU, p_device_inputs_ points at the
-  // host-accessible allocator (DML WRITE_COMBINE is not CPU-read-coherent), so route logits to the
-  // CPU interface instead; other backends keep logits on their device-inputs interface.
-  p_logits_ = (model_.p_device_->GetType() == DeviceType::AMDGPU)
-                  ? GetDeviceInterface(DeviceType::CPU)
-                  : model_.p_device_inputs_;
-  output_raw_ = std::make_unique<Tensor>(p_logits_, type_);
+  output_raw_ = std::make_unique<Tensor>(model_.p_device_logits_, type_);
 
   input_sequence_lengths.resize(state_.params_->search.batch_size);
 
@@ -48,10 +42,10 @@ DeviceSpan<float> Logits::Get() {
     const size_t num_beams = state_.params_->search.num_beams;
 
     // create new OrtValue for logits_of_last_token and use output_last_tokens_ to hold it
-    output_last_tokens_ = OrtValue::CreateTensor(p_logits_->GetAllocator(), shape_last, type_);
+    output_last_tokens_ = OrtValue::CreateTensor(model_.p_device_logits_->GetAllocator(), shape_last, type_);
 
     if (type_ == Ort::TypeToTensorType<Ort::Float16_t> || type_ == Ort::TypeToTensorType<Ort::BFloat16_t>)
-      logits_of_last_token_fp32_ = OrtValue::CreateTensor<float>(p_logits_->GetAllocator(), shape_);
+      logits_of_last_token_fp32_ = OrtValue::CreateTensor<float>(model_.p_device_logits_->GetAllocator(), shape_);
 
     logits_of_last_token = output_last_tokens_.get();
 
@@ -59,7 +53,7 @@ DeviceSpan<float> Logits::Get() {
     size_t vocab_index = 0;  // Simpler math to have this index go up by vocab_size for every logit chunk we process
 
     auto logits_raw = output_raw_->GetByteSpan();
-    auto logits_last_tokens = ByteWrapTensor(*p_logits_, *logits_of_last_token);
+    auto logits_last_tokens = ByteWrapTensor(*model_.p_device_logits_, *logits_of_last_token);
 
     for (int batch_index = 0; batch_index < state_.params_->search.batch_size; batch_index++) {
       // Find the first non pad token from the end
@@ -77,12 +71,12 @@ DeviceSpan<float> Logits::Get() {
 
   // Convert from float16/bfloat16 to float32 if necessary
   if (type_ == Ort::TypeToTensorType<Ort::Float16_t> || type_ == Ort::TypeToTensorType<Ort::BFloat16_t>) {
-    Cast(*logits_of_last_token, logits_of_last_token_fp32_, *p_logits_, Ort::TypeToTensorType<float>);
+    Cast(*logits_of_last_token, logits_of_last_token_fp32_, *model_.p_device_logits_, Ort::TypeToTensorType<float>);
     logits_of_last_token = logits_of_last_token_fp32_.get();
   }
 
   if (logits_.empty() || logits_of_last_token->GetTensorMutableRawData() != logits_.Span().data())
-    logits_ = WrapTensor<float>(*p_logits_, *logits_of_last_token);
+    logits_ = WrapTensor<float>(*model_.p_device_logits_, *logits_of_last_token);
 
   return logits_;
 }

--- a/src/models/logits.h
+++ b/src/models/logits.h
@@ -31,12 +31,6 @@ struct Logits {
 
   std::unique_ptr<Tensor> output_raw_;  // Raw logits output from model
 
-  // Device interface for the logits output + last-token/fp32 scratch. Normally p_device_inputs_, but
-  // logits is GPU-written / CPU-read (opposite of the pinned decode inputs). For AMDGPU the inputs use
-  // a host-accessible allocator whose heap is NOT CPU-read-coherent (DML CUSTOM/L0/WRITE_COMBINE), so
-  // logits go on the CPU interface instead; only the 3 decode inputs use the pinned allocator.
-  DeviceInterface* p_logits_{};
-
   std::vector<int> input_sequence_lengths;
   // OrtValue wrapped in a DeviceMemory object to make it universal
   DeviceSpan<float> logits_;

--- a/src/models/logits.h
+++ b/src/models/logits.h
@@ -31,6 +31,12 @@ struct Logits {
 
   std::unique_ptr<Tensor> output_raw_;  // Raw logits output from model
 
+  // Device interface for the logits output + last-token/fp32 scratch. Normally p_device_inputs_, but
+  // logits is GPU-written / CPU-read (opposite of the pinned decode inputs). For AMDGPU the inputs use
+  // a host-accessible allocator whose heap is NOT CPU-read-coherent (DML CUSTOM/L0/WRITE_COMBINE), so
+  // logits go on the CPU interface instead; only the 3 decode inputs use the pinned allocator.
+  DeviceInterface* p_logits_{};
+
   std::vector<int> input_sequence_lengths;
   // OrtValue wrapped in a DeviceMemory object to make it universal
   DeviceSpan<float> logits_;

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -508,13 +508,19 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   // if unavailable, creation returns null and callers fall back to the default device inputs path.
   if (!allocator.host_accessible_allocator_ && type == DeviceType::AMDGPU) {
     try {
-      // device_id is hardcoded 0, so this is correct for single-GPU only. On multi-GPU the
-      // device_id differs and GetSharedAllocator returns null (falls back, perf loss not error).
-      // TODO(multi-gpu): query EpDevice::MemoryInfo(HOST_ACCESSIBLE) instead of reconstructing.
-      auto host_info = OrtMemoryInfo::CreateV2("pinned", OrtMemoryInfoDeviceType_GPU,
-                                               /*vendor_id=*/0x1002, /*device_id=*/0,
-                                               OrtDeviceMemoryType_HOST_ACCESSIBLE, OrtDeviceAllocator);
-      allocator.host_accessible_allocator_ = GetOrtEnv().GetSharedAllocator(*host_info);
+      // Query the AMDGPU EP's advertised HOST_ACCESSIBLE memory-info instead of reconstructing it with
+      // hardcoded vendor/device ids, so it carries the real ids for this machine (multi-GPU safe). If
+      // none is advertised, leave it unset -> callers fall back to the default device inputs path.
+      const OrtMemoryInfo* host_info = nullptr;
+      for (const OrtEpDevice* ep_device : FindRegisteredEpDevices("AMDGPUExecutionProvider")) {
+        if (const OrtMemoryInfo* mi =
+                Ort::api->EpDevice_MemoryInfo(ep_device, OrtDeviceMemoryType_HOST_ACCESSIBLE)) {
+          host_info = mi;
+          break;
+        }
+      }
+      if (host_info)
+        allocator.host_accessible_allocator_ = GetOrtEnv().GetSharedAllocator(*host_info);
     } catch (const Ort::Exception&) {
       allocator.host_accessible_allocator_ = nullptr;
     }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -623,6 +623,9 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
       p_device_inputs_ = pinned;
   }
 
+  // Logits are CPU-read; AMDGPU host-accessible inputs aren't CPU-read-coherent, so route to CPU.
+  p_device_logits_ = (p_device_->GetType() == DeviceType::AMDGPU) ? GetDeviceInterface(DeviceType::CPU) : p_device_inputs_;
+
   // Search and sampling are performed on the CPU for all device types,
   // except for CUDA and NvTensorRtRtx, where this is performed on the device.
   if (p_device_->GetType() == DeviceType::CUDA ||

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -467,18 +467,25 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   const auto trivial_model = GetTrivialModel();
   allocator.session_ = OrtSession::Create(GetOrtEnv(), trivial_model.data(), trivial_model.size(), session_options.get());
 
-  // Names for the device memory types used by 'OrtMemoryInfo::Create'
-  // AMDGPU device memory-type name is "Hip" (the MIGraphX backend registers
-  // CreateMemoryInfo_V2("Hip", GPU, ...); a V1 CreateMemoryInfo("Hip") memory-info matches it
-  // by device attributes). This mirrors the original B003 GPU-KV path (commit 64d1b3a5).
+  // Names for the device memory types used by 'OrtMemoryInfo::Create'. AMDGPU is "Hip".
   static const char* device_memory_type_names[] = {"CPU (Not used, see above)", "Cuda", "DML", "WebGPU_Buf", "QnnHtpShared", "QnnHtpShared", "OpenVINO (Not used, see above)", "Cuda", "Cpu", "Hip"};
   static_assert(std::size(device_memory_type_names) == static_cast<size_t>(DeviceType::MAX));
 
   // Get the allocator from the OrtSession for the DeviceType (it's called 'AllocatorCreate' but it's really 'AllocatorGet')
   auto name = device_memory_type_names[static_cast<int>(type)];
+  // AMDGPU: use the selected device's id rather than a hardcoded 0. Single-GPU resolves to 0.
+  if (type == DeviceType::AMDGPU) {
+    auto ep_devices = FindRegisteredEpDevices("AMDGPUExecutionProvider");
+    if (user_provider_options)
+      ep_devices = ApplyDeviceFiltering(*user_provider_options, ep_devices);
+    if (!ep_devices.empty()) {
+      if (const OrtMemoryInfo* mi = Ort::api->EpDevice_MemoryInfo(ep_devices.front(), OrtDeviceMemoryType_DEFAULT))
+        Ort::ThrowOnError(Ort::api->MemoryInfoGetId(mi, &allocator.device_id_));
+    }
+  }
   try {
     auto memory_info = OrtMemoryInfo::Create(name, OrtAllocatorType::OrtDeviceAllocator,
-                                             0, OrtMemType::OrtMemTypeDefault);
+                                             allocator.device_id_, OrtMemType::OrtMemTypeDefault);
     allocator.allocator_ = Ort::Allocator::Create(*allocator.session_, *memory_info);
   } catch (const Ort::Exception& e) {
     // WebGPU memory type name changed from "WebGPU_Buffer" to "WebGPU_Buf" in ORT 1.24.3.
@@ -508,13 +515,16 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   // if unavailable, creation returns null and callers fall back to the default device inputs path.
   if (!allocator.host_accessible_allocator_ && type == DeviceType::AMDGPU) {
     try {
-      // Query the AMDGPU EP's advertised HOST_ACCESSIBLE memory-info instead of reconstructing it with
-      // hardcoded vendor/device ids, so it carries the real ids for this machine (multi-GPU safe). If
-      // none is advertised, leave it unset -> callers fall back to the default device inputs path.
+      // Use the host-accessible memory-info on the same device as the compute allocator.
       const OrtMemoryInfo* host_info = nullptr;
       for (const OrtEpDevice* ep_device : FindRegisteredEpDevices("AMDGPUExecutionProvider")) {
-        if (const OrtMemoryInfo* mi =
-                Ort::api->EpDevice_MemoryInfo(ep_device, OrtDeviceMemoryType_HOST_ACCESSIBLE)) {
+        const OrtMemoryInfo* mi =
+            Ort::api->EpDevice_MemoryInfo(ep_device, OrtDeviceMemoryType_HOST_ACCESSIBLE);
+        if (!mi)
+          continue;
+        int host_device_id = 0;
+        Ort::ThrowOnError(Ort::api->MemoryInfoGetId(mi, &host_device_id));
+        if (host_device_id == allocator.device_id_) {
           host_info = mi;
           break;
         }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -503,6 +503,24 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
     throw std::runtime_error("Unexpected failure to create device memory allocator for " + std::string(name));
   }
   device.InitOrt(*Ort::api, *allocator.allocator_);
+
+  // Host-accessible allocator for decode inputs (AMDGPU only). Request it via GetSharedAllocator;
+  // if unavailable, creation returns null and callers fall back to the default device inputs path.
+  if (!allocator.host_accessible_allocator_ && type == DeviceType::AMDGPU) {
+    try {
+      // device_id is hardcoded 0, so this is correct for single-GPU only. On multi-GPU the
+      // device_id differs and GetSharedAllocator returns null (falls back, perf loss not error).
+      // TODO(multi-gpu): query EpDevice::MemoryInfo(HOST_ACCESSIBLE) instead of reconstructing.
+      auto host_info = OrtMemoryInfo::CreateV2("pinned", OrtMemoryInfoDeviceType_GPU,
+                                               /*vendor_id=*/0x1002, /*device_id=*/0,
+                                               OrtDeviceMemoryType_HOST_ACCESSIBLE, OrtDeviceAllocator);
+      allocator.host_accessible_allocator_ = GetOrtEnv().GetSharedAllocator(*host_info);
+    } catch (const Ort::Exception&) {
+      allocator.host_accessible_allocator_ = nullptr;
+    }
+    if (allocator.host_accessible_allocator_)
+      device.InitHostAccessible(*allocator.host_accessible_allocator_);
+  }
 }
 
 void SessionInfo::Add(OrtSession& session) {
@@ -595,6 +613,15 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
     p_device_inputs_ = p_device_;
   else
     p_device_inputs_ = GetDeviceInterface(DeviceType::CPU);
+
+  // Host-accessible decode inputs (AMDGPU): route the small decode inputs through a
+  // host-accessible interface so the CPU updates them in place with no per-step roundtrip.
+  // KV cache and scoring stay on the default interface. Falls back if no allocator.
+  if (p_device_->GetType() == DeviceType::AMDGPU &&
+      p_device_->GetHostAccessibleAllocator() != nullptr) {
+    if (auto* pinned = GetAMDGPUPinnedInputsInterface())
+      p_device_inputs_ = pinned;
+  }
 
   // Search and sampling are performed on the CPU for all device types,
   // except for CUDA and NvTensorRtRtx, where this is performed on the device.

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -32,6 +32,7 @@
 #include "videochat_flash_processor.h"
 #include "mistral3_image_processor.h"
 #include "../dml/interface.h"
+#include "../amdgpu/interface.h"
 #include "../openvino/interface.h"
 #include "../qnn/interface.h"
 #include "../ryzenai/interface.h"
@@ -434,7 +435,7 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   // This ensures memory allocated on-device for model inputs/outputs is valid for the lifetime of GenAI.
 
   // Names for the device types used by 'SetProviderSessionOptions'
-  static const char* device_type_names[] = {"CPU (Not used, see above)", "cuda", "DML", "WebGPU", "QNN", "QNN", "OpenVINO (Not used, see above)", "NvTensorRtRtx", "RyzenAI"};
+  static const char* device_type_names[] = {"CPU (Not used, see above)", "cuda", "DML", "WebGPU", "QNN", "QNN", "OpenVINO (Not used, see above)", "NvTensorRtRtx", "RyzenAI", "AMDGPU"};
   static_assert(std::size(device_type_names) == static_cast<size_t>(DeviceType::MAX));
 
   // Create an OrtSessionOptions and set the options to use the DeviceType we're using here
@@ -467,7 +468,10 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   allocator.session_ = OrtSession::Create(GetOrtEnv(), trivial_model.data(), trivial_model.size(), session_options.get());
 
   // Names for the device memory types used by 'OrtMemoryInfo::Create'
-  static const char* device_memory_type_names[] = {"CPU (Not used, see above)", "Cuda", "DML", "WebGPU_Buf", "QnnHtpShared", "QnnHtpShared", "OpenVINO (Not used, see above)", "Cuda", "Cpu"};
+  // AMDGPU device memory-type name is "Hip" (the MIGraphX backend registers
+  // CreateMemoryInfo_V2("Hip", GPU, ...); a V1 CreateMemoryInfo("Hip") memory-info matches it
+  // by device attributes). This mirrors the original B003 GPU-KV path (commit 64d1b3a5).
+  static const char* device_memory_type_names[] = {"CPU (Not used, see above)", "Cuda", "DML", "WebGPU_Buf", "QnnHtpShared", "QnnHtpShared", "OpenVINO (Not used, see above)", "Cuda", "Cpu", "Hip"};
   static_assert(std::size(device_memory_type_names) == static_cast<size_t>(DeviceType::MAX));
 
   // Get the allocator from the OrtSession for the DeviceType (it's called 'AllocatorCreate' but it's really 'AllocatorGet')

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -35,6 +35,7 @@
 #include "videochat_flash_processor.h"
 #include "mistral3_image_processor.h"
 #include "../dml/interface.h"
+#include "../amdgpu/interface.h"
 #include "../openvino/interface.h"
 #include "../qnn/interface.h"
 #include "../ryzenai/interface.h"
@@ -459,7 +460,7 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   // This ensures memory allocated on-device for model inputs/outputs is valid for the lifetime of GenAI.
 
   // Names for the device types used by 'SetProviderSessionOptions'
-  static const char* device_type_names[] = {"CPU (Not used, see above)", "cuda", "DML", "WebGPU", "QNN", "QNN", "OpenVINO (Not used, see above)", "NvTensorRtRtx", "RyzenAI"};
+  static const char* device_type_names[] = {"CPU (Not used, see above)", "cuda", "DML", "WebGPU", "QNN", "QNN", "OpenVINO (Not used, see above)", "NvTensorRtRtx", "RyzenAI", "AMDGPU"};
   static_assert(std::size(device_type_names) == static_cast<size_t>(DeviceType::MAX));
 
   // Create an OrtSessionOptions and set the options to use the DeviceType we're using here

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -35,7 +35,6 @@
 #include "videochat_flash_processor.h"
 #include "mistral3_image_processor.h"
 #include "../dml/interface.h"
-#include "../amdgpu/interface.h"
 #include "../openvino/interface.h"
 #include "../qnn/interface.h"
 #include "../ryzenai/interface.h"
@@ -596,7 +595,7 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
 
   // Inputs-only interface backed by a host-accessible allocation, so the CPU updates the small
   // decode inputs in place with no per-step roundtrip. Null if the device offers no such allocator.
-  DeviceInterface* p_host_accessible_inputs = GetAMDGPUPinnedInputsInterface();
+  DeviceInterface* p_host_accessible_inputs = p_device_->GetHostAccessibleDevice();
 
   // Only CUDA, TRT-RTX, RyzenAI and DML does every input on the device
   // For WebGPU, use device memory only if graph capture is enabled, otherwise use CPU

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -492,6 +492,17 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   const auto trivial_model = GetTrivialModel();
   allocator.session_ = OrtSession::Create(GetOrtEnv(), trivial_model.data(), trivial_model.size(), session_options.get());
 
+  // AMDGPU: use the selected device's id rather than a hardcoded 0. Single-GPU resolves to 0.
+  if (type == DeviceType::AMDGPU) {
+    auto ep_devices = FindRegisteredEpDevices("AMDGPUExecutionProvider");
+    if (user_provider_options)
+      ep_devices = ApplyDeviceFiltering(*user_provider_options, ep_devices);
+    if (!ep_devices.empty()) {
+      if (const OrtMemoryInfo* mi = Ort::api->EpDevice_MemoryInfo(ep_devices.front(), OrtDeviceMemoryType_DEFAULT))
+        Ort::ThrowOnError(Ort::api->MemoryInfoGetId(mi, &allocator.device_id_));
+    }
+    SetAMDGPUDeviceId(allocator.device_id_);
+  }
   try {
     auto memory_info = device.GetMemoryInfo();
     allocator.allocator_ = Ort::Allocator::Create(*allocator.session_, *memory_info);
@@ -508,13 +519,16 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   // if unavailable, creation returns null and callers fall back to the default device inputs path.
   if (!allocator.host_accessible_allocator_ && type == DeviceType::AMDGPU) {
     try {
-      // Query the AMDGPU EP's advertised HOST_ACCESSIBLE memory-info instead of reconstructing it with
-      // hardcoded vendor/device ids, so it carries the real ids for this machine (multi-GPU safe). If
-      // none is advertised, leave it unset -> callers fall back to the default device inputs path.
+      // Use the host-accessible memory-info on the same device as the compute allocator.
       const OrtMemoryInfo* host_info = nullptr;
       for (const OrtEpDevice* ep_device : FindRegisteredEpDevices("AMDGPUExecutionProvider")) {
-        if (const OrtMemoryInfo* mi =
-                Ort::api->EpDevice_MemoryInfo(ep_device, OrtDeviceMemoryType_HOST_ACCESSIBLE)) {
+        const OrtMemoryInfo* mi =
+            Ort::api->EpDevice_MemoryInfo(ep_device, OrtDeviceMemoryType_HOST_ACCESSIBLE);
+        if (!mi)
+          continue;
+        int host_device_id = 0;
+        Ort::ThrowOnError(Ort::api->MemoryInfoGetId(mi, &host_device_id));
+        if (host_device_id == allocator.device_id_) {
           host_info = mi;
           break;
         }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -503,6 +503,24 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
     throw std::runtime_error("Unexpected failure to create device memory allocator for " + to_string(type));
   }
   device.InitOrt(*Ort::api, *allocator.allocator_);
+
+  // Host-accessible allocator for decode inputs (AMDGPU only). Request it via GetSharedAllocator;
+  // if unavailable, creation returns null and callers fall back to the default device inputs path.
+  if (!allocator.host_accessible_allocator_ && type == DeviceType::AMDGPU) {
+    try {
+      // device_id is hardcoded 0, so this is correct for single-GPU only. On multi-GPU the
+      // device_id differs and GetSharedAllocator returns null (falls back, perf loss not error).
+      // TODO(multi-gpu): query EpDevice::MemoryInfo(HOST_ACCESSIBLE) instead of reconstructing.
+      auto host_info = OrtMemoryInfo::CreateV2("pinned", OrtMemoryInfoDeviceType_GPU,
+                                               /*vendor_id=*/0x1002, /*device_id=*/0,
+                                               OrtDeviceMemoryType_HOST_ACCESSIBLE, OrtDeviceAllocator);
+      allocator.host_accessible_allocator_ = GetOrtEnv().GetSharedAllocator(*host_info);
+    } catch (const Ort::Exception&) {
+      allocator.host_accessible_allocator_ = nullptr;
+    }
+    if (allocator.host_accessible_allocator_)
+      device.InitHostAccessible(*allocator.host_accessible_allocator_);
+  }
 }
 
 void SessionInfo::Add(OrtSession& session) {
@@ -595,6 +613,15 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
     p_device_inputs_ = p_device_;
   else
     p_device_inputs_ = GetDeviceInterface(DeviceType::CPU);
+
+  // Host-accessible decode inputs (AMDGPU): route the small decode inputs through a
+  // host-accessible interface so the CPU updates them in place with no per-step roundtrip.
+  // KV cache and scoring stay on the default interface. Falls back if no allocator.
+  if (p_device_->GetType() == DeviceType::AMDGPU &&
+      p_device_->GetHostAccessibleAllocator() != nullptr) {
+    if (auto* pinned = GetAMDGPUPinnedInputsInterface())
+      p_device_inputs_ = pinned;
+  }
 
   // Search and sampling are performed on the CPU for all device types,
   // except for CUDA and NvTensorRtRtx, where this is performed on the device.

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -492,17 +492,8 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   const auto trivial_model = GetTrivialModel();
   allocator.session_ = OrtSession::Create(GetOrtEnv(), trivial_model.data(), trivial_model.size(), session_options.get());
 
-  // AMDGPU: use the selected device's id rather than a hardcoded 0. Single-GPU resolves to 0.
-  if (type == DeviceType::AMDGPU) {
-    auto ep_devices = FindRegisteredEpDevices("AMDGPUExecutionProvider");
-    if (user_provider_options)
-      ep_devices = ApplyDeviceFiltering(*user_provider_options, ep_devices);
-    if (!ep_devices.empty()) {
-      if (const OrtMemoryInfo* mi = Ort::api->EpDevice_MemoryInfo(ep_devices.front(), OrtDeviceMemoryType_DEFAULT))
-        Ort::ThrowOnError(Ort::api->MemoryInfoGetId(mi, &allocator.device_id_));
-    }
-    SetAMDGPUDeviceId(allocator.device_id_);
-  }
+  // Bind the allocator to the selected device rather than assuming device 0.
+  allocator.device_id_ = device.GetDeviceId(user_provider_options);
   try {
     auto memory_info = device.GetMemoryInfo();
     allocator.allocator_ = Ort::Allocator::Create(*allocator.session_, *memory_info);
@@ -515,32 +506,10 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   }
   device.InitOrt(*Ort::api, *allocator.allocator_);
 
-  // Host-accessible allocator for decode inputs (AMDGPU only). Request it via GetSharedAllocator;
-  // if unavailable, creation returns null and callers fall back to the default device inputs path.
-  if (!allocator.host_accessible_allocator_ && type == DeviceType::AMDGPU) {
-    try {
-      // Use the host-accessible memory-info on the same device as the compute allocator.
-      const OrtMemoryInfo* host_info = nullptr;
-      for (const OrtEpDevice* ep_device : FindRegisteredEpDevices("AMDGPUExecutionProvider")) {
-        const OrtMemoryInfo* mi =
-            Ort::api->EpDevice_MemoryInfo(ep_device, OrtDeviceMemoryType_HOST_ACCESSIBLE);
-        if (!mi)
-          continue;
-        int host_device_id = 0;
-        Ort::ThrowOnError(Ort::api->MemoryInfoGetId(mi, &host_device_id));
-        if (host_device_id == allocator.device_id_) {
-          host_info = mi;
-          break;
-        }
-      }
-      if (host_info)
-        allocator.host_accessible_allocator_ = GetOrtEnv().GetSharedAllocator(*host_info);
-    } catch (const Ort::Exception&) {
-      allocator.host_accessible_allocator_ = nullptr;
-    }
-    if (allocator.host_accessible_allocator_)
-      device.InitHostAccessible(*allocator.host_accessible_allocator_);
-  }
+  // Let the device set up any additional allocators it offers (e.g. host-accessible memory for
+  // decode inputs). Devices that offer none leave the defaults in place.
+  device.InitDeviceAllocators(user_provider_options, allocator.device_id_);
+  allocator.host_accessible_allocator_ = device.GetHostAccessibleAllocator();
 }
 
 void SessionInfo::Add(OrtSession& session) {
@@ -627,8 +596,7 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
 
   // Inputs-only interface backed by a host-accessible allocation, so the CPU updates the small
   // decode inputs in place with no per-step roundtrip. Null if the device offers no such allocator.
-  DeviceInterface* p_host_accessible_inputs =
-      p_device_->GetType() == DeviceType::AMDGPU ? GetAMDGPUPinnedInputsInterface() : nullptr;
+  DeviceInterface* p_host_accessible_inputs = GetAMDGPUPinnedInputsInterface();
 
   // Only CUDA, TRT-RTX, RyzenAI and DML does every input on the device
   // For WebGPU, use device memory only if graph capture is enabled, otherwise use CPU

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -625,25 +625,23 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
   CreateSessionOptions();
   EnsureDeviceOrtInit(*p_device_, *config_);
 
+  // Inputs-only interface backed by a host-accessible allocation, so the CPU updates the small
+  // decode inputs in place with no per-step roundtrip. Null if the device offers no such allocator.
+  DeviceInterface* p_host_accessible_inputs =
+      p_device_->GetType() == DeviceType::AMDGPU ? GetAMDGPUPinnedInputsInterface() : nullptr;
+
   // Only CUDA, TRT-RTX, RyzenAI and DML does every input on the device
   // For WebGPU, use device memory only if graph capture is enabled, otherwise use CPU
   if (p_device_->GetType() == DeviceType::CUDA || p_device_->GetType() == DeviceType::DML || p_device_->GetType() == DeviceType::NvTensorRtRtx ||
       p_device_->GetType() == DeviceType::RyzenAI ||
       (p_device_->GetType() == DeviceType::WEBGPU && IsGraphCaptureEnabled(config_->model.decoder.session_options)))
     p_device_inputs_ = p_device_;
+  else if (p_host_accessible_inputs)
+    p_device_inputs_ = p_host_accessible_inputs;
   else
     p_device_inputs_ = GetDeviceInterface(DeviceType::CPU);
 
-  // Host-accessible decode inputs (AMDGPU): route the small decode inputs through a
-  // host-accessible interface so the CPU updates them in place with no per-step roundtrip.
-  // KV cache and scoring stay on the default interface. Falls back if no allocator.
-  if (p_device_->GetType() == DeviceType::AMDGPU &&
-      p_device_->GetHostAccessibleAllocator() != nullptr) {
-    if (auto* pinned = GetAMDGPUPinnedInputsInterface())
-      p_device_inputs_ = pinned;
-  }
-
-  // Logits are CPU-read; AMDGPU host-accessible inputs aren't CPU-read-coherent, so route to CPU.
+  // Logits are read back on the CPU every step, which is slow from a host-accessible allocation.
   p_device_logits_ = (p_device_->GetType() == DeviceType::AMDGPU) ? GetDeviceInterface(DeviceType::CPU) : p_device_inputs_;
 
   // Search and sampling are performed on the CPU for all device types,

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -173,6 +173,7 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model>, External
 
   DeviceInterface* p_device_{};          // The device we're running on (matches device_type_) used for things that work the same on all devices
   DeviceInterface* p_device_inputs_{};   // For some model inputs, the device might be the CPU device (all but KV cache currently for WebGPU and DML)
+  DeviceInterface* p_device_logits_{};   // Logits are CPU-read; on AMDGPU the host-accessible input allocator isn't CPU-read-coherent, so logits use CPU. Others match p_device_inputs_.
   DeviceInterface* p_device_scoring_{};  // Device for search/scoring (sequences, token allocation).
   DeviceInterface* p_device_kvcache_{};  // The kvcache is always allocated in device memory  (TODO: Remove in favor of just p_device_?)
 

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -188,7 +188,7 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model>, External
 
   DeviceInterface* p_device_{};          // The device we're running on (matches device_type_) used for things that work the same on all devices
   DeviceInterface* p_device_inputs_{};   // For some model inputs, the device might be the CPU device (all but KV cache currently for WebGPU and DML)
-  DeviceInterface* p_device_logits_{};   // Logits are CPU-read; on AMDGPU the host-accessible input allocator isn't CPU-read-coherent, so logits use CPU. Others match p_device_inputs_.
+  DeviceInterface* p_device_logits_{};   // Logits are read back on the CPU every step
   DeviceInterface* p_device_scoring_{};  // Device for search/scoring (sequences, token allocation).
   DeviceInterface* p_device_kvcache_{};  // The kvcache is always allocated in device memory  (TODO: Remove in favor of just p_device_?)
 

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -188,7 +188,7 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model>, External
 
   DeviceInterface* p_device_{};          // The device we're running on (matches device_type_) used for things that work the same on all devices
   DeviceInterface* p_device_inputs_{};   // For some model inputs, the device might be the CPU device (all but KV cache currently for WebGPU and DML)
-  DeviceInterface* p_device_logits_{};   // Logits are read back on the CPU every step
+  DeviceInterface* p_device_logits_{};   // Matches p_device_inputs_ unless the device reads logits back on the CPU
   DeviceInterface* p_device_scoring_{};  // Device for search/scoring (sequences, token allocation).
   DeviceInterface* p_device_kvcache_{};  // The kvcache is always allocated in device memory  (TODO: Remove in favor of just p_device_?)
 

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -188,6 +188,7 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model>, External
 
   DeviceInterface* p_device_{};          // The device we're running on (matches device_type_) used for things that work the same on all devices
   DeviceInterface* p_device_inputs_{};   // For some model inputs, the device might be the CPU device (all but KV cache currently for WebGPU and DML)
+  DeviceInterface* p_device_logits_{};   // Logits are CPU-read; on AMDGPU the host-accessible input allocator isn't CPU-read-coherent, so logits use CPU. Others match p_device_inputs_.
   DeviceInterface* p_device_scoring_{};  // Device for search/scoring (sequences, token allocation).
   DeviceInterface* p_device_kvcache_{};  // The kvcache is always allocated in device memory  (TODO: Remove in favor of just p_device_?)
 

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -527,6 +527,11 @@ struct OrtEnv {
 
   OrtEnv& CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info, const OrtArenaCfg& arena_cfg);  ///< Wraps OrtApi::CreateAndRegisterAllocator
 
+  /// \brief Get an EP-advertised shared allocator matching mem_info (e.g. HOST_ACCESSIBLE), or
+  /// nullptr if none exists. Wraps OrtApi::GetSharedAllocator. The returned allocator is owned by
+  /// the OrtEnv — do NOT delete it.
+  Ort::Allocator* GetSharedAllocator(const OrtMemoryInfo& mem_info) const;
+
   /// \brief Copy tensors between devices. Wraps OrtApi::CopyTensors
   /// \param src_tensors Array of source OrtValue tensors
   /// \param dst_tensors Array of destination OrtValue tensors (must be pre-allocated)
@@ -827,6 +832,12 @@ struct OrtSession {
 struct OrtMemoryInfo {
   static std::unique_ptr<OrtMemoryInfo> CreateCpu(OrtAllocatorType type, OrtMemType mem_type1);
   static std::unique_ptr<OrtMemoryInfo> Create(const char* name, OrtAllocatorType type, int id, OrtMemType mem_type);
+  // Wraps CreateMemoryInfo_V2 — lets us request a specific OrtDeviceMemoryType (e.g.
+  // HOST_ACCESSIBLE) so an EP that registers both DEFAULT and HOST_ACCESSIBLE allocators
+  // (MIGraphX HipPinned, DML CUSTOM/L0) hands back the host-accessible one.
+  static std::unique_ptr<OrtMemoryInfo> CreateV2(const char* name, OrtMemoryInfoDeviceType device_type,
+                                                 uint32_t vendor_id, int32_t device_id,
+                                                 OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type);
 
   std::string GetAllocatorName() const;
   OrtAllocatorType GetAllocatorType() const;

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -876,12 +876,6 @@ struct OrtSession {
 struct OrtMemoryInfo {
   static std::unique_ptr<OrtMemoryInfo> CreateCpu(OrtAllocatorType type, OrtMemType mem_type1);
   static std::unique_ptr<OrtMemoryInfo> Create(const char* name, OrtAllocatorType type, int id, OrtMemType mem_type);
-  // Wraps CreateMemoryInfo_V2 — lets us request a specific OrtDeviceMemoryType (e.g.
-  // HOST_ACCESSIBLE) so an EP that registers both DEFAULT and HOST_ACCESSIBLE allocators
-  // hands back the host-accessible one.
-  static std::unique_ptr<OrtMemoryInfo> CreateV2(const char* name, OrtMemoryInfoDeviceType device_type,
-                                                 uint32_t vendor_id, int32_t device_id,
-                                                 OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type);
 
   std::string GetAllocatorName() const;
   OrtAllocatorType GetAllocatorType() const;

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -572,6 +572,11 @@ struct OrtEnv {
 
   OrtEnv& CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info, const OrtArenaCfg& arena_cfg);  ///< Wraps OrtApi::CreateAndRegisterAllocator
 
+  /// \brief Get an EP-advertised shared allocator matching mem_info (e.g. HOST_ACCESSIBLE), or
+  /// nullptr if none exists. Wraps OrtApi::GetSharedAllocator. The returned allocator is owned by
+  /// the OrtEnv — do NOT delete it.
+  Ort::Allocator* GetSharedAllocator(const OrtMemoryInfo& mem_info) const;
+
   /// \brief Copy tensors between devices. Wraps OrtApi::CopyTensors
   /// \param src_tensors Array of source OrtValue tensors
   /// \param dst_tensors Array of destination OrtValue tensors (must be pre-allocated)
@@ -871,6 +876,12 @@ struct OrtSession {
 struct OrtMemoryInfo {
   static std::unique_ptr<OrtMemoryInfo> CreateCpu(OrtAllocatorType type, OrtMemType mem_type1);
   static std::unique_ptr<OrtMemoryInfo> Create(const char* name, OrtAllocatorType type, int id, OrtMemType mem_type);
+  // Wraps CreateMemoryInfo_V2 — lets us request a specific OrtDeviceMemoryType (e.g.
+  // HOST_ACCESSIBLE) so an EP that registers both DEFAULT and HOST_ACCESSIBLE allocators
+  // (MIGraphX HipPinned, DML CUSTOM/L0) hands back the host-accessible one.
+  static std::unique_ptr<OrtMemoryInfo> CreateV2(const char* name, OrtMemoryInfoDeviceType device_type,
+                                                 uint32_t vendor_id, int32_t device_id,
+                                                 OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type);
 
   std::string GetAllocatorName() const;
   OrtAllocatorType GetAllocatorType() const;

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -878,7 +878,7 @@ struct OrtMemoryInfo {
   static std::unique_ptr<OrtMemoryInfo> Create(const char* name, OrtAllocatorType type, int id, OrtMemType mem_type);
   // Wraps CreateMemoryInfo_V2 — lets us request a specific OrtDeviceMemoryType (e.g.
   // HOST_ACCESSIBLE) so an EP that registers both DEFAULT and HOST_ACCESSIBLE allocators
-  // (MIGraphX HipPinned, DML CUSTOM/L0) hands back the host-accessible one.
+  // hands back the host-accessible one.
   static std::unique_ptr<OrtMemoryInfo> CreateV2(const char* name, OrtMemoryInfoDeviceType device_type,
                                                  uint32_t vendor_id, int32_t device_id,
                                                  OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type);

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -256,6 +256,15 @@ inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::Create(const char* name, Or
   return std::unique_ptr<OrtMemoryInfo>{p};
 }
 
+inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::CreateV2(const char* name, OrtMemoryInfoDeviceType device_type,
+                                                             uint32_t vendor_id, int32_t device_id,
+                                                             OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type) {
+  OrtMemoryInfo* p;
+  Ort::ThrowOnError(Ort::api->CreateMemoryInfo_V2(name, device_type, vendor_id, device_id, mem_type,
+                                                  /*alignment=*/0, allocator_type, &p));
+  return std::unique_ptr<OrtMemoryInfo>{p};
+}
+
 inline std::unique_ptr<OrtSyncStream> OrtSyncStream::Create(const OrtEpDevice* ep_device, const OrtKeyValuePairs* stream_options) {
   OrtSyncStream* p_stream = nullptr;
   Ort::ThrowOnError(Ort::api->CreateSyncStreamForEpDevice(ep_device, stream_options, &p_stream));
@@ -431,6 +440,12 @@ inline OrtEnv& OrtEnv::DisableTelemetryEvents() {
 inline OrtEnv& OrtEnv::CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info, const OrtArenaCfg& arena_cfg) {
   Ort::ThrowOnError(Ort::api->CreateAndRegisterAllocator(this, &mem_info, &arena_cfg));
   return *this;
+}
+
+inline Ort::Allocator* OrtEnv::GetSharedAllocator(const OrtMemoryInfo& mem_info) const {
+  OrtAllocator* p = nullptr;
+  Ort::ThrowOnError(Ort::api->GetSharedAllocator(const_cast<OrtEnv*>(this), &mem_info, &p));
+  return static_cast<Ort::Allocator*>(p);  // env-owned; may be nullptr if no match
 }
 
 inline void OrtEnv::CopyTensors(const std::vector<const OrtValue*>& src_tensors,

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -257,8 +257,8 @@ inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::Create(const char* name, Or
 }
 
 inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::CreateV2(const char* name, OrtMemoryInfoDeviceType device_type,
-                                                             uint32_t vendor_id, int32_t device_id,
-                                                             OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type) {
+                                                              uint32_t vendor_id, int32_t device_id,
+                                                              OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type) {
   OrtMemoryInfo* p;
   Ort::ThrowOnError(Ort::api->CreateMemoryInfo_V2(name, device_type, vendor_id, device_id, mem_type,
                                                   /*alignment=*/0, allocator_type, &p));

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -260,15 +260,6 @@ inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::Create(const char* name, Or
   return std::unique_ptr<OrtMemoryInfo>{p};
 }
 
-inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::CreateV2(const char* name, OrtMemoryInfoDeviceType device_type,
-                                                              uint32_t vendor_id, int32_t device_id,
-                                                              OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type) {
-  OrtMemoryInfo* p;
-  Ort::ThrowOnError(Ort::api->CreateMemoryInfo_V2(name, device_type, vendor_id, device_id, mem_type,
-                                                  /*alignment=*/0, allocator_type, &p));
-  return std::unique_ptr<OrtMemoryInfo>{p};
-}
-
 inline std::unique_ptr<OrtSyncStream> OrtSyncStream::Create(const OrtEpDevice* ep_device, const OrtKeyValuePairs* stream_options) {
   OrtSyncStream* p_stream = nullptr;
   Ort::ThrowOnError(Ort::api->CreateSyncStreamForEpDevice(ep_device, stream_options, &p_stream));

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -260,6 +260,15 @@ inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::Create(const char* name, Or
   return std::unique_ptr<OrtMemoryInfo>{p};
 }
 
+inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::CreateV2(const char* name, OrtMemoryInfoDeviceType device_type,
+                                                             uint32_t vendor_id, int32_t device_id,
+                                                             OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type) {
+  OrtMemoryInfo* p;
+  Ort::ThrowOnError(Ort::api->CreateMemoryInfo_V2(name, device_type, vendor_id, device_id, mem_type,
+                                                  /*alignment=*/0, allocator_type, &p));
+  return std::unique_ptr<OrtMemoryInfo>{p};
+}
+
 inline std::unique_ptr<OrtSyncStream> OrtSyncStream::Create(const OrtEpDevice* ep_device, const OrtKeyValuePairs* stream_options) {
   OrtSyncStream* p_stream = nullptr;
   Ort::ThrowOnError(Ort::api->CreateSyncStreamForEpDevice(ep_device, stream_options, &p_stream));
@@ -435,6 +444,12 @@ inline OrtEnv& OrtEnv::DisableTelemetryEvents() {
 inline OrtEnv& OrtEnv::CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info, const OrtArenaCfg& arena_cfg) {
   Ort::ThrowOnError(Ort::api->CreateAndRegisterAllocator(this, &mem_info, &arena_cfg));
   return *this;
+}
+
+inline Ort::Allocator* OrtEnv::GetSharedAllocator(const OrtMemoryInfo& mem_info) const {
+  OrtAllocator* p = nullptr;
+  Ort::ThrowOnError(Ort::api->GetSharedAllocator(const_cast<OrtEnv*>(this), &mem_info, &p));
+  return static_cast<Ort::Allocator*>(p);  // env-owned; may be nullptr if no match
 }
 
 inline void OrtEnv::CopyTensors(const std::vector<const OrtValue*>& src_tensors,

--- a/src/models/onnxruntime_inline.h
+++ b/src/models/onnxruntime_inline.h
@@ -261,8 +261,8 @@ inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::Create(const char* name, Or
 }
 
 inline std::unique_ptr<OrtMemoryInfo> OrtMemoryInfo::CreateV2(const char* name, OrtMemoryInfoDeviceType device_type,
-                                                             uint32_t vendor_id, int32_t device_id,
-                                                             OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type) {
+                                                              uint32_t vendor_id, int32_t device_id,
+                                                              OrtDeviceMemoryType mem_type, OrtAllocatorType allocator_type) {
   OrtMemoryInfo* p;
   Ort::ThrowOnError(Ort::api->CreateMemoryInfo_V2(name, device_type, vendor_id, device_id, mem_type,
                                                   /*alignment=*/0, allocator_type, &p));

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -13,6 +13,7 @@
 #include "../openvino/session_options.h"
 #include "../qnn/session_options.h"
 #include "../ryzenai/session_options.h"
+#include "../amdgpu/session_options.h"
 #include "../vitisai/session_options.h"
 #include "../webgpu/session_options.h"
 
@@ -171,6 +172,7 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
       {"OpenVINO", OpenVINOExecutionProvider::AppendExecutionProvider},
       {"RyzenAI", RyzenAIExecutionProvider::AppendExecutionProvider},
       {"QNN", QNNExecutionProvider::AppendExecutionProvider},
+      {"AMDGPU", AMDGPUExecutionProvider::AppendExecutionProvider},
       {"VitisAI", VitisAIExecutionProvider::AppendExecutionProvider},
       {"WebGPU", WebGPUExecutionProvider::AppendExecutionProvider},
   };

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -165,6 +165,7 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
   // Dispatch table: maps provider name (as it appears in genai_config.json) to
   // the corresponding provider-specific AppendExecutionProvider function.
   static const std::unordered_map<std::string, AppendExecutionProviderFn> append_execution_provider{
+      {"AMDGPU", AMDGPUExecutionProvider::AppendExecutionProvider},
       {"CPU", CPUAppendExecutionProvider},
       {"cuda", CUDAExecutionProvider::AppendExecutionProvider},
       {"DML", DMLExecutionProvider::AppendExecutionProvider},
@@ -172,7 +173,6 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
       {"OpenVINO", OpenVINOExecutionProvider::AppendExecutionProvider},
       {"RyzenAI", RyzenAIExecutionProvider::AppendExecutionProvider},
       {"QNN", QNNExecutionProvider::AppendExecutionProvider},
-      {"AMDGPU", AMDGPUExecutionProvider::AppendExecutionProvider},
       {"VitisAI", VitisAIExecutionProvider::AppendExecutionProvider},
       {"WebGPU", WebGPUExecutionProvider::AppendExecutionProvider},
   };

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -100,6 +100,7 @@ enum struct DeviceType {
   OpenVINO,
   NvTensorRtRtx,
   RyzenAI,
+  AMDGPU,
   MAX
 };
 
@@ -109,6 +110,12 @@ struct DeviceInterface {
   virtual DeviceType GetType() const = 0;
   virtual void InitOrt(const OrtApi& api, Ort::Allocator& allocator) = 0;
   virtual Ort::Allocator& GetAllocator() = 0;
+
+  // Host-accessible (CPU-writable, GPU-readable) allocator for decode inputs, if the backend and
+  // machine support it (MIGraphX HipPinned, DML CUSTOM/L0). Null default -> callers keep the
+  // current device-memory path. Set via InitHostAccessible after the EP allocator is created.
+  virtual Ort::Allocator* GetHostAccessibleAllocator() { return nullptr; }
+  virtual void InitHostAccessible(Ort::Allocator& /*allocator*/) {}
 
   template <typename T>
   DeviceSpan<T> Allocate(size_t count) { return DeviceSpan<T>(AllocateBase(sizeof(T) * count)); }

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -138,11 +138,18 @@ struct DeviceInterface {
   virtual Ort::Allocator& GetAllocator() = 0;
   virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const = 0;
 
-  // Host-accessible (CPU-writable, GPU-readable) allocator for decode inputs, if the backend and
-  // machine support it (MIGraphX HipPinned, DML CUSTOM/L0). Null default -> callers keep the
-  // current device-memory path. Set via InitHostAccessible after the EP allocator is created.
+  // Host-accessible (CPU-writable, GPU-readable) allocator for decode inputs, if the device
+  // supports it. Null default -> callers keep the current device-memory path.
   virtual Ort::Allocator* GetHostAccessibleAllocator() { return nullptr; }
-  virtual void InitHostAccessible(Ort::Allocator& /*allocator*/) {}
+
+  // Called once after the device allocator is created, so a device that offers additional
+  // allocators (e.g. host-accessible memory) can set them up. The default sets up nothing.
+  // `device_id` is the id the device allocator was created on.
+  virtual void InitDeviceAllocators(const ProviderOptions* /*user_options*/, int /*device_id*/) {}
+
+  // Id of the EP device this interface's allocators should bind to. 0 unless the device resolves a
+  // specific one from EP metadata.
+  virtual int GetDeviceId(const ProviderOptions* /*user_options*/) { return 0; }
 
   template <typename T>
   DeviceSpan<T> Allocate(size_t count) { return DeviceSpan<T>(AllocateBase(sizeof(T) * count)); }

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -142,6 +142,10 @@ struct DeviceInterface {
   // supports it. Null default -> callers keep the current device-memory path.
   virtual Ort::Allocator* GetHostAccessibleAllocator() { return nullptr; }
 
+  // Inputs-only interface backed by that allocator, so the decode inputs are updated in place.
+  // Null default -> callers keep the current device-memory path.
+  virtual DeviceInterface* GetHostAccessibleDevice() { return nullptr; }
+
   // Called once after the device allocator is created, so a device that offers additional
   // allocators (e.g. host-accessible memory) can set them up. The default sets up nothing.
   // `device_id` is the id the device allocator was created on.

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -126,6 +126,7 @@ enum struct DeviceType {
   OpenVINO,
   NvTensorRtRtx,
   RyzenAI,
+  AMDGPU,
   MAX
 };
 
@@ -136,6 +137,12 @@ struct DeviceInterface {
   virtual void InitOrt(const OrtApi& api, Ort::Allocator& allocator) = 0;
   virtual Ort::Allocator& GetAllocator() = 0;
   virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const = 0;
+
+  // Host-accessible (CPU-writable, GPU-readable) allocator for decode inputs, if the backend and
+  // machine support it (MIGraphX HipPinned, DML CUSTOM/L0). Null default -> callers keep the
+  // current device-memory path. Set via InitHostAccessible after the EP allocator is created.
+  virtual Ort::Allocator* GetHostAccessibleAllocator() { return nullptr; }
+  virtual void InitHostAccessible(Ort::Allocator& /*allocator*/) {}
 
   template <typename T>
   DeviceSpan<T> Allocate(size_t count) { return DeviceSpan<T>(AllocateBase(sizeof(T) * count)); }


### PR DESCRIPTION
This PR adds the AMDGPU execution provider to ONNX Runtime GenAI. The AMDGPU EP picks a concrete backend at runtime and OGA drives it as a single `DeviceType::AMDGPU`, so callers never manage the backend directly. It supersedes the earlier MIGraphX-only framing (#2093 and the previous version of this PR).

Users select it as `"amdgpu"`. We also accept `"AMDGPUExecutionProvider"`, the catalog name the AMD Windows ML EP MSIX advertises, so harnesses that match against WinML-discovered names work without special-casing. Both normalize to `"AMDGPU"`.

## What's in the three commits

**1. AMDGPU EP with GPU-resident KV cache.** Adds the EP wiring (`DeviceType::AMDGPU`, the dispatch-table entry, provider-name normalization, and the `src/amdgpu/` sources) plus a GPU-resident `DeviceInterface` that keeps the KV cache on the device, removing the per-token CPU/GPU roundtrip. Cross-device copies go through backend-agnostic opaque `DeviceBuffer` handles. It also emits the static-shape prefill config (`ep.migraphx.static_pad_*` and `hip_graph_enable`) so the backend compiles the prefill once and reuses a captured graph.

**2. Host-accessible decode inputs.** The small decode inputs (input_ids, position_ids, attention_mask) are allocated from a host-accessible allocator that the CPU can write and the GPU can read, so the CPU updates them in place with no per-step copy. The KV cache and scoring stay on the default device interface. If no host-accessible allocator is available, it falls back to the default input path.

**3. Logits on CPU.** Logits are GPU-written and CPU-read, the opposite of the decode inputs. On AMDGPU those inputs live in a host-accessible heap that is not coherent for CPU reads, so reading logits from it would return stale data. This commit routes logits to the CPU interface through a new `p_logits_` member, leaving only the decode inputs pinned.

## Configuration

```json
"provider_options": [{ "amdgpu": {} }]
```

or

```python
config.append_provider("amdgpu")
```

`"AMDGPUExecutionProvider"` also works (the catalog form).

## Design notes

Graph capture is always on for AMDGPU, so OGA sizes the attention mask and KV cache itself. The EP is told to pad the prefill token axis through the static-pad session-config entries, while OGA keeps ownership of mask and KV sizing. The host-accessible and logits routing are both backend-aware and fall back safely to the default path when the allocator isn't there.

## Known limitations

Beam search isn't supported (it needs `past_present_share_buffer=true`, which needs `num_beams=1`). The host-accessible allocator currently assumes `device_id=0`, so multi-GPU is a follow-up.
