### PR TITLE
Default to arm64 ONNX Runtime on Apple Silicon

### DIFF
--- a/cmake/ortlib.cmake
+++ b/cmake/ortlib.cmake
@@ -125,9 +125,25 @@ else()
   else()
     set(ORT_BINARY_PLATFORM "x64")
     if (APPLE)
-      if(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+      # Honor CMAKE_OSX_ARCHITECTURES when set; otherwise fall back to the host
+      # architecture so a plain build on Apple Silicon selects the arm64 ONNX
+      # Runtime binaries instead of defaulting to x64.
+      if (CMAKE_OSX_ARCHITECTURES)
+        set(_ort_apple_arch ${CMAKE_OSX_ARCHITECTURES})
+      else()
+        set(_ort_apple_arch ${CMAKE_HOST_SYSTEM_PROCESSOR})
+      endif()
+      # The prebuilt ONNX Runtime package only provides single-arch macOS
+      # binaries (osx-arm64 / osx-x64), so universal builds are not supported.
+      list(LENGTH _ort_apple_arch _ort_apple_arch_count)
+      if (_ort_apple_arch_count GREATER 1)
+        message(FATAL_ERROR "Universal macOS builds (CMAKE_OSX_ARCHITECTURES=\"${CMAKE_OSX_ARCHITECTURES}\") are not supported with the auto-downloaded ONNX Runtime binaries; specify a single architecture (arm64 or x86_64).")
+      endif()
+      if (_ort_apple_arch STREQUAL "arm64")
         set(ORT_BINARY_PLATFORM "arm64")
       endif()
+      unset(_ort_apple_arch)
+      unset(_ort_apple_arch_count)
       set(ORT_LIB_DIR ${ortlib_SOURCE_DIR}/runtimes/osx-${ORT_BINARY_PLATFORM}/native)
     elseif(WIN32)
       if (CMAKE_GENERATOR_PLATFORM)


### PR DESCRIPTION
## Problem

On macOS, the auto-download path in `cmake/ortlib.cmake` derived the ONNX Runtime binary platform solely from `CMAKE_OSX_ARCHITECTURES`, defaulting to `x64` whenever it was unset. A plain `./build.sh` on an Apple Silicon Mac therefore looked for the non-existent `osx-x64` ONNX Runtime library and failed at configure time:

```
CMake Error at cmake/global_variables.cmake:106 (message):
  Expected the ONNX Runtime library to be found at
  .../build/macOS/Release/_deps/ortlib-src/runtimes/osx-x64/native/libonnxruntime.dylib.
  Actual: Not found.
```

The downloaded ONNX Runtime package only ships `osx-arm64` (and `osx-x64`) under `runtimes/`, and the host is arm64, so the correct selection is `osx-arm64`.

## Fix

Fall back to `CMAKE_HOST_SYSTEM_PROCESSOR` when `CMAKE_OSX_ARCHITECTURES` is unset, mirroring how the Windows and Linux branches in the same block already derive the host architecture. Explicit cross / Intel builds via `CMAKE_OSX_ARCHITECTURES` are unchanged.

## Verification (Apple Silicon, macOS 15)

- Default configure (no arch flag) → selects `osx-arm64`, configure succeeds ✅
- `-DCMAKE_OSX_ARCHITECTURES=x86_64` → still selects `osx-x64` (existing behavior preserved) ✅
