### PR TITLE
Add option of fp4 QMoE for gpt-oss in model builder

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -468,6 +468,11 @@ def get_args():
                     This affects attention mask reformatting and position IDs handling.
                 use_8bits_moe = Use 8-bit quantization for MoE layers. Default is false.
                     If true, the QMoE op will use 8-bit quantization. If false, the QMoE op will use 4-bit quantization.
+                use_fp4_moe = Use FP4 (MXFP4) quantization for MoE layers on the CUDA EP. Default is false.
+                    If true, the QMoE op uses MXFP4 weights (quant_type="fp4", expert_weight_bits=4, block_size=32):
+                    4-bit e2m1 weights with ue8m0 (float8e8m0) block scales and a per-expert float32 global scale.
+                    Requires an ONNX Runtime build with onnxruntime_USE_FP4_QMOE=ON (CUDA Toolkit 12.8+).
+                    Mutually exclusive with use_8bits_moe. Only supported on the CUDA EP.
                 use_qdq = Use the QDQ decomposition for ops.
                     Use this option when you want to use quantize-dequantize ops. For example, you will have a quantized MatMul op instead of the MatMulNBits op.
                 use_webgpu_fp32 = Use FP32 I/O precision for WebGPU EP.

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -3229,16 +3229,19 @@ class Model:
         if "block_size" in self.moe_attrs:
             extra_kwargs["block_size"] = self.moe_attrs["block_size"]
 
-        # The builder ships raw, un-prepacked [E, N, K/pack] quantized expert
-        # weights (as produced by _symmetric_blockwise_quantize / quantize_matmul).
-        # The CUDA QMoE op defaults to interpreting weights as already
-        # CUTLASS-prepacked (weights_prepacked=-1/auto), so the raw layout must be
-        # flagged explicitly with weights_prepacked=0 to trigger the in-PrePack
-        # layout transform. This attribute requires an ONNX Runtime build that
-        # includes the QMoE PrePack hook (com.microsoft QMoE weights_prepacked
-        # tri-state); it is only meaningful for integer (INT4/INT8) QMoE.
+        # weights_prepacked is a tri-state CUDA QMoE attribute describing the
+        # expert-weight layout (see make_qmoe_weights, which produces the matching
+        # bytes):
+        #   None/auto -> omit the attribute; the op treats weights as already
+        #                CUTLASS-prepacked, which is what the builder ships for CUDA.
+        #   1         -> weights are CUTLASS-prepacked (explicit form of the above).
+        #   0         -> weights are raw [E, N, K/pack]; the runtime PrePack hook
+        #                transforms them at load time.
+        # It is only meaningful for integer (INT4/INT8) CUDA QMoE and requires an
+        # ONNX Runtime build with the com.microsoft QMoE PrePack hook, so only
+        # emit it on the CUDA EP.
         weights_prepacked = self.moe_attrs.get("weights_prepacked")
-        if weights_prepacked is not None:
+        if weights_prepacked is not None and self.ep == "cuda":
             extra_kwargs["weights_prepacked"] = weights_prepacked
 
         self.make_node(
@@ -3263,21 +3266,27 @@ class Model:
         dtype = torch.quint4x2 if self.moe_attrs["expert_weight_bits"] == 4 else torch.int8
         qweight, scales = None, None
 
+        weights_prepacked = self.moe_attrs.get("weights_prepacked")
+
         # CUDA QMoE consumes CUTLASS-prepacked expert weights (the kernel's
-        # fpA_intB mixed GEMM layout). Produce them offline so the QMoE op's
-        # default (weights_prepacked=auto=prepacked) reads them directly: quantize
-        # with ONNX Runtime's blockwise quantizer, keep the signed scales, then run
-        # pack_weights_for_cuda_mixed_gemm. This is the encoding validated by the
-        # com.microsoft QMoE CUDA parity tests. The builder's own
-        # _symmetric_blockwise_quantize uses a different scale/packing convention
-        # the kernel cannot consume.
-        if self.ep == "cuda" and self.moe_attrs.get("weights_prepacked") is None and self.qmoe_block_size > 0:
+        # fpA_intB mixed GEMM layout). Produce them offline so the QMoE op reads
+        # them directly: quantize with ONNX Runtime's blockwise quantizer, keep
+        # the signed scales, then run pack_weights_for_cuda_mixed_gemm. This is
+        # the encoding validated by the com.microsoft QMoE CUDA parity tests. The
+        # builder's own _symmetric_blockwise_quantize uses a different
+        # scale/packing convention the kernel cannot consume.
+        #
+        # Both weights_prepacked=None (auto, the op's prepacked default) and
+        # weights_prepacked=1 (explicitly prepacked) mean the op reads prepacked
+        # weights, so the builder must produce prepacked weights for both.
+        if self.ep == "cuda" and weights_prepacked in (None, 1) and self.qmoe_block_size > 0:
             block_size = int(self.qmoe_block_size)
             # The CUDA QMoE fpA_intB mixed-GEMM kernel only supports block sizes
-            # of 64 or 128 for block-wise quantization.
-            assert block_size in (64, 128), (
-                f"CUDA QMoE only supports block_size 64 or 128, got {block_size}."
-            )
+            # of 64 or 128. Use an explicit check (not assert, which python -O
+            # strips) so an unsupported value fails loudly instead of producing an
+            # invalid export.
+            if block_size not in (64, 128):
+                raise ValueError(f"CUDA QMoE only supports block_size 64 or 128, got {block_size}.")
             try:
                 qweight, scales = self._cutlass_prepacked_blockwise_quantize(weights, block_size)
                 self.moe_attrs["block_size"] = block_size
@@ -3285,16 +3294,15 @@ class Model:
             except Exception as e:
                 raise RuntimeError(f"CUTLASS-prepacked QMoE quantization failed with block_size={block_size}: {e}")
 
-        # When the model targets the raw (un-prepacked) QMoE weight layout
-        # (weights_prepacked == 0), produce weights with ONNX Runtime's
-        # MatMulNBits-compatible blockwise quantizer. This is the exact
-        # encoding the QMoE PrePack hook (com.microsoft QMoE) expects: raw
-        # [N, K/pack] bytes + positive blockwise scales, which it then lays out
-        # into the CUTLASS fpA_intB format at load time. The builder's own
-        # _symmetric_blockwise_quantize uses a different scale/packing
-        # convention that the kernel cannot consume.
-        if self.moe_attrs.get("weights_prepacked") == 0 and self.qmoe_block_size > 0:
+        # weights_prepacked == 0: ship raw [N, K/pack] weights with ONNX Runtime's
+        # MatMulNBits-compatible blockwise quantizer. This is the exact encoding
+        # the CUDA QMoE PrePack hook (com.microsoft QMoE) expects: raw bytes +
+        # blockwise scales, which it lays out into the CUTLASS fpA_intB format at
+        # load time. Only valid on the CUDA EP.
+        if self.ep == "cuda" and weights_prepacked == 0 and self.qmoe_block_size > 0:
             block_size = int(self.qmoe_block_size)
+            if block_size not in (64, 128):
+                raise ValueError(f"CUDA QMoE only supports block_size 64 or 128, got {block_size}.")
             try:
                 qweight, scales = self._matmulnbits_blockwise_quantize(weights, block_size)
                 self.moe_attrs["block_size"] = block_size
@@ -3353,8 +3361,10 @@ class Model:
         ``weights`` has logical shape ``[N, K]`` (quantized along ``K``). Returns
         ``(qweight, scales)`` where ``qweight`` is the prepacked uint8 tensor of
         shape ``[K, N/pack]`` (``pack`` = 2 for INT4, 1 for INT8) and ``scales``
-        is ``[N, K/block_size]`` positive float scales. Stacking the per-expert
-        results yields ``fc_weights`` ``[E, K, N/pack]`` and ``scales``
+        is ``[N, K/block_size]`` SIGNED float scales. The sign is required: the
+        CUDA kernel dequantizes as ``(q - 2^(bits-1)) * scale``, so abs() would
+        corrupt every block whose max-magnitude element is negative. Stacking the
+        per-expert results yields ``fc_weights`` ``[E, K, N/pack]`` and ``scales``
         ``[E, N, K/block_size]`` — the layout the QMoE op reads when
         ``weights_prepacked`` is left at its prepacked default.
         """

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -3282,11 +3282,11 @@ class Model:
         if self.ep == "cuda" and weights_prepacked in (None, 1) and self.qmoe_block_size > 0:
             block_size = int(self.qmoe_block_size)
             # The CUDA QMoE fpA_intB mixed-GEMM kernel only supports block sizes
-            # of 64 or 128. Use an explicit check (not assert, which python -O
+            # of 32, 64 or 128. Use an explicit check (not assert, which python -O
             # strips) so an unsupported value fails loudly instead of producing an
             # invalid export.
-            if block_size not in (64, 128):
-                raise ValueError(f"CUDA QMoE only supports block_size 64 or 128, got {block_size}.")
+            if block_size not in (32, 64, 128):
+                raise ValueError(f"CUDA QMoE only supports block_size 32, 64 or 128, got {block_size}.")
             try:
                 qweight, scales = self._cutlass_prepacked_blockwise_quantize(weights, block_size)
                 self.moe_attrs["block_size"] = block_size
@@ -3301,8 +3301,8 @@ class Model:
         # load time. Only valid on the CUDA EP.
         if self.ep == "cuda" and weights_prepacked == 0 and self.qmoe_block_size > 0:
             block_size = int(self.qmoe_block_size)
-            if block_size not in (64, 128):
-                raise ValueError(f"CUDA QMoE only supports block_size 64 or 128, got {block_size}.")
+            if block_size not in (32, 64, 128):
+                raise ValueError(f"CUDA QMoE only supports block_size 32, 64 or 128, got {block_size}.")
             try:
                 qweight, scales = self._matmulnbits_blockwise_quantize(weights, block_size)
                 self.moe_attrs["block_size"] = block_size

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -304,6 +304,13 @@ class Model:
         top_k_experts = config.num_experts_per_tok if hasattr(config, "num_experts_per_tok") else 0
         expert_weight_bits = 8 if extra_options.get("use_8bits_moe", False) else 4
         swiglu_limit = config.swiglu_limit if hasattr(config, "swiglu_limit") else None
+        # For CUDA QMoE the builder ships expert weights already CUTLASS-prepacked
+        # (offline via pack_weights_for_cuda_mixed_gemm, see make_qmoe_weights), so
+        # the QMoE op's default interpretation (weights_prepacked=-1/auto =
+        # prepacked) is exactly what we want and the attribute is omitted (None).
+        # Override via extra_options["qmoe_weights_prepacked"] (e.g. 0 to ship raw
+        # [E, N, K/pack] weights and let the runtime PrePack hook transform them).
+        weights_prepacked = int(extra_options["qmoe_weights_prepacked"]) if "qmoe_weights_prepacked" in extra_options else None
         self.moe_attrs = {
             "op_type": moe_op_type,                          # MoE op to use
             "num_experts": num_experts,                      # Number of experts in MoE layer
@@ -316,6 +323,7 @@ class Model:
             "swiglu_fusion": 0,                              # Fusion level for SwiGLU activation function
             "swiglu_limit": swiglu_limit,                    # Value used to clamp results into a certain range in SwiGLU activation function
             "use_sparse_mixer": False,                       # Use SparseMixer in MoE layer (used in Phi-3.5 MoE)
+            "weights_prepacked": weights_prepacked,          # QMoE int weight layout: 0=raw [E,N,K/pack], 1=CUTLASS-prepacked, -1/None=auto (omit attr)
         }
 
         # LM head-specific variables
@@ -3221,6 +3229,18 @@ class Model:
         if "block_size" in self.moe_attrs:
             extra_kwargs["block_size"] = self.moe_attrs["block_size"]
 
+        # The builder ships raw, un-prepacked [E, N, K/pack] quantized expert
+        # weights (as produced by _symmetric_blockwise_quantize / quantize_matmul).
+        # The CUDA QMoE op defaults to interpreting weights as already
+        # CUTLASS-prepacked (weights_prepacked=-1/auto), so the raw layout must be
+        # flagged explicitly with weights_prepacked=0 to trigger the in-PrePack
+        # layout transform. This attribute requires an ONNX Runtime build that
+        # includes the QMoE PrePack hook (com.microsoft QMoE weights_prepacked
+        # tri-state); it is only meaningful for integer (INT4/INT8) QMoE.
+        weights_prepacked = self.moe_attrs.get("weights_prepacked")
+        if weights_prepacked is not None:
+            extra_kwargs["weights_prepacked"] = weights_prepacked
+
         self.make_node(
             "QMoE",
             inputs=inputs,
@@ -3242,6 +3262,45 @@ class Model:
     def make_qmoe_weights(self, weights):
         dtype = torch.quint4x2 if self.moe_attrs["expert_weight_bits"] == 4 else torch.int8
         qweight, scales = None, None
+
+        # CUDA QMoE consumes CUTLASS-prepacked expert weights (the kernel's
+        # fpA_intB mixed GEMM layout). Produce them offline so the QMoE op's
+        # default (weights_prepacked=auto=prepacked) reads them directly: quantize
+        # with ONNX Runtime's blockwise quantizer, keep the signed scales, then run
+        # pack_weights_for_cuda_mixed_gemm. This is the encoding validated by the
+        # com.microsoft QMoE CUDA parity tests. The builder's own
+        # _symmetric_blockwise_quantize uses a different scale/packing convention
+        # the kernel cannot consume.
+        if self.ep == "cuda" and self.moe_attrs.get("weights_prepacked") is None and self.qmoe_block_size > 0:
+            block_size = int(self.qmoe_block_size)
+            # The CUDA QMoE fpA_intB mixed-GEMM kernel only supports block sizes
+            # of 64 or 128 for block-wise quantization.
+            assert block_size in (64, 128), (
+                f"CUDA QMoE only supports block_size 64 or 128, got {block_size}."
+            )
+            try:
+                qweight, scales = self._cutlass_prepacked_blockwise_quantize(weights, block_size)
+                self.moe_attrs["block_size"] = block_size
+                return qweight, scales.to(torch.float16)
+            except Exception as e:
+                raise RuntimeError(f"CUTLASS-prepacked QMoE quantization failed with block_size={block_size}: {e}")
+
+        # When the model targets the raw (un-prepacked) QMoE weight layout
+        # (weights_prepacked == 0), produce weights with ONNX Runtime's
+        # MatMulNBits-compatible blockwise quantizer. This is the exact
+        # encoding the QMoE PrePack hook (com.microsoft QMoE) expects: raw
+        # [N, K/pack] bytes + positive blockwise scales, which it then lays out
+        # into the CUTLASS fpA_intB format at load time. The builder's own
+        # _symmetric_blockwise_quantize uses a different scale/packing
+        # convention that the kernel cannot consume.
+        if self.moe_attrs.get("weights_prepacked") == 0 and self.qmoe_block_size > 0:
+            block_size = int(self.qmoe_block_size)
+            try:
+                qweight, scales = self._matmulnbits_blockwise_quantize(weights, block_size)
+                self.moe_attrs["block_size"] = block_size
+                return qweight, scales.to(torch.float16)
+            except Exception as e:
+                raise RuntimeError(f"MatMulNBits-compatible QMoE quantization failed with block_size={block_size}: {e}")
 
         # Use block-wise quantization for supported EPs when qmoe_block_size > 0.
         # CUDA and TRT-RTX default to 128; others default to 32.
@@ -3286,6 +3345,92 @@ class Model:
                 )
 
         return qweight, scales.to(torch.float16)
+
+    def _cutlass_prepacked_blockwise_quantize(self, weights, block_size):
+        """Quantize a single expert's weights and CUTLASS-prepack them for the
+        CUDA QMoE fpA_intB mixed-GEMM kernel.
+
+        ``weights`` has logical shape ``[N, K]`` (quantized along ``K``). Returns
+        ``(qweight, scales)`` where ``qweight`` is the prepacked uint8 tensor of
+        shape ``[K, N/pack]`` (``pack`` = 2 for INT4, 1 for INT8) and ``scales``
+        is ``[N, K/block_size]`` positive float scales. Stacking the per-expert
+        results yields ``fc_weights`` ``[E, K, N/pack]`` and ``scales``
+        ``[E, N, K/block_size]`` — the layout the QMoE op reads when
+        ``weights_prepacked`` is left at its prepacked default.
+        """
+        import numpy as np
+        from onnxruntime.capi import _pybind_state as _ortpyb
+
+        bits = int(self.moe_attrs["expert_weight_bits"])
+        w = weights.detach().cpu().to(torch.float32).contiguous().numpy()
+        n, k = w.shape
+        if k % block_size != 0:
+            raise ValueError(f"K ({k}) must be divisible by block_size ({block_size}) for QMoE blockwise quantization.")
+        num_blocks = k // block_size
+        pack = 8 // bits
+
+        # quantize_matmul_{4,8}bits expects the weight transposed to [K, N]
+        # (column = output channel), quantizing each column along K.
+        w_t = np.ascontiguousarray(w.T)  # [K, N]
+        qweight = np.zeros((n, num_blocks, block_size // pack), dtype=np.uint8)
+        scales = np.zeros((n, num_blocks), dtype=np.float32)
+        zero_points = np.zeros((n, (num_blocks + 1) // 2 if bits == 4 else num_blocks), dtype=np.uint8)
+
+        quantize = _ortpyb.quantize_matmul_4bits if bits == 4 else _ortpyb.quantize_matmul_8bits
+        # signature: (qweight, weight[K,N], scales, zero_points, block_size, N, K, is_symmetric)
+        quantize(qweight, w_t, scales, zero_points, block_size, n, k, True)
+
+        # quantize_matmul_{4,8}bits returns SIGNED blockwise scales (the scale
+        # carries the sign of the block's max-magnitude element). The CUDA QMoE
+        # kernel dequantizes as (q - 2^(bits-1)) * scale, so the sign MUST be
+        # preserved — taking abs() here corrupts every block whose anchor element
+        # is negative and yields garbage weights.
+
+        # CUTLASS-prepack with force_arch=80: the fpA_intB kernel always expects
+        # the SM80-style interleaved layout for SM >= 80 (validated on SM89/SM90),
+        # so 80 is the correct universal choice regardless of build/runtime GPU.
+        q_reshaped = qweight.reshape(n, -1)  # [N, K/pack]
+        packed = _ortpyb.pack_weights_for_cuda_mixed_gemm(q_reshaped, n, k, bits, 80)
+        out_cols = n // pack
+        packed = np.asarray(packed).view(np.uint8).reshape(k, out_cols)  # [K, N/pack]
+
+        return torch.from_numpy(np.ascontiguousarray(packed)), torch.from_numpy(scales)
+
+    def _matmulnbits_blockwise_quantize(self, weights, block_size):
+        """Quantize per-expert weights with ONNX Runtime's MatMulNBits blockwise
+        quantizer, matching the encoding the QMoE PrePack hook expects.
+
+        ``weights`` is a single expert's weight of logical shape ``[N, K]``
+        (quantized along the last/``K`` axis). Returns ``(qweight, scales)`` where
+        ``qweight`` is ``[N, K/pack]`` uint8 (2 INT4 elements per byte; INT8 is
+        one element per byte) and ``scales`` is ``[N, K/block_size]`` positive
+        float scales — the same layout produced by ``quantize_matmul_{4,8}bits``.
+        """
+        import numpy as np
+        from onnxruntime.capi import _pybind_state as _ortpyb
+
+        bits = int(self.moe_attrs["expert_weight_bits"])
+        w = weights.detach().cpu().to(torch.float32).contiguous().numpy()
+        n, k = w.shape
+        if k % block_size != 0:
+            raise ValueError(f"K ({k}) must be divisible by block_size ({block_size}) for QMoE blockwise quantization.")
+        num_blocks = k // block_size
+        pack = 8 // bits
+
+        # quantize_matmul_{4,8}bits expects the weight transposed to [K, N]
+        # (column = output channel), quantizing each column along K.
+        w_t = np.ascontiguousarray(w.T)  # [K, N]
+        qweight = np.zeros((n, k // pack), dtype=np.uint8)
+        scales = np.zeros((n, num_blocks), dtype=np.float32)
+        zero_points = np.zeros((n, (num_blocks + 1) // 2 if bits == 4 else num_blocks), dtype=np.uint8)
+
+        quantize = _ortpyb.quantize_matmul_4bits if bits == 4 else _ortpyb.quantize_matmul_8bits
+        # signature: (qweight, weight[K,N], scales, zero_points, block_size, N, K, is_symmetric)
+        quantize(qweight, w_t, scales, zero_points, block_size, n, k, True)
+
+        # The kernel applies (q - 2^(bits-1)) * scale, so scales must be positive.
+        scales = np.abs(scales)
+        return torch.from_numpy(qweight), torch.from_numpy(scales)
 
     def _symmetric_blockwise_quantize(self, weights, block_size):
         # Ensure weights are on CPU for quantization

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -302,7 +302,15 @@ class Model:
         moe_op_type = "QMoE" if self.onnx_dtype == ir.DataType.INT4 else "MoE"
         num_experts = config.num_local_experts if hasattr(config, "num_local_experts") else 0
         top_k_experts = config.num_experts_per_tok if hasattr(config, "num_experts_per_tok") else 0
-        expert_weight_bits = 8 if extra_options.get("use_8bits_moe", False) else 4
+        use_fp4_moe = extra_options.get("use_fp4_moe", False)
+        if use_fp4_moe and extra_options.get("use_8bits_moe", False):
+            raise ValueError("use_fp4_moe and use_8bits_moe are mutually exclusive.")
+        if use_fp4_moe and self.ep != "cuda":
+            raise ValueError(f"use_fp4_moe is only supported on the CUDA EP, got ep='{self.ep}'.")
+        # FP4 (MXFP4) is a 4-bit format; INT8 path is disabled when FP4 is requested.
+        expert_weight_bits = 4 if use_fp4_moe else (8 if extra_options.get("use_8bits_moe", False) else 4)
+        # QMoE quantization type: "int" (default INT4/INT8) or "fp4" (MXFP4).
+        moe_quant_type = "fp4" if use_fp4_moe else "int"
         swiglu_limit = config.swiglu_limit if hasattr(config, "swiglu_limit") else None
         # For CUDA QMoE the builder ships expert weights already CUTLASS-prepacked
         # (offline via pack_weights_for_cuda_mixed_gemm, see make_qmoe_weights), so
@@ -324,6 +332,7 @@ class Model:
             "swiglu_limit": swiglu_limit,                    # Value used to clamp results into a certain range in SwiGLU activation function
             "use_sparse_mixer": False,                       # Use SparseMixer in MoE layer (used in Phi-3.5 MoE)
             "weights_prepacked": weights_prepacked,          # QMoE int weight layout: 0=raw [E,N,K/pack], 1=CUTLASS-prepacked, -1/None=auto (omit attr)
+            "quant_type": moe_quant_type,                    # QMoE quantization type: "int" (INT4/INT8) or "fp4" (MXFP4).
         }
 
         # LM head-specific variables
@@ -338,7 +347,11 @@ class Model:
         # Quantization-specific variables (INT4, INT8, etc.)
         algo_config = self.make_algo_config(extra_options.get("int4_algo_config", "default"))
         self.matmul_block_size = int(extra_options.get("int4_block_size", 32))
-        self.qmoe_block_size = int(extra_options.get("qmoe_block_size", 128 if self.ep in {"cuda", "trt-rtx"} else 32))
+        # MXFP4 mandates a block size of 32; ignore any user override for FP4 QMoE.
+        if self.moe_attrs.get("quant_type") == "fp4":
+            self.qmoe_block_size = 32
+        else:
+            self.qmoe_block_size = int(extra_options.get("qmoe_block_size", 128 if self.ep in {"cuda", "trt-rtx"} else 32))
         self.quant_attrs = {
             "accuracy_level": int(extra_options.get("int4_accuracy_level", 4 if self.ep in ["cpu", "webgpu"] else 0)),
             "qmoe_block_size": int(self.qmoe_block_size),
@@ -3195,6 +3208,74 @@ class Model:
         )
         self.make_value(output, self.io_dtype, shape=["batch_size", "sequence_length", self.hidden_size])
 
+    def make_fp8e8m0_initializer(self, scales_uint8, name):
+        """Register a FLOAT8E8M0 initializer from raw ue8m0 code bytes (uint8).
+
+        MXFP4 block scales are stored as unsigned 8-bit exponents (ue8m0). torch has
+        no float8e8m0 dtype, so build the IR tensor directly from the raw uint8 bytes
+        and tag it FLOAT8E8M0 (the encoding the CUDA QMoE FP4 kernel expects).
+        """
+        arr = scales_uint8.detach().cpu().numpy().astype(np.uint8) if isinstance(scales_uint8, torch.Tensor) else np.asarray(scales_uint8, dtype=np.uint8)
+        ir_tensor = ir.Tensor(np.ascontiguousarray(arr), dtype=ir.DataType.FLOAT8E8M0, name=name)
+        value = self.make_value(name, ir_tensor.dtype, ir_tensor.shape)
+        value.const_value = ir_tensor
+        self.model.graph.register_initializer(value)
+
+    # Positive FP4 e2m1 representable magnitudes (codes 0-7); negatives use codes 8-15.
+    _FP4_E2M1_POS_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+    _FP4_E2M1_MAX = 6.0
+
+    def make_mxfp4_weights(self, weight, block_size=32):
+        """Quantize one expert weight matrix [N, K] to MXFP4 (FP4 e2m1 + ue8m0 scales).
+
+        Returns:
+            packed:       [K, N//2] uint8 — column-major packed FP4 codes (low nibble = even N).
+            block_scales: [N, K//block_size] uint8 — ue8m0 encoded block scales (FLOAT8E8M0 bytes).
+            global_scale: float — 1.0 for MXFP4.
+        """
+        n, k = weight.shape
+        if k % block_size != 0:
+            raise ValueError(f"MXFP4 requires K={k} divisible by block_size={block_size}.")
+        if n % 2 != 0:
+            raise ValueError(f"MXFP4 requires an even N={n} for nibble packing.")
+
+        w = weight.detach().float().cpu()
+        num_blocks = k // block_size
+        blocks = w.reshape(n, num_blocks, block_size)
+
+        # Per-block ue8m0 (power-of-two) scale. code 127 => scale 1.0 (used when amax==0).
+        block_amax = blocks.abs().amax(dim=-1)  # [N, num_blocks]
+        ideal = block_amax / self._FP4_E2M1_MAX
+        codes = torch.full((n, num_blocks), 127, dtype=torch.int64)
+        pos = ideal > 0
+        exps = torch.round(torch.log2(ideal[pos])).to(torch.int64) + 127
+        codes[pos] = torch.clamp(exps, 1, 254)
+        scales_float = torch.pow(2.0, (codes.float() - 127.0))  # all > 0
+
+        # Quantize each scaled value to the nearest FP4 e2m1 code.
+        scaled = blocks / scales_float.unsqueeze(-1)
+        fp4_codes = self._fp4_e2m1_codes(scaled).reshape(n, k)  # [N, K] uint8 codes 0-15
+
+        # Column-major pack: transpose to [K, N], pack pairs along N (even=low, odd=high).
+        codes_kn = fp4_codes.T.contiguous()  # [K, N]
+        low = codes_kn[:, 0::2].to(torch.uint8)
+        high = codes_kn[:, 1::2].to(torch.uint8)
+        packed = (high << 4) | low  # [K, N//2] uint8
+
+        return packed, codes.to(torch.uint8), 1.0
+
+    def _fp4_e2m1_codes(self, values):
+        """Map float values to nearest FP4 e2m1 4-bit codes (0-15). Sign bit is bit 3."""
+        pos_vals = torch.tensor(self._FP4_E2M1_POS_VALUES, dtype=torch.float32)
+        flat = values.float().reshape(-1)
+        sign = flat.sign()
+        absv = flat.abs().clamp(max=self._FP4_E2M1_MAX)
+        nearest_idx = (absv.unsqueeze(-1) - pos_vals.unsqueeze(0)).abs().argmin(dim=-1)  # 0-7
+        codes = nearest_idx.to(torch.uint8)
+        codes[sign < 0] += 8
+        codes[flat == 0] = 0
+        return codes.reshape(values.shape)
+
     def make_qmoe_op(self, name, **kwargs):
         inputs = [
             kwargs["root_input"],
@@ -3219,6 +3300,18 @@ class Model:
                 kwargs.get("zero_points3", ""),
             ])
 
+        is_fp4 = self.moe_attrs.get("quant_type") == "fp4"
+        if is_fp4:
+            # The FP4 (MXFP4) QMoE op consumes per-expert float32 global scales at
+            # fixed input positions 15 (fc1) and 16 (fc2). Positions 11-14 are the
+            # optional zero_points (11-13) and router_weights (14). The zero_points
+            # block above already appended inputs up to index 13 for non-TRT-RTX EPs
+            # (FP4 is CUDA-only); pad index 14 (router_weights) then add the globals.
+            while len(inputs) < 15:
+                inputs.append("")  # 14: router_weights (unused)
+            inputs.append(kwargs.get("global_scales1", ""))  # 15: fc1 global scale
+            inputs.append(kwargs.get("global_scales2", ""))  # 16: fc2 global scale
+
         output = f"{name}/output_0"
 
         extra_kwargs = (
@@ -3228,6 +3321,10 @@ class Model:
         # Only include block_size attribute if it was set
         if "block_size" in self.moe_attrs:
             extra_kwargs["block_size"] = self.moe_attrs["block_size"]
+
+        if is_fp4:
+            # Select the MXFP4 kernel path; integer QMoE leaves quant_type at its default.
+            extra_kwargs["quant_type"] = "fp4"
 
         # weights_prepacked is a tri-state CUDA QMoE attribute describing the
         # expert-weight layout (see make_qmoe_weights, which produces the matching
@@ -3241,7 +3338,7 @@ class Model:
         # ONNX Runtime build with the com.microsoft QMoE PrePack hook, so only
         # emit it on the CUDA EP.
         weights_prepacked = self.moe_attrs.get("weights_prepacked")
-        if weights_prepacked is not None and self.ep == "cuda":
+        if weights_prepacked is not None and self.ep == "cuda" and not is_fp4:
             extra_kwargs["weights_prepacked"] = weights_prepacked
 
         self.make_node(

--- a/src/python/py/models/builders/gptoss.py
+++ b/src/python/py/models/builders/gptoss.py
@@ -53,7 +53,9 @@ class GPTOSSModel(Model):
         super().make_layernorm(layer_id, layernorm, skip, simple, location)
 
     def make_rotary_embedding_caches_from_scratch(self):
-        inv_freq = self.rope_attrs["theta"] ** (torch.arange(0, self.head_size, 2, dtype=torch.float) / self.head_size)
+        inv_freq = 1.0 / (
+            self.rope_attrs["theta"] ** (torch.arange(0, self.head_size, 2, dtype=torch.float) / self.head_size)
+        )
         inv_freq = self.make_inv_freq_rescaled(inv_freq)
 
         t = torch.arange(self.rope_attrs["cache_length"], dtype=torch.float32)
@@ -580,17 +582,17 @@ class GPTOSSModel(Model):
         down_proj_bias = f"model.layers.{layer_id}.moe.experts.down_proj.bias"
         down_proj_zero_points = f"model.layers.{layer_id}.moe.experts.down_proj.zero_points"
 
-        # Apply transpose depending on EP/op requirements and Quark expert presence
-        # For quantized QMoE on CUDA, kernels expect scales along the hidden_size axis,
-        # so we keep original orientation (last axis = hidden_size) when quantizing.
-        # For non-quantized MoE or non-CUDA EPs, transpose to align MatMul layout.
+        # HF GptOssExperts stores the expert weights input-major:
+        #   gate_up_proj = [E, hidden, 2*inter], down_proj = [E, inter, hidden].
+        # Every downstream consumer (non-quant MoE, and the QMoE quantizers in
+        # make_qmoe_weights) expects output-major [E, N, K] with the contraction
+        # axis (K) last: gate_up = [E, 2*inter, hidden], down = [E, hidden, inter].
+        # Transpose for all EPs/ops; the CUDA QMoE path is no exception (keeping
+        # the original orientation swaps N and K, which silently corrupts the
+        # quantized weights/scales and yields garbage output).
         if not has_quark_experts:
-            if op_type == "QMoE" and self.ep == "cuda":
-                gate_up_proj_layout = mlp.experts.gate_up_proj
-                down_proj_layout = mlp.experts.down_proj
-            else:
-                gate_up_proj_layout = mlp.experts.gate_up_proj.transpose(-1, -2)
-                down_proj_layout = mlp.experts.down_proj.transpose(-1, -2)
+            gate_up_proj_layout = mlp.experts.gate_up_proj.transpose(-1, -2)
+            down_proj_layout = mlp.experts.down_proj.transpose(-1, -2)
 
         if op_type == "MoE" and not has_quark_experts:
             # Save non-quantized MoE weights as initializers

--- a/src/python/py/models/builders/gptoss.py
+++ b/src/python/py/models/builders/gptoss.py
@@ -582,6 +582,11 @@ class GPTOSSModel(Model):
         down_proj_bias = f"model.layers.{layer_id}.moe.experts.down_proj.bias"
         down_proj_zero_points = f"model.layers.{layer_id}.moe.experts.down_proj.zero_points"
 
+        # FP4 (MXFP4) per-expert float32 global scales (empty for the integer QMoE path).
+        is_fp4_moe = self.moe_attrs.get("quant_type") == "fp4"
+        gate_up_proj_global_scales = ""
+        down_proj_global_scales = ""
+
         # HF GptOssExperts stores the expert weights input-major:
         #   gate_up_proj = [E, hidden, 2*inter], down_proj = [E, inter, hidden].
         # Every downstream consumer (non-quant MoE, and the QMoE quantizers in
@@ -607,64 +612,105 @@ class GPTOSSModel(Model):
                 to=self.io_dtype,
             )
         else:
-            if has_quark_experts:
-                # Use pre-quantized Quark experts
-                gate_up_proj_qweight_tensor, gate_up_proj_scales_tensor, gate_up_proj_zero_points_tensor = (
-                    mlp.experts.fc1_weights,
-                    mlp.experts.fc1_scales,
-                    mlp.experts.fc1_zero_points,
-                )
-                down_proj_qweight_tensor, down_proj_scales_tensor, down_proj_zero_points_tensor = (
-                    mlp.experts.fc2_weights,
-                    mlp.experts.fc2_scales,
-                    mlp.experts.fc2_zero_points,
-                )
-
-                # Save zero point as initializers
-                self.make_initializer(gate_up_proj_zero_points_tensor, gate_up_proj_zero_points)
-                self.make_initializer(down_proj_zero_points_tensor, down_proj_zero_points)
-            else:
-                # Create and save quantized MoE weights as initializers
-                gate_up_proj_qweight_list, gate_up_proj_scales_list = [], []
-                down_proj_qweight_list, down_proj_scales_list = [], []
+            if is_fp4_moe and not has_quark_experts:
+                # MXFP4 path: quantize each expert to FP4 e2m1 weights with ue8m0 block
+                # scales. The CUDA QMoE FP4 op consumes column-major packed weights
+                # [E, K, N/2] uint8, FLOAT8E8M0 block scales [E, N, K//32], and per-expert
+                # float32 global scales [E] (fed at QMoE inputs 15/16).
+                gate_up_packed_list, gate_up_block_scales_list, gate_up_global_list = [], [], []
+                down_packed_list, down_block_scales_list, down_global_list = [], [], []
 
                 for i in range(self.moe_attrs["num_experts"]):
-                    qweight1, scales1 = self.make_qmoe_weights(gate_up_proj_layout[i])
-                    gate_up_proj_qweight_list.append(qweight1)
-                    gate_up_proj_scales_list.append(scales1)
-                    qweight2, scales2 = self.make_qmoe_weights(down_proj_layout[i])
-                    down_proj_qweight_list.append(qweight2)
-                    down_proj_scales_list.append(scales2)
+                    p1, bs1, g1 = self.make_mxfp4_weights(gate_up_proj_layout[i], 32)
+                    gate_up_packed_list.append(p1)
+                    gate_up_block_scales_list.append(bs1)
+                    gate_up_global_list.append(g1)
+                    p2, bs2, g2 = self.make_mxfp4_weights(down_proj_layout[i], 32)
+                    down_packed_list.append(p2)
+                    down_block_scales_list.append(bs2)
+                    down_global_list.append(g2)
 
-                gate_up_proj_qweight_tensor = torch.stack(gate_up_proj_qweight_list, dim=0).to(torch.uint8)
-                gate_up_proj_scales_tensor = torch.stack(gate_up_proj_scales_list, dim=0)
-                down_proj_qweight_tensor = torch.stack(down_proj_qweight_list, dim=0).to(torch.uint8)
-                down_proj_scales_tensor = torch.stack(down_proj_scales_list, dim=0)
+                self.moe_attrs["block_size"] = 32
 
-            # Determine shape based on Quark vs non-Quark
-            pack_size = 8 // self.moe_attrs["expert_weight_bits"]
-            if has_quark_experts:
-                hidden_size_padded = self.hidden_size
-                intermediate_size_padded = self.intermediate_size
+                gate_up_packed_tensor = torch.stack(gate_up_packed_list, dim=0).to(torch.uint8)
+                gate_up_block_scales_tensor = torch.stack(gate_up_block_scales_list, dim=0).to(torch.uint8)
+                down_packed_tensor = torch.stack(down_packed_list, dim=0).to(torch.uint8)
+                down_block_scales_tensor = torch.stack(down_block_scales_list, dim=0).to(torch.uint8)
+                gate_up_global_tensor = torch.tensor(gate_up_global_list, dtype=torch.float32)
+                down_global_tensor = torch.tensor(down_global_list, dtype=torch.float32)
+
+                # Packed FP4 weights [E, K, N/2] uint8
+                self.make_initializer(gate_up_packed_tensor, gate_up_proj_weight)
+                self.make_initializer(down_packed_tensor, down_proj_weight)
+
+                # Block scales as FLOAT8E8M0 [E, N, K//32]
+                self.make_fp8e8m0_initializer(gate_up_block_scales_tensor, gate_up_proj_scales)
+                self.make_fp8e8m0_initializer(down_block_scales_tensor, down_proj_scales)
+
+                # Per-expert float32 global scales [E]
+                gate_up_proj_global_scales = f"model.layers.{layer_id}.moe.experts.gate_up_proj.global_scales"
+                down_proj_global_scales = f"model.layers.{layer_id}.moe.experts.down_proj.global_scales"
+                self.make_initializer(gate_up_global_tensor, gate_up_proj_global_scales)
+                self.make_initializer(down_global_tensor, down_proj_global_scales)
             else:
-                hidden_size_padded = gate_up_proj_qweight_list[0].shape[-1] * pack_size
-                intermediate_size_padded = down_proj_qweight_list[0].shape[-1] * pack_size
+                if has_quark_experts:
+                    # Use pre-quantized Quark experts
+                    gate_up_proj_qweight_tensor, gate_up_proj_scales_tensor, gate_up_proj_zero_points_tensor = (
+                        mlp.experts.fc1_weights,
+                        mlp.experts.fc1_scales,
+                        mlp.experts.fc1_zero_points,
+                    )
+                    down_proj_qweight_tensor, down_proj_scales_tensor, down_proj_zero_points_tensor = (
+                        mlp.experts.fc2_weights,
+                        mlp.experts.fc2_scales,
+                        mlp.experts.fc2_zero_points,
+                    )
 
-            # Save qweight tensors
-            self.make_initializer(
-                gate_up_proj_qweight_tensor.view(self.moe_attrs["num_experts"], -1, hidden_size_padded // pack_size),
-                gate_up_proj_weight,
-            )
-            self.make_initializer(
-                down_proj_qweight_tensor.view(
-                    self.moe_attrs["num_experts"], self.hidden_size, intermediate_size_padded // pack_size
-                ),
-                down_proj_weight,
-            )
+                    # Save zero point as initializers
+                    self.make_initializer(gate_up_proj_zero_points_tensor, gate_up_proj_zero_points)
+                    self.make_initializer(down_proj_zero_points_tensor, down_proj_zero_points)
+                else:
+                    # Create and save quantized MoE weights as initializers
+                    gate_up_proj_qweight_list, gate_up_proj_scales_list = [], []
+                    down_proj_qweight_list, down_proj_scales_list = [], []
 
-            # Save scales tensors
-            self.make_initializer(gate_up_proj_scales_tensor, gate_up_proj_scales, to=self.io_dtype)
-            self.make_initializer(down_proj_scales_tensor, down_proj_scales, to=self.io_dtype)
+                    for i in range(self.moe_attrs["num_experts"]):
+                        qweight1, scales1 = self.make_qmoe_weights(gate_up_proj_layout[i])
+                        gate_up_proj_qweight_list.append(qweight1)
+                        gate_up_proj_scales_list.append(scales1)
+                        qweight2, scales2 = self.make_qmoe_weights(down_proj_layout[i])
+                        down_proj_qweight_list.append(qweight2)
+                        down_proj_scales_list.append(scales2)
+
+                    gate_up_proj_qweight_tensor = torch.stack(gate_up_proj_qweight_list, dim=0).to(torch.uint8)
+                    gate_up_proj_scales_tensor = torch.stack(gate_up_proj_scales_list, dim=0)
+                    down_proj_qweight_tensor = torch.stack(down_proj_qweight_list, dim=0).to(torch.uint8)
+                    down_proj_scales_tensor = torch.stack(down_proj_scales_list, dim=0)
+
+                # Determine shape based on Quark vs non-Quark
+                pack_size = 8 // self.moe_attrs["expert_weight_bits"]
+                if has_quark_experts:
+                    hidden_size_padded = self.hidden_size
+                    intermediate_size_padded = self.intermediate_size
+                else:
+                    hidden_size_padded = gate_up_proj_qweight_list[0].shape[-1] * pack_size
+                    intermediate_size_padded = down_proj_qweight_list[0].shape[-1] * pack_size
+
+                # Save qweight tensors
+                self.make_initializer(
+                    gate_up_proj_qweight_tensor.view(self.moe_attrs["num_experts"], -1, hidden_size_padded // pack_size),
+                    gate_up_proj_weight,
+                )
+                self.make_initializer(
+                    down_proj_qweight_tensor.view(
+                        self.moe_attrs["num_experts"], self.hidden_size, intermediate_size_padded // pack_size
+                    ),
+                    down_proj_weight,
+                )
+
+                # Save scales tensors
+                self.make_initializer(gate_up_proj_scales_tensor, gate_up_proj_scales, to=self.io_dtype)
+                self.make_initializer(down_proj_scales_tensor, down_proj_scales, to=self.io_dtype)
 
         # Save biases (shared for all paths)
         if has_quark_experts:
@@ -694,6 +740,8 @@ class GPTOSSModel(Model):
             bias2=down_proj_bias,
             zero_points1=gate_up_proj_zero_points if use_zero_points else "",
             zero_points2=down_proj_zero_points if use_zero_points else "",
+            global_scales1=gate_up_proj_global_scales,
+            global_scales2=down_proj_global_scales,
         )
 
         # Assign output 0 of previous MoE as root input to next SkipLayerNorm

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -2125,6 +2125,23 @@ class Qwen35MoeTextModel(Qwen35TextModel):
             for k in keys_to_remove:
                 del algo_config.customized_weight_config[k]
 
+        # Keep the routing-critical projections out of INT4 quantization.
+        # The MoE router selects the top-k experts and the shared-expert gate
+        # scales the always-on expert. Both are tiny matmuls, but 4-bit rounding
+        # of their weights perturbs the routing logits enough to flip top-k
+        # expert selection (measured ~1.4 of 8 experts change per token), which
+        # injects a large error into every MoE layer. Excluding them costs only
+        # a few MB but materially improves quantized-model accuracy.
+        if self.onnx_dtype in {ir.DataType.INT4, ir.DataType.INT8}:
+            nodes_to_exclude = self.quant_attrs.setdefault("nodes_to_exclude", [])
+            for i in range(self.num_layers):
+                router_node = f"/model/layers.{i}/moe/router/MatMul"
+                shared_gate_node = f"/model/layers.{i}/shared_expert_gate/MatMul"
+                if router_node not in nodes_to_exclude:
+                    nodes_to_exclude.append(router_node)
+                if shared_gate_node not in nodes_to_exclude:
+                    nodes_to_exclude.append(shared_gate_node)
+
     def make_layer(self, layer_id, layer):
         """Override to use MoE instead of dense MLP."""
         attn_module = layer.linear_attn if self.layer_types[layer_id] == "linear_attention" else layer.self_attn
@@ -2258,7 +2275,7 @@ class Qwen35MoeTextModel(Qwen35TextModel):
         self.make_sigmoid(gate_sigmoid_name, f"{gate_matmul_name}/output_0", self.io_dtype,
                           shape=["batch_size", "sequence_length", 1])
 
-        gated_mul_name = f"{basename}/Mul"
+        gated_mul_name = f"{basename}/gate/Mul"
         self.make_mul(gated_mul_name,
                       [f"{down_matmul}/output_0", f"{gate_sigmoid_name}/output_0"],
                       dtype=self.io_dtype,

--- a/test/python/models/test_qmoe_weights.py
+++ b/test/python/models/test_qmoe_weights.py
@@ -1,0 +1,119 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License
+
+"""Unit tests for CUDA QMoE expert-weight quantization in the model builder.
+
+These guard the INT4 QMoE encoding fix for Qwen3.5/3.6 MoE models. The CUDA path
+must:
+  1. dispatch to the CUTLASS-prepack quantizer for ``weights_prepacked`` None/1
+     (both mean the op reads prepacked weights) and to the raw MatMulNBits
+     quantizer for ``weights_prepacked`` 0,
+  2. only do so on the CUDA EP,
+  3. reject unsupported block sizes with a real exception (not a ``python -O``
+     strippable ``assert``), and
+  4. keep the SIGNED blockwise scales (taking ``abs()`` reintroduces the
+     garbage-output bug).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from onnxruntime_genai.models.builders.base import Model
+
+
+class _FakeMoEModel:
+    """Minimal stand-in exposing ``make_qmoe_weights`` and recording which
+    quantization path it dispatched to."""
+
+    make_qmoe_weights = Model.make_qmoe_weights
+
+    def __init__(self, ep, block_size, weights_prepacked):
+        self.ep = ep
+        self.qmoe_block_size = block_size
+        self.moe_attrs = {"expert_weight_bits": 4, "weights_prepacked": weights_prepacked}
+        self.quant_attrs = {"qmoe_block_size": block_size}
+        self.calls = []
+
+    def _cutlass_prepacked_blockwise_quantize(self, weights, block_size):
+        self.calls.append(("cutlass", block_size))
+        return torch.zeros(1, dtype=torch.uint8), torch.zeros(1, dtype=torch.float32)
+
+    def _matmulnbits_blockwise_quantize(self, weights, block_size):
+        self.calls.append(("matmulnbits", block_size))
+        return torch.zeros(1, dtype=torch.uint8), torch.zeros(1, dtype=torch.float32)
+
+    def _symmetric_blockwise_quantize(self, weights, block_size):
+        self.calls.append(("symmetric", block_size))
+        return torch.zeros(1, dtype=torch.uint8), torch.zeros(1, dtype=torch.float32)
+
+
+_W = torch.zeros(8, 128)  # dummy expert weight [N, K]
+
+
+@pytest.mark.parametrize("weights_prepacked", [None, 1])
+def test_cuda_prepacked_path_for_none_and_one(weights_prepacked):
+    """None (auto=prepacked) and 1 (explicitly prepacked) both produce
+    CUTLASS-prepacked weights so the emitted layout matches the op attribute."""
+    model = _FakeMoEModel("cuda", 128, weights_prepacked)
+    model.make_qmoe_weights(_W)
+    assert model.calls == [("cutlass", 128)]
+
+
+def test_cuda_raw_path_for_zero():
+    """weights_prepacked=0 ships raw weights for the runtime PrePack hook."""
+    model = _FakeMoEModel("cuda", 128, 0)
+    model.make_qmoe_weights(_W)
+    assert model.calls == [("matmulnbits", 128)]
+
+
+def test_non_cuda_does_not_use_cuda_only_paths():
+    """The CUDA-only encodings must not be used on other EPs, even when
+    weights_prepacked is set."""
+    model = _FakeMoEModel("cpu", 128, 0)
+    model.make_qmoe_weights(_W)
+    assert ("cutlass", 128) not in model.calls
+    assert ("matmulnbits", 128) not in model.calls
+    assert model.calls == [("symmetric", 128)]
+
+
+@pytest.mark.parametrize("weights_prepacked", [None, 0, 1])
+@pytest.mark.parametrize("bad_block", [16, 32, 256])
+def test_cuda_rejects_unsupported_block_size(weights_prepacked, bad_block):
+    """Unsupported block sizes must raise a real exception (not an assert that
+    ``python -O`` would strip)."""
+    model = _FakeMoEModel("cuda", bad_block, weights_prepacked)
+    with pytest.raises(ValueError, match="block_size 64 or 128"):
+        model.make_qmoe_weights(_W)
+
+
+def _ort_cuda_available():
+    try:
+        import onnxruntime as ort
+        from onnxruntime.capi import _pybind_state as _pyb
+
+        return (
+            hasattr(_pyb, "quantize_matmul_4bits")
+            and hasattr(_pyb, "pack_weights_for_cuda_mixed_gemm")
+            and "CUDAExecutionProvider" in ort.get_available_providers()
+        )
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _ort_cuda_available(), reason="onnxruntime CUDA pybind not available")
+def test_cutlass_prepacked_scales_are_signed():
+    """Regression guard for the abs(scales) bug: blockwise scales must keep their
+    sign, and the encoded shapes must match the QMoE op's prepacked layout."""
+    model = _FakeMoEModel("cuda", 128, None)
+    torch.manual_seed(0)
+    weights = torch.randn(256, 256) * 0.05  # [N, K]
+    qweight, scales = Model._cutlass_prepacked_blockwise_quantize(model, weights, 128)
+
+    assert qweight.dtype == torch.uint8
+    assert tuple(qweight.shape) == (256, 128)  # [K, N/2] for INT4
+    assert tuple(scales.shape) == (256, 2)  # [N, K/block]
+    # With zero-mean weights about half the blocks have a negative anchor; the
+    # scale must carry that sign. abs() would make every scale non-negative.
+    assert (scales < 0).any(), "blockwise scales should be signed (abs() regression)"


### PR DESCRIPTION
Add option to build gpt-oss model with FP4 QMoE.