### PR TITLE
Add bounds checking to OgaSequencesGetSequence C API functions

### DIFF
--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <cstdint>
 #include <cstddef>
+#include <limits>
 #include "span.h"
 #include "ort_genai_c.h"
 #include "generators.h"
@@ -161,10 +162,16 @@ size_t OGA_API_CALL OgaSequencesCount(const OgaSequences* p) {
 }
 
 size_t OGA_API_CALL OgaSequencesGetSequenceCount(const OgaSequences* p, size_t sequence) {
+  if (sequence >= p->size()) {
+    return 0;
+  }
   return (*p)[sequence].size();
 }
 
 const int32_t* OGA_API_CALL OgaSequencesGetSequenceData(const OgaSequences* p, size_t sequence) {
+  if (sequence >= p->size()) {
+    return nullptr;
+  }
   return (*p)[sequence].data();
 }
 
@@ -750,8 +757,14 @@ OgaResult* OGA_API_CALL OgaCreateTensorFromBuffer(void* data, const int64_t* sha
   auto ort_element_type = static_cast<ONNXTensorElementDataType>(element_type);
   size_t byte_count = Ort::SizeOf(ort_element_type);
   auto shape = std::span<const int64_t>{shape_dims, shape_dims_count};
-  for (size_t i = 0; i < shape_dims_count; i++)
-    byte_count *= shape_dims[i];
+  for (size_t i = 0; i < shape_dims_count; i++) {
+    if (shape_dims[i] < 0)
+      throw std::runtime_error("shape dimension must be non-negative");
+    const size_t dim = static_cast<size_t>(shape_dims[i]);
+    if (dim != 0 && byte_count > std::numeric_limits<size_t>::max() / dim)
+      throw std::runtime_error("tensor byte count overflow");
+    byte_count *= dim;
+  }
   std::unique_ptr<OrtValue> ort_tensor;
   if (data)
     ort_tensor = OrtValue::CreateTensor(*p_memory_info, data, byte_count, shape, ort_element_type);

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -756,6 +756,8 @@ OgaResult* OGA_API_CALL OgaCreateTensorFromBuffer(void* data, const int64_t* sha
   auto p_memory_info = OrtMemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
   auto ort_element_type = static_cast<ONNXTensorElementDataType>(element_type);
   size_t byte_count = Ort::SizeOf(ort_element_type);
+  if (shape_dims_count > 0 && shape_dims == nullptr)
+    throw std::runtime_error("shape_dims must not be null when shape_dims_count is non-zero");
   auto shape = std::span<const int64_t>{shape_dims, shape_dims_count};
   for (size_t i = 0; i < shape_dims_count; i++) {
     if (shape_dims[i] < 0)

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -288,6 +288,23 @@ TEST(CAPITests, AppendTokensToSequence) {
 #endif
 }
 
+TEST(CAPITests, SequencesOutOfBoundsAccess) {
+  auto sequences = OgaSequences::Create();
+
+  std::vector<int32_t> tokens{100, 200, 300};
+  sequences->Append(tokens.data(), tokens.size());
+
+  ASSERT_EQ(sequences->Count(), 1u);
+  EXPECT_EQ(sequences->SequenceCount(0), tokens.size());
+  EXPECT_NE(sequences->SequenceData(0), nullptr);
+
+  // Out-of-bounds indices must not read past the underlying storage.
+  EXPECT_EQ(sequences->SequenceCount(1), 0u);
+  EXPECT_EQ(sequences->SequenceData(1), nullptr);
+  EXPECT_EQ(sequences->SequenceCount(1000), 0u);
+  EXPECT_EQ(sequences->SequenceData(1000), nullptr);
+}
+
 TEST(CAPITests, MaxLength) {
   // Batch size 1 case
   std::vector<int32_t> input_ids_0{1, 2, 3, 5, 8};


### PR DESCRIPTION
## Description

`OgaSequencesGetSequenceCount` and `OgaSequencesGetSequenceData` accessed the underlying vector via `operator[]` without validating the `sequence` index. When a caller passes an index `>= OgaSequencesCount()`, this results in an out-of-bounds read of heap memory (undefined behavior), which can disclose adjacent heap contents.

This mirrors the validation already present in `OgaAppendTokenToSequence`, which checks the index before access.

## Changes

- `OgaSequencesGetSequenceCount`: return `0` when `sequence >= size()`.
- `OgaSequencesGetSequenceData`: return `nullptr` when `sequence >= size()`.
  - Returning a value (instead of throwing) keeps a valid C ABI so no C++ exception crosses the C API boundary. This protects all language bindings (C, C++, Python, C#, Java) that route through these functions.
- `OgaCreateTensorFromBuffer`: reject negative shape dimensions and guard the byte-count multiplication against `size_t` overflow (defense-in-depth).
- Added `CAPITests.SequencesOutOfBoundsAccess` unit test (no model required) verifying valid access works and out-of-bounds indices return `0` / `nullptr`.

## Testing

Built the library and unit tests, and ran:

```
[ RUN      ] CAPITests.AppendTokensToSequence
[       OK ] CAPITests.AppendTokensToSequence
[ RUN      ] CAPITests.SequencesOutOfBoundsAccess
[       OK ] CAPITests.SequencesOutOfBoundsAccess
[ RUN      ] CAPITests.MaxLength
[       OK ] CAPITests.MaxLength
[  PASSED  ] 3 tests.
```