### PR TITLE
Fix OrtGlobals::Allocator destruction order

### DIFF
--- a/src/generators.h
+++ b/src/generators.h
@@ -151,8 +151,14 @@ struct OrtGlobals {
   std::unique_ptr<OrtEnv> env_;
 
   struct Allocator {
-    std::unique_ptr<Ort::Allocator> allocator_;
+    // Field order matters here. The OrtAllocator returned by OrtApi::CreateAllocator (called via
+    // Ort::Allocator::Create) "wraps the internal allocator from the OrtSession and becomes invalid when the session
+    // does" -- see
+    // https://github.com/microsoft/onnxruntime/blob/3c8c46029735a89c8d1ea0aa6c1812db5b78ad72/include/onnxruntime/core/session/onnxruntime_c_api.h#L2852-L2862
+    // Members are destroyed in reverse declaration order, so session_ must be declared BEFORE allocator_ so that
+    // ~allocator_ runs first.
     std::unique_ptr<OrtSession> session_;
+    std::unique_ptr<Ort::Allocator> allocator_;
   };
   Allocator device_allocators_[static_cast<int>(DeviceType::MAX)];
 

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -426,6 +426,9 @@ struct Abstract {
  */
 struct Allocator : OrtAllocator {
   static Allocator& GetWithDefaultOptions();  ///< ::OrtAllocator default instance that is owned by Onnxruntime
+  /// Wraps the internal allocator owned by `session` (forwards to OrtApi::CreateAllocator). The returned Allocator
+  /// becomes invalid when `session` is destroyed -- callers must ensure the Allocator is destroyed before the
+  /// OrtSession.
   static std::unique_ptr<Allocator> Create(const OrtSession& session, const OrtMemoryInfo& memory_info);
 
   void* Alloc(size_t size);

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -847,6 +847,18 @@ struct OgaEngine : OgaAbstract {
   static void operator delete(void* p) { OgaDestroyEngine(reinterpret_cast<OgaEngine*>(p)); }
 };
 
+/**
+ * \brief RAII wrapper that calls OgaShutdown() on destruction.
+ *
+ * \warning Without explicit shutdown, GenAI's globals are destroyed at static-destruction time in undefined order,
+ *          which may crash.
+ *
+ * \note Typical usage is to construct an instance early in the program so its destructor runs before process exit.
+ *
+ * \note Only one OgaHandle should be live in the process, and its scope must encompass all GenAI use. GenAI's globals
+ *       are not re-creatable after OgaShutdown(); a second OgaHandle whose lifetime starts after the first one's
+ *       destruction would leave subsequent GenAI calls broken.
+ */
 struct OgaHandle {
   OgaHandle() = default;
   ~OgaHandle() noexcept {

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -88,7 +88,16 @@ typedef struct OgaStreamingProcessor OgaStreamingProcessor;
  */
 
 /**
- * \brief Call this on process exit to cleanly shutdown the genai library & its onnxruntime usage
+ * \brief Shuts down the GenAI library and releases all GenAI-owned ONNX Runtime globals.
+ *
+ * \warning Callers SHOULD invoke OgaShutdown() before process exit. If it is not called, GenAI's globals are destroyed
+ *          at static-destruction time in undefined order, which may crash.
+ *
+ * \note C++ callers should prefer the OgaHandle RAII wrapper in ort_genai.h; C# callers should prefer the
+ *       OgaHandle IDisposable wrapper. Both invoke OgaShutdown() on destruction.
+ *
+ * \note Must be the last GenAI call in the process. Any OgaModel / OgaGenerator / OgaTokenizer / etc. handles owned
+ *       by the caller must be released first.
  */
 OGA_EXPORT void OGA_API_CALL OgaShutdown();
 


### PR DESCRIPTION
## Summary

`OrtGlobals::Allocator` in `src/generators.h` declares `allocator_` before `session_`. Because C++ destroys non-static members in reverse declaration order, `session_` is destroyed first, which invalidates the session-scoped `OrtAllocator` per ORT's documented contract on `OrtApi::CreateAllocator`:

> The allocator wraps the internal allocator from the OrtSession and becomes invalid when the session does.

The subsequent `~allocator_` then calls `OrtApi::ReleaseAllocator` against the now-invalid handle. For plugin EPs (WebGPU, QNN, …), this drops into the ORT plugin-EP deleter lambda whose `[this]` capture is a dangling `PluginExecutionProvider*`, crashing with `INVALID_POINTER_READ_AVRF` at shutdown.

**Fix:** one-line declaration-order swap so `session_` is declared first and destroyed last. The fix is in the first commit; the second commit is doc-only.

## Why this surfaces now

Three conditions are needed to make the crash deterministic:

1. **A plugin EP** (WebGPU/QNN) — uses the lambda-capture deleter on the ORT side.
2. **Explicit `OgaShutdown()`** before process exit (the recommended pattern from #311). This moves `~OrtGlobals::Allocator` out of `LdrShutdownProcess` noise into a clean point in the process lifetime.
3. **App Verifier page-heap** active. Without it, the dangling read returns stale memory and the process probably exits while silently corrupting heap.

## Validation

Reproduced and verified end-to-end with the WebGPU plugin EP under App Verifier: deterministic AVRF crashes at shutdown before the fix → clean shutdown after.

GenAI unit tests on this branch (local CPU-only Release build) — shutdown path exercised cleanly:

```
[==========] 74 tests from 8 test suites ran. (4060 ms total)
[  PASSED  ] 53 tests.
[  SKIPPED ] 21 tests
Shutting down OnnxRuntime... done
```

The defect exists identically at `v0.12.1` (shipped) and at `main` HEAD.

## Minimal ORT-only reproducer (no GenAI)

The dangling-pointer read can be hit using only the ORT C API by deliberately misusing the `CreateAllocator` lifetime contract against any plugin EP:

```cpp
RegisterExecutionProviderLibrary(env, "WebGpuExecutionProvider", dll_path);
SessionOptionsAppendExecutionProvider_V2(opts, env, &device, 1, nullptr, nullptr, 0);
CreateSession(env, model_path, opts, &session);
const OrtMemoryInfo* mi = EpDevice_MemoryInfo(device, OrtDeviceMemoryType_DEFAULT);
OrtAllocator* leaked = nullptr;
CreateAllocator(session, mi, &leaked);
ReleaseSession(session);          // destroys PluginExecutionProvider
ReleaseAllocator(leaked);         // AVRF in plugin-EP deleter lambda
```

This is what GenAI does at shutdown, just spread across `~OrtGlobals::Allocator`.

## Changes

**Commit 1 — Fix OrtGlobals::Allocator destruction order**
- `src/generators.h`: swap declaration order of `allocator_` and `session_`; add a comment explaining why field order matters here, with a permalink to ORT's `OrtApi::CreateAllocator` contract.

**Commit 2 — Document OgaShutdown / OgaHandle / Allocator::Create lifetime contracts** (doc-only)
- `src/ort_genai_c.h`: expand `OgaShutdown` doxygen to warn that skipping the explicit shutdown can crash (globals destroyed in undefined static-destruction order); direct C++/C# callers to the `OgaHandle` wrappers. Motivated by the rationale given in #311, which introduced `OgaShutdown()`.
- `src/ort_genai.h`: add a docstring on `OgaHandle` mirroring the `OgaShutdown` structure, including a `\note` that only one `OgaHandle` should be live in the process since GenAI's globals are not re-creatable after `OgaShutdown()`.
- `src/models/onnxruntime_api.h`: document `Allocator::Create`'s lifetime constraint — the Allocator becomes invalid when the OrtSession is destroyed. This is the contract whose violation caused the bug fixed in the first commit.

The doc commit is independently revertable if you'd prefer to merge only the fix.
