### PR TITLE
feat: add audio content blocks for Gemma multimodal prompts in model_mm

### DIFF
--- a/examples/c/src/common.cpp
+++ b/examples/c/src/common.cpp
@@ -476,12 +476,17 @@ nlohmann::ordered_json GetUserContent(const std::string& model_type, int num_ima
     content_json = nlohmann::ordered_json(content);
 
   } else {
-    // Gemma-3 style: structured content
+    // Gemma-style structured content (Gemma-3 / Gemma-4)
     content_json = nlohmann::ordered_json::array();
 
     // Add N image blocks
     for (int i = 0; i < num_images; i++) {
       content_json.push_back(nlohmann::ordered_json::object({{"type", "image"}}));
+    }
+
+    // Add N audio blocks (e.g. Gemma-4 audio support)
+    for (int i = 0; i < num_audios; i++) {
+      content_json.push_back(nlohmann::ordered_json::object({{"type", "audio"}}));
     }
 
     // Always add a text block (with the user prompt)


### PR DESCRIPTION
### Description

`GetUserContent()` in `examples/c/src/common.cpp` only emitted `image` and
`text` content blocks for the Gemma-style structured-content path. Audio
inputs (`num_audios`) were silently ignored, so no `{"type":"audio"}` block
was added and the chat template never rendered an `<|audio|>` marker.

As a result, for Gemma-4 audio inference the audio soft tokens were appended
at the very front of the templated prompt (via the fallback in
`ProcessGemma4Prompt`), outside the user turn. The model therefore did not
associate the audio with the request and replied with things like
*"Please provide the audio you would like me to transcribe."*

This PR emits one `{"type":"audio"}` block per audio clip so the chat
template inserts the `<|audio|>` marker at the correct position within the
user turn, allowing the audio soft tokens to be expanded in place.

### Changes

- `examples/c/src/common.cpp`: add a loop that appends N `{"type":"audio"}`
  blocks (one per audio clip) in the Gemma-style structured-content branch.