### PR TITLE
[model-builder] Cap max_length at 4096 to reduce KV cache memory usage

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -618,7 +618,8 @@ class Model:
                 "do_sample": config.do_sample if hasattr(config, "do_sample") else False,
                 "early_stopping": True,
                 "length_penalty": config.length_penalty if hasattr(config, "length_penalty") else 1.0,
-                "max_length": self.context_length,
+                # Cap max_length at 4096 to limit memory usage for KV cache
+                "max_length": min(4096, self.context_length),
                 "min_length": 0,
                 "no_repeat_ngram_size": config.no_repeat_ngram_size if hasattr(config, "no_repeat_ngram_size") else 0,
                 "num_beams": config.num_beams if hasattr(config, "num_beams") else 1,


### PR DESCRIPTION
This change limits the default max_length in `genai_config.json` to **4096** tokens (or the model's native context_length if smaller) to reduce memory consumption for KV cache allocation, especially important resource-constrained environments.

For models with very large context windows (e.g., 131K tokens), this significantly reduces initial memory allocation when using `past_present_share_buffer=true`.