### PR TITLE
webgpu: bypass manual mRoPE for text-only Qwen3.5 when GQA fuses RoPE

### DIFF
--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -1014,31 +1014,45 @@ class Qwen35TextModel(Model):
         # SkipSimplifiedLayerNormalization can be used directly.
         self.layernorm_attrs["add_offset"] = 1
 
-        # Position IDs input.
-        # In text-only mode the runtime provides standard 2D [B, S] position_ids.
-        # We expand them to 3D [3, B, S] inside the graph so mRoPE works unchanged.
-        # In VL mode the pipeline provides 3D position_ids directly.
-        if self.is_text_only:
-            self.input_shapes["position_ids"] = ["batch_size", "sequence_length"]
+        # Text-only mRoPE collapses to standard 1D RoPE because
+        # Qwen3_5TextRotaryEmbedding expands a 2D position_ids to 3 identical
+        # axes and apply_interleaved_mrope returns freqs[0] unchanged. When
+        # GQA can perform fused RoPE we therefore bypass the manual mRoPE
+        # subgraph entirely, which removes the Shape -> Memcpy path that
+        # blocks WebGPU graph capture.
+        self.use_text_only_fused_rope = (
+            self.is_text_only and self.attention_attrs["use_rope_in_attn"]
+        )
+
+        if self.use_text_only_fused_rope:
+            # Standard 2D cos/sin caches consumed by GQA's cos_cache/sin_cache inputs.
+            self.make_rotary_embedding_caches()
         else:
-            self.input_shapes["position_ids"] = [3, "batch_size", "sequence_length"]
-        self.input_names["position_ids"] = "position_ids"
+            # Position IDs input.
+            # In text-only mode the runtime provides standard 2D [B, S] position_ids.
+            # We expand them to 3D [3, B, S] inside the graph so mRoPE works unchanged.
+            # In VL mode the pipeline provides 3D position_ids directly.
+            if self.is_text_only:
+                self.input_shapes["position_ids"] = ["batch_size", "sequence_length"]
+            else:
+                self.input_shapes["position_ids"] = [3, "batch_size", "sequence_length"]
+            self.input_names["position_ids"] = "position_ids"
 
-        # mRoPE config
-        self.mrope_sections = self.rope_attrs.get("mrope", {}).get("sections", [])
-        if not self.mrope_sections:
-            raise ValueError("MRoPE sections not found in text_config rope_parameters/rope_scaling mrope_section")
-        if len(self.mrope_sections) != 3:
-            raise ValueError(
-                f"Expected 3 MRoPE sections [T, H, W], got {len(self.mrope_sections)}: {self.mrope_sections}"
-            )
-        self.mrope_rotary_dim = int(self.rope_attrs["partial_rotary_factor"] * self.head_size)
+            # mRoPE config
+            self.mrope_sections = self.rope_attrs.get("mrope", {}).get("sections", [])
+            if not self.mrope_sections:
+                raise ValueError("MRoPE sections not found in text_config rope_parameters/rope_scaling mrope_section")
+            if len(self.mrope_sections) != 3:
+                raise ValueError(
+                    f"Expected 3 MRoPE sections [T, H, W], got {len(self.mrope_sections)}: {self.mrope_sections}"
+                )
+            self.mrope_rotary_dim = int(self.rope_attrs["partial_rotary_factor"] * self.head_size)
 
-        # Force RoPE computation in float32 for numerical stability
-        self.rope_attrs["cast_to_fp32"] = True
+            # Force RoPE computation in float32 for numerical stability
+            self.rope_attrs["cast_to_fp32"] = True
 
-        # Pre-compute cos/sin cache tables and interleaving masks for mRoPE
-        self._make_rotary_caches()
+            # Pre-compute cos/sin cache tables and interleaving masks for mRoPE
+            self._make_rotary_caches()
 
         # Store linear attention config
         self.linear_key_head_dim = getattr(config, "linear_key_head_dim", 128)
@@ -1055,8 +1069,10 @@ class Qwen35TextModel(Model):
         # Full attention uses QK norm and output gating
         self.attention_attrs["q_norm"] = True
         self.attention_attrs["k_norm"] = True
-        # Disable fused RoPE in attention op - we apply mRoPE manually
-        self.attention_attrs["use_rope_in_attn"] = False
+        if not self.use_text_only_fused_rope:
+            # mRoPE is applied manually before GQA, so disable fused RoPE
+            # in the attention op.
+            self.attention_attrs["use_rope_in_attn"] = False
 
         # Replace standard KV cache I/O with hybrid cache I/O
         self._setup_hybrid_cache_io()
@@ -1129,6 +1145,10 @@ class Qwen35TextModel(Model):
         self.output_names["present.value"] = filtered_value_outputs
 
     def make_position_ids_reformatting(self):
+        if self.use_text_only_fused_rope:
+            # Fused RoPE in GQA consumes seqlens_k internally, so there is
+            # no position_ids tensor on the data flow to reformat.
+            return None
         if self.is_text_only:
             # The graph input is 2D position_ids [B, S].
             # Expand to 3D [3, B, S] for mRoPE by stacking 3 copies.
@@ -1154,7 +1174,8 @@ class Qwen35TextModel(Model):
 
     def make_preprocessing_nodes(self):
         super().make_preprocessing_nodes()
-        self.position_ids_reformatted = self.make_position_ids_reformatting()
+        if not self.use_text_only_fused_rope:
+            self.position_ids_reformatted = self.make_position_ids_reformatting()
 
     def make_attention(self, layer_id, attention, root_input, **kwargs):
         """Dispatch to full attention or GatedDeltaNet based on layer type."""
@@ -1268,7 +1289,7 @@ class Qwen35TextModel(Model):
         self.make_qk_norm(layer_id, attn)
 
         # 5. Apply interleaved mRoPE to Q and K
-        if self.attention_attrs["rope"]:
+        if self.attention_attrs["rope"] and not self.use_text_only_fused_rope:
             q_shape = ["batch_size", "sequence_length", self.num_attn_heads * self.head_size]
             k_shape = ["batch_size", "sequence_length", self.num_kv_heads * self.head_size]
 
@@ -1303,6 +1324,12 @@ class Qwen35TextModel(Model):
         present_k = f"present.{layer_id}.key"
         present_v = f"present.{layer_id}.value"
 
+        # Under the text-only bypass GQA performs RoPE internally using the
+        # standard 2D cos/sin caches; otherwise mRoPE was applied above and
+        # GQA receives empty cache names so do_rotary stays disabled.
+        cos_cache = "cos_cache" if self.use_text_only_fused_rope else ""
+        sin_cache = "sin_cache" if self.use_text_only_fused_rope else ""
+
         attn_name = f"/model/layers.{layer_id}/attn/{self.attention_attrs['op_type']}"
         self.make_attention_op(
             attn_name,
@@ -1314,8 +1341,8 @@ class Qwen35TextModel(Model):
             past_v=past_v,
             present_k=present_k,
             present_v=present_v,
-            cos_cache="",
-            sin_cache="",
+            cos_cache=cos_cache,
+            sin_cache=sin_cache,
         )
         attn_output = f"{attn_name}/output_0"
 


### PR DESCRIPTION
## Summary

For text-only Qwen3.5, multi-head RoPE (mRoPE) collapses to standard 1D RoPE:
`Qwen3_5TextRotaryEmbedding` expands a 2D `position_ids` into 3 identical axes
and `apply_interleaved_mrope` returns `freqs[0]` unchanged. The manual mRoPE
subgraph (Shape → Expand → interleaved cos/sin caches → custom kernel) is
therefore equivalent to a plain fused-RoPE pass inside GQA.

When the GQA operator supports fused RoPE (`use_rope_in_attn=True`, e.g. on
WebGPU), this PR detects the text-only case and routes through the fused path,
bypassing the manual mRoPE subgraph entirely. This removes the `Shape →
Memcpy` node that reads a dynamic tensor shape at runtime — the path that
prevents WebGPU graph capture on Qwen3.5 text-only models.

**Changes** (`src/python/py/models/builders/qwen.py` only):
- Add `use_text_only_fused_rope` flag: true when `is_text_only` and `use_rope_in_attn`.
- When flag is set: call `make_rotary_embedding_caches()` (standard 2D cos/sin for GQA), skip mRoPE config, leave `use_rope_in_attn=True`.
- When flag is not set: keep existing mRoPE path unchanged (VL mode and non-fused-RoPE EPs).
- `make_position_ids_reformatting`: early-return `None` when fused RoPE is active (no `position_ids` tensor on the data flow).

## Test plan

- [ ] Verify text-only Qwen3.5-0.8B generates correct output on WebGPU with graph capture enabled
- [ ] Verify multimodal Qwen3.5 (VL mode) is unaffected — still uses manual mRoPE path
- [ ] Run existing Qwen integration tests: `qwen3-0.6b`, `qwen2.5-0.5b-instruct`