### PR TITLE
Auto-detect fixed kv-cache shape in DefaultKeyValueCache

### DIFF
--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -257,6 +257,16 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
   // When that's the case the cache must be allocated to exactly that size and
   // reused as a shared past/present buffer; max_length cannot drive the size
   // because ORT rejects any tensor that doesn't match the model's static dim.
+  //
+  // Limitation: only uniform per-layer static sizes are recognised here —
+  // every past_key layer must declare the same fixed seq_len. Models that
+  // declare *different* static seq_lens per layer (e.g. a mix of full-attention
+  // and sliding-window layers with distinct static caps) fall through to
+  // dynamic handling. Lifting this restriction would extend the existing
+  // layer_shapes_ infrastructure used for per-layer head_dim detection above:
+  // store the per-layer detected seq_len into layer_shapes_[i][2] instead of
+  // a single scalar, and let the share-buffer branch's per-layer loop do the
+  // rest. Deferred until a model in the wild actually needs it.
   int64_t fixed_kv_seq_len = 0;
   {
     bool all_fixed_and_uniform = layer_count_ > 0;

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -8,7 +8,6 @@
 #include "../openvino/interface.h"
 #include "../qnn/interface.h"
 #include <algorithm>
-#include <mutex>
 
 namespace Generators {
 
@@ -156,7 +155,7 @@ namespace {
 //   - reject beam search (num_beams != 1),
 //   - force past_present_share_buffer on,
 //   - log info on the detected size,
-//   - warn once per process if search.max_length exceeds the detected size.
+//   - warn if search.max_length exceeds the detected size.
 // Returns the detected static seq_len, or 0 if the model has symbolic
 // kv-cache dims or per-layer static sizes disagree.
 //
@@ -210,16 +209,13 @@ int64_t DetectAndConfigureFixedKvShape(const SessionInfo& session_info,
                     std::to_string(common_seq_len) +
                     "; allocating shared past/present buffer to that size.");
   }
-  if (search.max_length > static_cast<int>(common_seq_len)) {
-    // De-duplicate across repeated Generator constructions (e.g. benchmark loops).
-    static std::once_flag warned_once;
-    std::call_once(warned_once, [&] {
-      Log("warning", "Model has fixed kv-cache seq_len=" +
-                         std::to_string(common_seq_len) +
-                         " but search.max_length=" +
-                         std::to_string(search.max_length) +
-                         "; cache is sized to the model's limit, so generation beyond it will fail.");
-    });
+  if (search.max_length > static_cast<int>(common_seq_len) &&
+      g_log.enabled && g_log.warning) {
+    Log("warning", "Model has fixed kv-cache seq_len=" +
+                       std::to_string(common_seq_len) +
+                       " but search.max_length=" +
+                       std::to_string(search.max_length) +
+                       "; cache is sized to the model's limit, so generation beyond it will fail.");
   }
   return common_seq_len;
 }

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -8,6 +8,7 @@
 #include "../openvino/interface.h"
 #include "../qnn/interface.h"
 #include <algorithm>
+#include <mutex>
 
 namespace Generators {
 
@@ -250,6 +251,65 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
     }
   }
 
+  // Auto-detect a fixed kv-cache shape from the model's past_key input shapes.
+  // Some compiled backends (e.g. AMD RyzenAI) emit models where the kv-cache
+  // seq_len dimension is a static positive integer instead of a symbolic dim.
+  // When that's the case the cache must be allocated to exactly that size and
+  // reused as a shared past/present buffer; max_length cannot drive the size
+  // because ORT rejects any tensor that doesn't match the model's static dim.
+  int64_t fixed_kv_seq_len = 0;
+  {
+    bool all_fixed_and_uniform = layer_count_ > 0;
+    int64_t common_seq_len = 0;
+    for (int i = 0; i < layer_count_; ++i) {
+      auto input_shape = model_.session_info_.GetInputShape(input_name_strings_[i * 2]);
+      if (input_shape.size() < 2) {
+        all_fixed_and_uniform = false;
+        break;
+      }
+      const int64_t seq_dim = input_shape[input_shape.size() - 2];
+      if (seq_dim <= 0) {  // symbolic/dynamic dim (typically -1)
+        all_fixed_and_uniform = false;
+        break;
+      }
+      if (common_seq_len == 0) {
+        common_seq_len = seq_dim;
+      } else if (common_seq_len != seq_dim) {
+        all_fixed_and_uniform = false;
+        break;
+      }
+    }
+    if (all_fixed_and_uniform && common_seq_len > 0) {
+      fixed_kv_seq_len = common_seq_len;
+    }
+  }
+
+  if (fixed_kv_seq_len > 0) {
+    if (state_.params_->search.num_beams != 1) {
+      throw std::runtime_error(
+          "Beam search (num_beams > 1) is not supported for models with a fixed kv-cache "
+          "shape (model expects seq_len=" +
+          std::to_string(fixed_kv_seq_len) + ").");
+    }
+    past_present_share_buffer_ = true;
+    if (g_log.enabled) {
+      Log("info", "DefaultKeyValueCache: auto-detected fixed kv-cache seq_len=" +
+                      std::to_string(fixed_kv_seq_len) +
+                      "; allocating shared past/present buffer to that size.");
+    }
+    if (state_.params_->search.max_length > static_cast<int>(fixed_kv_seq_len)) {
+      // De-duplicate across repeated Generator constructions (e.g. benchmark loops).
+      static std::once_flag warned_once;
+      std::call_once(warned_once, [&] {
+        Log("warning", "Model has fixed kv-cache seq_len=" +
+                           std::to_string(fixed_kv_seq_len) +
+                           " but search.max_length=" +
+                           std::to_string(state_.params_->search.max_length) +
+                           "; cache is sized to the model's limit, so generation beyond it will fail.");
+      });
+    }
+  }
+
   if (state_.params_->use_graph_capture && !past_present_share_buffer_) {
     // share buffer is a precondition for graph capture
     throw std::runtime_error("Graph capture is not supported with past_present_share_buffer set to false.");
@@ -299,12 +359,17 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
       shape_[2] = std::min(max_length, sliding_window_size);
     }
   } else if (past_present_share_buffer_) {
-    shape_[2] = state_.params_->search.max_length;
+    // For fixed kv-cache models the cache size comes from the model graph,
+    // not from max_length — see the auto-detection block earlier in this ctor.
+    const int64_t cache_seq_len = fixed_kv_seq_len > 0
+                                      ? fixed_kv_seq_len
+                                      : static_cast<int64_t>(state_.params_->search.max_length);
+    shape_[2] = cache_seq_len;
 
     // If per-layer shapes exist (from head_dim auto-detection), update their sequence dim too
     if (!layer_shapes_.empty()) {
       for (int i = 0; i < layer_count_; ++i) {
-        layer_shapes_[i][2] = state_.params_->search.max_length;
+        layer_shapes_[i][2] = cache_seq_len;
       }
     }
   }

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -149,6 +149,83 @@ void CombinedKeyValueCache::PickPastState(DeviceSpan<int32_t> beam_indices, int 
   }
 }
 
+namespace {
+
+// Auto-detect a fixed kv-cache shape from the model's past_key input shapes,
+// and, when detected, apply the implied configuration:
+//   - reject beam search (num_beams != 1),
+//   - force past_present_share_buffer on,
+//   - log info on the detected size,
+//   - warn once per process if search.max_length exceeds the detected size.
+// Returns the detected static seq_len, or 0 if the model has symbolic
+// kv-cache dims or per-layer static sizes disagree.
+//
+// Background: some compiled backends (e.g. AMD RyzenAI) emit models where the
+// kv-cache seq_len dimension is a static positive integer instead of a
+// symbolic dim. In that case the cache must be allocated to exactly that size
+// and reused as a shared past/present buffer; max_length cannot drive the
+// size because ORT rejects any tensor that doesn't match the model's static
+// dim.
+//
+// Limitation: only uniform per-layer static sizes are recognised — every
+// past_key layer must declare the same fixed seq_len. Models that declare
+// different static seq_lens per layer (e.g. a mix of full-attention and
+// sliding-window layers with distinct static caps) fall through to dynamic
+// handling. Lifting this restriction would extend the existing layer_shapes_
+// infrastructure used for per-layer head_dim detection in
+// DefaultKeyValueCache: store the per-layer detected seq_len into
+// layer_shapes_[i][2] instead of a single scalar, and let the share-buffer
+// branch's per-layer loop do the rest. Deferred until a model in the wild
+// actually needs it.
+int64_t DetectAndConfigureFixedKvShape(const SessionInfo& session_info,
+                                       const std::vector<std::string>& input_name_strings,
+                                       int layer_count,
+                                       const Config::Search& search,
+                                       bool& past_present_share_buffer) {
+  if (layer_count <= 0) return 0;
+
+  // input_name_strings stores [past_key.0, past_value.0, past_key.1, past_value.1, ...].
+  int64_t common_seq_len = 0;
+  for (int i = 0; i < layer_count; ++i) {
+    auto input_shape = session_info.GetInputShape(input_name_strings[i * 2]);
+    if (input_shape.size() < 2) return 0;
+    const int64_t seq_dim = input_shape[input_shape.size() - 2];
+    if (seq_dim <= 0) return 0;  // symbolic/dynamic dim (typically -1)
+    if (common_seq_len == 0) {
+      common_seq_len = seq_dim;
+    } else if (common_seq_len != seq_dim) {
+      return 0;
+    }
+  }
+
+  if (search.num_beams != 1) {
+    throw std::runtime_error(
+        "Beam search (num_beams > 1) is not supported for models with a fixed kv-cache "
+        "shape (model expects seq_len=" +
+        std::to_string(common_seq_len) + ").");
+  }
+  past_present_share_buffer = true;
+  if (g_log.enabled) {
+    Log("info", "DefaultKeyValueCache: auto-detected fixed kv-cache seq_len=" +
+                    std::to_string(common_seq_len) +
+                    "; allocating shared past/present buffer to that size.");
+  }
+  if (search.max_length > static_cast<int>(common_seq_len)) {
+    // De-duplicate across repeated Generator constructions (e.g. benchmark loops).
+    static std::once_flag warned_once;
+    std::call_once(warned_once, [&] {
+      Log("warning", "Model has fixed kv-cache seq_len=" +
+                         std::to_string(common_seq_len) +
+                         " but search.max_length=" +
+                         std::to_string(search.max_length) +
+                         "; cache is sized to the model's limit, so generation beyond it will fail.");
+    });
+  }
+  return common_seq_len;
+}
+
+}  // namespace
+
 DefaultKeyValueCache::DefaultKeyValueCache(State& state)
     : state_{state},
       layer_count_{model_.config_->model.decoder.num_hidden_layers},
@@ -251,74 +328,9 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
     }
   }
 
-  // Auto-detect a fixed kv-cache shape from the model's past_key input shapes.
-  // Some compiled backends (e.g. AMD RyzenAI) emit models where the kv-cache
-  // seq_len dimension is a static positive integer instead of a symbolic dim.
-  // When that's the case the cache must be allocated to exactly that size and
-  // reused as a shared past/present buffer; max_length cannot drive the size
-  // because ORT rejects any tensor that doesn't match the model's static dim.
-  //
-  // Limitation: only uniform per-layer static sizes are recognised here —
-  // every past_key layer must declare the same fixed seq_len. Models that
-  // declare *different* static seq_lens per layer (e.g. a mix of full-attention
-  // and sliding-window layers with distinct static caps) fall through to
-  // dynamic handling. Lifting this restriction would extend the existing
-  // layer_shapes_ infrastructure used for per-layer head_dim detection above:
-  // store the per-layer detected seq_len into layer_shapes_[i][2] instead of
-  // a single scalar, and let the share-buffer branch's per-layer loop do the
-  // rest. Deferred until a model in the wild actually needs it.
-  int64_t fixed_kv_seq_len = 0;
-  {
-    bool all_fixed_and_uniform = layer_count_ > 0;
-    int64_t common_seq_len = 0;
-    for (int i = 0; i < layer_count_; ++i) {
-      auto input_shape = model_.session_info_.GetInputShape(input_name_strings_[i * 2]);
-      if (input_shape.size() < 2) {
-        all_fixed_and_uniform = false;
-        break;
-      }
-      const int64_t seq_dim = input_shape[input_shape.size() - 2];
-      if (seq_dim <= 0) {  // symbolic/dynamic dim (typically -1)
-        all_fixed_and_uniform = false;
-        break;
-      }
-      if (common_seq_len == 0) {
-        common_seq_len = seq_dim;
-      } else if (common_seq_len != seq_dim) {
-        all_fixed_and_uniform = false;
-        break;
-      }
-    }
-    if (all_fixed_and_uniform && common_seq_len > 0) {
-      fixed_kv_seq_len = common_seq_len;
-    }
-  }
-
-  if (fixed_kv_seq_len > 0) {
-    if (state_.params_->search.num_beams != 1) {
-      throw std::runtime_error(
-          "Beam search (num_beams > 1) is not supported for models with a fixed kv-cache "
-          "shape (model expects seq_len=" +
-          std::to_string(fixed_kv_seq_len) + ").");
-    }
-    past_present_share_buffer_ = true;
-    if (g_log.enabled) {
-      Log("info", "DefaultKeyValueCache: auto-detected fixed kv-cache seq_len=" +
-                      std::to_string(fixed_kv_seq_len) +
-                      "; allocating shared past/present buffer to that size.");
-    }
-    if (state_.params_->search.max_length > static_cast<int>(fixed_kv_seq_len)) {
-      // De-duplicate across repeated Generator constructions (e.g. benchmark loops).
-      static std::once_flag warned_once;
-      std::call_once(warned_once, [&] {
-        Log("warning", "Model has fixed kv-cache seq_len=" +
-                           std::to_string(fixed_kv_seq_len) +
-                           " but search.max_length=" +
-                           std::to_string(state_.params_->search.max_length) +
-                           "; cache is sized to the model's limit, so generation beyond it will fail.");
-      });
-    }
-  }
+  const int64_t fixed_kv_seq_len = DetectAndConfigureFixedKvShape(
+      model_.session_info_, input_name_strings_, layer_count_,
+      state_.params_->search, past_present_share_buffer_);
 
   if (state_.params_->use_graph_capture && !past_present_share_buffer_) {
     // share buffer is a precondition for graph capture


### PR DESCRIPTION
  ## Summary

  Some compiled backends (e.g. AMD RyzenAI, and likely future NPU/accelerator targets) emit decoder models where the `past_key_values.N.{key,value}` ONNX inputs declare a **static positive integer** in the `seq_len` dimension instead of the usual symbolic `past_sequence_length` parameter. Such models require the kv-cache tensor to be allocated to exactly that size and reused as a shared past/present buffer — ORT will reject any cache tensor whose shape doesn't match the model's static dim, and the runtime cannot pick a size from `search.max_length` after the fact.

  This PR makes OGA notice the static dim at cache construction and size the kv-cache accordingly, with no config schema change, no public API change, and no client cooperation required.

  ## How it works

  In `DefaultKeyValueCache`'s constructor, right after the existing per-layer `head_dim` auto-detection (which already reads `SessionInfo::GetInputShape`), walk each layer's `past_key.N` input and look at the second-to-last dim:

  - All layers report a **positive integer** for that dim and the values agree → treat the model as fixed-shape; let `fixed_kv_seq_len = that value`.
  - Any layer reports `<= 0` (symbolic, typically `-1`) or values disagree → leave detection off; behavior unchanged.

  When detection fires:

  - `past_present_share_buffer_` is forced `true` (model demands it; the existing share-buffer code path already does the right thing for a pre-sized buffer reused as both past and present).
  - The cache is allocated to `fixed_kv_seq_len`, not `search.max_length`. A new local `cache_seq_len = fixed_kv_seq_len > 0 ? fixed_kv_seq_len : search.max_length` replaces the direct read of `search.max_length` in the share-buffer branch, so dynamic-shape models are byte-equivalent to before.
  - Beam search (`num_beams != 1`) is rejected with a clear `std::runtime_error` — beam picking reshuffles past tensors, which is incompatible with a model-mandated fixed shape.
  - An `info` log records the detected size (gated by `g_log.enabled`, consistent with surrounding logs).
  - If `search.max_length > fixed_kv_seq_len`, a `warning` is emitted once per process (`std::call_once`) noting the cache is sized to the model's limit. We **do not clamp** `search.max_length` because `state_.params_` is `std::shared_ptr<const GeneratorParams>` and is owned by the caller; clamping would require a public API change.

  ## Files changed

  - `src/models/kv_cache.cpp` — `+67/-2`. One detection block in `DefaultKeyValueCache::DefaultKeyValueCache`, one `shape_[2]` source change in the share-buffer branch, and `#include <mutex>` for `std::call_once`.

  No header changes. No public API changes. No config schema changes. No changes to `Combined/Windowed/LFM2/Cross/ModelManaged` cache classes (out of scope for this PR — AMD RyzenAI decoder-only models route through `DefaultKeyValueCache`).

  ## Reused infrastructure

  - `SessionInfo::GetInputShape(name)` — `src/models/model.cpp:533-538`. Same call already used at `kv_cache.cpp:217` for `head_dim` auto-detection. Returns the ONNX-declared shape with `<= 0` for symbolic dims (confirmed by sibling checks in `src/models/multi_modal.cpp` and `src/models/recurrent_state.cpp`).
  - `Log("warning"|"info", ...)` — `src/logging.h:82`. Same pattern as the existing `Log` calls in `kv_cache.cpp` (lines 156, 201, 239).
  - The share-buffer data-path — `kv_cache.cpp:301-310` (shape), `:357-361` (Add: inputs = presents), `:366-367` (Update no-op), `:409-410` (RewindTo no-op). All already correctly handle a pre-sized buffer.

  ## Verification

  Tested end-to-end on Windows x64, RelWithDebInfo, CPU EP, with `Llama-3.2-1B-Instruct` (Q4F16). Since no existing test model under `test/test_models/` declares a static kv-cache `seq_len`, I produced a patched copy of the Llama model whose past_key/value (and present.key/value)  ONNX shapes were rewritten in place — only graph metadata, no weight reload — from symbolic `past_sequence_length` to a static `dim_value = 128`. With those static dims in place, ORT will reject any cache tensor that isn't exactly `[1, 8, 128, 64]`; bound-and-run success is therefore proof that the cache was sized correctly.

  | # | Model | `-ml` flag | `search.max_length` | Detection | Outcome |
  |---|---|---|---|---|---|
  | 1 | Fixed-shape (patched, static `[1,8,128,64]`) | `-1` (use config) | `4096` (JSON) | fires | ✅ warning printed, model bound + ran 32 tokens against the 128-slot cache. Without detection the cache would be `[1,8,4096,64]` → bind failure. |
  | 2 | Fixed-shape | `1024` (runtime override) | `1024` | fires | ✅ warning printed, cache stayed at 128, ran 16 tokens. Confirms runtime `SetSearchOption` overrides of `max_length` are ignored for cache sizing. |
  | 3 | Original dynamic-shape Llama | `-1` → `131072` | `131072` | does not fire | ✅ no warning, no `info`, normal run. Regression preserved. |
  | 4 | Fixed-shape, multi-iter (`-w 1 -r 3` → 4 cache constructions) | `-1` | `4096` | fires once | ✅ exactly one warning across the run (`std::call_once`). |

  Verbatim warning emitted in test 1:

  ```
  [warning]  Model has fixed kv-cache seq_len=128 but search.max_length=4096; cache is sized to the model's limit, so generation beyond it will fail.
  ```

  ## Backward compatibility

  For every model that ships today with symbolic kv-cache dims (i.e. essentially all decoder models built via the OGA model builder or the Microsoft ORT pipelines), `seq_dim <= 0` at every layer → detection short-circuits → cache construction is byte-identical to `main`. No behavior change is exposed to existing users.
