### PR TITLE
Avoid disclosing config file contents in parse error messages

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1600,10 +1600,13 @@ void ParseConfig(const fs::path& filename, std::string_view json_overlay, Config
   RootObject_Element root_object{root};
   try {
     JSON::Parse(root_object, std::string_view(buffer.data(), buffer.size()));
-  } catch (const std::exception& message) {
-    std::ostringstream oss;
-    oss << "Error encountered while parsing '" << filename.string() << "' " << message.what();
-    throw std::runtime_error(oss.str());
+  } catch (const std::exception&) {
+    // Intentionally omit the parser's message here: it can echo verbatim
+    // content (such as JSON key names) from the file being parsed. When the
+    // path is influenced by untrusted input this would disclose file contents
+    // through the error message. The path is retained so the failing file can
+    // still be identified.
+    throw std::runtime_error("Error encountered while parsing '" + filename.string() + "'");
   }
 
   if (!json_overlay.empty()) {

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>  // for memcmp
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <numeric>
@@ -51,9 +52,10 @@ TEST(CAPITests, Config) {
 // Verifies that a config parse failure does not disclose file contents
 // (e.g. JSON key names) in the error message, while still naming the file.
 TEST(CAPITests, ConfigParseErrorDoesNotLeakContent) {
+  const auto unique_suffix = std::to_string(
+      std::chrono::high_resolution_clock::now().time_since_epoch().count());
   auto tmp_dir = std::filesystem::temp_directory_path() /
-                 "genai_config_leak_test";
-  std::filesystem::remove_all(tmp_dir);
+                 ("genai_config_leak_test_" + unique_suffix);
   std::filesystem::create_directories(tmp_dir);
 
   const char* secret_key = "SUPER_SECRET_KEY";
@@ -64,10 +66,13 @@ TEST(CAPITests, ConfigParseErrorDoesNotLeakContent) {
 
   bool threw = false;
   try {
-    auto config = OgaConfig::Create(tmp_dir.string().c_str());
+    OgaConfig::Create(tmp_dir.string().c_str());
   } catch (const std::exception& e) {
     threw = true;
     const std::string message = e.what();
+    // Ensure we actually exercised the parse-error path (not, e.g., a
+    // file-open failure), so the leak assertion below is meaningful.
+    EXPECT_NE(message.find("Error encountered while parsing"), std::string::npos);
     // The failing file is still identified...
     EXPECT_NE(message.find("genai_config.json"), std::string::npos);
     // ...but the file's contents (the key name) are not echoed back.

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -48,6 +48,36 @@ TEST(CAPITests, Config) {
 #endif
 }
 
+// Verifies that a config parse failure does not disclose file contents
+// (e.g. JSON key names) in the error message, while still naming the file.
+TEST(CAPITests, ConfigParseErrorDoesNotLeakContent) {
+  auto tmp_dir = std::filesystem::temp_directory_path() /
+                 "genai_config_leak_test";
+  std::filesystem::remove_all(tmp_dir);
+  std::filesystem::create_directories(tmp_dir);
+
+  const char* secret_key = "SUPER_SECRET_KEY";
+  {
+    std::ofstream out(tmp_dir / "genai_config.json", std::ios::binary);
+    out << "{\"model\":{\"" << secret_key << "\":\"value\"}}";
+  }
+
+  bool threw = false;
+  try {
+    auto config = OgaConfig::Create(tmp_dir.string().c_str());
+  } catch (const std::exception& e) {
+    threw = true;
+    const std::string message = e.what();
+    // The failing file is still identified...
+    EXPECT_NE(message.find("genai_config.json"), std::string::npos);
+    // ...but the file's contents (the key name) are not echoed back.
+    EXPECT_EQ(message.find(secret_key), std::string::npos);
+  }
+  EXPECT_TRUE(threw);
+
+  std::filesystem::remove_all(tmp_dir);
+}
+
 // Regression test: appending CPU provider should not throw.
 // See https://github.com/microsoft/onnxruntime-genai/pull/2179
 TEST(CAPITests, AppendCpuProvider) {


### PR DESCRIPTION
## Description

When `genai_config.json` fails to parse, `ParseConfig` (in `src/config.cpp`) rethrew the raw JSON parser message. That message can embed verbatim content from the file being parsed — for example, a JSON key name (`Unknown value "<key>"`). If the config path is influenced by untrusted input, this echoes contents of the targeted file back through the error string.

## Change

- In `ParseConfig`, on a JSON parse failure, keep the file path in the error message (so the failing file can still be identified) but no longer append the parser's raw message content.
- Added `CAPITests.ConfigParseErrorDoesNotLeakContent` (no model required): writes a `genai_config.json` containing an unknown key, calls `OgaConfig::Create`, and asserts the resulting error names `genai_config.json` but does **not** contain the key from the file.

## Scope / non-goals

This intentionally does not alter path handling. Accepting an arbitrary filesystem path is the intended behavior of `OgaCreateConfig` / `OgaCreateModel`; validating which paths are permissible is the responsibility of the calling application, and adding path/`../`/UNC restrictions here would break legitimate use cases (relative paths, models on network shares).

## Testing

Built and ran the affected tests:

```
[ RUN      ] CAPITests.Config
[       OK ] CAPITests.Config
[ RUN      ] CAPITests.ConfigParseErrorDoesNotLeakContent
[       OK ] CAPITests.ConfigParseErrorDoesNotLeakContent
[  PASSED  ] 2 tests.
```