### PR TITLE
Fix: Skip CPU provider in SetProviderSessionOptions

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -18,7 +18,9 @@ namespace Generators {
 std::string_view NormalizeProviderName(std::string_view name) {
   std::string lower_name(name);
   std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); });
-  if (lower_name == "qnn") {
+  if (lower_name == "cpu" || lower_name == "cpuexecutionprovider") {
+    return "CPU";
+  } else if (lower_name == "qnn") {
     return "QNN";
   } else if (lower_name == "webgpu") {
     return "WebGPU";

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -173,6 +173,12 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
   }
 
   for (const auto& provider : providers_list) {
+    // CPU EP is always implicitly registered, skip it to avoid passing it
+    // to ORT's AppendExecutionProvider which does not accept "cpu" as a name.
+    if (provider == "cpu" || provider == "CPU" || provider == "CPUExecutionProvider") {
+      continue;
+    }
+
     auto provider_options_it = std::find_if(provider_options_list.begin(), provider_options_list.end(),
                                             [&provider](const Config::ProviderOptions& po) { return po.name == provider; });
 

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -175,13 +175,23 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
   }
 
   for (const auto& provider : providers_list) {
-    // CPU EP is always implicitly registered, skip it to avoid passing it
-    // to ORT's AppendExecutionProvider which does not accept "cpu" as a name.
+    // CPU EP is always implicitly registered and cannot be appended via
+    // ORT's AppendExecutionProvider API. Throw if users attempt to set
+    // CPU-specific provider options (which would be silently lost), but
+    // accept bare "cpu" as a no-op for backward compatibility.
     {
       std::string lower_provider(provider);
       std::transform(lower_provider.begin(), lower_provider.end(), lower_provider.begin(),
                      [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); });
       if (lower_provider == "cpu" || lower_provider == "cpuexecutionprovider") {
+        auto provider_options_it = std::find_if(provider_options_list.begin(), provider_options_list.end(),
+                                                [&provider](const Config::ProviderOptions& po) { return po.name == provider; });
+        if (provider_options_it != provider_options_list.end() && !provider_options_it->options.empty()) {
+          throw std::runtime_error(
+              "CPU execution provider does not support provider options. "
+              "CPU is always available as the default fallback and does not need to be explicitly registered. "
+              "Remove the CPU provider entry and its options from your configuration.");
+        }
         continue;
       }
     }

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -4,7 +4,6 @@
 #include "session_options.h"
 
 #include <algorithm>
-#include <cctype>
 #include <functional>
 #include <unordered_map>
 
@@ -147,9 +146,25 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
                                                          const Config&,
                                                          bool);
 
+  // CPU EP is always implicitly registered — no action needed.
+  // Throws if users attempt to set provider options (which would be silently lost).
+  static auto CPUAppendExecutionProvider = [](OrtSessionOptions&,
+                                              const Config::ProviderOptions& provider_options,
+                                              const Config&,
+                                              bool) -> DeviceInterface* {
+    if (!provider_options.options.empty()) {
+      throw std::runtime_error(
+          "CPU execution provider does not support provider options. "
+          "CPU is always available as the default fallback and does not need to be explicitly registered. "
+          "Remove the CPU provider entry and its options from your configuration.");
+    }
+    return nullptr;
+  };
+
   // Dispatch table: maps provider name (as it appears in genai_config.json) to
   // the corresponding provider-specific AppendExecutionProvider function.
   static const std::unordered_map<std::string, AppendExecutionProviderFn> append_execution_provider{
+      {"CPU", CPUAppendExecutionProvider},
       {"cuda", CUDAExecutionProvider::AppendExecutionProvider},
       {"DML", DMLExecutionProvider::AppendExecutionProvider},
       {"NvTensorRtRtx", NvTensorRtRtxExecutionProvider::AppendExecutionProvider},
@@ -175,27 +190,6 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
   }
 
   for (const auto& provider : providers_list) {
-    // CPU EP is always implicitly registered and cannot be appended via
-    // ORT's AppendExecutionProvider API. Throw if users attempt to set
-    // CPU-specific provider options (which would be silently lost), but
-    // accept bare "cpu" as a no-op for backward compatibility.
-    {
-      std::string lower_provider(provider);
-      std::transform(lower_provider.begin(), lower_provider.end(), lower_provider.begin(),
-                     [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); });
-      if (lower_provider == "cpu" || lower_provider == "cpuexecutionprovider") {
-        auto provider_options_it = std::find_if(provider_options_list.begin(), provider_options_list.end(),
-                                                [&provider](const Config::ProviderOptions& po) { return po.name == provider; });
-        if (provider_options_it != provider_options_list.end() && !provider_options_it->options.empty()) {
-          throw std::runtime_error(
-              "CPU execution provider does not support provider options. "
-              "CPU is always available as the default fallback and does not need to be explicitly registered. "
-              "Remove the CPU provider entry and its options from your configuration.");
-        }
-        continue;
-      }
-    }
-
     auto provider_options_it = std::find_if(provider_options_list.begin(), provider_options_list.end(),
                                             [&provider](const Config::ProviderOptions& po) { return po.name == provider; });
 

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -3,6 +3,8 @@
 
 #include "session_options.h"
 
+#include <algorithm>
+#include <cctype>
 #include <functional>
 #include <unordered_map>
 
@@ -175,8 +177,13 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
   for (const auto& provider : providers_list) {
     // CPU EP is always implicitly registered, skip it to avoid passing it
     // to ORT's AppendExecutionProvider which does not accept "cpu" as a name.
-    if (provider == "cpu" || provider == "CPU" || provider == "CPUExecutionProvider") {
-      continue;
+    {
+      std::string lower_provider(provider);
+      std::transform(lower_provider.begin(), lower_provider.end(), lower_provider.begin(),
+                     [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); });
+      if (lower_provider == "cpu" || lower_provider == "cpuexecutionprovider") {
+        continue;
+      }
     }
 
     auto provider_options_it = std::find_if(provider_options_list.begin(), provider_options_list.end(),

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -48,6 +48,31 @@ TEST(CAPITests, Config) {
 #endif
 }
 
+// Regression test: appending CPU provider should not throw.
+// See https://github.com/microsoft/onnxruntime-genai/pull/2179
+TEST(CAPITests, AppendCpuProvider) {
+#if TEST_PHI2
+  auto config = OgaConfig::Create(PHI2_PATH);
+  config->ClearProviders();
+  config->AppendProvider("cpu");
+  auto model = OgaModel::Create(*config);
+  ASSERT_NE(model.get(), nullptr);
+
+  // Also test other case variants
+  auto config2 = OgaConfig::Create(PHI2_PATH);
+  config2->ClearProviders();
+  config2->AppendProvider("CPU");
+  auto model2 = OgaModel::Create(*config2);
+  ASSERT_NE(model2.get(), nullptr);
+
+  auto config3 = OgaConfig::Create(PHI2_PATH);
+  config3->ClearProviders();
+  config3->AppendProvider("CPUExecutionProvider");
+  auto model3 = OgaModel::Create(*config3);
+  ASSERT_NE(model3.get(), nullptr);
+#endif
+}
+
 TEST(CAPITests, TokenizerCAPI) {
 #if TEST_PHI2
   auto config = OgaConfig::Create(PHI2_PATH);


### PR DESCRIPTION
## Fix: Skip CPU provider in SetProviderSessionOptions

### Problem
When users call `config.append_provider('cpu')`, onnxruntime-genai 0.13.x throws:
`
RuntimeError: [ErrorCode:InvalidArgument] Unknown provider name 'cpu'. Possible options: ...
`

This worked in v0.12.1 but regressed in v0.13.1.

### Root Cause
PR #2038 (*Decouple plugin execution providers from USE_WINML*, March 2026) introduced `src/models/session_options.cpp` with a fallthrough path that passes unrecognized provider names to ORT's `AppendExecutionProviderV1`. ORT's strict whitelist (added in commit `4d03aeff0e`) rejects `cpu` since CPU EP is always implicitly registered and never needs an explicit append call.

### Fix
In `SetProviderSessionOptions`, detect CPU provider names (case-insensitive: `cpu`, `cpuexecutionprovider`) and:
- **If no provider options are set**: skip silently (backward-compatible no-op)
- **If provider options are present**: throw a clear error explaining that CPU EP does not support provider options and does not need explicit registration

This ensures:
1. Existing code using `append_provider('cpu')` continues to work
2. Misconfigurations (setting CPU provider options that would be silently lost) are caught early with a helpful error message

### Testing
Added regression test `TEST(CAPITests, AppendCpuProvider)` that verifies `cpu`, `CPU`, and `CPUExecutionProvider` all succeed without error.