### PR TITLE
Add per_layer_inputs support for Gemma4 and fix pixel_position_ids

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -343,6 +343,8 @@ struct DecoderInputs_Element : JSON::Element {
       v_.lstm_hidden_state = JSON::Get<std::string_view>(value);
     } else if (name == "lstm_cell_state") {
       v_.lstm_cell_state = JSON::Get<std::string_view>(value);
+    } else if (name == "per_layer_inputs") {
+      v_.per_layer_inputs = JSON::Get<std::string_view>(value);
     } else if (name == "targets_length") {
       v_.targets_length = JSON::Get<std::string_view>(value);
     } else {
@@ -1048,6 +1050,8 @@ struct EmbeddingOutputs_Element : JSON::Element {
   void OnValue(std::string_view name, JSON::Value value) override {
     if (name == "inputs_embeds") {
       v_.embeddings = JSON::Get<std::string_view>(value);
+    } else if (name == "per_layer_inputs") {
+      v_.per_layer_inputs = JSON::Get<std::string_view>(value);
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.h
+++ b/src/config.h
@@ -212,6 +212,7 @@ struct Config {
 
       struct Outputs {
         std::string embeddings{Defaults::InputsEmbedsName};
+        std::string per_layer_inputs;  // Gemma4: per-layer conditioning from embedding to decoder
       } outputs;
     } embedding;
 
@@ -356,6 +357,9 @@ struct Config {
         std::string targets;
         std::string lstm_hidden_state;
         std::string lstm_cell_state;
+
+        // Gemma4 per-layer inputs (e.g. per-layer embeddings from embedding model)
+        std::string per_layer_inputs;
 
         // Parakeet TDT decoder (prediction network) extra inputs
         std::string targets_length;

--- a/src/models/embeddings.cpp
+++ b/src/models/embeddings.cpp
@@ -7,10 +7,10 @@
 
 namespace Generators {
 
-Embeddings::Embeddings(State& state, Embeddings::Mode mode, const std::string& name)
+Embeddings::Embeddings(State& state, Embeddings::Mode mode, const std::string& name, int64_t hidden_size)
     : state_{state},
       shape_{static_cast<int64_t>(state_.params_->search.batch_size) * state_.params_->search.num_beams,
-             0, model_.config_->model.decoder.hidden_size},
+             0, hidden_size > 0 ? hidden_size : model_.config_->model.decoder.hidden_size},
       type_{mode == Embeddings::Mode::Input
                 ? model_.session_info_.GetInputDataType(name)
                 : model_.session_info_.GetOutputDataType(name)},

--- a/src/models/embeddings.h
+++ b/src/models/embeddings.h
@@ -13,7 +13,7 @@ struct Embeddings {
     Output
   };
 
-  Embeddings(State& state, Embeddings::Mode mode, const std::string& name);
+  Embeddings(State& state, Embeddings::Mode mode, const std::string& name, int64_t hidden_size = 0);
   Embeddings(const Embeddings&) = delete;
   Embeddings& operator=(const Embeddings&) = delete;
 

--- a/src/models/gemma4_multimodal_processor.cpp
+++ b/src/models/gemma4_multimodal_processor.cpp
@@ -222,13 +222,17 @@ std::unique_ptr<NamedTensors> Gemma4MultiModalProcessor::Process(const Tokenizer
     CheckResult(OrtxTensorResultGetAt(image_result.get(), 0, pixel_values_owner.ToBeAssigned()));
     pixel_values = pixel_values_owner.get();
 
-    // pixel_position_ids is the second output from the Gemma4 image preprocessor
-    if (OrtxTensorResultGetAt(image_result.get(), 1, pixel_position_ids_owner.ToBeAssigned()) == kOrtxOK && pixel_position_ids_owner.get()) {
+    // pixel_position_ids is the second output from the Gemma4 image preprocessor.
+    // Note: ToBeAssigned() uses a PointerAssigner whose destructor sets the owner;
+    // we must not check .get() in the same expression or it will still be null.
+    auto pos_status = OrtxTensorResultGetAt(image_result.get(), 1, pixel_position_ids_owner.ToBeAssigned());
+    if (pos_status == kOrtxOK && pixel_position_ids_owner.get()) {
       pixel_position_ids = pixel_position_ids_owner.get();
     }
 
     // num_soft_tokens is the third output — the actual number of vision tokens after pooling
-    if (OrtxTensorResultGetAt(image_result.get(), 2, num_soft_tokens_owner.ToBeAssigned()) == kOrtxOK && num_soft_tokens_owner.get()) {
+    auto nst_status = OrtxTensorResultGetAt(image_result.get(), 2, num_soft_tokens_owner.ToBeAssigned());
+    if (nst_status == kOrtxOK && num_soft_tokens_owner.get()) {
       const int64_t* nst_data{};
       const int64_t* nst_shape{};
       size_t nst_dims;

--- a/src/models/gemma4_multimodal_processor.cpp
+++ b/src/models/gemma4_multimodal_processor.cpp
@@ -322,26 +322,33 @@ std::unique_ptr<NamedTensors> Gemma4MultiModalProcessor::Process(const Tokenizer
 
     if (actual_patches < num_padded_patches) {
       // Trim: copy only the first actual_patches from the padded tensor.
-      // For 3D [batch, patches, dim], copy batch * actual_patches * dim elements.
+      // The preprocessor outputs float32 data, so we trim using float32 strides,
+      // then cast to the model's pixel_values type (float, fp16, or bf16).
       const int64_t batch = (pv_dims == 3) ? pv_shape[0] : 1;
       auto trimmed_shape = (pv_dims == 3) ? std::vector<int64_t>{batch, actual_patches, patch_dim}
                                           : std::vector<int64_t>{actual_patches, patch_dim};
 
-      // Respect the model's pixel_values type (float, fp16, or bf16)
-      auto trimmed_pv = OrtValue::CreateTensor(allocator, trimmed_shape, pixel_values_type_);
-      const size_t elem_size = (pixel_values_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) ? 4 : 2;  // float=4, fp16/bf16=2
-      // For 3D with batch > 1, copy each batch slice separately (padded stride differs from trimmed stride).
-      // Use raw byte pointers since the type may be float, fp16, or bf16.
-      auto* dst = static_cast<uint8_t*>(trimmed_pv->GetTensorMutableRawData());
-      const auto* src = reinterpret_cast<const uint8_t*>(pv_data);
-      const size_t src_stride = static_cast<size_t>(num_padded_patches * patch_dim) * elem_size;
-      const size_t dst_stride = static_cast<size_t>(actual_patches * patch_dim) * elem_size;
+      // Trim in float32 (source is always float32 from the preprocessor)
+      auto trimmed_fp32 = OrtValue::CreateTensor<float>(allocator, trimmed_shape);
+      float* dst = trimmed_fp32->GetTensorMutableData<float>();
+      const float* src = pv_data;
+      const size_t src_row = static_cast<size_t>(num_padded_patches * patch_dim);
+      const size_t dst_row = static_cast<size_t>(actual_patches * patch_dim);
       for (int64_t b = 0; b < batch; ++b) {
-        std::memcpy(dst + b * dst_stride, src + b * src_stride, dst_stride);
+        std::memcpy(dst + b * dst_row, src + b * src_row, dst_row * sizeof(float));
       }
 
-      named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
-                             std::make_shared<Tensor>(std::move(trimmed_pv)));
+      // Cast to model's pixel_values type if needed (e.g. float32 -> float16)
+      if (pixel_values_type_ == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
+                               std::make_shared<Tensor>(std::move(trimmed_fp32)));
+      } else {
+        auto trimmed_target = OrtValue::CreateTensor(allocator, trimmed_shape, pixel_values_type_);
+        auto p_device = GetDeviceInterface(DeviceType::CPU);
+        Cast(*trimmed_fp32, trimmed_target, *p_device, pixel_values_type_);
+        named_tensors->emplace(std::string(Config::Defaults::PixelValuesName),
+                               std::make_shared<Tensor>(std::move(trimmed_target)));
+      }
     } else {
       EmplaceProcessedTensor(*named_tensors, Config::Defaults::PixelValuesName, pixel_values, pixel_values_type_, allocator);
     }

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -601,6 +601,15 @@ EmbeddingState::EmbeddingState(const MultiModalLanguageModel& model, const Gener
       model_{model} {
   input_ids_.Add();
   inputs_embeds_.Add();
+
+  // Gemma4: embedding model produces per_layer_inputs alongside inputs_embeds
+  if (!model_.config_->model.embedding.outputs.per_layer_inputs.empty()) {
+    auto shape = model_.session_info_.GetOutputShape(model_.config_->model.embedding.outputs.per_layer_inputs);
+    int64_t per_layer_dim = shape.size() >= 3 ? shape.back() : 0;
+    per_layer_inputs_ = std::make_unique<Embeddings>(*this, Embeddings::Mode::Output,
+                                                     model_.config_->model.embedding.outputs.per_layer_inputs, per_layer_dim);
+    per_layer_inputs_->Add();
+  }
 }
 
 void EmbeddingState::SetExtraInputs(const int64_t num_images, const int64_t num_image_tokens, const int64_t num_audio_tokens) {
@@ -650,6 +659,15 @@ DecoderState::DecoderState(const MultiModalLanguageModel& model, DeviceSpan<int3
       recurrent_state_{CreateRecurrentState(*this)} {
   inputs_embeds_.Add();
 
+  // Gemma4: decoder accepts per_layer_inputs from the embedding model
+  if (!model_.config_->model.decoder.inputs.per_layer_inputs.empty()) {
+    auto shape = model_.session_info_.GetInputShape(model_.config_->model.decoder.inputs.per_layer_inputs);
+    int64_t per_layer_dim = shape.size() >= 3 ? shape.back() : 0;
+    per_layer_inputs_ = std::make_unique<Embeddings>(*this, Embeddings::Mode::Input,
+                                                     model_.config_->model.decoder.inputs.per_layer_inputs, per_layer_dim);
+    per_layer_inputs_->Add();
+  }
+
   // Some multimodal decoders (e.g., Gemma4) require input_ids alongside inputs_embeds.
   // Use a decoder-only SessionInfo to avoid false positives: the combined session_info_
   // includes embedding session inputs (which always has input_ids), causing this check
@@ -690,6 +708,7 @@ void DecoderState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int tot
     recurrent_state_->Update();
   logits_.Update(next_tokens, new_length);
   inputs_embeds_.UpdateSequenceLength(new_length);
+  if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
 }
 
 // Overload for pipeline to call
@@ -700,6 +719,7 @@ void DecoderState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int tot
     recurrent_state_->Update();
   logits_.Update(next_tokens, new_length);
   inputs_embeds_.UpdateSequenceLength(new_length);
+  if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
 }
 
 MultiModalPipelineState::MultiModalPipelineState(const MultiModalLanguageModel& model, DeviceSpan<int32_t> sequence_lengths, const GeneratorParams& params)
@@ -796,6 +816,9 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
       embedding_state_->audio_features_->AllocateEmptyFeatures();
     }
     embedding_state_->inputs_embeds_.ReuseEmbeddingsBuffer(decoder_state_->inputs_embeds_);
+    if (embedding_state_->per_layer_inputs_ && decoder_state_->per_layer_inputs_) {
+      embedding_state_->per_layer_inputs_->ReuseEmbeddingsBuffer(*decoder_state_->per_layer_inputs_);
+    }
     embedding_state_->Run(current_length, next_tokens, next_indices);
 
     auto logits = decoder_state_->Run(current_length, next_tokens, next_indices);
@@ -808,6 +831,9 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
   }
 
   embedding_state_->inputs_embeds_.ReuseEmbeddingsBuffer(decoder_state_->inputs_embeds_);
+  if (embedding_state_->per_layer_inputs_ && decoder_state_->per_layer_inputs_) {
+    embedding_state_->per_layer_inputs_->ReuseEmbeddingsBuffer(*decoder_state_->per_layer_inputs_);
+  }
   embedding_state_->Run(current_length, next_tokens, next_indices);
   return decoder_state_->Run(current_length, next_tokens, next_indices);
 }

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -126,6 +126,7 @@ struct EmbeddingState : State {
   std::unique_ptr<MultiModalFeatures> audio_features_;        // Optional model input
   Embeddings inputs_embeds_{*this, Embeddings::Mode::Output,  // Model output
                             model_.config_->model.embedding.outputs.embeddings};
+  std::unique_ptr<Embeddings> per_layer_inputs_;  // Optional model output (Gemma4)
 };
 
 struct DecoderState : State {
@@ -145,6 +146,7 @@ struct DecoderState : State {
   const MultiModalLanguageModel& model_;
   Embeddings inputs_embeds_{*this, Embeddings::Mode::Input,  // Model input
                             model_.config_->model.decoder.inputs.embeddings};
+  std::unique_ptr<Embeddings> per_layer_inputs_;        // Optional model input (Gemma4: per-layer conditioning)
   std::unique_ptr<DefaultInputIDs> decoder_input_ids_;  // Optional model input (e.g., Gemma4 decoder needs input_ids)
   std::unique_ptr<PositionInputs> position_inputs_;     // Model input
   DefaultKeyValueCache kv_cache_{*this};                // Model input


### PR DESCRIPTION
## Summary

Fix Gemma4 multimodal processing: pixel\_values trimming NaN bug, pixel\_position\_ids extraction, and per\_layer\_inputs forwarding.

### 1. Fix pixel\_values trimming (NaN in vision encoder)

The image preprocessor (`Gemma4ImageTransform`) outputs `pixel_values` as **float32**. When trimming padded patches, the original code used `pixel_values_type_` (float16) for `elem_size` and stride calculations — copying 2 bytes per element from a 4-byte float32 buffer, reinterpreting float32 bit patterns as float16.

**NaN propagation chain:**

\`\`\`
Preprocessor (float32) → memcpy with fp16 strides → garbage pixel_values
→ vision encoder NaN → NaN embeddings → NaN logits
\`\`\`

**Fix:** Trim in float32 (correct strides), then cast to `pixel_values_type_` via ORT's `Cast` op. The non-trimming path is unchanged — `EmplaceProcessedTensor` already handles the float32→float16 conversion correctly.

### 2. Fix pixel\_position\_ids and num\_soft\_tokens extraction

`OrtxObjectPtr::ToBeAssigned()` returns a `PointerAssigner` temporary whose destructor assigns the owned pointer. When combined with `&&` in the same expression:

\`\`\`cpp
// BUG: owner.get() is still null when checked — destructor hasn't run yet
if (GetAt(..., owner.ToBeAssigned()) == kOrtxOK && owner.get()) {
\`\`\`

This silently dropped `pixel_position_ids` and `num_soft_tokens`, causing "Missing Input: pixel\_position\_ids" errors in the vision encoder.

**Fix:** Split into separate statements so the `PointerAssigner` destructor runs before `.get()` is checked.

### 3. Add per\_layer\_inputs forwarding (embedding → decoder)

Gemma4's embedding model produces `per_layer_inputs [B, S, 8960]` alongside `inputs_embeds`. This tensor carries per-layer conditioning signals used by the decoder's gating mechanism.

**Changes:**

- **Config:** Parse `per_layer_inputs` in `Decoder::Inputs` and `Embedding::Outputs`
- **Embeddings:** Add optional `hidden_size` override (per\_layer\_inputs dim is 8960, not `hidden_size` 1536)
- **Pipeline:** `EmbeddingState` registers per\_layer\_inputs as output, `DecoderState` as input, connected via `ReuseEmbeddingsBuffer` in both prompt and generation paths

### Files changed

| File | Change |
|------|--------|
| `config.h` / `config.cpp` | Parse `per_layer_inputs` in decoder inputs and embedding outputs |
| `embeddings.h` / `embeddings.cpp` | Optional `hidden_size` parameter (default = `decoder.hidden_size`) |
| `multi_modal.h` / `multi_modal.cpp` | per\_layer\_inputs forwarding: embedding output → decoder input |
| `gemma4_multimodal_processor.cpp` | ToBeAssigned lifetime fix + pixel\_values trimming fix |

### Testing

- Text-only generation (CPU fp32): clean output ✅
- Text-only generation (CUDA fp16): clean output ✅
- Multimodal image+text: pixel\_position\_ids extracted, no NaN ✅
- per\_layer\_inputs forwarded embedding → decoder ✅
- Existing models (Phi4MM, Qwen2VL, Mistral3): unaffected ✅
- Backward compatible: all new fields default to empty/zero ✅
