### PR TITLE
Cleanup TensorObject created by OrtxTensorResultGetAt

### DIFF
--- a/src/models/gemma4_multimodal_processor.cpp
+++ b/src/models/gemma4_multimodal_processor.cpp
@@ -211,27 +211,28 @@ std::unique_ptr<NamedTensors> Gemma4MultiModalProcessor::Process(const Tokenizer
   }
 
   // Process images if present
+  // OrtxTensorResultGetAt allocates a new TensorObject the caller owns; wrap in OrtxObjectPtr to dispose.
   ort_extensions::OrtxObjectPtr<OrtxTensorResult> image_result;
+  ort_extensions::OrtxObjectPtr<OrtxTensor> pixel_values_owner, pixel_position_ids_owner, num_soft_tokens_owner;
   OrtxTensor* pixel_values = nullptr;
   OrtxTensor* pixel_position_ids = nullptr;
   size_t actual_soft_tokens = vision_soft_tokens_per_image_;
   if (payload.images) {
     CheckResult(OrtxImagePreProcess(image_processor_.get(), payload.images->images_.get(), image_result.ToBeAssigned()));
-    CheckResult(OrtxTensorResultGetAt(image_result.get(), 0, &pixel_values));
+    CheckResult(OrtxTensorResultGetAt(image_result.get(), 0, pixel_values_owner.ToBeAssigned()));
+    pixel_values = pixel_values_owner.get();
 
     // pixel_position_ids is the second output from the Gemma4 image preprocessor
-    OrtxTensor* temp_tensor = nullptr;
-    if (OrtxTensorResultGetAt(image_result.get(), 1, &temp_tensor) == kOrtxOK && temp_tensor) {
-      pixel_position_ids = temp_tensor;
+    if (OrtxTensorResultGetAt(image_result.get(), 1, pixel_position_ids_owner.ToBeAssigned()) == kOrtxOK && pixel_position_ids_owner.get()) {
+      pixel_position_ids = pixel_position_ids_owner.get();
     }
 
     // num_soft_tokens is the third output — the actual number of vision tokens after pooling
-    OrtxTensor* num_soft_tokens_tensor = nullptr;
-    if (OrtxTensorResultGetAt(image_result.get(), 2, &num_soft_tokens_tensor) == kOrtxOK && num_soft_tokens_tensor) {
+    if (OrtxTensorResultGetAt(image_result.get(), 2, num_soft_tokens_owner.ToBeAssigned()) == kOrtxOK && num_soft_tokens_owner.get()) {
       const int64_t* nst_data{};
       const int64_t* nst_shape{};
       size_t nst_dims;
-      CheckResult(OrtxGetTensorData(num_soft_tokens_tensor, reinterpret_cast<const void**>(&nst_data),
+      CheckResult(OrtxGetTensorData(num_soft_tokens_owner.get(), reinterpret_cast<const void**>(&nst_data),
                                     &nst_shape, &nst_dims));
       if (nst_data && nst_data[0] > 0) {
         actual_soft_tokens = static_cast<size_t>(nst_data[0]);
@@ -251,8 +252,10 @@ std::unique_ptr<NamedTensors> Gemma4MultiModalProcessor::Process(const Tokenizer
     ort_extensions::OrtxObjectPtr<OrtxTensorResult> audio_result;
     CheckResult(OrtxFeatureExtraction(audio_processor_.get(), payload.audios->audios_.get(), audio_result.ToBeAssigned()));
 
-    OrtxTensor* audio_features = nullptr;
-    CheckResult(OrtxTensorResultGetAt(audio_result.get(), 0, &audio_features));
+    // OrtxTensorResultGetAt allocates a new TensorObject the caller owns; wrap in OrtxObjectPtr to dispose.
+    ort_extensions::OrtxObjectPtr<OrtxTensor> audio_features_owner;
+    CheckResult(OrtxTensorResultGetAt(audio_result.get(), 0, audio_features_owner.ToBeAssigned()));
+    OrtxTensor* audio_features = audio_features_owner.get();
 
     EmplaceProcessedTensor(*named_tensors, Config::Defaults::AudioEmbedsName, audio_features, audio_features_type_, allocator);
 

--- a/src/models/gemma_image_processor.cpp
+++ b/src/models/gemma_image_processor.cpp
@@ -102,8 +102,10 @@ std::unique_ptr<NamedTensors> GemmaImageProcessor::Process(const Tokenizer& toke
   ort_extensions::OrtxObjectPtr<OrtxTensorResult> result;
   CheckResult(OrtxImagePreProcess(processor_.get(), images->images_.get(), result.ToBeAssigned()));
 
-  OrtxTensor* pixel_values = nullptr;
-  CheckResult(OrtxTensorResultGetAt(result.get(), 0, &pixel_values));
+  // OrtxTensorResultGetAt allocates a new TensorObject the caller owns; wrap in OrtxObjectPtr to dispose.
+  ort_extensions::OrtxObjectPtr<OrtxTensor> pixel_values_owner;
+  CheckResult(OrtxTensorResultGetAt(result.get(), 0, pixel_values_owner.ToBeAssigned()));
+  OrtxTensor* pixel_values = pixel_values_owner.get();
 
   auto [input_ids, token_type_ids, num_img_tokens] = ProcessImagePrompt(tokenizer, prompt, pixel_values, allocator);
   named_tensors->emplace(std::string(Config::Defaults::InputIdsName), std::make_shared<Tensor>(std::move(input_ids)));

--- a/src/models/mistral3_image_processor.cpp
+++ b/src/models/mistral3_image_processor.cpp
@@ -250,13 +250,16 @@ std::unique_ptr<NamedTensors> Mistral3ImageProcessor::Process(
   CheckResult(OrtxImagePreProcess(processor_.get(), images->images_.get(),
                                   result.ToBeAssigned()));
 
-  OrtxTensor* pixel_values = nullptr;
-  CheckResult(OrtxTensorResultGetAt(result.get(), 0, &pixel_values));
+  // OrtxTensorResultGetAt allocates a new TensorObject the caller owns; wrap in OrtxObjectPtr to dispose.
+  ort_extensions::OrtxObjectPtr<OrtxTensor> pixel_values_owner;
+  CheckResult(OrtxTensorResultGetAt(result.get(), 0, pixel_values_owner.ToBeAssigned()));
+  OrtxTensor* pixel_values = pixel_values_owner.get();
 
   // Tensor 1: image_sizes[N, 2] from PixtralImageSizes (post-resize, pre-padding).
   // Models must be exported with PixtralImageSizes in processor_config.json.
-  OrtxTensor* image_sizes = nullptr;
-  CheckResult(OrtxTensorResultGetAt(result.get(), 1, &image_sizes));
+  ort_extensions::OrtxObjectPtr<OrtxTensor> image_sizes_owner;
+  CheckResult(OrtxTensorResultGetAt(result.get(), 1, image_sizes_owner.ToBeAssigned()));
+  OrtxTensor* image_sizes = image_sizes_owner.get();
 
   auto [input_ids, num_img_tokens] =
       ProcessPixtralPrompt(tokenizer, prompt, pixel_values, image_sizes, patch_size_,

--- a/src/models/phi_image_processor.cpp
+++ b/src/models/phi_image_processor.cpp
@@ -109,14 +109,18 @@ std::unique_ptr<NamedTensors> PhiImageProcessor::Process(const Tokenizer& tokeni
   ort_extensions::OrtxObjectPtr<OrtxTensorResult> result;
   CheckResult(OrtxImagePreProcess(processor_.get(), images->images_.get(), result.ToBeAssigned()));
 
-  OrtxTensor* pixel_values = nullptr;
-  CheckResult(OrtxTensorResultGetAt(result.get(), 0, &pixel_values));
+  // OrtxTensorResultGetAt allocates a new TensorObject the caller owns; wrap in OrtxObjectPtr to dispose.
+  ort_extensions::OrtxObjectPtr<OrtxTensor> pixel_values_owner;
+  CheckResult(OrtxTensorResultGetAt(result.get(), 0, pixel_values_owner.ToBeAssigned()));
+  OrtxTensor* pixel_values = pixel_values_owner.get();
 
-  OrtxTensor* image_sizes = nullptr;
-  CheckResult(OrtxTensorResultGetAt(result.get(), 1, &image_sizes));
+  ort_extensions::OrtxObjectPtr<OrtxTensor> image_sizes_owner;
+  CheckResult(OrtxTensorResultGetAt(result.get(), 1, image_sizes_owner.ToBeAssigned()));
+  OrtxTensor* image_sizes = image_sizes_owner.get();
 
-  OrtxTensor* num_img_tokens = nullptr;
-  CheckResult(OrtxTensorResultGetAt(result.get(), 2, &num_img_tokens));
+  ort_extensions::OrtxObjectPtr<OrtxTensor> num_img_tokens_owner;
+  CheckResult(OrtxTensorResultGetAt(result.get(), 2, num_img_tokens_owner.ToBeAssigned()));
+  OrtxTensor* num_img_tokens = num_img_tokens_owner.get();
 
   named_tensors->emplace(std::string(Config::Defaults::InputIdsName),
                          std::make_shared<Tensor>(ProcessImagePrompt(tokenizer, prompt, num_img_tokens, allocator)));

--- a/src/models/phi_multimodal_processor.cpp
+++ b/src/models/phi_multimodal_processor.cpp
@@ -127,25 +127,36 @@ std::unique_ptr<NamedTensors> PhiMultiModalProcessor::Process(const Tokenizer& t
   Ort::Allocator& allocator{Ort::Allocator::GetWithDefaultOptions()};
   auto named_tensors = std::make_unique<NamedTensors>();
 
+  // OrtxTensorResultGetAt allocates a new TensorObject the caller owns; wrap in OrtxObjectPtr to dispose.
   ort_extensions::OrtxObjectPtr<OrtxTensorResult> image_result;
+  ort_extensions::OrtxObjectPtr<OrtxTensor> pixel_values_owner, image_sizes_owner,
+      image_attention_mask_owner, num_img_tokens_owner;
   OrtxTensor *pixel_values{}, *image_sizes{}, *image_attention_mask{}, *num_img_tokens{};
   if (payload.images) {
     CheckResult(OrtxImagePreProcess(image_processor_.get(), payload.images->images_.get(), image_result.ToBeAssigned()));
 
-    CheckResult(OrtxTensorResultGetAt(image_result.get(), 0, &pixel_values));
-    CheckResult(OrtxTensorResultGetAt(image_result.get(), 1, &image_sizes));
-    CheckResult(OrtxTensorResultGetAt(image_result.get(), 2, &image_attention_mask));
-    CheckResult(OrtxTensorResultGetAt(image_result.get(), 3, &num_img_tokens));
+    CheckResult(OrtxTensorResultGetAt(image_result.get(), 0, pixel_values_owner.ToBeAssigned()));
+    CheckResult(OrtxTensorResultGetAt(image_result.get(), 1, image_sizes_owner.ToBeAssigned()));
+    CheckResult(OrtxTensorResultGetAt(image_result.get(), 2, image_attention_mask_owner.ToBeAssigned()));
+    CheckResult(OrtxTensorResultGetAt(image_result.get(), 3, num_img_tokens_owner.ToBeAssigned()));
+    pixel_values = pixel_values_owner.get();
+    image_sizes = image_sizes_owner.get();
+    image_attention_mask = image_attention_mask_owner.get();
+    num_img_tokens = num_img_tokens_owner.get();
   }
 
   ort_extensions::OrtxObjectPtr<OrtxTensorResult> audio_result;
+  ort_extensions::OrtxObjectPtr<OrtxTensor> audio_embeds_owner, audio_attention_mask_owner, audio_sizes_owner;
   OrtxTensor *audio_embeds{}, *audio_attention_mask{}, *audio_sizes{};
   if (payload.audios) {
     CheckResult(OrtxFeatureExtraction(audio_processor_.get(), payload.audios->audios_.get(), audio_result.ToBeAssigned()));
 
-    CheckResult(OrtxTensorResultGetAt(audio_result.get(), 0, &audio_embeds));
-    CheckResult(OrtxTensorResultGetAt(audio_result.get(), 1, &audio_attention_mask));
-    CheckResult(OrtxTensorResultGetAt(audio_result.get(), 2, &audio_sizes));
+    CheckResult(OrtxTensorResultGetAt(audio_result.get(), 0, audio_embeds_owner.ToBeAssigned()));
+    CheckResult(OrtxTensorResultGetAt(audio_result.get(), 1, audio_attention_mask_owner.ToBeAssigned()));
+    CheckResult(OrtxTensorResultGetAt(audio_result.get(), 2, audio_sizes_owner.ToBeAssigned()));
+    audio_embeds = audio_embeds_owner.get();
+    audio_attention_mask = audio_attention_mask_owner.get();
+    audio_sizes = audio_sizes_owner.get();
   }
 
   auto [input_ids, audio_projection_mode] = ProcessImageAudioPrompt(tokenizer, payload.prompt, num_img_tokens, audio_sizes, allocator);

--- a/src/models/qwen2_5_vl_image_processor.cpp
+++ b/src/models/qwen2_5_vl_image_processor.cpp
@@ -200,12 +200,16 @@ std::unique_ptr<NamedTensors> QwenImageProcessor::Process(const Tokenizer& token
   ort_extensions::OrtxObjectPtr<OrtxTensorResult> result;
   CheckResult(OrtxImagePreProcess(processor_.get(), images->images_.get(), result.ToBeAssigned()));
 
-  OrtxTensor* pixel_values = nullptr;
-  CheckResult(OrtxTensorResultGetAt(result.get(), 0, &pixel_values));
+  // OrtxTensorResultGetAt allocates a new TensorObject that the caller owns.
+  // Wrap in OrtxObjectPtr so it's disposed on scope exit (avoids TensorObject leak).
+  ort_extensions::OrtxObjectPtr<OrtxTensor> pixel_values_owner;
+  CheckResult(OrtxTensorResultGetAt(result.get(), 0, pixel_values_owner.ToBeAssigned()));
+  OrtxTensor* pixel_values = pixel_values_owner.get();
 
-  OrtxTensor* image_grid_thw = nullptr;
+  ort_extensions::OrtxObjectPtr<OrtxTensor> image_grid_thw_owner;
   // Try to get image_grid_thw from processor (second output)
-  auto status = OrtxTensorResultGetAt(result.get(), 1, &image_grid_thw);
+  auto status = OrtxTensorResultGetAt(result.get(), 1, image_grid_thw_owner.ToBeAssigned());
+  OrtxTensor* image_grid_thw = image_grid_thw_owner.get();
 
   // Get pixel_values data and shape
   const float* pixel_values_data{};


### PR DESCRIPTION
OrtxTensorResultGetAt allocates a TensorObject that isn't freed.