### PR TITLE
Multilingual Streaming Nemotron ASR + CUDA support

### DIFF
--- a/examples/python/nemotron_speech.py
+++ b/examples/python/nemotron_speech.py
@@ -97,11 +97,12 @@ def simulate_microphone(model_path, audio_path, execution_provider, use_vad=None
     duration = len(audio) / sample_rate
 
     config = get_config(model_path, execution_provider)
+    selected_lang = None
     if language is not None:
         if language not in LANG_TO_ID:
             raise ValueError(f"Unknown language '{language}'. Known: {sorted(LANG_TO_ID)}")
-        lang_id, lang_name = LANG_TO_ID[language]
-        config.overlay(json.dumps({"model": {"default_lang_id": int(lang_id)}}))
+        selected_lang = LANG_TO_ID[language]
+        lang_id, lang_name = selected_lang
         print(f"  Language: {language} -> {lang_name} (lang_id={lang_id})")
     model = og.Model(config)
     processor = og.StreamingProcessor(model)
@@ -122,6 +123,9 @@ def simulate_microphone(model_path, audio_path, execution_provider, use_vad=None
     tokenizer_stream = tokenizer.create_stream()
     params = og.GeneratorParams(model)
     generator = og.Generator(model, params)
+    # Per-generator language selection
+    if selected_lang is not None:
+        generator.set_runtime_option("lang_id", str(int(selected_lang[0])))
 
     print("-" * 60)
     stream_start = time.perf_counter()

--- a/examples/python/nemotron_speech.py
+++ b/examples/python/nemotron_speech.py
@@ -10,6 +10,24 @@ import numpy as np
 import onnxruntime_genai as og
 from common import get_config
 
+# Maps short language codes / locale tags to the encoder lang_id index used by
+# the multilingual Nemotron prompt. Mirrors the upstream NeMo prompt schema.
+LANG_TO_ID = {
+    "en": 0, "en-US": 0, "en-GB": 1,
+    "es-ES": 2, "es": 3, "es-US": 3,
+    "zh-CN": 4, "zh-TW": 5,
+    "hi": 6, "ar": 7,
+    "fr": 8, "fr-FR": 8, "fr-CA": 100,
+    "de": 9, "de-DE": 9,
+    "it": 10, "ru": 11,
+    "pt-BR": 12, "pt": 13, "pt-PT": 13,
+    "ja": 14, "ko": 15, "nl": 16,
+    "pl": 17, "tr": 18, "uk": 19, "ro": 20, "el": 21, "cs": 22,
+    "hu": 23, "sv": 24, "da": 25, "fi": 26, "no": 27, "sk": 28,
+    "hr": 29, "bg": 30,
+    "auto": 101,
+}
+
 
 def load_config(model_path):
     """Read sample_rate and chunk_samples from genai_config.json."""
@@ -47,13 +65,19 @@ def decode_tokens(generator, tokenizer_stream):
     return text
 
 
-def simulate_microphone(model_path, audio_path, execution_provider, use_vad=None):
+def simulate_microphone(model_path, audio_path, execution_provider, use_vad=None, language=None):
     """Stream audio through Generator + StreamingProcessor API."""
     sample_rate, chunk_samples = load_config(model_path)
     audio = load_audio(audio_path, sample_rate)
     duration = len(audio) / sample_rate
 
     config = get_config(model_path, execution_provider)
+    if language is not None:
+        if language not in LANG_TO_ID:
+            raise ValueError(f"Unknown language '{language}'. Known: {sorted(LANG_TO_ID)}")
+        lang_id = LANG_TO_ID[language]
+        config.overlay(json.dumps({"model": {"lang_id": int(lang_id)}}))
+        print(f"  Language: {language} (lang_id={lang_id})")
     model = og.Model(config)
     processor = og.StreamingProcessor(model)
 
@@ -117,6 +141,9 @@ def main():
     parser.add_argument("--audio_file", type=str, required=True)
     parser.add_argument("--use_vad", type=str, choices=["true", "false"], default=None,
                         help="Override VAD setting from genai_config.json (true/false).")
+    parser.add_argument("--language", "-l", type=str, default=None,
+                        help="Language code for the multilingual encoder (e.g. en, de, es, fr, nl, pl, hr). "
+                             "Overrides model.lang_id from genai_config.json.")
     parser.add_argument("-e", "--execution_provider", type=str, required=False, default="follow_config",
                         choices=["cpu", "cuda", "dml", "follow_config"],
                         help="Execution provider to run with. Defaults to follow_config.")
@@ -128,7 +155,7 @@ def main():
     if args.use_vad is not None:
         use_vad_override = args.use_vad == "true"
     simulate_microphone(args.model_path, args.audio_file, args.execution_provider,
-                        use_vad=use_vad_override)
+                        use_vad=use_vad_override, language=args.language)
 
 
 if __name__ == "__main__":

--- a/examples/python/nemotron_speech.py
+++ b/examples/python/nemotron_speech.py
@@ -76,7 +76,7 @@ def simulate_microphone(model_path, audio_path, execution_provider, use_vad=None
         if language not in LANG_TO_ID:
             raise ValueError(f"Unknown language '{language}'. Known: {sorted(LANG_TO_ID)}")
         lang_id = LANG_TO_ID[language]
-        config.overlay(json.dumps({"model": {"lang_id": int(lang_id)}}))
+        config.overlay(json.dumps({"model": {"default_lang_id": int(lang_id)}}))
         print(f"  Language: {language} (lang_id={lang_id})")
     model = og.Model(config)
     processor = og.StreamingProcessor(model)
@@ -143,7 +143,7 @@ def main():
                         help="Override VAD setting from genai_config.json (true/false).")
     parser.add_argument("--language", "-l", type=str, default=None,
                         help="Language code for the multilingual encoder (e.g. en, de, es, fr, nl, pl, hr). "
-                             "Overrides model.lang_id from genai_config.json.")
+                             "Overrides model.default_lang_id from genai_config.json.")
     parser.add_argument("-e", "--execution_provider", type=str, required=False, default="follow_config",
                         choices=["cpu", "cuda", "dml", "follow_config"],
                         help="Execution provider to run with. Defaults to follow_config.")

--- a/examples/python/nemotron_speech.py
+++ b/examples/python/nemotron_speech.py
@@ -10,22 +10,47 @@ import numpy as np
 import onnxruntime_genai as og
 from common import get_config
 
-# Maps short language codes / locale tags to the encoder lang_id index used by
-# the multilingual Nemotron prompt. Mirrors the upstream NeMo prompt schema.
+# Maps short language codes / locale tags to (lang_id, human-readable name).
+# Mirrors the upstream NeMo multilingual Nemotron prompt schema.
 LANG_TO_ID = {
-    "en": 0, "en-US": 0, "en-GB": 1,
-    "es-ES": 2, "es": 3, "es-US": 3,
-    "zh-CN": 4, "zh-TW": 5,
-    "hi": 6, "ar": 7,
-    "fr": 8, "fr-FR": 8, "fr-CA": 100,
-    "de": 9, "de-DE": 9,
-    "it": 10, "ru": 11,
-    "pt-BR": 12, "pt": 13, "pt-PT": 13,
-    "ja": 14, "ko": 15, "nl": 16,
-    "pl": 17, "tr": 18, "uk": 19, "ro": 20, "el": 21, "cs": 22,
-    "hu": 23, "sv": 24, "da": 25, "fi": 26, "no": 27, "sk": 28,
-    "hr": 29, "bg": 30,
-    "auto": 101,
+    "en":    (0,   "English (default / US)"),
+    "en-US": (0,   "English (United States)"),
+    "en-GB": (1,   "English (United Kingdom)"),
+    "es-ES": (2,   "Spanish (Spain)"),
+    "es":    (3,   "Spanish (default / Latin America)"),
+    "es-US": (3,   "Spanish (US Latin American)"),
+    "zh-CN": (4,   "Chinese (Simplified, Mainland)"),
+    "zh-TW": (5,   "Chinese (Traditional, Taiwan)"),
+    "hi":    (6,   "Hindi"),
+    "ar":    (7,   "Arabic"),
+    "fr":    (8,   "French (default / France)"),
+    "fr-FR": (8,   "French (France)"),
+    "fr-CA": (100, "French (Canada)"),
+    "de":    (9,   "German"),
+    "de-DE": (9,   "German (Germany)"),
+    "it":    (10,  "Italian"),
+    "ru":    (11,  "Russian"),
+    "pt-BR": (12,  "Portuguese (Brazil)"),
+    "pt":    (13,  "Portuguese (default / Portugal)"),
+    "pt-PT": (13,  "Portuguese (Portugal)"),
+    "ja":    (14,  "Japanese"),
+    "ko":    (15,  "Korean"),
+    "nl":    (16,  "Dutch"),
+    "pl":    (17,  "Polish"),
+    "tr":    (18,  "Turkish"),
+    "uk":    (19,  "Ukrainian"),
+    "ro":    (20,  "Romanian"),
+    "el":    (21,  "Greek"),
+    "cs":    (22,  "Czech"),
+    "hu":    (23,  "Hungarian"),
+    "sv":    (24,  "Swedish"),
+    "da":    (25,  "Danish"),
+    "fi":    (26,  "Finnish"),
+    "no":    (27,  "Norwegian"),
+    "sk":    (28,  "Slovak"),
+    "hr":    (29,  "Croatian"),
+    "bg":    (30,  "Bulgarian"),
+    "auto":  (101, "Auto-detect"),
 }
 
 
@@ -75,9 +100,9 @@ def simulate_microphone(model_path, audio_path, execution_provider, use_vad=None
     if language is not None:
         if language not in LANG_TO_ID:
             raise ValueError(f"Unknown language '{language}'. Known: {sorted(LANG_TO_ID)}")
-        lang_id = LANG_TO_ID[language]
+        lang_id, lang_name = LANG_TO_ID[language]
         config.overlay(json.dumps({"model": {"default_lang_id": int(lang_id)}}))
-        print(f"  Language: {language} (lang_id={lang_id})")
+        print(f"  Language: {language} -> {lang_name} (lang_id={lang_id})")
     model = og.Model(config)
     processor = og.StreamingProcessor(model)
 
@@ -136,14 +161,18 @@ def simulate_microphone(model_path, audio_path, execution_provider, use_vad=None
 
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("--model_path", type=str, required=True)
     parser.add_argument("--audio_file", type=str, required=True)
     parser.add_argument("--use_vad", type=str, choices=["true", "false"], default=None,
                         help="Override VAD setting from genai_config.json (true/false).")
-    parser.add_argument("--language", "-l", type=str, default=None,
-                        help="Language code for the multilingual encoder (e.g. en, de, es, fr, nl, pl, hr). "
-                             "Overrides model.default_lang_id from genai_config.json.")
+    lang_help = "Language / locale code for the multilingual encoder. " \
+                "Overrides model.default_lang_id from genai_config.json. " \
+                "Use a bare ISO 639-1 code (e.g. 'de', 'fr', 'pt') for the default locale, " \
+                "or a BCP-47 locale tag for region-specific variants. " \
+                "Pass 'auto' to let the model detect the language. Supported codes:\n" \
+                + "\n".join(f"  {code:<7} {name}" for code, (_, name) in sorted(LANG_TO_ID.items()))
+    parser.add_argument("--language", "-l", type=str, default=None, help=lang_help)
     parser.add_argument("-e", "--execution_provider", type=str, required=False, default="follow_config",
                         choices=["cpu", "cuda", "dml", "follow_config"],
                         help="Execution provider to run with. Defaults to follow_config.")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1147,8 +1147,8 @@ struct Model_Element : JSON::Element {
       v_.blank_id = static_cast<int>(JSON::Get<double>(value));
     } else if (name == "max_symbols_per_step") {
       v_.max_symbols_per_step = static_cast<int>(JSON::Get<double>(value));
-    } else if (name == "lang_id") {
-      v_.lang_id = static_cast<int>(JSON::Get<double>(value));
+    } else if (name == "default_lang_id") {
+      v_.default_lang_id = static_cast<int>(JSON::Get<double>(value));
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -250,8 +250,8 @@ struct EncoderInputs_Element : JSON::Element {
       v_.cache_last_time = JSON::Get<std::string_view>(value);
     } else if (name == "cache_last_channel_len") {
       v_.cache_last_channel_len = JSON::Get<std::string_view>(value);
-    } else if (name == "prompt") {
-      v_.prompt = JSON::Get<std::string_view>(value);
+    } else if (name == "lang_id") {
+      v_.lang_id = JSON::Get<std::string_view>(value);
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1147,8 +1147,6 @@ struct Model_Element : JSON::Element {
       v_.blank_id = static_cast<int>(JSON::Get<double>(value));
     } else if (name == "max_symbols_per_step") {
       v_.max_symbols_per_step = static_cast<int>(JSON::Get<double>(value));
-    } else if (name == "num_prompts") {
-      v_.num_prompts = static_cast<int>(JSON::Get<double>(value));
     } else if (name == "lang_id") {
       v_.lang_id = static_cast<int>(JSON::Get<double>(value));
     } else {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1147,8 +1147,6 @@ struct Model_Element : JSON::Element {
       v_.blank_id = static_cast<int>(JSON::Get<double>(value));
     } else if (name == "max_symbols_per_step") {
       v_.max_symbols_per_step = static_cast<int>(JSON::Get<double>(value));
-    } else if (name == "default_lang_id") {
-      v_.default_lang_id = static_cast<int>(JSON::Get<double>(value));
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -250,6 +250,8 @@ struct EncoderInputs_Element : JSON::Element {
       v_.cache_last_time = JSON::Get<std::string_view>(value);
     } else if (name == "cache_last_channel_len") {
       v_.cache_last_channel_len = JSON::Get<std::string_view>(value);
+    } else if (name == "prompt") {
+      v_.prompt = JSON::Get<std::string_view>(value);
     } else {
       throw JSON::unknown_value_error{};
     }
@@ -1145,6 +1147,10 @@ struct Model_Element : JSON::Element {
       v_.blank_id = static_cast<int>(JSON::Get<double>(value));
     } else if (name == "max_symbols_per_step") {
       v_.max_symbols_per_step = static_cast<int>(JSON::Get<double>(value));
+    } else if (name == "num_prompts") {
+      v_.num_prompts = static_cast<int>(JSON::Get<double>(value));
+    } else if (name == "lang_id") {
+      v_.lang_id = static_cast<int>(JSON::Get<double>(value));
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.h
+++ b/src/config.h
@@ -154,7 +154,7 @@ struct Config {
     int chunk_samples{};
     int blank_id{};
     int max_symbols_per_step{};
-    int lang_id{};       // Default language/prompt index used when the encoder takes a lang_id input
+    int default_lang_id{};  // Default language/prompt index fed to the encoder's lang_id input
 
     struct Encoder {
       std::string filename;

--- a/src/config.h
+++ b/src/config.h
@@ -154,7 +154,6 @@ struct Config {
     int chunk_samples{};
     int blank_id{};
     int max_symbols_per_step{};
-    int default_lang_id{};  // Default language/prompt index fed to the encoder's lang_id input
 
     struct Encoder {
       std::string filename;

--- a/src/config.h
+++ b/src/config.h
@@ -67,7 +67,7 @@ struct Config {
     static constexpr std::string_view CacheLastChannelName = "cache_last_channel";
     static constexpr std::string_view CacheLastTimeName = "cache_last_time";
     static constexpr std::string_view CacheLastChannelLenName = "cache_last_channel_len";
-    static constexpr std::string_view PromptName = "prompt";
+    static constexpr std::string_view LangIdName = "lang_id";
     static constexpr std::string_view EncoderOutputLengthsName = "encoded_lengths";
     static constexpr std::string_view CacheLastChannelNextName = "cache_last_channel_next";
     static constexpr std::string_view CacheLastTimeNextName = "cache_last_time_next";
@@ -179,7 +179,7 @@ struct Config {
         std::string cache_last_channel{Defaults::CacheLastChannelName};
         std::string cache_last_time{Defaults::CacheLastTimeName};
         std::string cache_last_channel_len{Defaults::CacheLastChannelLenName};
-        std::string prompt{Defaults::PromptName};
+        std::string lang_id{Defaults::LangIdName};
       } inputs;
 
       struct Outputs {

--- a/src/config.h
+++ b/src/config.h
@@ -67,6 +67,7 @@ struct Config {
     static constexpr std::string_view CacheLastChannelName = "cache_last_channel";
     static constexpr std::string_view CacheLastTimeName = "cache_last_time";
     static constexpr std::string_view CacheLastChannelLenName = "cache_last_channel_len";
+    static constexpr std::string_view PromptName = "prompt";
     static constexpr std::string_view EncoderOutputLengthsName = "encoded_lengths";
     static constexpr std::string_view CacheLastChannelNextName = "cache_last_channel_next";
     static constexpr std::string_view CacheLastTimeNextName = "cache_last_time_next";
@@ -153,6 +154,8 @@ struct Config {
     int chunk_samples{};
     int blank_id{};
     int max_symbols_per_step{};
+    int num_prompts{};   // Size of the one-hot prompt vector for multilingual prompt-conditioned encoders (0 = no prompt)
+    int lang_id{};       // Default language/prompt index used when the encoder takes a prompt input
 
     struct Encoder {
       std::string filename;
@@ -176,6 +179,7 @@ struct Config {
         std::string cache_last_channel{Defaults::CacheLastChannelName};
         std::string cache_last_time{Defaults::CacheLastTimeName};
         std::string cache_last_channel_len{Defaults::CacheLastChannelLenName};
+        std::string prompt{Defaults::PromptName};
       } inputs;
 
       struct Outputs {

--- a/src/config.h
+++ b/src/config.h
@@ -154,8 +154,7 @@ struct Config {
     int chunk_samples{};
     int blank_id{};
     int max_symbols_per_step{};
-    int num_prompts{};   // Size of the one-hot prompt vector for multilingual prompt-conditioned encoders (0 = no prompt)
-    int lang_id{};       // Default language/prompt index used when the encoder takes a prompt input
+    int lang_id{};       // Default language/prompt index used when the encoder takes a lang_id input
 
     struct Encoder {
       std::string filename;

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -4,6 +4,8 @@
 // Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "generators.h"
+#include <cstring>
+#include <cstdlib>
 #include "models/streaming_processor.h"
 #include "models/nemotron_speech.h"
 #include "sequences.h"
@@ -565,6 +567,13 @@ void Generator::ComputeLogits(DeviceSpan<int32_t> next_tokens) {
 }
 
 void Generator::SetRuntimeOption(const char* key, const char* value) {
+  // Nemotron speech models support per-generator "lang_id" override so that
+  // a single loaded model can serve generators in different languages.
+  if (is_nemotron_speech_model_ && key != nullptr && std::strcmp(key, "lang_id") == 0) {
+    int lang_id = std::atoi(value);
+    static_cast<NemotronSpeechState*>(state_.get())->SetLangId(lang_id);
+    return;
+  }
   state_->SetRunOption(key, value);
 }
 

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -14,10 +14,13 @@ namespace Generators {
 
 namespace {
 // Picks the DeviceInterface that matches the OrtValue's actual memory location.
-// Required because ORT may place outputs on CPU even when the EP is CUDA.
-DeviceInterface& DeviceFor(const OrtValue& v) {
-  const bool on_gpu = v.GetTensorMemoryInfo().GetDeviceType() == OrtMemoryInfoDeviceType_GPU;
-  return *GetDeviceInterface(on_gpu ? DeviceType::CUDA : DeviceType::CPU);
+// Required because ORT may place outputs on CPU even when the EP is on a device
+// (e.g. CUDA, DML, QNN). For non-CPU placements we fall back to the model's
+// own input device interface rather than hardcoding a specific EP, so this
+// works across any backend the model was built with.
+DeviceInterface& DeviceFor(const OrtValue& v, DeviceInterface& model_device) {
+  const bool on_cpu = v.GetTensorMemoryInfo().GetDeviceType() == OrtMemoryInfoDeviceType_CPU;
+  return on_cpu ? *GetDeviceInterface(DeviceType::CPU) : model_device;
 }
 }  // namespace
 
@@ -471,7 +474,7 @@ void NemotronSpeechState::RunEncoder() {
   auto encoded_len_cpu = OrtValue::CreateTensor(cpu_alloc, len_shape,
                                                 ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
   ByteWrapTensor(cpu_dev, *encoded_len_cpu)
-      .CopyFrom(ByteWrapTensor(DeviceFor(*encoded_len_owner), *encoded_len_owner));
+      .CopyFrom(ByteWrapTensor(DeviceFor(*encoded_len_owner, *model_.p_device_inputs_), *encoded_len_owner));
   encoded_len_ = *encoded_len_cpu->GetTensorData<int64_t>();
 
   encoder_state_->cache_.cache_last_channel.reset(encoder_state_->outputs_[2]);
@@ -507,7 +510,7 @@ std::span<const int32_t> NemotronSpeechState::StepToken() {
   // encoded_output_'s actual device varies (ORT may place it on CPU even with
   // CUDA EP). Pick the matching DeviceInterface so CopyFrom uses the right
   // memcpy direction.
-  auto enc_span = ByteWrapTensor(DeviceFor(*encoded_output_), *encoded_output_);
+  auto enc_span = ByteWrapTensor(DeviceFor(*encoded_output_, *model_.p_device_inputs_), *encoded_output_);
   auto frame_span = ByteWrapTensor(cpu_dev, *encoder_frame_);
 
   DeviceSpan<int32_t> dummy_tokens;
@@ -531,7 +534,7 @@ std::span<const int32_t> NemotronSpeechState::StepToken() {
     auto dec_out_type = model_.session_info_.GetOutputDataType(nemotron_config_.dec_out_outputs);
     auto decoder_frame = OrtValue::CreateTensor(cpu_alloc_step, decoder_frame_shape, dec_out_type);
     ByteWrapTensor(cpu_dev, *decoder_frame)
-        .CopyFrom(ByteWrapTensor(DeviceFor(*pred_out0_owner), *pred_out0_owner));
+        .CopyFrom(ByteWrapTensor(DeviceFor(*pred_out0_owner, *model_.p_device_inputs_), *pred_out0_owner));
 
     // Run joiner
     joiner_state_->SetInputFrames(encoder_frame_.get(), decoder_frame.get());
@@ -544,7 +547,7 @@ std::span<const int32_t> NemotronSpeechState::StepToken() {
     auto logits_type = joiner_out0_owner->GetTensorTypeAndShapeInfo()->GetElementType();
     auto logits_cpu = OrtValue::CreateTensor(cpu_alloc_step, logits_shape, logits_type);
     ByteWrapTensor(cpu_dev, *logits_cpu)
-        .CopyFrom(ByteWrapTensor(DeviceFor(*joiner_out0_owner), *joiner_out0_owner));
+        .CopyFrom(ByteWrapTensor(DeviceFor(*joiner_out0_owner, *model_.p_device_inputs_), *joiner_out0_owner));
     const float* logits = logits_cpu->GetTensorData<float>();
     int total_logits = 1;
     for (auto d : logits_shape) total_logits *= static_cast<int>(d);

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -546,9 +546,7 @@ std::span<const int32_t> NemotronSpeechState::StepToken() {
     prediction_state_->UpdateInputs();
     prediction_state_->Run(0, dummy_tokens);
 
-    // Reshape decoder output for joiner: [1, dim] -> [1, 1, dim]. Decoder output
-    // is on the EP device; allocate decoder_frame on CPU so the joiner input
-    // matches the CPU-resident encoder_frame_ (ORT will upload both).
+    // Reshape decoder output for joiner: [1, dim] -> [1, 1, dim].
     // Take ownership of prediction output[0] so it's released this iteration
     // (the next prediction Run will overwrite the slot and leak the old buffer otherwise).
     std::unique_ptr<OrtValue> pred_out0_owner{prediction_state_->outputs_[0]};
@@ -564,9 +562,7 @@ std::span<const int32_t> NemotronSpeechState::StepToken() {
     joiner_state_->SetInputFrames(encoder_frame_.get(), decoder_frame.get());
     joiner_state_->Run(0, dummy_tokens);
 
-    // Argmax over logits. Take ownership of joiner output[0] so it's released this iteration
-    // (the next joiner Run would otherwise overwrite the slot and leak the old buffer).
-    // The buffer may live on the EP device, so copy to CPU before reading.
+    // Argmax over logits. Take ownership of joiner output[0] so it's released this iteration.
     std::unique_ptr<OrtValue> joiner_out0_owner{joiner_state_->outputs_[0]};
     joiner_state_->outputs_[0] = nullptr;
     auto logits_shape = joiner_out0_owner->GetTensorTypeAndShapeInfo()->GetShape();

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -12,6 +12,24 @@
 
 namespace Generators {
 
+namespace {
+// Picks the DeviceInterface that matches the OrtValue's actual memory location.
+// Required because ORT may place outputs on CPU even when the EP is CUDA;
+// wrapping a CPU tensor with a CUDA DeviceInterface causes a sticky
+// cudaErrorInvalidValue at the next CUDA kernel launch.
+DeviceInterface& DeviceFor(const OrtValue& v) {
+  auto& mem = v.GetTensorMemoryInfo();
+  switch (mem.GetDeviceType()) {
+    case OrtMemoryInfoDeviceType_CPU:
+      return *GetDeviceInterface(DeviceType::CPU);
+    case OrtMemoryInfoDeviceType_GPU:
+      return *GetDeviceInterface(DeviceType::CUDA);
+    default:
+      return *GetDeviceInterface(DeviceType::CPU);
+  }
+}
+}  // namespace
+
 void NemotronConfig::PopulateFromConfig(const Config& config) {
   const auto& enc = config.model.encoder;
   const auto& dec = config.model.decoder;
@@ -80,19 +98,21 @@ void NemotronEncoderCache::Initialize(const NemotronConfig& cfg, const SessionIn
   auto cache_time_type = session_info.GetInputDataType(cfg.enc_in_cache_time);
   auto cache_channel_len_type = session_info.GetInputDataType(cfg.enc_in_cache_channel_len);
 
-  // cache_last_channel: [batch, num_layers, left_context, hidden_dim]
+  // cache_last_channel: [batch, num_layers, left_context, hidden_dim] (device memory)
   auto ch_shape = std::array<int64_t, 4>{1, cfg.num_encoder_layers, cfg.left_context, cfg.hidden_dim};
   cache_last_channel = OrtValue::CreateTensor(allocator, ch_shape, cache_channel_type);
-  ByteWrapTensor(*GetDeviceInterface(DeviceType::CPU), *cache_last_channel).Zero();
+  ByteWrapTensor(device, *cache_last_channel).Zero();
 
-  // cache_last_time: [batch, num_layers, hidden_dim, conv_context]
+  // cache_last_time: [batch, num_layers, hidden_dim, conv_context] (device memory)
   auto tm_shape = std::array<int64_t, 4>{1, cfg.num_encoder_layers, cfg.hidden_dim, cfg.conv_context};
   cache_last_time = OrtValue::CreateTensor(allocator, tm_shape, cache_time_type);
-  ByteWrapTensor(*GetDeviceInterface(DeviceType::CPU), *cache_last_time).Zero();
+  ByteWrapTensor(device, *cache_last_time).Zero();
 
-  // cache_last_channel_len: [1]
+  // cache_last_channel_len: [1] int64 scalar; keep on CPU (host-written each step,
+  // ORT will copy to device automatically if the session expects it there).
+  auto& cpu_alloc = GetDeviceInterface(DeviceType::CPU)->GetAllocator();
   auto len_shape = std::array<int64_t, 1>{1};
-  cache_last_channel_len = OrtValue::CreateTensor(allocator, len_shape, cache_channel_len_type);
+  cache_last_channel_len = OrtValue::CreateTensor(cpu_alloc, len_shape, cache_channel_len_type);
   *cache_last_channel_len->GetTensorMutableData<int64_t>() = 0;
 }
 
@@ -104,13 +124,13 @@ void NemotronDecoderState::Initialize(const NemotronConfig& cfg, const SessionIn
   auto lstm_hidden_type = session_info.GetInputDataType(cfg.dec_in_lstm_hidden);
   auto lstm_cell_type = session_info.GetInputDataType(cfg.dec_in_lstm_cell);
 
-  // LSTM states: [lstm_layers, 1, lstm_dim]
+  // LSTM states: [lstm_layers, 1, lstm_dim] (device memory)
   auto state_shape = std::array<int64_t, 3>{cfg.decoder_lstm_layers, 1, cfg.decoder_lstm_dim};
   lstm_hidden_state = OrtValue::CreateTensor(allocator, state_shape, lstm_hidden_type);
-  ByteWrapTensor(*GetDeviceInterface(DeviceType::CPU), *lstm_hidden_state).Zero();
+  ByteWrapTensor(device, *lstm_hidden_state).Zero();
 
   lstm_cell_state = OrtValue::CreateTensor(allocator, state_shape, lstm_cell_type);
-  ByteWrapTensor(*GetDeviceInterface(DeviceType::CPU), *lstm_cell_state).Zero();
+  ByteWrapTensor(device, *lstm_cell_state).Zero();
 
   last_token = cfg.blank_id;  // Start with blank/SOS token
 }
@@ -174,18 +194,21 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
     : State{params, model},
       model_{model} {
   auto& cfg = model_.nemotron_config_;
-  auto& allocator = model_.allocator_cpu_;
-  auto& device = *model_.p_device_;
+  auto& cpu_dev = *GetDeviceInterface(DeviceType::CPU);
+  auto& cpu_alloc = cpu_dev.GetAllocator();
+  auto& inf_dev = *model_.p_device_inputs_;
+  auto& inf_alloc = inf_dev.GetAllocator();
 
-  cache_.Initialize(cfg, model_.session_info_, allocator, device);
+  // Allocate cache on inference device so ORT consumes it without an
+  // implicit CPU→device copy on every Run.
+  cache_.Initialize(cfg, model_.session_info_, inf_alloc, inf_dev);
 
   has_length_input_ = model_.session_info_.HasInput(cfg.enc_in_length);
 
-  // Create signal_length tensor if the encoder model expects it
   if (has_length_input_) {
     auto len_type = model_.session_info_.GetInputDataType(cfg.enc_in_length);
     auto len_shape = std::array<int64_t, 1>{1};
-    signal_length_ = OrtValue::CreateTensor(allocator, len_shape, len_type);
+    signal_length_ = OrtValue::CreateTensor(cpu_alloc, len_shape, len_type);
   }
 
   // Register inputs: mel, [length], cache_channel, cache_time, cache_channel_len
@@ -220,7 +243,7 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
     if (lang_id_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64)
       throw std::runtime_error("Encoder lang_id input must be int64");
     auto lang_id_shape = std::array<int64_t, 1>{1};
-    lang_id_tensor_ = OrtValue::CreateTensor(allocator, lang_id_shape, lang_id_type);
+    lang_id_tensor_ = OrtValue::CreateTensor(cpu_alloc, lang_id_shape, lang_id_type);
     *lang_id_tensor_->GetTensorMutableData<int64_t>() = static_cast<int64_t>(cfg.lang_id);
     lang_id_input_idx_ = inputs_.size();
     input_names_.push_back(cfg.enc_in_lang_id.c_str());
@@ -234,11 +257,27 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
   output_names_.push_back(cfg.enc_out_length.c_str());
   outputs_.push_back(nullptr);
 
+  // Pre-allocate cache outputs on the inference device so ORT writes them
+  // there directly. Without pre-allocation, ORT places these outputs on CPU
+  // and feeding them back as inputs on the next chunk triggers a CUDA copy
+  // path that fails inside Transpose (cudaErrorInvalidValue).
+  cache_channel_next_output_idx_ = outputs_.size();
   output_names_.push_back(cfg.enc_out_cache_channel.c_str());
-  outputs_.push_back(nullptr);
+  {
+    auto ch_shape = std::array<int64_t, 4>{1, cfg.num_encoder_layers, cfg.left_context, cfg.hidden_dim};
+    auto ch_type = model_.session_info_.GetOutputDataType(cfg.enc_out_cache_channel);
+    cache_channel_next_ = OrtValue::CreateTensor(inf_alloc, ch_shape, ch_type);
+  }
+  outputs_.push_back(cache_channel_next_.get());
 
+  cache_time_next_output_idx_ = outputs_.size();
   output_names_.push_back(cfg.enc_out_cache_time.c_str());
-  outputs_.push_back(nullptr);
+  {
+    auto tm_shape = std::array<int64_t, 4>{1, cfg.num_encoder_layers, cfg.hidden_dim, cfg.conv_context};
+    auto tm_type = model_.session_info_.GetOutputDataType(cfg.enc_out_cache_time);
+    cache_time_next_ = OrtValue::CreateTensor(inf_alloc, tm_shape, tm_type);
+  }
+  outputs_.push_back(cache_time_next_.get());
 
   output_names_.push_back(cfg.enc_out_cache_channel_len.c_str());
   outputs_.push_back(nullptr);
@@ -271,15 +310,14 @@ NemotronPredictionSubState::NemotronPredictionSubState(const NemotronSpeechModel
     : State{params, model},
       model_{model} {
   auto& cfg = model_.nemotron_config_;
-  auto& allocator = model_.allocator_cpu_;
-  auto& device = *model_.p_device_;
+  auto& cpu_dev = *GetDeviceInterface(DeviceType::CPU);
+  auto& cpu_alloc = cpu_dev.GetAllocator();
 
-  lstm_state_.Initialize(cfg, model_.session_info_, allocator, device);
+  lstm_state_.Initialize(cfg, model_.session_info_, cpu_alloc, cpu_dev);
 
-  // Create targets tensor
   auto targets_type = model_.session_info_.GetInputDataType(cfg.dec_in_targets);
   auto targets_shape = std::array<int64_t, 2>{1, 1};
-  targets_ = OrtValue::CreateTensor(allocator, targets_shape, targets_type);
+  targets_ = OrtValue::CreateTensor(cpu_alloc, targets_shape, targets_type);
 
   // Register inputs
   targets_input_idx_ = inputs_.size();
@@ -365,7 +403,7 @@ NemotronSpeechState::NemotronSpeechState(const NemotronSpeechModel& model,
   prediction_state_ = std::make_unique<NemotronPredictionSubState>(model, params);
   joiner_state_ = std::make_unique<NemotronJoinerSubState>(model, params);
 
-  // Pre-allocate encoder frame for joiner input
+  // Pre-allocate encoder frame for joiner input (CPU; ORT uploads to device if needed).
   auto enc_out_type = model_.session_info_.GetOutputDataType(nemotron_config_.enc_out_encoded);
   auto frame_shape = std::array<int64_t, 3>{1, 1, nemotron_config_.hidden_dim};
   encoder_frame_ = OrtValue::CreateTensor(model_.allocator_cpu_, frame_shape, enc_out_type);
@@ -406,14 +444,16 @@ OrtValue* NemotronSpeechState::GetOutput(const char* name) {
 }
 
 void NemotronSpeechState::ResetStreamingState() {
-  auto& allocator = model_.allocator_cpu_;
-  auto& device = *model_.p_device_;
+  auto& cpu_dev = *GetDeviceInterface(DeviceType::CPU);
+  auto& cpu_alloc = cpu_dev.GetAllocator();
 
-  encoder_state_->cache_.Reset(nemotron_config_, model_.session_info_, allocator, device);
+  auto& inf_dev = *model_.p_device_inputs_;
+  auto& inf_alloc = inf_dev.GetAllocator();
+  encoder_state_->cache_.Reset(nemotron_config_, model_.session_info_, inf_alloc, inf_dev);
   encoder_state_->UpdateCacheInputs();
   encoder_state_->first_run_ = true;
 
-  prediction_state_->lstm_state_.Reset(nemotron_config_, model_.session_info_, allocator, device);
+  prediction_state_->lstm_state_.Reset(nemotron_config_, model_.session_info_, cpu_alloc, cpu_dev);
   prediction_state_->UpdateInputs();
   prediction_state_->first_run_ = true;
 
@@ -445,15 +485,31 @@ void NemotronSpeechState::RunEncoder() {
   // Grab encoder outputs
   encoded_output_.reset(encoder_state_->outputs_[0]);
   encoder_state_->outputs_[0] = nullptr;
-  encoded_len_ = *encoder_state_->outputs_[1]->GetTensorData<int64_t>();
 
-  // Cache outputs are already moved into encoder_state_->cache_ by Run()
-  // But State::Run uses output pointers differently - the outputs are written to by ORT
-  // We need to take ownership of the cache outputs
-  encoder_state_->cache_.cache_last_channel.reset(encoder_state_->outputs_[2]);
-  encoder_state_->outputs_[2] = nullptr;
-  encoder_state_->cache_.cache_last_time.reset(encoder_state_->outputs_[3]);
-  encoder_state_->outputs_[3] = nullptr;
+  // encoded_len is int64[1]. ORT may place output on device; copy to CPU before reading.
+  std::unique_ptr<OrtValue> encoded_len_owner{encoder_state_->outputs_[1]};
+  encoder_state_->outputs_[1] = nullptr;
+  auto& cpu_dev = *GetDeviceInterface(DeviceType::CPU);
+  auto& cpu_alloc = cpu_dev.GetAllocator();
+  auto len_shape = std::array<int64_t, 1>{1};
+  auto encoded_len_cpu = OrtValue::CreateTensor(cpu_alloc, len_shape,
+      ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+  ByteWrapTensor(cpu_dev, *encoded_len_cpu)
+      .CopyFrom(ByteWrapTensor(DeviceFor(*encoded_len_owner), *encoded_len_owner));
+  encoded_len_ = *encoded_len_cpu->GetTensorData<int64_t>();
+
+  // Cache outputs were written into our pre-allocated device buffers
+  // (cache_channel_next_/cache_time_next_). Swap them with the input cache
+  // buffers so the next chunk reads the just-produced values and writes
+  // into the now-stale buffer.
+  std::swap(encoder_state_->cache_.cache_last_channel, encoder_state_->cache_channel_next_);
+  std::swap(encoder_state_->cache_.cache_last_time, encoder_state_->cache_time_next_);
+  encoder_state_->outputs_[encoder_state_->cache_channel_next_output_idx_] =
+      encoder_state_->cache_channel_next_.get();
+  encoder_state_->outputs_[encoder_state_->cache_time_next_output_idx_] =
+      encoder_state_->cache_time_next_.get();
+
+  // cache_last_channel_len is a tiny int64[1] scalar; let ORT manage it.
   encoder_state_->cache_.cache_last_channel_len.reset(encoder_state_->outputs_[4]);
   encoder_state_->outputs_[4] = nullptr;
 
@@ -475,9 +531,14 @@ std::span<const int32_t> NemotronSpeechState::StepToken() {
   int64_t hidden_dim = enc_shape[2];
   size_t frame_bytes = static_cast<size_t>(hidden_dim) * sizeof(float);
 
-  auto enc_span = ByteWrapTensor(*model_.p_device_, *encoded_output_);
-  auto frame_span = ByteWrapTensor(*model_.p_device_, *encoder_frame_);
-  auto& allocator = model_.allocator_cpu_;
+  auto& cpu_dev = *GetDeviceInterface(DeviceType::CPU);
+  auto& cpu_alloc_step = cpu_dev.GetAllocator();
+
+  // encoded_output_'s actual device varies (ORT may place it on CPU even with
+  // CUDA EP). Pick the matching DeviceInterface so CopyFrom uses the right
+  // memcpy direction.
+  auto enc_span = ByteWrapTensor(DeviceFor(*encoded_output_), *encoded_output_);
+  auto frame_span = ByteWrapTensor(cpu_dev, *encoder_frame_);
 
   DeviceSpan<int32_t> dummy_tokens;
 
@@ -490,21 +551,29 @@ std::span<const int32_t> NemotronSpeechState::StepToken() {
     prediction_state_->UpdateInputs();
     prediction_state_->Run(0, dummy_tokens);
 
-    // Reshape decoder output for joiner: [1, dim] -> [1, 1, dim]
+    // Reshape decoder output for joiner: [1, dim] -> [1, 1, dim]. Decoder output
+    // is on the EP device; allocate decoder_frame on CPU so the joiner input
+    // matches the CPU-resident encoder_frame_ (ORT will upload both).
     auto dec_out_shape = prediction_state_->outputs_[0]->GetTensorTypeAndShapeInfo()->GetShape();
     auto decoder_frame_shape = std::array<int64_t, 3>{1, 1, dec_out_shape[1]};
     auto dec_out_type = model_.session_info_.GetOutputDataType(nemotron_config_.dec_out_outputs);
-    auto decoder_frame = OrtValue::CreateTensor(allocator, decoder_frame_shape, dec_out_type);
-    ByteWrapTensor(*model_.p_device_, *decoder_frame)
-        .CopyFrom(ByteWrapTensor(*model_.p_device_, *prediction_state_->outputs_[0]));
+    auto decoder_frame = OrtValue::CreateTensor(cpu_alloc_step, decoder_frame_shape, dec_out_type);
+    ByteWrapTensor(cpu_dev, *decoder_frame)
+        .CopyFrom(ByteWrapTensor(DeviceFor(*prediction_state_->outputs_[0]), *prediction_state_->outputs_[0]));
 
     // Run joiner
     joiner_state_->SetInputFrames(encoder_frame_.get(), decoder_frame.get());
     joiner_state_->Run(0, dummy_tokens);
 
-    // Argmax over logits
-    const float* logits = joiner_state_->outputs_[0]->GetTensorData<float>();
-    auto logits_shape = joiner_state_->outputs_[0]->GetTensorTypeAndShapeInfo()->GetShape();
+    // Argmax over logits — joiner output may be on EP device. Copy to CPU.
+    std::unique_ptr<OrtValue> joiner_out0_owner{joiner_state_->outputs_[0]};
+    joiner_state_->outputs_[0] = nullptr;
+    auto logits_shape = joiner_out0_owner->GetTensorTypeAndShapeInfo()->GetShape();
+    auto logits_type = joiner_out0_owner->GetTensorTypeAndShapeInfo()->GetElementType();
+    auto logits_cpu = OrtValue::CreateTensor(cpu_alloc_step, logits_shape, logits_type);
+    ByteWrapTensor(cpu_dev, *logits_cpu)
+        .CopyFrom(ByteWrapTensor(DeviceFor(*joiner_out0_owner), *joiner_out0_owner));
+    const float* logits = logits_cpu->GetTensorData<float>();
     int total_logits = 1;
     for (auto d : logits_shape) total_logits *= static_cast<int>(d);
 

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -58,7 +58,7 @@ void NemotronConfig::PopulateFromConfig(const Config& config) {
   chunk_samples = config.model.chunk_samples;
   blank_id = config.model.blank_id;
   max_symbols_per_step = config.model.max_symbols_per_step;
-  lang_id = config.model.lang_id;
+  lang_id = config.model.default_lang_id;
   blank_penalty = config.search.blank_penalty;
 
   // Vocab size from top-level config

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <algorithm>
 #include <cstring>
 #include <stdexcept>
 #include <vector>
@@ -39,6 +40,12 @@ void NemotronConfig::PopulateFromConfig(const Config& config) {
   chunk_samples = config.model.chunk_samples;
   blank_id = config.model.blank_id;
   max_symbols_per_step = config.model.max_symbols_per_step;
+  num_prompts = config.model.num_prompts;
+  lang_id = config.model.lang_id;
+  // chunk_samples / hop_length = mel frames per chunk; divide by subsampling factor for encoded frames.
+  if (hop_length > 0 && subsampling_factor > 0) {
+    chunk_encoded_frames = (chunk_samples / hop_length) / subsampling_factor;
+  }
   blank_penalty = config.search.blank_penalty;
 
   // Vocab size from top-level config
@@ -53,6 +60,7 @@ void NemotronConfig::PopulateFromConfig(const Config& config) {
   enc_in_cache_channel = enc.inputs.cache_last_channel;
   enc_in_cache_time = enc.inputs.cache_last_time;
   enc_in_cache_channel_len = enc.inputs.cache_last_channel_len;
+  enc_in_prompt = enc.inputs.prompt;
   enc_out_length = enc.outputs.output_lengths;
   enc_out_cache_channel = enc.outputs.cache_last_channel_next;
   enc_out_cache_time = enc.outputs.cache_last_time_next;
@@ -207,6 +215,32 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
   cache_channel_len_input_idx_ = inputs_.size();
   input_names_.push_back(cfg.enc_in_cache_channel_len.c_str());
   inputs_.push_back(cache_.cache_last_channel_len.get());
+
+  // Optional prompt input (multilingual prompt-conditioned encoder).
+  // Shape: [1, chunk_encoded_frames, num_prompts] one-hot at lang_id.
+  has_prompt_input_ = !cfg.enc_in_prompt.empty() && model_.session_info_.HasInput(cfg.enc_in_prompt);
+  if (has_prompt_input_) {
+    if (cfg.num_prompts <= 0)
+      throw std::runtime_error("Encoder has a 'prompt' input but model.num_prompts is not set in genai_config.json");
+    if (cfg.chunk_encoded_frames <= 0)
+      throw std::runtime_error("Cannot infer chunk_encoded_frames; check chunk_samples/hop_length/subsampling_factor");
+    if (cfg.lang_id < 0 || cfg.lang_id >= cfg.num_prompts)
+      throw std::runtime_error("model.lang_id (" + std::to_string(cfg.lang_id) + ") out of range [0, " + std::to_string(cfg.num_prompts) + ")");
+
+    auto prompt_type = model_.session_info_.GetInputDataType(cfg.enc_in_prompt);
+    if (prompt_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT)
+      throw std::runtime_error("Encoder prompt input must be float32");
+    auto prompt_shape = std::array<int64_t, 3>{1, cfg.chunk_encoded_frames, cfg.num_prompts};
+    prompt_tensor_ = OrtValue::CreateTensor(allocator, prompt_shape, prompt_type);
+    float* p = prompt_tensor_->GetTensorMutableData<float>();
+    std::fill(p, p + cfg.chunk_encoded_frames * cfg.num_prompts, 0.0f);
+    for (int t = 0; t < cfg.chunk_encoded_frames; ++t) {
+      p[t * cfg.num_prompts + cfg.lang_id] = 1.0f;
+    }
+    prompt_input_idx_ = inputs_.size();
+    input_names_.push_back(cfg.enc_in_prompt.c_str());
+    inputs_.push_back(prompt_tensor_.get());
+  }
 
   // Register outputs: encoded, length, cache_channel_next, cache_time_next, cache_channel_len_next
   output_names_.push_back(cfg.enc_out_encoded.c_str());

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -52,7 +52,6 @@ void NemotronConfig::PopulateFromConfig(const Config& config) {
   chunk_samples = config.model.chunk_samples;
   blank_id = config.model.blank_id;
   max_symbols_per_step = config.model.max_symbols_per_step;
-  lang_id = config.model.default_lang_id;
   blank_penalty = config.search.blank_penalty;
 
   // Vocab size from top-level config
@@ -238,7 +237,9 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
       throw std::runtime_error("Encoder lang_id input must be int64");
     auto lang_id_shape = std::array<int64_t, 1>{1};
     lang_id_tensor_ = OrtValue::CreateTensor(cpu_alloc, lang_id_shape, lang_id_type);
-    *lang_id_tensor_->GetTensorMutableData<int64_t>() = static_cast<int64_t>(cfg.lang_id);
+    // Default to language index 0; callers can change it per-generator at runtime
+    // via OgaGenerator_SetRuntimeOption(gen, "lang_id", "<int>").
+    *lang_id_tensor_->GetTensorMutableData<int64_t>() = 0;
     lang_id_input_idx_ = inputs_.size();
     input_names_.push_back(cfg.enc_in_lang_id.c_str());
     inputs_.push_back(lang_id_tensor_.get());
@@ -276,6 +277,11 @@ void NemotronEncoderSubState::UpdateCacheInputs() {
   inputs_[cache_channel_input_idx_] = cache_.cache_last_channel.get();
   inputs_[cache_time_input_idx_] = cache_.cache_last_time.get();
   inputs_[cache_channel_len_input_idx_] = cache_.cache_last_channel_len.get();
+}
+
+void NemotronEncoderSubState::SetLangId(int lang_id) {
+  if (!has_lang_id_input_ || !lang_id_tensor_) return;
+  *lang_id_tensor_->GetTensorMutableData<int64_t>() = static_cast<int64_t>(lang_id);
 }
 
 DeviceSpan<float> NemotronEncoderSubState::Run(int /*total_length*/, DeviceSpan<int32_t>& /*next_tokens*/, DeviceSpan<int32_t> /*next_indices*/) {
@@ -418,6 +424,15 @@ OrtValue* NemotronSpeechState::GetOutput(const char* name) {
   if (auto* val = prediction_state_->GetOutput(name)) return val;
   if (auto* val = joiner_state_->GetOutput(name)) return val;
   return State::GetOutput(name);
+}
+
+void NemotronSpeechState::SetLangId(int lang_id) {
+  if (!encoder_state_->HasLangIdInput()) {
+    throw std::runtime_error(
+        "Cannot set lang_id: encoder graph has no lang_id input "
+        "(this model is not a prompt-conditioned multilingual model).");
+  }
+  encoder_state_->SetLangId(lang_id);
 }
 
 void NemotronSpeechState::ResetStreamingState() {

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -42,10 +42,6 @@ void NemotronConfig::PopulateFromConfig(const Config& config) {
   max_symbols_per_step = config.model.max_symbols_per_step;
   num_prompts = config.model.num_prompts;
   lang_id = config.model.lang_id;
-  // chunk_samples / hop_length = mel frames per chunk; divide by subsampling factor for encoded frames.
-  if (hop_length > 0 && subsampling_factor > 0) {
-    chunk_encoded_frames = (chunk_samples / hop_length) / subsampling_factor;
-  }
   blank_penalty = config.search.blank_penalty;
 
   // Vocab size from top-level config
@@ -60,7 +56,7 @@ void NemotronConfig::PopulateFromConfig(const Config& config) {
   enc_in_cache_channel = enc.inputs.cache_last_channel;
   enc_in_cache_time = enc.inputs.cache_last_time;
   enc_in_cache_channel_len = enc.inputs.cache_last_channel_len;
-  enc_in_prompt = enc.inputs.prompt;
+  enc_in_lang_id = enc.inputs.lang_id;
   enc_out_length = enc.outputs.output_lengths;
   enc_out_cache_channel = enc.outputs.cache_last_channel_next;
   enc_out_cache_time = enc.outputs.cache_last_time_next;
@@ -216,30 +212,25 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
   input_names_.push_back(cfg.enc_in_cache_channel_len.c_str());
   inputs_.push_back(cache_.cache_last_channel_len.get());
 
-  // Optional prompt input (multilingual prompt-conditioned encoder).
-  // Shape: [1, chunk_encoded_frames, num_prompts] one-hot at lang_id.
-  has_prompt_input_ = !cfg.enc_in_prompt.empty() && model_.session_info_.HasInput(cfg.enc_in_prompt);
-  if (has_prompt_input_) {
+  // Optional lang_id input (multilingual prompt-conditioned encoder).
+  // Shape: [1] int64 scalar carrying the language index; the encoder graph
+  // builds the one-hot prompt tensor internally.
+  has_lang_id_input_ = !cfg.enc_in_lang_id.empty() && model_.session_info_.HasInput(cfg.enc_in_lang_id);
+  if (has_lang_id_input_) {
     if (cfg.num_prompts <= 0)
-      throw std::runtime_error("Encoder has a 'prompt' input but model.num_prompts is not set in genai_config.json");
-    if (cfg.chunk_encoded_frames <= 0)
-      throw std::runtime_error("Cannot infer chunk_encoded_frames; check chunk_samples/hop_length/subsampling_factor");
+      throw std::runtime_error("Encoder has a 'lang_id' input but model.num_prompts is not set in genai_config.json");
     if (cfg.lang_id < 0 || cfg.lang_id >= cfg.num_prompts)
       throw std::runtime_error("model.lang_id (" + std::to_string(cfg.lang_id) + ") out of range [0, " + std::to_string(cfg.num_prompts) + ")");
 
-    auto prompt_type = model_.session_info_.GetInputDataType(cfg.enc_in_prompt);
-    if (prompt_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT)
-      throw std::runtime_error("Encoder prompt input must be float32");
-    auto prompt_shape = std::array<int64_t, 3>{1, cfg.chunk_encoded_frames, cfg.num_prompts};
-    prompt_tensor_ = OrtValue::CreateTensor(allocator, prompt_shape, prompt_type);
-    float* p = prompt_tensor_->GetTensorMutableData<float>();
-    std::fill(p, p + cfg.chunk_encoded_frames * cfg.num_prompts, 0.0f);
-    for (int t = 0; t < cfg.chunk_encoded_frames; ++t) {
-      p[t * cfg.num_prompts + cfg.lang_id] = 1.0f;
-    }
-    prompt_input_idx_ = inputs_.size();
-    input_names_.push_back(cfg.enc_in_prompt.c_str());
-    inputs_.push_back(prompt_tensor_.get());
+    auto lang_id_type = model_.session_info_.GetInputDataType(cfg.enc_in_lang_id);
+    if (lang_id_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64)
+      throw std::runtime_error("Encoder lang_id input must be int64");
+    auto lang_id_shape = std::array<int64_t, 1>{1};
+    lang_id_tensor_ = OrtValue::CreateTensor(allocator, lang_id_shape, lang_id_type);
+    *lang_id_tensor_->GetTensorMutableData<int64_t>() = static_cast<int64_t>(cfg.lang_id);
+    lang_id_input_idx_ = inputs_.size();
+    input_names_.push_back(cfg.enc_in_lang_id.c_str());
+    inputs_.push_back(lang_id_tensor_.get());
   }
 
   // Register outputs: encoded, length, cache_channel_next, cache_time_next, cache_channel_len_next

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -40,7 +40,6 @@ void NemotronConfig::PopulateFromConfig(const Config& config) {
   chunk_samples = config.model.chunk_samples;
   blank_id = config.model.blank_id;
   max_symbols_per_step = config.model.max_symbols_per_step;
-  num_prompts = config.model.num_prompts;
   lang_id = config.model.lang_id;
   blank_penalty = config.search.blank_penalty;
 
@@ -217,11 +216,6 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
   // builds the one-hot prompt tensor internally.
   has_lang_id_input_ = !cfg.enc_in_lang_id.empty() && model_.session_info_.HasInput(cfg.enc_in_lang_id);
   if (has_lang_id_input_) {
-    if (cfg.num_prompts <= 0)
-      throw std::runtime_error("Encoder has a 'lang_id' input but model.num_prompts is not set in genai_config.json");
-    if (cfg.lang_id < 0 || cfg.lang_id >= cfg.num_prompts)
-      throw std::runtime_error("model.lang_id (" + std::to_string(cfg.lang_id) + ") out of range [0, " + std::to_string(cfg.num_prompts) + ")");
-
     auto lang_id_type = model_.session_info_.GetInputDataType(cfg.enc_in_lang_id);
     if (lang_id_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64)
       throw std::runtime_error("Encoder lang_id input must be int64");

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -243,34 +243,20 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
     inputs_.push_back(lang_id_tensor_.get());
   }
 
-  // Register outputs: encoded, length, cache_channel_next, cache_time_next, cache_channel_len_next
+  // Register outputs: encoded, length, cache_channel_next, cache_time_next, cache_channel_len_next.
+  // ORT allocates each output on the EP device; we take ownership after Run and
+  // hand the new tensors back as the next chunk's cache inputs in UpdateInputs().
   output_names_.push_back(cfg.enc_out_encoded.c_str());
   outputs_.push_back(nullptr);
 
   output_names_.push_back(cfg.enc_out_length.c_str());
   outputs_.push_back(nullptr);
 
-  // Pre-allocate cache outputs on the inference device so ORT writes them
-  // there directly. Without pre-allocation, ORT places these outputs on CPU
-  // and feeding them back as inputs on the next chunk triggers a CUDA copy
-  // path that fails inside Transpose (cudaErrorInvalidValue).
-  cache_channel_next_output_idx_ = outputs_.size();
   output_names_.push_back(cfg.enc_out_cache_channel.c_str());
-  {
-    auto ch_shape = std::array<int64_t, 4>{1, cfg.num_encoder_layers, cfg.left_context, cfg.hidden_dim};
-    auto ch_type = model_.session_info_.GetOutputDataType(cfg.enc_out_cache_channel);
-    cache_channel_next_ = OrtValue::CreateTensor(inf_alloc, ch_shape, ch_type);
-  }
-  outputs_.push_back(cache_channel_next_.get());
+  outputs_.push_back(nullptr);
 
-  cache_time_next_output_idx_ = outputs_.size();
   output_names_.push_back(cfg.enc_out_cache_time.c_str());
-  {
-    auto tm_shape = std::array<int64_t, 4>{1, cfg.num_encoder_layers, cfg.hidden_dim, cfg.conv_context};
-    auto tm_type = model_.session_info_.GetOutputDataType(cfg.enc_out_cache_time);
-    cache_time_next_ = OrtValue::CreateTensor(inf_alloc, tm_shape, tm_type);
-  }
-  outputs_.push_back(cache_time_next_.get());
+  outputs_.push_back(nullptr);
 
   output_names_.push_back(cfg.enc_out_cache_channel_len.c_str());
   outputs_.push_back(nullptr);
@@ -488,21 +474,17 @@ void NemotronSpeechState::RunEncoder() {
   auto& cpu_alloc = cpu_dev.GetAllocator();
   auto len_shape = std::array<int64_t, 1>{1};
   auto encoded_len_cpu = OrtValue::CreateTensor(cpu_alloc, len_shape,
-      ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+                                                ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
   ByteWrapTensor(cpu_dev, *encoded_len_cpu)
       .CopyFrom(ByteWrapTensor(DeviceFor(*encoded_len_owner), *encoded_len_owner));
   encoded_len_ = *encoded_len_cpu->GetTensorData<int64_t>();
 
-  // Cache outputs were written into our pre-allocated device buffers
-  // (cache_channel_next_/cache_time_next_). Swap them with the input cache
-  // buffers so the next chunk reads the just-produced values and writes
-  // into the now-stale buffer.
-  std::swap(encoder_state_->cache_.cache_last_channel, encoder_state_->cache_channel_next_);
-  std::swap(encoder_state_->cache_.cache_last_time, encoder_state_->cache_time_next_);
-  encoder_state_->outputs_[encoder_state_->cache_channel_next_output_idx_] =
-      encoder_state_->cache_channel_next_.get();
-  encoder_state_->outputs_[encoder_state_->cache_time_next_output_idx_] =
-      encoder_state_->cache_time_next_.get();
+  // Take ownership of cache outputs; the next chunk's UpdateInputs() will
+  // rebind inputs_[cache_*] to these new buffers.
+  encoder_state_->cache_.cache_last_channel.reset(encoder_state_->outputs_[2]);
+  encoder_state_->outputs_[2] = nullptr;
+  encoder_state_->cache_.cache_last_time.reset(encoder_state_->outputs_[3]);
+  encoder_state_->outputs_[3] = nullptr;
 
   // cache_last_channel_len is a tiny int64[1] scalar; let ORT manage it.
   encoder_state_->cache_.cache_last_channel_len.reset(encoder_state_->outputs_[4]);

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -14,19 +14,12 @@ namespace Generators {
 
 namespace {
 // Picks the DeviceInterface that matches the OrtValue's actual memory location.
-// Required because ORT may place outputs on CPU even when the EP is CUDA;
-// wrapping a CPU tensor with a CUDA DeviceInterface causes a sticky
-// cudaErrorInvalidValue at the next CUDA kernel launch.
+// Required because ORT may place outputs on CPU even when the EP is CUDA
+// (e.g. graph contains CPU-only ops); wrapping a CPU tensor with the CUDA
+// DeviceInterface causes a sticky cudaErrorInvalidValue at the next kernel.
 DeviceInterface& DeviceFor(const OrtValue& v) {
-  auto& mem = v.GetTensorMemoryInfo();
-  switch (mem.GetDeviceType()) {
-    case OrtMemoryInfoDeviceType_CPU:
-      return *GetDeviceInterface(DeviceType::CPU);
-    case OrtMemoryInfoDeviceType_GPU:
-      return *GetDeviceInterface(DeviceType::CUDA);
-    default:
-      return *GetDeviceInterface(DeviceType::CPU);
-  }
+  const bool on_gpu = v.GetTensorMemoryInfo().GetDeviceType() == OrtMemoryInfoDeviceType_GPU;
+  return *GetDeviceInterface(on_gpu ? DeviceType::CUDA : DeviceType::CPU);
 }
 }  // namespace
 

--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -14,9 +14,7 @@ namespace Generators {
 
 namespace {
 // Picks the DeviceInterface that matches the OrtValue's actual memory location.
-// Required because ORT may place outputs on CPU even when the EP is CUDA
-// (e.g. graph contains CPU-only ops); wrapping a CPU tensor with the CUDA
-// DeviceInterface causes a sticky cudaErrorInvalidValue at the next kernel.
+// Required because ORT may place outputs on CPU even when the EP is CUDA.
 DeviceInterface& DeviceFor(const OrtValue& v) {
   const bool on_gpu = v.GetTensorMemoryInfo().GetDeviceType() == OrtMemoryInfoDeviceType_GPU;
   return *GetDeviceInterface(on_gpu ? DeviceType::CUDA : DeviceType::CPU);
@@ -243,9 +241,6 @@ NemotronEncoderSubState::NemotronEncoderSubState(const NemotronSpeechModel& mode
     inputs_.push_back(lang_id_tensor_.get());
   }
 
-  // Register outputs: encoded, length, cache_channel_next, cache_time_next, cache_channel_len_next.
-  // ORT allocates each output on the EP device; we take ownership after Run and
-  // hand the new tensors back as the next chunk's cache inputs in UpdateInputs().
   output_names_.push_back(cfg.enc_out_encoded.c_str());
   outputs_.push_back(nullptr);
 
@@ -382,7 +377,7 @@ NemotronSpeechState::NemotronSpeechState(const NemotronSpeechModel& model,
   prediction_state_ = std::make_unique<NemotronPredictionSubState>(model, params);
   joiner_state_ = std::make_unique<NemotronJoinerSubState>(model, params);
 
-  // Pre-allocate encoder frame for joiner input (CPU; ORT uploads to device if needed).
+  // Pre-allocate encoder frame for joiner input
   auto enc_out_type = model_.session_info_.GetOutputDataType(nemotron_config_.enc_out_encoded);
   auto frame_shape = std::array<int64_t, 3>{1, 1, nemotron_config_.hidden_dim};
   encoder_frame_ = OrtValue::CreateTensor(model_.allocator_cpu_, frame_shape, enc_out_type);
@@ -479,8 +474,6 @@ void NemotronSpeechState::RunEncoder() {
       .CopyFrom(ByteWrapTensor(DeviceFor(*encoded_len_owner), *encoded_len_owner));
   encoded_len_ = *encoded_len_cpu->GetTensorData<int64_t>();
 
-  // Take ownership of cache outputs; the next chunk's UpdateInputs() will
-  // rebind inputs_[cache_*] to these new buffers.
   encoder_state_->cache_.cache_last_channel.reset(encoder_state_->outputs_[2]);
   encoder_state_->outputs_[2] = nullptr;
   encoder_state_->cache_.cache_last_time.reset(encoder_state_->outputs_[3]);
@@ -528,7 +521,7 @@ std::span<const int32_t> NemotronSpeechState::StepToken() {
     prediction_state_->UpdateInputs();
     prediction_state_->Run(0, dummy_tokens);
 
-    // Reshape decoder output for joiner: [1, dim] -> [1, 1, dim].
+    // Reshape decoder output for joiner: [1, dim] -> [1, 1, dim]
     // Take ownership of prediction output[0] so it's released this iteration
     // (the next prediction Run will overwrite the slot and leak the old buffer otherwise).
     std::unique_ptr<OrtValue> pred_out0_owner{prediction_state_->outputs_[0]};

--- a/src/models/nemotron_speech.h
+++ b/src/models/nemotron_speech.h
@@ -135,9 +135,6 @@ struct NemotronEncoderSubState : State {
   std::unique_ptr<OrtValue> signal_length_;
   std::unique_ptr<OrtValue> lang_id_tensor_;
 
-  std::unique_ptr<OrtValue> cache_channel_next_;
-  std::unique_ptr<OrtValue> cache_time_next_;
-
   // Whether the encoder model has a "length" input
   bool has_length_input_{};
   // Whether the encoder model has a "lang_id" input (prompt-conditioned multilingual model)
@@ -150,8 +147,6 @@ struct NemotronEncoderSubState : State {
   size_t cache_time_input_idx_{};
   size_t cache_channel_len_input_idx_{};
   size_t lang_id_input_idx_{};
-  size_t cache_channel_next_output_idx_{};
-  size_t cache_time_next_output_idx_{};
 };
 
 /// Sub-state for the RNNT prediction network (decoder LSTM).

--- a/src/models/nemotron_speech.h
+++ b/src/models/nemotron_speech.h
@@ -43,8 +43,8 @@ struct NemotronConfig {
   // Pre-encode cache
   int pre_encode_cache_size{};
 
-  // Prompt-conditioned encoder (multilingual models). num_prompts==0 disables.
-  int num_prompts{};
+  // Prompt-conditioned encoder (multilingual models). Default language index
+  // passed to the encoder's lang_id input; the graph builds the one-hot internally.
   int lang_id{};
 
   // Encoder I/O names

--- a/src/models/nemotron_speech.h
+++ b/src/models/nemotron_speech.h
@@ -46,8 +46,6 @@ struct NemotronConfig {
   // Prompt-conditioned encoder (multilingual models). num_prompts==0 disables.
   int num_prompts{};
   int lang_id{};
-  // Number of encoded frames per chunk (chunk_samples / hop_length / subsampling_factor).
-  int chunk_encoded_frames{};
 
   // Encoder I/O names
   std::string enc_in_audio;
@@ -55,7 +53,7 @@ struct NemotronConfig {
   std::string enc_in_cache_channel;
   std::string enc_in_cache_time;
   std::string enc_in_cache_channel_len;
-  std::string enc_in_prompt;
+  std::string enc_in_lang_id;
   std::string enc_out_encoded;
   std::string enc_out_length;
   std::string enc_out_cache_channel;
@@ -135,12 +133,12 @@ struct NemotronEncoderSubState : State {
   const NemotronSpeechModel& model_;
   NemotronEncoderCache cache_;
   std::unique_ptr<OrtValue> signal_length_;
-  std::unique_ptr<OrtValue> prompt_tensor_;
+  std::unique_ptr<OrtValue> lang_id_tensor_;
 
   // Whether the encoder model has a "length" input
   bool has_length_input_{};
-  // Whether the encoder model has a "prompt" input (prompt-conditioned multilingual model)
-  bool has_prompt_input_{};
+  // Whether the encoder model has a "lang_id" input (prompt-conditioned multilingual model)
+  bool has_lang_id_input_{};
 
   // Indices into inputs_/outputs_ vectors
   size_t mel_input_idx_{};
@@ -148,7 +146,7 @@ struct NemotronEncoderSubState : State {
   size_t cache_channel_input_idx_{};
   size_t cache_time_input_idx_{};
   size_t cache_channel_len_input_idx_{};
-  size_t prompt_input_idx_{};
+  size_t lang_id_input_idx_{};
 };
 
 /// Sub-state for the RNNT prediction network (decoder LSTM).

--- a/src/models/nemotron_speech.h
+++ b/src/models/nemotron_speech.h
@@ -135,10 +135,6 @@ struct NemotronEncoderSubState : State {
   std::unique_ptr<OrtValue> signal_length_;
   std::unique_ptr<OrtValue> lang_id_tensor_;
 
-  // Pre-allocated cache_*_next outputs on the inference device. ORT writes
-  // here directly so the cache stays on device across chunks (otherwise ORT
-  // places outputs on CPU and subsequent runs trigger a CUDA copy-path bug
-  // inside Transpose).
   std::unique_ptr<OrtValue> cache_channel_next_;
   std::unique_ptr<OrtValue> cache_time_next_;
 

--- a/src/models/nemotron_speech.h
+++ b/src/models/nemotron_speech.h
@@ -43,10 +43,6 @@ struct NemotronConfig {
   // Pre-encode cache
   int pre_encode_cache_size{};
 
-  // Prompt-conditioned encoder (multilingual models). Default language index
-  // passed to the encoder's lang_id input; the graph builds the one-hot internally.
-  int lang_id{};
-
   // Encoder I/O names
   std::string enc_in_audio;
   std::string enc_in_length;
@@ -127,6 +123,10 @@ struct NemotronEncoderSubState : State {
   /// Update registered input pointers after cache is modified.
   void UpdateCacheInputs();
 
+  void SetLangId(int lang_id);
+
+  bool HasLangIdInput() const { return has_lang_id_input_; }
+
  private:
   friend struct NemotronSpeechState;
 
@@ -205,6 +205,8 @@ struct NemotronSpeechState : State {
   std::span<const int32_t> GetStepTokens() const { return last_tokens_; }
   size_t TokenCount() const { return token_count_; }
   void ResetStreamingState();
+
+  void SetLangId(int lang_id);
 
   OrtValue* GetInput(const char* name) override;
   OrtValue* GetOutput(const char* name) override;

--- a/src/models/nemotron_speech.h
+++ b/src/models/nemotron_speech.h
@@ -135,6 +135,13 @@ struct NemotronEncoderSubState : State {
   std::unique_ptr<OrtValue> signal_length_;
   std::unique_ptr<OrtValue> lang_id_tensor_;
 
+  // Pre-allocated cache_*_next outputs on the inference device. ORT writes
+  // here directly so the cache stays on device across chunks (otherwise ORT
+  // places outputs on CPU and subsequent runs trigger a CUDA copy-path bug
+  // inside Transpose).
+  std::unique_ptr<OrtValue> cache_channel_next_;
+  std::unique_ptr<OrtValue> cache_time_next_;
+
   // Whether the encoder model has a "length" input
   bool has_length_input_{};
   // Whether the encoder model has a "lang_id" input (prompt-conditioned multilingual model)
@@ -147,6 +154,8 @@ struct NemotronEncoderSubState : State {
   size_t cache_time_input_idx_{};
   size_t cache_channel_len_input_idx_{};
   size_t lang_id_input_idx_{};
+  size_t cache_channel_next_output_idx_{};
+  size_t cache_time_next_output_idx_{};
 };
 
 /// Sub-state for the RNNT prediction network (decoder LSTM).

--- a/src/models/nemotron_speech.h
+++ b/src/models/nemotron_speech.h
@@ -43,12 +43,19 @@ struct NemotronConfig {
   // Pre-encode cache
   int pre_encode_cache_size{};
 
+  // Prompt-conditioned encoder (multilingual models). num_prompts==0 disables.
+  int num_prompts{};
+  int lang_id{};
+  // Number of encoded frames per chunk (chunk_samples / hop_length / subsampling_factor).
+  int chunk_encoded_frames{};
+
   // Encoder I/O names
   std::string enc_in_audio;
   std::string enc_in_length;
   std::string enc_in_cache_channel;
   std::string enc_in_cache_time;
   std::string enc_in_cache_channel_len;
+  std::string enc_in_prompt;
   std::string enc_out_encoded;
   std::string enc_out_length;
   std::string enc_out_cache_channel;
@@ -128,9 +135,12 @@ struct NemotronEncoderSubState : State {
   const NemotronSpeechModel& model_;
   NemotronEncoderCache cache_;
   std::unique_ptr<OrtValue> signal_length_;
+  std::unique_ptr<OrtValue> prompt_tensor_;
 
   // Whether the encoder model has a "length" input
   bool has_length_input_{};
+  // Whether the encoder model has a "prompt" input (prompt-conditioned multilingual model)
+  bool has_prompt_input_{};
 
   // Indices into inputs_/outputs_ vectors
   size_t mel_input_idx_{};
@@ -138,6 +148,7 @@ struct NemotronEncoderSubState : State {
   size_t cache_channel_input_idx_{};
   size_t cache_time_input_idx_{};
   size_t cache_channel_len_input_idx_{};
+  size_t prompt_input_idx_{};
 };
 
 /// Sub-state for the RNNT prediction network (decoder LSTM).


### PR DESCRIPTION
Adds support for NVIDIA's multilingual streaming Nemotron ASR model (nemotron_speech) with both CPU and CUDA execution providers.

CUDA support is functional and validated end-to-end, but might not yet be fully optimized.

E.g. run of the new model
```

python /home/nebanfic/onnxruntime-genai/examples/python/nemotron_speech.py   
--model_path /datadisks/disk2/nebanfic/multilingual_onnx_fp32   --audio_file /home/nebanfic/data_german/audio_test/test_000282.wav   --language de   -e cuda
Setting model to cuda
  Language: de (lang_id=9)
  Use VAD: false
------------------------------------------------------------
 Genau wieder munte er der anzieht und die gezeichneten Verursacht, übt auch die Milchstraße Anziehungskräfte auf die Sagittariusgalaxie aus
============================================================
  Genau wieder munte er der anzieht und die gezeichneten Verursacht, übt auch die Milchstraße Anziehungskräfte auf die Sagittariusgalaxie aus
```