### PR TITLE
[Draft] Fix CPUExecutionProvider compatibility on WinML builds

### DIFF
--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -188,6 +188,12 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
         device = session_device;  // Set the device if not already set by a previous provider
       }
     } else {
+      // CPU EP is always built-in to ORT as the implicit fallback provider.
+      // Skip plugin registration to avoid failures on WinML where CPU is not
+      // in the ExecutionProviderCatalog.
+      if (provider_options.name == "cpu" || provider_options.name == "CPUExecutionProvider") {
+        continue;
+      }
       if (!AppendExecutionProviderV2(session_options, provider_options,
                                      DeviceType::CPU, provider_options.name)) {
         AppendExecutionProviderV1(session_options, provider_options);

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -3,6 +3,8 @@
 
 #include "session_options.h"
 
+#include <algorithm>
+#include <cctype>
 #include <functional>
 #include <unordered_map>
 
@@ -191,7 +193,11 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
       // CPU EP is always built-in to ORT as the implicit fallback provider.
       // Skip plugin registration to avoid failures on WinML where CPU is not
       // in the ExecutionProviderCatalog.
-      if (provider_options.name == "cpu" || provider_options.name == "CPUExecutionProvider") {
+      std::string provider_name_lower = provider_options.name;
+      std::transform(provider_name_lower.begin(), provider_name_lower.end(),
+                     provider_name_lower.begin(),
+                     [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); });
+      if (provider_name_lower == "cpu" || provider_name_lower == "cpuexecutionprovider") {
         continue;
       }
       if (!AppendExecutionProviderV2(session_options, provider_options,


### PR DESCRIPTION
## Summary

Skip CPU EP plugin registration in `SetProviderSessionOptions` when the provider name is `cpu` or `CPUExecutionProvider`. ORT always uses CPU as its implicit final fallback, so explicitly registering it via the V2 plugin path is unnecessary and **fails on newer WinML SDK versions** where CPU is no longer in the `ExecutionProviderCatalog`.

## Problem

The latest `onnxruntime-genai-winml` package no longer supports `CPUExecutionProvider`, causing incompatibility with existing FL Whisper GenAI models that previously worked on `onnxruntime-genai-winml==0.12.1`.

The root cause: newer `Microsoft.WindowsAppSDK.ML` NuGet packages removed CPU from their EP catalog. When a model's `genai_config.json` specifies `CPUExecutionProvider`, the code tries to register it via the V2 plugin path (`FindRegisteredEpDevices`), finds nothing, falls through to V1, and fails.

## Fix

Add an early `continue` for CPU EP in the generic provider path — since ORT always falls back to CPU implicitly, no explicit registration is needed.

## Testing

- Models specifying `CPUExecutionProvider` in `genai_config.json` will load successfully on WinML builds
- No behavioral change for non-WinML builds (CPU EP was already implicitly used)

## Related

- ADO Work Item: https://dev.azure.com/microsoft/OS/_workitems/edit/62376990