### PR TITLE
Fix divide by zero error

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -338,6 +338,11 @@ std::shared_ptr<Tensor> Tokenizer::EncodeBatch(std::span<const char*> strings) c
   if (strings.empty()) {
     throw std::runtime_error("EncodeBatch: input strings must not be empty");
   }
+  for (size_t i = 0; i < strings.size(); i++) {
+    if (strings[i] == nullptr) {
+      throw std::runtime_error("EncodeBatch: input string at index " + std::to_string(i) + " must not be null");
+    }
+  }
 
   std::vector<std::vector<int32_t>> sequences;
   std::vector<std::span<const int32_t>> span_sequences;

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -335,6 +335,10 @@ std::vector<int32_t> Tokenizer::EncodeBatch(std::span<const std::string> strings
 }
 
 std::shared_ptr<Tensor> Tokenizer::EncodeBatch(std::span<const char*> strings) const {
+  if (strings.empty()) {
+    throw std::runtime_error("EncodeBatch: input strings must not be empty");
+  }
+
   std::vector<std::vector<int32_t>> sequences;
   std::vector<std::span<const int32_t>> span_sequences;
   for (size_t i = 0; i < strings.size(); i++) {

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -662,6 +662,8 @@ OgaResult* OGA_API_CALL OgaTokenizerEncode(const OgaTokenizer* tokenizer, const 
 
 OgaResult* OGA_API_CALL OgaTokenizerEncodeBatch(const OgaTokenizer* tokenizer, const char** strings, size_t count, OgaTensor** out) {
   OGA_TRY
+  if (count > 0 && strings == nullptr)
+    throw std::runtime_error("EncodeBatch: strings pointer must not be null when count > 0");
   auto tensor = tokenizer->EncodeBatch(std::span<const char*>(strings, count));
   *out = ReturnShared<OgaTensor>(tensor);
   return nullptr;

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -133,6 +133,16 @@ TEST(CAPITests, TokenizerCAPI) {
 #endif
 }
 
+TEST(CAPITests, EncodeBatchEmptyInputThrows) {
+#if TEST_PHI2
+  auto model = OgaModel::Create(PHI2_PATH);
+  auto tokenizer = OgaTokenizer::Create(*model);
+
+  // EncodeBatch with zero strings should throw, not crash with SIGFPE
+  ASSERT_THROW(tokenizer->EncodeBatch(nullptr, 0), std::runtime_error);
+#endif
+}
+
 TEST(CAPITests, TokenizerUpdateOptions) {
 #if TEST_PHI2
   auto config = OgaConfig::Create(PHI2_PATH);

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -140,6 +140,11 @@ TEST(CAPITests, EncodeBatchEmptyInputThrows) {
 
   // EncodeBatch with zero strings should throw, not crash with SIGFPE
   ASSERT_THROW(tokenizer->EncodeBatch(nullptr, 0), std::runtime_error);
+
+  // Invalid pointers with count > 0 should also be rejected deterministically.
+  ASSERT_THROW(tokenizer->EncodeBatch(nullptr, 1), std::runtime_error);
+  const char* bad_strings[] = {nullptr};
+  ASSERT_THROW(tokenizer->EncodeBatch(bad_strings, 1), std::runtime_error);
 #endif
 }
 


### PR DESCRIPTION
This pull request improves error handling for the `EncodeBatch` function in the tokenizer by adding input validation and corresponding unit tests. The main goal is to prevent crashes when the function is called with empty input.

**Error handling improvements:**

* [`src/models/model.cpp`](diffhunk://#diff-3da792c72182817b1bdb08f4ec7eb7687fa19d9219aea8ccfdb310a1061a5c7bR338-R341): Added a check in `Tokenizer::EncodeBatch` to throw a `std::runtime_error` if the input string list is empty, preventing a crash when called with no input strings.

**Testing enhancements:**

* [`test/c_api_tests.cpp`](diffhunk://#diff-75846cf69fad01c861880f6fc4a0a9e4c5506b3142a15924beb4eef7c876ac7eR136-R145): Added a new test (`EncodeBatchEmptyInputThrows`) to verify that calling `EncodeBatch` with zero input strings throws a `std::runtime_error` instead of causing a crash.