### PR TITLE
Add grid dimension validation

### DIFF
--- a/src/models/qwen_vl_vision.cpp
+++ b/src/models/qwen_vl_vision.cpp
@@ -249,9 +249,22 @@ std::vector<float> QwenVisionPipeline::Run(const float* pixel_data, const std::v
 // Matches HuggingFace transformers implementation:
 // https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py#L367
 std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, int64_t grid_h, int64_t grid_w) {
+  // Validate config-derived divisors before any division
+  if (spatial_merge_size_ <= 0) {
+    throw std::runtime_error("CalculateWindowIndex: spatial_merge_size must be positive");
+  }
+  if (patch_size_ <= 0) {
+    throw std::runtime_error("CalculateWindowIndex: patch_size must be positive");
+  }
+
   // Validate grid dimensions are positive and within reasonable bounds
   if (grid_t <= 0 || grid_h <= 0 || grid_w <= 0) {
     throw std::runtime_error("CalculateWindowIndex: grid dimensions must be positive");
+  }
+
+  // Require grid_h/grid_w to be divisible by spatial_merge_size to avoid truncation
+  if (grid_h % spatial_merge_size_ != 0 || grid_w % spatial_merge_size_ != 0) {
+    throw std::runtime_error("CalculateWindowIndex: grid_h and grid_w must be divisible by spatial_merge_size");
   }
 
   // Calculate LLM grid dimensions after spatial merging

--- a/src/models/qwen_vl_vision.cpp
+++ b/src/models/qwen_vl_vision.cpp
@@ -249,6 +249,11 @@ std::vector<float> QwenVisionPipeline::Run(const float* pixel_data, const std::v
 // Matches HuggingFace transformers implementation:
 // https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py#L367
 std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, int64_t grid_h, int64_t grid_w) {
+  // Validate grid dimensions are positive and within reasonable bounds
+  if (grid_t <= 0 || grid_h <= 0 || grid_w <= 0) {
+    throw std::runtime_error("CalculateWindowIndex: grid dimensions must be positive");
+  }
+
   // Calculate LLM grid dimensions after spatial merging
   int64_t llm_grid_h = grid_h / spatial_merge_size_;
   int64_t llm_grid_w = grid_w / spatial_merge_size_;
@@ -260,21 +265,34 @@ std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, in
   int64_t pad_h = (vit_merger_window_size - (llm_grid_h % vit_merger_window_size)) % vit_merger_window_size;
   int64_t pad_w = (vit_merger_window_size - (llm_grid_w % vit_merger_window_size)) % vit_merger_window_size;
 
-  int64_t num_windows_h = (llm_grid_h + pad_h) / vit_merger_window_size;
-  int64_t num_windows_w = (llm_grid_w + pad_w) / vit_merger_window_size;
+  int64_t padded_h = llm_grid_h + pad_h;
+  int64_t padded_w = llm_grid_w + pad_w;
+
+  // Check for integer overflow in allocation size: grid_t * padded_h * padded_w
+  constexpr int64_t kMaxElements = static_cast<int64_t>(1) << 30;  // ~1 billion elements, ~8GB
+  if (padded_h > kMaxElements || padded_w > kMaxElements || grid_t > kMaxElements) {
+    throw std::runtime_error("CalculateWindowIndex: grid dimensions are too large");
+  }
+  int64_t alloc_size = grid_t * padded_h * padded_w;
+  if (alloc_size > kMaxElements) {
+    throw std::runtime_error("CalculateWindowIndex: total grid size exceeds maximum allowed");
+  }
+
+  int64_t num_windows_h = padded_h / vit_merger_window_size;
+  int64_t num_windows_w = padded_w / vit_merger_window_size;
 
   std::vector<int64_t> window_index;
   window_index.reserve(grid_t * llm_grid_h * llm_grid_w);
 
   // Create initial index grid
-  std::vector<int64_t> index(grid_t * (llm_grid_h + pad_h) * (llm_grid_w + pad_w), -100);
+  std::vector<int64_t> index(alloc_size, -100);
 
   // Fill non-padded positions with sequential indices
   for (int64_t t = 0; t < grid_t; ++t) {
     for (int64_t h = 0; h < llm_grid_h; ++h) {
       for (int64_t w = 0; w < llm_grid_w; ++w) {
         int64_t idx = t * llm_grid_h * llm_grid_w + h * llm_grid_w + w;
-        int64_t padded_idx = t * (llm_grid_h + pad_h) * (llm_grid_w + pad_w) + h * (llm_grid_w + pad_w) + w;
+        int64_t padded_idx = t * padded_h * padded_w + h * padded_w + w;
         index[padded_idx] = idx;
       }
     }
@@ -290,7 +308,7 @@ std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, in
           for (int64_t pw = 0; pw < vit_merger_window_size; ++pw) {
             int64_t h = wh * vit_merger_window_size + ph;
             int64_t w = ww * vit_merger_window_size + pw;
-            int64_t padded_idx = t * (llm_grid_h + pad_h) * (llm_grid_w + pad_w) + h * (llm_grid_w + pad_w) + w;
+            int64_t padded_idx = t * padded_h * padded_w + h * padded_w + w;
 
             // Only add non-padded indices
             if (index[padded_idx] != -100) {

--- a/src/models/qwen_vl_vision.cpp
+++ b/src/models/qwen_vl_vision.cpp
@@ -246,35 +246,6 @@ std::vector<float> QwenVisionPipeline::Run(const float* pixel_data, const std::v
 }
 
 // Calculate window indices dynamically based on grid dimensions
-void ValidateWindowIndexParams(int64_t grid_t, int64_t grid_h, int64_t grid_w,
-                               int64_t spatial_merge_size, int64_t patch_size, int64_t window_size) {
-  if (spatial_merge_size <= 0)
-    throw std::runtime_error("CalculateWindowIndex: spatial_merge_size must be positive");
-  if (patch_size <= 0)
-    throw std::runtime_error("CalculateWindowIndex: patch_size must be positive");
-  if (grid_t <= 0 || grid_h <= 0 || grid_w <= 0)
-    throw std::runtime_error("CalculateWindowIndex: grid dimensions must be positive");
-  if (grid_h % spatial_merge_size != 0 || grid_w % spatial_merge_size != 0)
-    throw std::runtime_error("CalculateWindowIndex: grid_h and grid_w must be divisible by spatial_merge_size");
-
-  int64_t vit_merger_window_size = window_size / spatial_merge_size / patch_size;
-  if (vit_merger_window_size <= 0)
-    throw std::runtime_error("CalculateWindowIndex: vit_merger_window_size must be positive (check window_size, spatial_merge_size, patch_size config)");
-
-  constexpr int64_t kMaxElements = static_cast<int64_t>(1) << 30;
-  int64_t llm_grid_h = grid_h / spatial_merge_size;
-  int64_t llm_grid_w = grid_w / spatial_merge_size;
-  if (llm_grid_h > kMaxElements || llm_grid_w > kMaxElements || grid_t > kMaxElements)
-    throw std::runtime_error("CalculateWindowIndex: grid dimensions are too large");
-
-  int64_t pad_h = (vit_merger_window_size - (llm_grid_h % vit_merger_window_size)) % vit_merger_window_size;
-  int64_t pad_w = (vit_merger_window_size - (llm_grid_w % vit_merger_window_size)) % vit_merger_window_size;
-  int64_t padded_h = llm_grid_h + pad_h;
-  int64_t padded_w = llm_grid_w + pad_w;
-  if (padded_h > 0 && padded_w > 0 && grid_t > kMaxElements / padded_h / padded_w)
-    throw std::runtime_error("CalculateWindowIndex: total grid size exceeds maximum allowed");
-}
-
 // Matches HuggingFace transformers implementation:
 // https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py#L367
 std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, int64_t grid_h, int64_t grid_w) {

--- a/src/models/qwen_vl_vision.cpp
+++ b/src/models/qwen_vl_vision.cpp
@@ -246,26 +246,39 @@ std::vector<float> QwenVisionPipeline::Run(const float* pixel_data, const std::v
 }
 
 // Calculate window indices dynamically based on grid dimensions
+void ValidateWindowIndexParams(int64_t grid_t, int64_t grid_h, int64_t grid_w,
+                               int64_t spatial_merge_size, int64_t patch_size, int64_t window_size) {
+  if (spatial_merge_size <= 0)
+    throw std::runtime_error("CalculateWindowIndex: spatial_merge_size must be positive");
+  if (patch_size <= 0)
+    throw std::runtime_error("CalculateWindowIndex: patch_size must be positive");
+  if (grid_t <= 0 || grid_h <= 0 || grid_w <= 0)
+    throw std::runtime_error("CalculateWindowIndex: grid dimensions must be positive");
+  if (grid_h % spatial_merge_size != 0 || grid_w % spatial_merge_size != 0)
+    throw std::runtime_error("CalculateWindowIndex: grid_h and grid_w must be divisible by spatial_merge_size");
+
+  int64_t vit_merger_window_size = window_size / spatial_merge_size / patch_size;
+  if (vit_merger_window_size <= 0)
+    throw std::runtime_error("CalculateWindowIndex: vit_merger_window_size must be positive (check window_size, spatial_merge_size, patch_size config)");
+
+  constexpr int64_t kMaxElements = static_cast<int64_t>(1) << 30;
+  int64_t llm_grid_h = grid_h / spatial_merge_size;
+  int64_t llm_grid_w = grid_w / spatial_merge_size;
+  if (llm_grid_h > kMaxElements || llm_grid_w > kMaxElements || grid_t > kMaxElements)
+    throw std::runtime_error("CalculateWindowIndex: grid dimensions are too large");
+
+  int64_t pad_h = (vit_merger_window_size - (llm_grid_h % vit_merger_window_size)) % vit_merger_window_size;
+  int64_t pad_w = (vit_merger_window_size - (llm_grid_w % vit_merger_window_size)) % vit_merger_window_size;
+  int64_t padded_h = llm_grid_h + pad_h;
+  int64_t padded_w = llm_grid_w + pad_w;
+  if (padded_h > 0 && padded_w > 0 && grid_t > kMaxElements / padded_h / padded_w)
+    throw std::runtime_error("CalculateWindowIndex: total grid size exceeds maximum allowed");
+}
+
 // Matches HuggingFace transformers implementation:
 // https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py#L367
 std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, int64_t grid_h, int64_t grid_w) {
-  // Validate config-derived divisors before any division
-  if (spatial_merge_size_ <= 0) {
-    throw std::runtime_error("CalculateWindowIndex: spatial_merge_size must be positive");
-  }
-  if (patch_size_ <= 0) {
-    throw std::runtime_error("CalculateWindowIndex: patch_size must be positive");
-  }
-
-  // Validate grid dimensions are positive and within reasonable bounds
-  if (grid_t <= 0 || grid_h <= 0 || grid_w <= 0) {
-    throw std::runtime_error("CalculateWindowIndex: grid dimensions must be positive");
-  }
-
-  // Require grid_h/grid_w to be divisible by spatial_merge_size to avoid truncation
-  if (grid_h % spatial_merge_size_ != 0 || grid_w % spatial_merge_size_ != 0) {
-    throw std::runtime_error("CalculateWindowIndex: grid_h and grid_w must be divisible by spatial_merge_size");
-  }
+  ValidateWindowIndexParams(grid_t, grid_h, grid_w, spatial_merge_size_, patch_size_, window_size_);
 
   // Calculate LLM grid dimensions after spatial merging
   int64_t llm_grid_h = grid_h / spatial_merge_size_;
@@ -273,15 +286,6 @@ std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, in
 
   // Calculate window size at the merged resolution
   int64_t vit_merger_window_size = window_size_ / spatial_merge_size_ / patch_size_;
-  if (vit_merger_window_size <= 0) {
-    throw std::runtime_error("CalculateWindowIndex: vit_merger_window_size must be positive (check window_size, spatial_merge_size, patch_size config)");
-  }
-
-  // Validate merged grid dimensions before computing padding and allocation
-  constexpr int64_t kMaxElements = static_cast<int64_t>(1) << 30;  // ~1 billion elements, ~8GB
-  if (llm_grid_h > kMaxElements || llm_grid_w > kMaxElements || grid_t > kMaxElements) {
-    throw std::runtime_error("CalculateWindowIndex: grid dimensions are too large");
-  }
 
   // Calculate padding needed to fit into windows
   int64_t pad_h = (vit_merger_window_size - (llm_grid_h % vit_merger_window_size)) % vit_merger_window_size;
@@ -290,10 +294,6 @@ std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, in
   int64_t padded_h = llm_grid_h + pad_h;
   int64_t padded_w = llm_grid_w + pad_w;
 
-  // Use division-based overflow check: grid_t * padded_h * padded_w <= kMaxElements
-  if (padded_h > 0 && padded_w > 0 && grid_t > kMaxElements / padded_h / padded_w) {
-    throw std::runtime_error("CalculateWindowIndex: total grid size exceeds maximum allowed");
-  }
   int64_t alloc_size = grid_t * padded_h * padded_w;
 
   int64_t num_windows_h = padded_h / vit_merger_window_size;

--- a/src/models/qwen_vl_vision.cpp
+++ b/src/models/qwen_vl_vision.cpp
@@ -260,6 +260,15 @@ std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, in
 
   // Calculate window size at the merged resolution
   int64_t vit_merger_window_size = window_size_ / spatial_merge_size_ / patch_size_;
+  if (vit_merger_window_size <= 0) {
+    throw std::runtime_error("CalculateWindowIndex: vit_merger_window_size must be positive (check window_size, spatial_merge_size, patch_size config)");
+  }
+
+  // Validate merged grid dimensions before computing padding and allocation
+  constexpr int64_t kMaxElements = static_cast<int64_t>(1) << 30;  // ~1 billion elements, ~8GB
+  if (llm_grid_h > kMaxElements || llm_grid_w > kMaxElements || grid_t > kMaxElements) {
+    throw std::runtime_error("CalculateWindowIndex: grid dimensions are too large");
+  }
 
   // Calculate padding needed to fit into windows
   int64_t pad_h = (vit_merger_window_size - (llm_grid_h % vit_merger_window_size)) % vit_merger_window_size;
@@ -268,15 +277,11 @@ std::vector<int64_t> QwenVisionPipeline::CalculateWindowIndex(int64_t grid_t, in
   int64_t padded_h = llm_grid_h + pad_h;
   int64_t padded_w = llm_grid_w + pad_w;
 
-  // Check for integer overflow in allocation size: grid_t * padded_h * padded_w
-  constexpr int64_t kMaxElements = static_cast<int64_t>(1) << 30;  // ~1 billion elements, ~8GB
-  if (padded_h > kMaxElements || padded_w > kMaxElements || grid_t > kMaxElements) {
-    throw std::runtime_error("CalculateWindowIndex: grid dimensions are too large");
-  }
-  int64_t alloc_size = grid_t * padded_h * padded_w;
-  if (alloc_size > kMaxElements) {
+  // Use division-based overflow check: grid_t * padded_h * padded_w <= kMaxElements
+  if (padded_h > 0 && padded_w > 0 && grid_t > kMaxElements / padded_h / padded_w) {
     throw std::runtime_error("CalculateWindowIndex: total grid size exceeds maximum allowed");
   }
+  int64_t alloc_size = grid_t * padded_h * padded_w;
 
   int64_t num_windows_h = padded_h / vit_merger_window_size;
   int64_t num_windows_w = padded_w / vit_merger_window_size;

--- a/src/models/qwen_vl_vision.h
+++ b/src/models/qwen_vl_vision.h
@@ -12,6 +12,11 @@
 
 namespace Generators {
 
+// Validates grid dimensions and config parameters for the Qwen vision window indexing.
+// Throws std::runtime_error on invalid inputs. Exposed for unit testing.
+void ValidateWindowIndexParams(int64_t grid_t, int64_t grid_h, int64_t grid_w,
+                               int64_t spatial_merge_size, int64_t patch_size, int64_t window_size);
+
 // Internal vision pipeline (no external DLL interface required after Python binding removal).
 struct QwenVisionPipeline {
   QwenVisionPipeline(OrtEnv& env,

--- a/src/models/qwen_vl_vision.h
+++ b/src/models/qwen_vl_vision.h
@@ -7,15 +7,44 @@
 #include <vector>
 #include <memory>
 #include <cstdint>
+#include <stdexcept>
 
 #include "onnxruntime_api.h"
 
 namespace Generators {
 
 // Validates grid dimensions and config parameters for the Qwen vision window indexing.
-// Throws std::runtime_error on invalid inputs. Exposed for unit testing.
-void ValidateWindowIndexParams(int64_t grid_t, int64_t grid_h, int64_t grid_w,
-                               int64_t spatial_merge_size, int64_t patch_size, int64_t window_size);
+// Throws std::runtime_error on invalid inputs.
+// Defined inline in the header so that unit tests can call it directly without requiring
+// DLL export, since this is a free function not part of the public C API.
+inline void ValidateWindowIndexParams(int64_t grid_t, int64_t grid_h, int64_t grid_w,
+                                      int64_t spatial_merge_size, int64_t patch_size, int64_t window_size) {
+  if (spatial_merge_size <= 0)
+    throw std::runtime_error("CalculateWindowIndex: spatial_merge_size must be positive");
+  if (patch_size <= 0)
+    throw std::runtime_error("CalculateWindowIndex: patch_size must be positive");
+  if (grid_t <= 0 || grid_h <= 0 || grid_w <= 0)
+    throw std::runtime_error("CalculateWindowIndex: grid dimensions must be positive");
+  if (grid_h % spatial_merge_size != 0 || grid_w % spatial_merge_size != 0)
+    throw std::runtime_error("CalculateWindowIndex: grid_h and grid_w must be divisible by spatial_merge_size");
+
+  int64_t vit_merger_window_size = window_size / spatial_merge_size / patch_size;
+  if (vit_merger_window_size <= 0)
+    throw std::runtime_error("CalculateWindowIndex: vit_merger_window_size must be positive (check window_size, spatial_merge_size, patch_size config)");
+
+  constexpr int64_t kMaxElements = static_cast<int64_t>(1) << 30;
+  int64_t llm_grid_h = grid_h / spatial_merge_size;
+  int64_t llm_grid_w = grid_w / spatial_merge_size;
+  if (llm_grid_h > kMaxElements || llm_grid_w > kMaxElements || grid_t > kMaxElements)
+    throw std::runtime_error("CalculateWindowIndex: grid dimensions are too large");
+
+  int64_t pad_h = (vit_merger_window_size - (llm_grid_h % vit_merger_window_size)) % vit_merger_window_size;
+  int64_t pad_w = (vit_merger_window_size - (llm_grid_w % vit_merger_window_size)) % vit_merger_window_size;
+  int64_t padded_h = llm_grid_h + pad_h;
+  int64_t padded_w = llm_grid_w + pad_w;
+  if (padded_h > 0 && padded_w > 0 && grid_t > kMaxElements / padded_h / padded_w)
+    throw std::runtime_error("CalculateWindowIndex: total grid size exceeds maximum allowed");
+}
 
 // Internal vision pipeline (no external DLL interface required after Python binding removal).
 struct QwenVisionPipeline {

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -484,25 +484,6 @@ Print all primes between 1 and n
 
 // --- Validation tests (no model files required) ---
 
-TEST(ValidationTests, ValidateConfigPathAcceptsRelative) {
-  EXPECT_NO_THROW(Generators::ValidateConfigPath("model.onnx", "filename"));
-  EXPECT_NO_THROW(Generators::ValidateConfigPath("subdir/model.onnx", "filename"));
-  EXPECT_NO_THROW(Generators::ValidateConfigPath("./model.onnx", "filename"));
-}
-
-TEST(ValidationTests, ValidateConfigPathRejectsAbsolute) {
-  EXPECT_THROW(Generators::ValidateConfigPath("/etc/passwd", "filename"), std::runtime_error);
-#if defined(_WIN32)
-  EXPECT_THROW(Generators::ValidateConfigPath("C:\\Windows\\System32\\evil.dll", "filename"), std::runtime_error);
-#endif
-}
-
-TEST(ValidationTests, ValidateConfigPathRejectsTraversal) {
-  EXPECT_THROW(Generators::ValidateConfigPath("../../../etc/passwd", "filename"), std::runtime_error);
-  EXPECT_THROW(Generators::ValidateConfigPath("subdir/../../etc/passwd", "filename"), std::runtime_error);
-  EXPECT_THROW(Generators::ValidateConfigPath("..", "filename"), std::runtime_error);
-}
-
 TEST(ValidationTests, WindowIndexAcceptsValidParams) {
   EXPECT_NO_THROW(Generators::ValidateWindowIndexParams(1, 28, 28, 2, 14, 112));
   EXPECT_NO_THROW(Generators::ValidateWindowIndexParams(1, 2, 2, 2, 14, 56));
@@ -532,10 +513,11 @@ TEST(ValidationTests, WindowIndexRejectsZeroMergerWindowSize) {
 }
 
 TEST(ValidationTests, WindowIndexRejectsExcessiveDimensions) {
-  int64_t huge = static_cast<int64_t>(1) << 31;
+  int64_t huge = (static_cast<int64_t>(1) << 31) + 2;  // After /2, llm_grid_h > kMaxElements (1<<30)
   EXPECT_THROW(Generators::ValidateWindowIndexParams(1, huge, 2, 2, 14, 112), std::runtime_error);
 }
 
 TEST(ValidationTests, WindowIndexRejectsTotalSizeOverflow) {
-  EXPECT_THROW(Generators::ValidateWindowIndexParams(1000, 2000, 2000, 2, 14, 112), std::runtime_error);
+  // Each dim individually <= kMaxElements, but grid_t * padded_h * padded_w > kMaxElements
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1000, 2000000, 2000000, 2, 14, 112), std::runtime_error);
 }

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -13,6 +13,9 @@
 #include <ort_genai.h>
 #include <gtest/gtest.h>
 
+#include "models/model.h"
+#include "models/qwen_vl_vision.h"
+
 #include "test_utils.h"
 
 // External global variable from main.cpp for custom model path
@@ -478,3 +481,61 @@ Print all primes between 1 and n
   std::cout << tokenizer->Decode(result) << "\r\n";
 }
 #endif
+
+// --- Validation tests (no model files required) ---
+
+TEST(ValidationTests, ValidateConfigPathAcceptsRelative) {
+  EXPECT_NO_THROW(Generators::ValidateConfigPath("model.onnx", "filename"));
+  EXPECT_NO_THROW(Generators::ValidateConfigPath("subdir/model.onnx", "filename"));
+  EXPECT_NO_THROW(Generators::ValidateConfigPath("./model.onnx", "filename"));
+}
+
+TEST(ValidationTests, ValidateConfigPathRejectsAbsolute) {
+  EXPECT_THROW(Generators::ValidateConfigPath("/etc/passwd", "filename"), std::runtime_error);
+#if defined(_WIN32)
+  EXPECT_THROW(Generators::ValidateConfigPath("C:\\Windows\\System32\\evil.dll", "filename"), std::runtime_error);
+#endif
+}
+
+TEST(ValidationTests, ValidateConfigPathRejectsTraversal) {
+  EXPECT_THROW(Generators::ValidateConfigPath("../../../etc/passwd", "filename"), std::runtime_error);
+  EXPECT_THROW(Generators::ValidateConfigPath("subdir/../../etc/passwd", "filename"), std::runtime_error);
+  EXPECT_THROW(Generators::ValidateConfigPath("..", "filename"), std::runtime_error);
+}
+
+TEST(ValidationTests, WindowIndexAcceptsValidParams) {
+  EXPECT_NO_THROW(Generators::ValidateWindowIndexParams(1, 28, 28, 2, 14, 112));
+  EXPECT_NO_THROW(Generators::ValidateWindowIndexParams(1, 2, 2, 2, 14, 56));
+}
+
+TEST(ValidationTests, WindowIndexRejectsZeroDivisors) {
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, 28, 28, 0, 14, 112), std::runtime_error);
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, 28, 28, -1, 14, 112), std::runtime_error);
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, 28, 28, 2, 0, 112), std::runtime_error);
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, 28, 28, 2, -14, 112), std::runtime_error);
+}
+
+TEST(ValidationTests, WindowIndexRejectsInvalidGridDims) {
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(0, 28, 28, 2, 14, 112), std::runtime_error);
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, -28, 28, 2, 14, 112), std::runtime_error);
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, 28, 0, 2, 14, 112), std::runtime_error);
+}
+
+TEST(ValidationTests, WindowIndexRejectsNonDivisibleGrid) {
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, 27, 28, 2, 14, 112), std::runtime_error);
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, 28, 27, 2, 14, 112), std::runtime_error);
+}
+
+TEST(ValidationTests, WindowIndexRejectsZeroMergerWindowSize) {
+  // window_size=1 / spatial_merge_size=2 / patch_size=14 = 0
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, 28, 28, 2, 14, 1), std::runtime_error);
+}
+
+TEST(ValidationTests, WindowIndexRejectsExcessiveDimensions) {
+  int64_t huge = static_cast<int64_t>(1) << 31;
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1, huge, 2, 2, 14, 112), std::runtime_error);
+}
+
+TEST(ValidationTests, WindowIndexRejectsTotalSizeOverflow) {
+  EXPECT_THROW(Generators::ValidateWindowIndexParams(1000, 2000, 2000, 2, 14, 112), std::runtime_error);
+}


### PR DESCRIPTION
This pull request adds important validation and safety checks to the `QwenVisionPipeline::CalculateWindowIndex` function in `src/models/qwen_vl_vision.cpp`. The changes are focused on improving robustness by validating input dimensions and preventing integer overflows during memory allocation.

**Input Validation and Safety Improvements:**

* Added checks to ensure that all grid dimensions (`grid_t`, `grid_h`, `grid_w`) are positive; throws an exception if not.
* Added upper bounds for grid dimensions and total allocation size to prevent integer overflow and excessive memory usage (limits each dimension and the total number of elements to ~1 billion). Throws exceptions if exceeded.
* Refactored allocation and indexing logic to use the new validated and padded dimensions, improving clarity and safety. [[1]](diffhunk://#diff-a6f6231999dd369ccb24bdb364bd552aa89589dc3450bfdaa3e58a2cfe2d4ab2L263-R295) [[2]](diffhunk://#diff-a6f6231999dd369ccb24bdb364bd552aa89589dc3450bfdaa3e58a2cfe2d4ab2L293-R311)