### PR TITLE
Fix BFloat16 logits returned as garbage in Logits::Get()

### DIFF
--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -122,6 +122,8 @@ struct CudaInterfaceImplBase : DeviceInterface {
       cuda::LaunchFp32ToFp16(reinterpret_cast<const float*>(input_data), reinterpret_cast<uint16_t*>(output_data), static_cast<int>(element_count), GetStream());
     } else if (input_type == Ort::TypeToTensorType<Ort::Float16_t> && output_type == Ort::TypeToTensorType<float>) {
       cuda::LaunchFp16ToFp32(reinterpret_cast<const uint16_t*>(input_data), reinterpret_cast<float*>(output_data), static_cast<int>(element_count), GetStream());
+    } else if (input_type == Ort::TypeToTensorType<Ort::BFloat16_t> && output_type == Ort::TypeToTensorType<float>) {
+      cuda::LaunchBf16ToFp32(reinterpret_cast<const uint16_t*>(input_data), reinterpret_cast<float*>(output_data), static_cast<int>(element_count), GetStream());
     } else if (input_type == Ort::TypeToTensorType<int32_t> && output_type == Ort::TypeToTensorType<int64_t>) {
       cuda::LaunchInt32ToInt64(reinterpret_cast<const int32_t*>(input_data), reinterpret_cast<int64_t*>(output_data), static_cast<int>(element_count), GetStream());
     } else

--- a/src/cuda/kernels.h
+++ b/src/cuda/kernels.h
@@ -13,6 +13,7 @@ void Launch_UpdateAttentionMask(T* mask_data, T* old_data, int batch_beam_size, 
 
 void LaunchAddLogitsMask(float* batch_logits, int batch_beam_size, int vocab_size, const uint32_t* logits_mask, cudaStream_t stream);
 void LaunchFp16ToFp32(const uint16_t* fp16, float* fp32, int count, cudaStream_t stream);
+void LaunchBf16ToFp32(const uint16_t* bf16, float* fp32, int count, cudaStream_t stream);
 void LaunchFp32ToFp16(const float* fp32, uint16_t* fp16, int count, cudaStream_t stream);
 void LaunchInt32ToInt64(const int32_t* src, int64_t* dst, int count, cudaStream_t stream);
 

--- a/src/cuda/model_kernels.cu
+++ b/src/cuda/model_kernels.cu
@@ -136,8 +136,8 @@ __global__ void ConvertBf16ToFp32(const __nv_bfloat16* src, float* dst, int coun
 }
 
 void LaunchBf16ToFp32(const uint16_t* bf16, float* fp32, int count, cudaStream_t stream) {
-  int block_size = 256;
-  int num_blocks = (count + block_size - 1) / block_size;
+  constexpr int block_size = 256;
+  const int num_blocks = (count + block_size - 1) / block_size;
   ConvertBf16ToFp32<<<num_blocks, block_size, 0, stream>>>(reinterpret_cast<const __nv_bfloat16*>(bf16), fp32, count);
   CUDA_CHECK_LAUNCH();
 }

--- a/src/cuda/model_kernels.cu
+++ b/src/cuda/model_kernels.cu
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <cuda_fp16.h>
+#include <cuda_bf16.h>
 #include <cuda_runtime.h>
 #include <stdint.h>
 #include <limits>
@@ -125,6 +126,19 @@ void LaunchFp32ToFp16(const float* fp32, uint16_t* fp16, int count, cudaStream_t
   int block_size = 256;
   int num_blocks = (count + block_size - 1) / block_size;
   ConvertFp32ToFp16<<<num_blocks, block_size, 0, stream>>>(fp32, reinterpret_cast<half*>(fp16), count);
+  CUDA_CHECK_LAUNCH();
+}
+
+__global__ void ConvertBf16ToFp32(const __nv_bfloat16* src, float* dst, int count) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx < count)
+    dst[idx] = __bfloat162float(src[idx]);
+}
+
+void LaunchBf16ToFp32(const uint16_t* bf16, float* fp32, int count, cudaStream_t stream) {
+  int block_size = 256;
+  int num_blocks = (count + block_size - 1) / block_size;
+  ConvertBf16ToFp32<<<num_blocks, block_size, 0, stream>>>(reinterpret_cast<const __nv_bfloat16*>(bf16), fp32, count);
   CUDA_CHECK_LAUNCH();
 }
 

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -44,7 +44,7 @@ DeviceSpan<float> Logits::Get() {
     // create new OrtValue for logits_of_last_token and use output_last_tokens_ to hold it
     output_last_tokens_ = OrtValue::CreateTensor(model_.p_device_inputs_->GetAllocator(), shape_last, type_);
 
-    if (type_ == Ort::TypeToTensorType<Ort::Float16_t>)
+    if (type_ == Ort::TypeToTensorType<Ort::Float16_t> || type_ == Ort::TypeToTensorType<Ort::BFloat16_t>)
       logits_of_last_token_fp32_ = OrtValue::CreateTensor<float>(model_.p_device_inputs_->GetAllocator(), shape_);
 
     logits_of_last_token = output_last_tokens_.get();
@@ -69,8 +69,8 @@ DeviceSpan<float> Logits::Get() {
     element_count = shape_[0] * shape_[2];  // shape_[1] is now 1, so the element count must be updated
   }
 
-  // Convert from float16 to float32 if necessary
-  if (type_ == Ort::TypeToTensorType<Ort::Float16_t>) {
+  // Convert from float16/bfloat16 to float32 if necessary
+  if (type_ == Ort::TypeToTensorType<Ort::Float16_t> || type_ == Ort::TypeToTensorType<Ort::BFloat16_t>) {
     Cast(*logits_of_last_token, logits_of_last_token_fp32_, *model_.p_device_inputs_, Ort::TypeToTensorType<float>);
     logits_of_last_token = logits_of_last_token_fp32_.get();
   }


### PR DESCRIPTION
### Summary

`Logits::Get()` only converted the model's raw logits to `float32` when the output type was **Float16**. For **BFloat16** the conversion was skipped, and the subsequent `WrapTensor<float>` reinterpreted the raw 2-byte bf16 values as 4-byte float32 — corrupting every logit (wrong argmax, incoherent generation). The identical model in Float16 worked correctly.

Fixes #2202.

### Changes

- `src/models/logits.cpp`: treat `BFloat16` the same as `Float16` in both the fp32 staging-buffer allocation and the `Cast` to float32.
- `src/cuda/model_kernels.cu` + `src/cuda/kernels.h`: add `LaunchBf16ToFp32` (on-device bf16→f32 conversion).
- `src/cuda/interface.cpp`: route `BFloat16 → float` through the new kernel in the CUDA `Cast`. (The CPU `Cast` already supported bf16→f32, so the generic `Cast` helper otherwise falls back to a host round-trip.)

### Verification

On a bf16 decoder (vocab 262144), the first-token argmax now matches the Float16 / HuggingFace reference, and greedy generation is byte-identical to the fp16 export. Before the fix, genai returned argmax 4539 (a value that did not correspond to any position in the model's actual output); after, it returns 496 (correct).