### PR TITLE
Fix external weights loading for in-memory models without changing cwd

### DIFF
--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -15,12 +15,19 @@
 #define ENABLE_INTSAFE_SIGNED_FUNCTIONS  // Only unsigned intsafe math/casts available without this def
 #include <intsafe.h>
 #include <tchar.h>
+#include <direct.h>
 #endif  // _WIN32
 
 #include <sys/stat.h>
 
-#include <string>
 #include <fstream>
+#include <stdexcept>
+#include <string>
+
+#ifndef _WIN32
+#include <limits.h>
+#include <unistd.h>
+#endif
 
 namespace fs {
 
@@ -176,6 +183,25 @@ class path {
 // Namespace-level functions
 inline bool exists(const path& p) {
   return p.exists();
+}
+
+inline path absolute(const path& p) {
+  if (!p.is_relative()) {
+    return p;
+  }
+
+#ifdef _WIN32
+  char cwd_buffer[_MAX_PATH];
+  if (!_getcwd(cwd_buffer, sizeof(cwd_buffer))) {
+#else
+  char cwd_buffer[PATH_MAX];
+  if (!getcwd(cwd_buffer, sizeof(cwd_buffer))) {
+#endif
+    throw std::runtime_error("Failed to get current working directory");
+  }
+
+  path cwd_path{cwd_buffer};
+  return cwd_path / p;
 }
 
 }  // namespace fs

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -36,51 +36,13 @@
 #if defined(_WIN32)
 #include <direct.h>
 #define GETCWD _getcwd
-#define CHDIR _wchdir
-#include <windows.h>
 #else
 #include <unistd.h>
 #define GETCWD getcwd
-#define CHDIR chdir
 #include <limits.h>
 #endif
 
 namespace Generators {
-
-namespace {
-
-class DirGuard {
- private:
-  fs::path original_dir_;
-
- public:
-  DirGuard() {
-    char buffer[PATH_MAX];
-    if (GETCWD(buffer, sizeof(buffer))) {
-      original_dir_ = fs::path(buffer);
-    } else {
-      throw std::runtime_error("Failed to get current working directory");
-    }
-  }
-
-  DirGuard(const DirGuard&) = delete;
-  DirGuard& operator=(const DirGuard&) = delete;
-  DirGuard(DirGuard&&) = delete;
-
-  void ChangeTo(const fs::path& new_dir) {
-    if (CHDIR(new_dir.c_str()) != 0) {
-      throw std::runtime_error("Failed to change directory to: " + new_dir.string());
-    }
-  }
-
-  ~DirGuard() {
-    if (CHDIR(original_dir_.c_str()) != 0 && g_log.enabled) {
-      Log("warning", "Failed to change back to original directory: " + original_dir_.string());
-    }
-  }
-};
-
-}  // namespace
 
 State::State(const GeneratorParams& params, const Model& model)
     : model_{model},
@@ -776,21 +738,11 @@ std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::str
     if (model_data_it->second.empty()) {
       throw std::runtime_error("Failed to load model data from memory for " + model_filename);
     }
-    // TODO (baijumeswani): Loading ONNX models from memory that hold references to data stored in external files
-    // is not supported at the moment. This limitation stems from the fact that ONNX models typically
-    // reference these external files using relative paths to the model file. When loading a model from memory,
-    // the relative paths may not resolve correctly, leading to issues in locating the referenced data.
-    // To work around this, we change the current working directory to the model's config path
-    // before creating the session. This allows the model to resolve relative paths correctly.
-    // Note that this is not a problem for models that do not reference external files.
-    // This is a temporary solution and can be potentially addressed by exposing means to set a working directory
-    // for the OrtSession through the ONNX Runtime API.
-    // This solution is not ideal since it modifies the global state of the process, and is hence not thread-safe.
-    DirGuard dir_guard;
-    dir_guard.ChangeTo(config_->config_path);
-    auto session = OrtSession::Create(ort_env, model_data_it->second.data(), model_data_it->second.size(), session_options);
-
-    return session;
+    // For models loaded from memory that reference external data files, tell ORT where to find them
+    // via the kOrtSessionOptionsModelExternalInitializersFileFolderPath session config entry.
+    session_options->AddConfigEntry("session.model_external_initializers_file_folder_path",
+                                    config_->config_path.string().c_str());
+    return OrtSession::Create(ort_env, model_data_it->second.data(), model_data_it->second.size(), session_options);
   }
 
   // Otherwise, load the model from the file system

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -44,6 +44,13 @@
 
 namespace Generators {
 
+namespace {
+
+constexpr const char* kOrtSessionOptionsModelExternalInitializersFileFolderPath =
+    "session.model_external_initializers_file_folder_path";
+
+}  // namespace
+
 State::State(const GeneratorParams& params, const Model& model)
     : model_{model},
       params_{params.shared_from_this()},
@@ -740,8 +747,9 @@ std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::str
     }
     // For models loaded from memory that reference external data files, tell ORT where to find them
     // via the kOrtSessionOptionsModelExternalInitializersFileFolderPath session config entry.
-    session_options->AddConfigEntry("session.model_external_initializers_file_folder_path",
-                                    config_->config_path.string().c_str());
+    const fs::path external_initializers_path = fs::absolute(config_->config_path);
+    session_options->AddConfigEntry(kOrtSessionOptionsModelExternalInitializersFileFolderPath,
+                                    external_initializers_path.string().c_str());
     return OrtSession::Create(ort_env, model_data_it->second.data(), model_data_it->second.size(), session_options);
   }
 


### PR DESCRIPTION
This replaces the previous `chdir` workaround used when loading an ONNX model from memory while its external weight files remain on disk.

Instead of temporarily changing the process working directory (which has security issues and is not thread-safe), we now set ONNX Runtime's session option:

```cpp
session.model_external_initializers_file_folder_path
```

to the model config directory before creating the session from the in-memory model buffer. This lets ORT resolve external initializer files correctly without mutating global process state.

This makes the model-from-memory path thread-safe and keeps file-based model loading behavior unchanged.