### PR TITLE
[RyzenAI] make speech sub-model optional in PhiMultiModalProcessor

### DIFF
--- a/src/models/phi_multimodal_processor.cpp
+++ b/src/models/phi_multimodal_processor.cpp
@@ -103,14 +103,9 @@ ProcessImageAudioPrompt(const Generators::Tokenizer& tokenizer, const std::strin
 
 PhiMultiModalProcessor::PhiMultiModalProcessor(Config& config, const SessionInfo& session_info)
     : pixel_values_type_{session_info.GetInputDataType(config.model.vision.inputs.pixel_values)},
-      attention_mask_type_{session_info.GetInputDataType(config.model.vision.inputs.attention_mask)},
-      audio_features_type_{session_info.GetInputDataType(config.model.speech.inputs.audio_embeds)},
-      audio_sizes_type_{session_info.GetInputDataType(config.model.speech.inputs.audio_sizes)} {
+      attention_mask_type_{session_info.GetInputDataType(config.model.vision.inputs.attention_mask)} {
   const auto image_processor_config = (config.config_path / fs::path(config.model.vision.config_filename)).string();
   CheckResult(OrtxCreateProcessor(image_processor_.ToBeAssigned(), image_processor_config.c_str()));
-
-  const auto audio_processor_config = (config.config_path / fs::path(config.model.speech.config_filename)).string();
-  CheckResult(OrtxCreateSpeechFeatureExtractor(audio_processor_.ToBeAssigned(), audio_processor_config.c_str()));
 
   config.AddMapping(std::string(Config::Defaults::InputIdsName), config.model.embedding.inputs.input_ids);
 
@@ -118,9 +113,27 @@ PhiMultiModalProcessor::PhiMultiModalProcessor(Config& config, const SessionInfo
   config.AddMapping(std::string(Config::Defaults::AttentionMaskName), config.model.vision.inputs.attention_mask);
   config.AddMapping(std::string(Config::Defaults::ImageSizesName), config.model.vision.inputs.image_sizes);
 
-  config.AddMapping(std::string(Config::Defaults::AudioEmbedsName), config.model.speech.inputs.audio_embeds);
-  config.AddMapping(std::string(Config::Defaults::AudioAttentionMaskName), config.model.speech.inputs.attention_mask);
-  config.AddMapping(std::string(Config::Defaults::AudioSizesName), config.model.speech.inputs.audio_sizes);
+  // Initialize speech/audio processor only when configured. A phi4mm genai_config.json with
+  // the "speech" block cleared (filename + config_filename both empty) loads vision-only and
+  // skips the ~0.8 GB speech ONNX entirely. Matches the Gemma4 processor's pattern.
+  if (!config.model.speech.config_filename.empty()) {
+    auto speech_config_path = config.config_path / fs::path(config.model.speech.config_filename);
+    if (fs::exists(speech_config_path)) {
+      has_speech_ = true;
+      audio_features_type_ = session_info.GetInputDataType(config.model.speech.inputs.audio_embeds);
+      audio_sizes_type_ = session_info.GetInputDataType(config.model.speech.inputs.audio_sizes);
+
+      CheckResult(OrtxCreateSpeechFeatureExtractor(audio_processor_.ToBeAssigned(), speech_config_path.string().c_str()));
+
+      config.AddMapping(std::string(Config::Defaults::AudioEmbedsName), config.model.speech.inputs.audio_embeds);
+      config.AddMapping(std::string(Config::Defaults::AudioAttentionMaskName), config.model.speech.inputs.attention_mask);
+      config.AddMapping(std::string(Config::Defaults::AudioSizesName), config.model.speech.inputs.audio_sizes);
+    } else if (!config.model.speech.filename.empty()) {
+      throw std::runtime_error("Speech model is configured (speech.filename=" + config.model.speech.filename +
+                               ") but the audio processor config file was not found at: " +
+                               speech_config_path.string());
+    }
+  }
 }
 
 std::unique_ptr<NamedTensors> PhiMultiModalProcessor::Process(const Tokenizer& tokenizer, const Payload& payload) const {
@@ -140,7 +153,12 @@ std::unique_ptr<NamedTensors> PhiMultiModalProcessor::Process(const Tokenizer& t
 
   ort_extensions::OrtxObjectPtr<OrtxTensorResult> audio_result;
   OrtxTensor *audio_embeds{}, *audio_attention_mask{}, *audio_sizes{};
-  if (payload.audios) {
+  if (payload.audios && !has_speech_) {
+    throw std::runtime_error(
+        "Audio input was provided but audio/speech support is not configured. "
+        "Ensure the genai_config.json has a 'speech' section with both 'filename' and 'config_filename'.");
+  }
+  if (payload.audios && has_speech_) {
     CheckResult(OrtxFeatureExtraction(audio_processor_.get(), payload.audios->audios_.get(), audio_result.ToBeAssigned()));
 
     CheckResult(OrtxTensorResultGetAt(audio_result.get(), 0, &audio_embeds));
@@ -181,7 +199,7 @@ std::unique_ptr<NamedTensors> PhiMultiModalProcessor::Process(const Tokenizer& t
                            std::make_shared<Tensor>(ProcessTensor<int64_t>(num_img_tokens, allocator)));
   }
 
-  if (payload.audios) {
+  if (payload.audios && has_speech_) {
     if (audio_features_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
       named_tensors->emplace(std::string(Config::Defaults::AudioEmbedsName),
                              std::make_shared<Tensor>(ProcessTensor<float>(audio_embeds, allocator)));

--- a/src/models/phi_multimodal_processor.cpp
+++ b/src/models/phi_multimodal_processor.cpp
@@ -115,7 +115,7 @@ PhiMultiModalProcessor::PhiMultiModalProcessor(Config& config, const SessionInfo
 
   // Initialize speech/audio processor only when configured. A phi4mm genai_config.json with
   // the "speech" block cleared (filename + config_filename both empty) loads vision-only and
-  // skips the ~0.8 GB speech ONNX entirely. Matches the Gemma4 processor's pattern.
+  // skip the speech ONNX entirely. Matches the Gemma4 processor's pattern.
   if (!config.model.speech.config_filename.empty()) {
     auto speech_config_path = config.config_path / fs::path(config.model.speech.config_filename);
     if (fs::exists(speech_config_path)) {

--- a/src/models/phi_multimodal_processor.h
+++ b/src/models/phi_multimodal_processor.h
@@ -19,6 +19,8 @@ struct PhiMultiModalProcessor : Processor {
   ONNXTensorElementDataType attention_mask_type_;
   ONNXTensorElementDataType audio_features_type_;
   ONNXTensorElementDataType audio_sizes_type_;
+
+  bool has_speech_{false};
 };
 
 }  // namespace Generators


### PR DESCRIPTION
## Summary

Make the speech sub-model optional in `PhiMultiModalProcessor`, mirroring
the pattern already used by `Gemma4MultiModalProcessor` (added in #2103).

A `phi4mm` `genai_config.json` with the `speech` block cleared
(`filename` and `config_filename` both empty / removed) can now load
vision-only and skip the speech ONNX entirely, reducing peak
memory usage for image-only use cases.

## Problem

PR #2103 added auto-detection of `speech.filename` in `model.cpp` and
allocation of an empty `audio_features` tensor in `multi_modal.cpp`
when the embedding ONNX requires it. However, `PhiMultiModalProcessor`
itself was not gated and still unconditionally:

1. Calls `session_info.GetInputDataType(config.model.speech.inputs.audio_embeds)`
   (and `audio_sizes`) in the initializer list.
   `SessionInfo` aggregates inputs only from sessions that were actually
   loaded — with no speech session, this throws: "Model input was not found: audio_embeds"
2. Calls `OrtxCreateSpeechFeatureExtractor(audio_processor_, "")` with an
empty `speech.config_filename`, which fails to open the file.
3. Registers `AudioEmbeds` / `AudioAttentionMask` / `AudioSizes`
mappings against an unconfigured speech section.

The net effect is that even though `model.cpp` correctly skips loading
`speech.onnx`, the processor construction in `MultiModalProcessor`'s
factory still throws during `og.Model(...)`, blocking vision-only
phi4mm loads.

## Fix

Apply the exact same gating pattern that `Gemma4MultiModalProcessor`
already uses:

- Add a `bool has_speech_{false}` member to `PhiMultiModalProcessor`.
- Move all audio-related construction (audio dtype queries,
`OrtxCreateSpeechFeatureExtractor`, three `AddMapping` calls) inside
an `if (!speech.config_filename.empty() && fs::exists(...))` block
that sets `has_speech_ = true` on success.
- Throw a precise error if `speech.filename` is set but the audio
processor config file is missing on disk.
- In `Process()`, throw a clear user-facing error if `payload.audios`
is supplied while `has_speech_` is `false`.
- Gate the audio feature extraction and the audio output emit block
on `payload.audios && has_speech_`.

No changes to vision-only image processing or to the
`ProcessImageAudioPrompt` helper — the existing `if (audio_sizes)`
guards inside it correctly produce `num_audios == 0` on the
vision-only path, so `audio_projection_mode` resolves to `1`
(Vision, language) as expected.


## Usage

To run phi4mm vision-only:

```json
"speech": { "filename": "", "config_filename": "" }

(or remove the speech block entirely from genai_config.json). The speech ONNX and audio_processor_config.json no longer need to be present on disk.