### PR TITLE
[model_qa.py] Warn when an unrecognized EP name falls back to CPU

### DIFF
--- a/examples/python/common.py
+++ b/examples/python/common.py
@@ -569,6 +569,7 @@ def get_ep_args(parser: argparse.ArgumentParser) -> None:
         "OpenVINOExecutionProvider",       # Intel IHV EP
         "QNNExecutionProvider",            # Qualcomm IHV EP
         "VitisAIExecutionProvider",        # AMD IHV EP
+        "webgpu",                          # GenAI canonical name for WebGPU EP
         "WebGpuExecutionProvider",         # WebGPU EP
     ]
 

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -216,9 +216,8 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
         // instead of silently degrading performance.
         if (is_primary_session_options && g_log.enabled && g_log.warning) {
           Log("warning", "Execution provider '" + provider_options.name +
-                             "' is not a built-in provider or a registered plugin EP; "
-                             "the model will run on CPU, which may be slow. For a built-in "
-                             "provider, use its canonical genai name (e.g. \"webgpu\", \"cuda\", \"dml\").");
+                             "' is not a built-in provider or a registered plugin EP; GenAI will keep model inputs and the KV cache in CPU memory, which may be slow. If you intended a built-in "
+                             "provider, use its canonical GenAI name (e.g. \"webgpu\", \"cuda\", \"dml\").");
         }
         AppendExecutionProviderV1(session_options, provider_options);
       }

--- a/src/models/session_options.cpp
+++ b/src/models/session_options.cpp
@@ -205,8 +205,21 @@ DeviceInterface* SetProviderSessionOptions(OrtSessionOptions& session_options,
         device = session_device;  // Set the device if not already set by a previous provider
       }
     } else {
+      // Not a built-in provider: register it as a plugin EP (V2), falling back to the
+      // legacy append (V1). Neither path returns a genai DeviceInterface, so the
+      // model's inputs and KV cache stay in CPU memory for this session.
       if (!AppendExecutionProviderV2(session_options, provider_options,
                                      DeviceType::CPU, provider_options.name)) {
+        // The name is neither a built-in provider nor a registered plugin EP. The
+        // usual cause is a misspelled built-in name (e.g. an ORT-style name that
+        // NormalizeProviderName does not map). Warn so the CPU fallback is visible
+        // instead of silently degrading performance.
+        if (is_primary_session_options && g_log.enabled && g_log.warning) {
+          Log("warning", "Execution provider '" + provider_options.name +
+                             "' is not a built-in provider or a registered plugin EP; "
+                             "the model will run on CPU, which may be slow. For a built-in "
+                             "provider, use its canonical genai name (e.g. \"webgpu\", \"cuda\", \"dml\").");
+        }
         AppendExecutionProviderV1(session_options, provider_options);
       }
     }


### PR DESCRIPTION
A provider name that is neither a built-in provider nor a registered plugin EP is registered via the legacy append path with a CPU device, leaving model inputs and the KV cache in CPU memory. This was silent and could cause a large, hard-to-diagnose slowdown. Log a warning (primary session only, when V2 plugin registration fails) suggesting the canonical genai provider name.

Also add "webgpu" as an accepted -e choice in the Python example, mirroring the existing cuda/CUDAExecutionProvider pairing.