### PR TITLE
Enable Qwen3.5 35B-A3B MoE text export for TRT-RTX EP

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -29,7 +29,7 @@ std::string_view NormalizeProviderName(std::string_view name) {
     return "OpenVINO";
   } else if (lower_name == "vitisai") {
     return "VitisAI";
-  } else if (lower_name == "nvtensorrtrtx") {
+  } else if (lower_name == "nvtensorrtrtx" || lower_name == "nvtensorrtrtxexecutionprovider") {
     return "NvTensorRtRtx";
   }
   return name;  // Return name unchanged

--- a/src/models/model_type.h
+++ b/src/models/model_type.h
@@ -17,7 +17,7 @@ namespace Generators {
 struct ModelType {
   inline static bool IsLLM(const std::string& model_type) {
     // Large-language model (LLM)
-    static constexpr std::array<std::string_view, 25> LLM = {"chatglm", "decoder", "ernie4_5", "gemma", "gemma2", "gemma3_text", "gemma4_text", "gpt2", "gptoss", "granite", "hunyuandensev1", "internlm2", "lfm2", "llama", "mistral", "nemotron", "olmo", "phi", "phimoe", "phi3", "phi3small", "qwen2", "qwen3", "qwen3_5_text", "smollm3"};
+    static constexpr std::array<std::string_view, 26> LLM = {"chatglm", "decoder", "ernie4_5", "gemma", "gemma2", "gemma3_text", "gemma4_text", "gpt2", "gptoss", "granite", "hunyuandensev1", "internlm2", "lfm2", "llama", "mistral", "nemotron", "olmo", "phi", "phimoe", "phi3", "phi3small", "qwen2", "qwen3", "qwen3_5_moe_text", "qwen3_5_text", "smollm3"};
     return std::find(LLM.begin(), LLM.end(), model_type) != LLM.end();
   }
 

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -2095,12 +2095,22 @@ class Qwen35MoeTextModel(Qwen35TextModel):
 
         super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
 
-        self.model_type = "Qwen3_5_MoeForConditionalGeneration"
+        # The base builder derives the GenAI model.type by stripping the suffix
+        # after "For" and lowercasing, matching Qwen3.5 text-only export.
+        self.model_type = (
+            "Qwen3_5_Moe_textForCausalLM"
+            if self.is_text_only
+            else "Qwen3_5_MoeForConditionalGeneration"
+        )
 
         # MoE attributes specific to Qwen3.5-MoE
         self.moe_attrs["activation_type"] = "swiglu"
         self.moe_attrs["swiglu_fusion"] = 1
         self.moe_attrs["normalize_routing_weights"] = True
+        if self.moe_attrs.get("swiglu_limit") is None and self.ep == "trt-rtx":
+            # TRT-RTX EP builds currently require QMoE swiglu_limit to be present;
+            # use +inf to preserve the "no clamp" behavior when the model omits it.
+            self.moe_attrs["swiglu_limit"] = float("inf")
 
         self.moe_intermediate_size = getattr(config, "moe_intermediate_size", 512)
         self.shared_expert_intermediate_size = getattr(config, "shared_expert_intermediate_size", self.moe_intermediate_size)


### PR DESCRIPTION
## Summary

Enable Qwen3.5 35B-A3B MoE text-only export and inference with the TRT-RTX execution provider.

- Emit a decoder-only GenAI model type for TRT-RTX text-only Qwen3.5-MoE exports.
- Keep the existing `qwen3_5_moe` VLM path intact for non-TRT-RTX/non-text behavior.
- Preserve model-provided `swiglu_limit` when available, and fall back to `+inf` when the config omits it.
- Allow Python examples to use the GenAI provider name `NvTensorRtRtx` while registering the external ORT EP library as `NvTensorRTRTXExecutionProvider`.

## Validation

- Exported Qwen3.5 35B-A3B MoE INT4 QDQ text-only model with TRT-RTX EP.
- Verified generated config:
  - `model.type = qwen3_5_moe_text`
  - decoder file is `text.onnx`
  - TRT-RTX provider options include `enable_cuda_graph = 1`
- Verified exported ONNX:
  - QMoE node count: 40
  - no QMoE nodes missing `swiglu_limit`
- Ran TRT-RTX EP inference with `model-qa.py` using `-e NvTensorRtRtx`.
- Smoke-tested the same `-e NvTensorRtRtx` alias on Qwen3.5 0.8B and 9B TRT-RTX packages.

## Notes

- This change does not remove or alter the existing `qwen3_5_moe` VLM model registration.
- The TRT-RTX text-only path is selected only for the TRT-RTX export path with text-only settings.
- The Python example alias is intentionally minimal: it only maps the GenAI provider name to the external ORT EP library name during registration.
