### PR TITLE
Add GetMemoryInfo to DeviceInterface

### DIFF
--- a/src/cpu/interface.cpp
+++ b/src/cpu/interface.cpp
@@ -59,6 +59,10 @@ struct CpuInterface : DeviceInterface {
     return *ort_allocator_;
   }
 
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    throw std::runtime_error("GetMemoryInfo for CPU should not be used.");
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<CpuMemory>(size);
   }
@@ -166,10 +170,6 @@ struct CpuInterface : DeviceInterface {
   std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override { return std::make_unique<BeamSearch_Cpu>(params); }
 
   void Synchronize() override {}  // Nothing to do as CPU is always in sync with itself
-
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    throw std::runtime_error("GetMemoryInfo for CPU should not be used.");
-  }
 };
 
 std::unique_ptr<DeviceInterface> CreateCpuInterface() {

--- a/src/cpu/interface.cpp
+++ b/src/cpu/interface.cpp
@@ -57,6 +57,14 @@ struct CpuInterface : DeviceInterface {
     return *ort_allocator_;
   }
 
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    assert(!"GetMemoryInfo for CPU should not be used.");
+    return OrtMemoryInfo::Create("Cpu",
+                                 OrtAllocatorType::OrtDeviceAllocator,
+                                 0,
+                                 OrtMemType::OrtMemTypeDefault);
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<CpuMemory>(size);
   }

--- a/src/cpu/interface.cpp
+++ b/src/cpu/interface.cpp
@@ -59,10 +59,6 @@ struct CpuInterface : DeviceInterface {
     return *ort_allocator_;
   }
 
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    throw std::runtime_error("GetMemoryInfo for CPU should not be used.");
-  }
-
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<CpuMemory>(size);
   }
@@ -170,6 +166,10 @@ struct CpuInterface : DeviceInterface {
   std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override { return std::make_unique<BeamSearch_Cpu>(params); }
 
   void Synchronize() override {}  // Nothing to do as CPU is always in sync with itself
+
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    throw std::runtime_error("GetMemoryInfo for CPU should not be used.");
+  }
 };
 
 std::unique_ptr<DeviceInterface> CreateCpuInterface() {

--- a/src/cpu/interface.cpp
+++ b/src/cpu/interface.cpp
@@ -58,11 +58,7 @@ struct CpuInterface : DeviceInterface {
   }
 
   std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    assert(!"GetMemoryInfo for CPU should not be used.");
-    return OrtMemoryInfo::Create("Cpu",
-                                 OrtAllocatorType::OrtDeviceAllocator,
-                                 0,
-                                 OrtMemType::OrtMemTypeDefault);
+    throw std::runtime_error("GetMemoryInfo for CPU should not be used.");
   }
 
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {

--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -90,6 +90,13 @@ struct CudaInterfaceImplBase : DeviceInterface {
     return *ort_allocator_;
   }
 
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return OrtMemoryInfo::Create("Cuda",
+                                 OrtAllocatorType::OrtDeviceAllocator,
+                                 0,
+                                 OrtMemType::OrtMemTypeDefault);
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<GpuMemory>(size);
   }
@@ -177,13 +184,6 @@ struct CudaInterfaceImplBase : DeviceInterface {
 
   void GetAvailableMemory(size_t& free_bytes, size_t& total_bytes) override {
     cudaMemGetInfo(&free_bytes, &total_bytes);
-  }
-
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    return OrtMemoryInfo::Create("Cuda",
-                                 OrtAllocatorType::OrtDeviceAllocator,
-                                 0,
-                                 OrtMemType::OrtMemTypeDefault);
   }
 };
 

--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -90,13 +90,6 @@ struct CudaInterfaceImplBase : DeviceInterface {
     return *ort_allocator_;
   }
 
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    return OrtMemoryInfo::Create("Cuda",
-                                 OrtAllocatorType::OrtDeviceAllocator,
-                                 0,
-                                 OrtMemType::OrtMemTypeDefault);
-  }
-
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<GpuMemory>(size);
   }
@@ -184,6 +177,13 @@ struct CudaInterfaceImplBase : DeviceInterface {
 
   void GetAvailableMemory(size_t& free_bytes, size_t& total_bytes) override {
     cudaMemGetInfo(&free_bytes, &total_bytes);
+  }
+
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return OrtMemoryInfo::Create("Cuda",
+                                 OrtAllocatorType::OrtDeviceAllocator,
+                                 0,
+                                 OrtMemType::OrtMemTypeDefault);
   }
 };
 

--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -90,6 +90,13 @@ struct CudaInterfaceImplBase : DeviceInterface {
     return *ort_allocator_;
   }
 
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return OrtMemoryInfo::Create("Cuda",
+                                 OrtAllocatorType::OrtDeviceAllocator,
+                                 0,
+                                 OrtMemType::OrtMemTypeDefault);
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<GpuMemory>(size);
   }

--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -81,7 +81,6 @@ struct CudaInterfaceImplBase : DeviceInterface {
   }
 
   void InitOrt(const OrtApi& api, Ort::Allocator& allocator) override {
-    Ort::api = &api;
     assert(!ort_allocator_);
     ort_allocator_ = &allocator;
   }
@@ -246,8 +245,11 @@ void operator delete(void* p, size_t /*size*/) noexcept {
 #endif
 
 extern "C" {
-Generators::DeviceInterface* GetInterface(GenaiInterface* p_genai, const char* deviceType) {
+Generators::DeviceInterface* GetInterface(GenaiInterface* p_genai, const char* deviceType, const OrtApi* ort_api) {
   Generators::gp_genai = p_genai;
+  // Ensure Ort::api is initialized in this shared library (onnxruntime-genai-cuda add-on) immediately. Delaying the
+  // initialization to CudaInterfaceImplBase::InitOrt would be inadequate, as GetMemoryInfo runs before InitOrt.
+  Ort::api = ort_api;
   if (strcasecmp(deviceType, "NvTensorRtRtx") == 0) {
     Generators::g_cuda_device = std::make_unique<Generators::NvTensorRtRtxInterfaceImpl>();
   } else {

--- a/src/dml/interface.cpp
+++ b/src/dml/interface.cpp
@@ -137,13 +137,6 @@ struct InterfaceImpl : DeviceInterface {
     return *ort_allocator_;
   }
 
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    return OrtMemoryInfo::Create("DML",
-                                 OrtAllocatorType::OrtDeviceAllocator,
-                                 0,
-                                 OrtMemType::OrtMemTypeDefault);
-  }
-
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<GpuMemory>(size);
   }
@@ -213,6 +206,13 @@ struct InterfaceImpl : DeviceInterface {
 #endif
 
   void Synchronize() override {}
+
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return OrtMemoryInfo::Create("DML",
+                                 OrtAllocatorType::OrtDeviceAllocator,
+                                 0,
+                                 OrtMemType::OrtMemTypeDefault);
+  }
 };
 
 }  // namespace Dml

--- a/src/dml/interface.cpp
+++ b/src/dml/interface.cpp
@@ -138,6 +138,13 @@ struct InterfaceImpl : DeviceInterface {
     return *ort_allocator_;
   }
 
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return OrtMemoryInfo::Create("DML",
+                                 OrtAllocatorType::OrtDeviceAllocator,
+                                 0,
+                                 OrtMemType::OrtMemTypeDefault);
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<GpuMemory>(size);
   }

--- a/src/dml/interface.cpp
+++ b/src/dml/interface.cpp
@@ -137,6 +137,13 @@ struct InterfaceImpl : DeviceInterface {
     return *ort_allocator_;
   }
 
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return OrtMemoryInfo::Create("DML",
+                                 OrtAllocatorType::OrtDeviceAllocator,
+                                 0,
+                                 OrtMemType::OrtMemTypeDefault);
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<GpuMemory>(size);
   }
@@ -206,13 +213,6 @@ struct InterfaceImpl : DeviceInterface {
 #endif
 
   void Synchronize() override {}
-
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    return OrtMemoryInfo::Create("DML",
-                                 OrtAllocatorType::OrtDeviceAllocator,
-                                 0,
-                                 OrtMemType::OrtMemTypeDefault);
-  }
 };
 
 }  // namespace Dml

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -288,9 +288,9 @@ DeviceInterface* OrtGlobals::LoadCudaInterface(DeviceType type) {
     if (!*cuda_library_)
       throw std::runtime_error("Shared library load failure (see first error)");
 
-    Generators::DeviceInterface* GetInterface(GenaiInterface * p_genai, const char* deviceType);
+    Generators::DeviceInterface* GetInterface(GenaiInterface * p_genai, const char* deviceType, const OrtApi* ort_api);
     return reinterpret_cast<decltype(&GetInterface)>(
-        cuda_library_->GetSymbol("GetInterface"))(&g_genai, to_string(type).c_str());
+        cuda_library_->GetSymbol("GetInterface"))(&g_genai, to_string(type).c_str(), Ort::api);
   } catch (const std::exception& e) {
     throw std::runtime_error("Cuda interface not available: " + std::string(e.what()));
   }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -456,37 +456,15 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
   const auto trivial_model = GetTrivialModel();
   allocator.session_ = OrtSession::Create(GetOrtEnv(), trivial_model.data(), trivial_model.size(), session_options.get());
 
-  // Names for the device memory types used by 'OrtMemoryInfo::Create'
-  static const char* device_memory_type_names[] = {"CPU (Not used, see above)", "Cuda", "DML", "WebGPU_Buf", "QnnHtpShared", "QnnHtpShared", "OpenVINO (Not used, see above)", "Cuda", "Cpu"};
-  static_assert(std::size(device_memory_type_names) == static_cast<size_t>(DeviceType::MAX));
-
-  // Get the allocator from the OrtSession for the DeviceType (it's called 'AllocatorCreate' but it's really 'AllocatorGet')
-  auto name = device_memory_type_names[static_cast<int>(type)];
   try {
-    auto memory_info = OrtMemoryInfo::Create(name, OrtAllocatorType::OrtDeviceAllocator,
-                                             0, OrtMemType::OrtMemTypeDefault);
+    auto memory_info = device.GetMemoryInfo();
     allocator.allocator_ = Ort::Allocator::Create(*allocator.session_, *memory_info);
   } catch (const Ort::Exception& e) {
-    // WebGPU memory type name changed from "WebGPU_Buffer" to "WebGPU_Buf" in ORT 1.24.3.
-    // Try the old name before giving up.
-    if (type == DeviceType::WEBGPU) {
-      auto fallback_info = OrtMemoryInfo::Create("WebGPU_Buffer", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
-      try {
-        allocator.allocator_ = Ort::Allocator::Create(*allocator.session_, *fallback_info);
-      } catch (const Ort::Exception& fallback_e) {
-        throw std::runtime_error(
-            "Failed to create allocator for WebGPU. "
-            "Primary name '" +
-            std::string(name) + "' error: " + std::string(e.what()) +
-            "; fallback 'WebGPU_Buffer' error: " + std::string(fallback_e.what()));
-      }
-    } else {
-      throw std::runtime_error("Failed to create allocator for " + std::string(name) + ": " + std::string(e.what()));
-    }
+    throw std::runtime_error("Failed to create allocator for " + to_string(type) + ": " + std::string(e.what()));
   }
   if (!allocator.allocator_) {
     allocator = {};  // Reset everything just to be safe
-    throw std::runtime_error("Unexpected failure to create device memory allocator for " + std::string(name));
+    throw std::runtime_error("Unexpected failure to create device memory allocator for " + to_string(type));
   }
   device.InitOrt(*Ort::api, *allocator.allocator_);
 }

--- a/src/openvino/interface.cpp
+++ b/src/openvino/interface.cpp
@@ -18,7 +18,7 @@ struct InterfaceImpl : DeviceInterface {
 
   void InitOrt(const OrtApi& /*api*/, Ort::Allocator& allocator) override {
     // since we use the CPU interface for allocation (right now), InitOrt should not be getting called.
-    assert(false);
+    throw std::runtime_error("InitOrt for OpenVINO should not be getting called. Expected to use CPU interface instead.");
   }
 
   Ort::Allocator& GetAllocator() override {
@@ -26,11 +26,7 @@ struct InterfaceImpl : DeviceInterface {
   }
 
   virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    assert(!"GetMemoryInfo for OpenVINO should not be used. Expected to use CPU interface instead.");
-    return OrtMemoryInfo::Create("Cpu",
-                                 OrtAllocatorType::OrtDeviceAllocator,
-                                 0,
-                                 OrtMemType::OrtMemTypeDefault);
+    throw std::runtime_error("GetMemoryInfo for OpenVINO should not be used. Expected to use CPU interface instead.");
   }
 
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {

--- a/src/openvino/interface.cpp
+++ b/src/openvino/interface.cpp
@@ -25,10 +25,6 @@ struct InterfaceImpl : DeviceInterface {
     return GetDeviceInterface(DeviceType::CPU)->GetAllocator();
   }
 
-  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    throw std::runtime_error("GetMemoryInfo for OpenVINO should not be used. Expected to use CPU interface instead.");
-  }
-
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return GetDeviceInterface(DeviceType::CPU)->AllocateBase(size);
   }
@@ -41,6 +37,10 @@ struct InterfaceImpl : DeviceInterface {
   std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override { return std::make_unique<BeamSearch_Cpu>(params); }
 
   void Synchronize() override {}  // Nothing to do
+
+  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    throw std::runtime_error("GetMemoryInfo for OpenVINO should not be used. Expected to use CPU interface instead.");
+  }
 };
 
 }  // namespace OpenVINO

--- a/src/openvino/interface.cpp
+++ b/src/openvino/interface.cpp
@@ -25,6 +25,10 @@ struct InterfaceImpl : DeviceInterface {
     return GetDeviceInterface(DeviceType::CPU)->GetAllocator();
   }
 
+  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    throw std::runtime_error("GetMemoryInfo for OpenVINO should not be used. Expected to use CPU interface instead.");
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return GetDeviceInterface(DeviceType::CPU)->AllocateBase(size);
   }
@@ -37,10 +41,6 @@ struct InterfaceImpl : DeviceInterface {
   std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override { return std::make_unique<BeamSearch_Cpu>(params); }
 
   void Synchronize() override {}  // Nothing to do
-
-  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    throw std::runtime_error("GetMemoryInfo for OpenVINO should not be used. Expected to use CPU interface instead.");
-  }
 };
 
 }  // namespace OpenVINO

--- a/src/openvino/interface.cpp
+++ b/src/openvino/interface.cpp
@@ -25,6 +25,14 @@ struct InterfaceImpl : DeviceInterface {
     return GetCpuInterface()->GetAllocator();
   }
 
+  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    assert(!"GetMemoryInfo for OpenVINO should not be used. Expected to use CPU interface instead.");
+    return OrtMemoryInfo::Create("Cpu",
+                                 OrtAllocatorType::OrtDeviceAllocator,
+                                 0,
+                                 OrtMemType::OrtMemTypeDefault);
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return GetCpuInterface()->AllocateBase(size);
   }

--- a/src/qnn/interface.cpp
+++ b/src/qnn/interface.cpp
@@ -44,6 +44,12 @@ struct QnnMemory final : DeviceBuffer {
 };
 
 struct QnnInterfaceBase : DeviceInterface {
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    // Note: "QnnHtpShared" allocator is the correct name for both HTP and GPU backends. Eventually, the plan is to
+    // migrate to "QnnShared".
+    return OrtMemoryInfo::Create("QnnHtpShared", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+  }
+
   void InitOrt(const OrtApi& /*api*/, Ort::Allocator& allocator) override {
     assert(!ort_allocator_);
     ort_allocator_ = &allocator;
@@ -65,12 +71,6 @@ struct QnnInterfaceBase : DeviceInterface {
   std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override { return std::make_unique<BeamSearch_Cpu>(params); }
 
   void Synchronize() override {}  // Nothing to do
-
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    // Note: "QnnHtpShared" allocator is the correct name for both HTP and GPU backends. Eventually, the plan is to
-    // migrate to "QnnShared".
-    return OrtMemoryInfo::Create("QnnHtpShared", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
-  }
 };
 
 struct HtpInterfaceImpl : QnnInterfaceBase {

--- a/src/qnn/interface.cpp
+++ b/src/qnn/interface.cpp
@@ -44,12 +44,6 @@ struct QnnMemory final : DeviceBuffer {
 };
 
 struct QnnInterfaceBase : DeviceInterface {
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    // Note: "QnnHtpShared" allocator is the correct name for both HTP and GPU backends. Eventually, the plan is to
-    // migrate to "QnnShared".
-    return OrtMemoryInfo::Create("QnnHtpShared", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
-  }
-
   void InitOrt(const OrtApi& /*api*/, Ort::Allocator& allocator) override {
     assert(!ort_allocator_);
     ort_allocator_ = &allocator;
@@ -71,6 +65,12 @@ struct QnnInterfaceBase : DeviceInterface {
   std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override { return std::make_unique<BeamSearch_Cpu>(params); }
 
   void Synchronize() override {}  // Nothing to do
+
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    // Note: "QnnHtpShared" allocator is the correct name for both HTP and GPU backends. Eventually, the plan is to
+    // migrate to "QnnShared".
+    return OrtMemoryInfo::Create("QnnHtpShared", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+  }
 };
 
 struct HtpInterfaceImpl : QnnInterfaceBase {

--- a/src/qnn/interface.cpp
+++ b/src/qnn/interface.cpp
@@ -44,6 +44,12 @@ struct QnnMemory final : DeviceBuffer {
 };
 
 struct QnnInterfaceBase : DeviceInterface {
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    // Note: "QnnHtpShared" allocator is the correct name for both HTP and GPU backends. Eventually, the plan is to
+    // migrate to "QnnShared".
+    return OrtMemoryInfo::Create("QnnHtpShared", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+  }
+
   void InitOrt(const OrtApi& /*api*/, Ort::Allocator& allocator) override {
     assert(!ort_allocator_);
     ort_allocator_ = &allocator;
@@ -80,9 +86,11 @@ struct HtpInterfaceImpl : QnnInterfaceBase {
     //             "enable_dx12_shared_memory_allocator" in `GpuInterfaceImpl::ShapeInitSessionProviderOptions`.
     //         2.) Oga keeps one global allocator for HTP and one for GPU, each of which is created once. Because each device
     //             only supports once allocator, the fact that each device's chosen allocator is sticky is ok.
-    for (const auto& opt : user_options->options) {
-      if (opt.first == "enable_htp_shared_memory_allocator") {
-        init_options.options.emplace_back(opt);
+    if (user_options != nullptr) {
+      for (const auto& opt : user_options->options) {
+        if (opt.first == "enable_htp_shared_memory_allocator") {
+          init_options.options.emplace_back(opt);
+        }
       }
     }
 
@@ -96,9 +104,11 @@ struct GpuInterfaceImpl : QnnInterfaceBase {
 
   void ShapeInitSessionProviderOptions(Config::ProviderOptions& init_options,
                                        const Config::ProviderOptions* user_options) const override {
-    for (const auto& opt : user_options->options) {
-      if (opt.first == "enable_dx12_shared_memory_allocator") {
-        init_options.options.emplace_back(opt);
+    if (user_options != nullptr) {
+      for (const auto& opt : user_options->options) {
+        if (opt.first == "enable_dx12_shared_memory_allocator") {
+          init_options.options.emplace_back(opt);
+        }
       }
     }
 
@@ -109,7 +119,7 @@ struct GpuInterfaceImpl : QnnInterfaceBase {
 }  // namespace QNN
 
 DeviceInterface* GetQNNInterface(DeviceType device_type) {
-  assert(type == DeviceType::QnnHtp || type == DeviceType::QnnGpu);
+  assert(device_type == DeviceType::QnnHtp || device_type == DeviceType::QnnGpu);
 
   static std::unique_ptr<DeviceInterface> g_htp_device = std::make_unique<QNN::HtpInterfaceImpl>();
   static std::unique_ptr<DeviceInterface> g_gpu_device = std::make_unique<QNN::GpuInterfaceImpl>();

--- a/src/qnn/session_options.cpp
+++ b/src/qnn/session_options.cpp
@@ -16,38 +16,31 @@ static bool IsAllocatorAvailable(const Config& config, DeviceType device_type) {
   //   a. The graphics drivers installed on the system
   //   b. The QNN EP package loaded by onnxruntime-genai
   // If either dependency is out-of-date, the allocator will not be available.
+  Config::ProviderOptions init_session_provider_options{"QNN", {}};
+  const auto& user_provider_options_list = config.model.decoder.session_options.provider_options;
+  const auto user_provider_options_it = std::find_if(
+      user_provider_options_list.begin(), user_provider_options_list.end(),
+      [](const Config::ProviderOptions& po) { return po.name == "QNN"; });
+  const Config::ProviderOptions* user_provider_options =
+      user_provider_options_it != user_provider_options_list.end() ? &*user_provider_options_it : nullptr;
+  GetQNNInterface(device_type)->ShapeInitSessionProviderOptions(init_session_provider_options, user_provider_options);
+
   auto session_options = OrtSessionOptions::Create();
-
-  auto provider_options = Config::ProviderOptions{"QNN", {}};
-  const auto& config_providers = config.model.decoder.session_options.providers;
-  const auto& config_provider_options = config.model.decoder.session_options.provider_options;
-
-  auto it = std::find_if(config_providers.begin(), config_providers.end(), [](const std::string& p) { return p == "QNN"; });
-  if (it != config_providers.end()) {
-    const auto i = std::distance(config_providers.begin(), it);
-    if (config_provider_options.size() > static_cast<size_t>(i)) {
-      for (const auto& pair : config_provider_options[i].options) {
-        provider_options.options.emplace_back(pair);
-      }
-    }
-  }
-
-  if (!AppendExecutionProviderV2(*session_options, provider_options,
+  if (!AppendExecutionProviderV2(*session_options, init_session_provider_options,
                                  device_type, "QNNExecutionProvider")) {
-    AppendExecutionProviderV1(*session_options, provider_options);
+    AppendExecutionProviderV1(*session_options, init_session_provider_options);
   }
 
   session_options->SetLogSeverityLevel(ORT_LOGGING_LEVEL_ERROR);
 
-  const auto trivial_model = Generators::GetTrivialModel();
+  const auto trivial_model = GetTrivialModel();
   const auto session = OrtSession::Create(GetOrtEnv(),
                                           trivial_model.data(),
                                           trivial_model.size(),
                                           session_options.get());
 
   try {
-    const auto memory_info = OrtMemoryInfo::Create("QnnHtpShared", OrtAllocatorType::OrtDeviceAllocator,
-                                                   0, OrtMemType::OrtMemTypeDefault);
+    const auto memory_info = GetQNNInterface(device_type)->GetMemoryInfo();
     const auto allocator = Ort::Allocator::Create(*session, *memory_info);
     return allocator != nullptr;
   } catch (const Ort::Exception&) {

--- a/src/ryzenai/interface.h
+++ b/src/ryzenai/interface.h
@@ -8,6 +8,13 @@ namespace Generators {
 struct RyzenAIInterface : DeviceInterface {
   using ProviderOptions = std::vector<std::pair<std::string, std::string>>;
 
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return OrtMemoryInfo::Create("Cpu",
+                                 OrtAllocatorType::OrtDeviceAllocator,
+                                 0,
+                                 OrtMemType::OrtMemTypeDefault);
+  }
+
   virtual void SetupProvider(OrtSessionOptions&, const ProviderOptions&) = 0;
 
   static void Shutdown();

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -108,7 +108,6 @@ struct DeviceInterface {
   virtual DeviceType GetType() const = 0;
   virtual void InitOrt(const OrtApi& api, Ort::Allocator& allocator) = 0;
   virtual Ort::Allocator& GetAllocator() = 0;
-  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const = 0;
 
   template <typename T>
   DeviceSpan<T> Allocate(size_t count) { return DeviceSpan<T>(AllocateBase(sizeof(T) * count)); }
@@ -150,6 +149,8 @@ struct DeviceInterface {
     assert(false);
     return nullptr;
   }  // Temporary until we fully factor out providers
+
+  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const = 0;
 };
 
 // A shared_ptr based type that we expose through our C API should inherit from this type.

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -108,6 +108,7 @@ struct DeviceInterface {
   virtual DeviceType GetType() const = 0;
   virtual void InitOrt(const OrtApi& api, Ort::Allocator& allocator) = 0;
   virtual Ort::Allocator& GetAllocator() = 0;
+  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const = 0;
 
   template <typename T>
   DeviceSpan<T> Allocate(size_t count) { return DeviceSpan<T>(AllocateBase(sizeof(T) * count)); }
@@ -149,8 +150,6 @@ struct DeviceInterface {
     assert(false);
     return nullptr;
   }  // Temporary until we fully factor out providers
-
-  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const = 0;
 };
 
 // A shared_ptr based type that we expose through our C API should inherit from this type.

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -108,6 +108,7 @@ struct DeviceInterface {
   virtual DeviceType GetType() const = 0;
   virtual void InitOrt(const OrtApi& api, Ort::Allocator& allocator) = 0;
   virtual Ort::Allocator& GetAllocator() = 0;
+  virtual std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const = 0;
 
   template <typename T>
   DeviceSpan<T> Allocate(size_t count) { return DeviceSpan<T>(AllocateBase(sizeof(T) * count)); }

--- a/src/webgpu/interface.cpp
+++ b/src/webgpu/interface.cpp
@@ -182,6 +182,24 @@ struct InterfaceImpl : DeviceInterface {
     return *ort_allocator_;
   }
 
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    try {
+      return OrtMemoryInfo::Create("WebGPU_Buf", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+    } catch (const Ort::Exception& e) {
+      // WebGPU memory type name changed from "WebGPU_Buffer" to "WebGPU_Buf" in ORT 1.24.3.
+      // Try the old name before giving up.
+      try {
+        return OrtMemoryInfo::Create("WebGPU_Buffer", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+      } catch (const Ort::Exception& fallback_e) {
+        throw std::runtime_error(
+            "Failed to create memory info for WebGPU. "
+            "Primary name 'WebGPU_Buf' error: " +
+            std::string(e.what()) +
+            "; fallback 'WebGPU_Buffer' error: " + std::string(fallback_e.what()));
+      }
+    }
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<WebGPUMemory>(size, ort_allocator_, ort_memory_info_);
   }
@@ -314,24 +332,6 @@ struct InterfaceImpl : DeviceInterface {
     for (const auto& opt : user_options->options) {
       if (std::find(kWebGpuGlobalOptions.begin(), kWebGpuGlobalOptions.end(), opt.first) != kWebGpuGlobalOptions.end()) {
         init_options.options.emplace_back(opt);
-      }
-    }
-  }
-
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    try {
-      return OrtMemoryInfo::Create("WebGPU_Buf", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
-    } catch (const Ort::Exception& e) {
-      // WebGPU memory type name changed from "WebGPU_Buffer" to "WebGPU_Buf" in ORT 1.24.3.
-      // Try the old name before giving up.
-      try {
-        return OrtMemoryInfo::Create("WebGPU_Buffer", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
-      } catch (const Ort::Exception& fallback_e) {
-        throw std::runtime_error(
-            "Failed to create memory info for WebGPU. "
-            "Primary name 'WebGPU_Buf' error: " +
-            std::string(e.what()) +
-            "; fallback 'WebGPU_Buffer' error: " + std::string(fallback_e.what()));
       }
     }
   }

--- a/src/webgpu/interface.cpp
+++ b/src/webgpu/interface.cpp
@@ -182,24 +182,6 @@ struct InterfaceImpl : DeviceInterface {
     return *ort_allocator_;
   }
 
-  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
-    try {
-      return OrtMemoryInfo::Create("WebGPU_Buf", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
-    } catch (const Ort::Exception& e) {
-      // WebGPU memory type name changed from "WebGPU_Buffer" to "WebGPU_Buf" in ORT 1.24.3.
-      // Try the old name before giving up.
-      try {
-        return OrtMemoryInfo::Create("WebGPU_Buffer", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
-      } catch (const Ort::Exception& fallback_e) {
-        throw std::runtime_error(
-            "Failed to create memory info for WebGPU. "
-            "Primary name 'WebGPU_Buf' error: " +
-            std::string(e.what()) +
-            "; fallback 'WebGPU_Buffer' error: " + std::string(fallback_e.what()));
-      }
-    }
-  }
-
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<WebGPUMemory>(size, ort_allocator_, ort_memory_info_);
   }
@@ -332,6 +314,24 @@ struct InterfaceImpl : DeviceInterface {
     for (const auto& opt : user_options->options) {
       if (std::find(kWebGpuGlobalOptions.begin(), kWebGpuGlobalOptions.end(), opt.first) != kWebGpuGlobalOptions.end()) {
         init_options.options.emplace_back(opt);
+      }
+    }
+  }
+
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    try {
+      return OrtMemoryInfo::Create("WebGPU_Buf", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+    } catch (const Ort::Exception& e) {
+      // WebGPU memory type name changed from "WebGPU_Buffer" to "WebGPU_Buf" in ORT 1.24.3.
+      // Try the old name before giving up.
+      try {
+        return OrtMemoryInfo::Create("WebGPU_Buffer", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+      } catch (const Ort::Exception& fallback_e) {
+        throw std::runtime_error(
+            "Failed to create memory info for WebGPU. "
+            "Primary name 'WebGPU_Buf' error: " +
+            std::string(e.what()) +
+            "; fallback 'WebGPU_Buffer' error: " + std::string(fallback_e.what()));
       }
     }
   }

--- a/src/webgpu/interface.cpp
+++ b/src/webgpu/interface.cpp
@@ -182,6 +182,24 @@ struct InterfaceImpl : DeviceInterface {
     return *ort_allocator_;
   }
 
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    try {
+      return OrtMemoryInfo::Create("WebGPU_Buf", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+    } catch (const Ort::Exception& e) {
+      // WebGPU memory type name changed from "WebGPU_Buffer" to "WebGPU_Buf" in ORT 1.24.3.
+      // Try the old name before giving up.
+      try {
+        return OrtMemoryInfo::Create("WebGPU_Buffer", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
+      } catch (const Ort::Exception& fallback_e) {
+        throw std::runtime_error(
+            "Failed to create memory info for WebGPU. "
+            "Primary name 'WebGPU_Buf' error: " +
+            std::string(e.what()) +
+            "; fallback 'WebGPU_Buffer' error: " + std::string(fallback_e.what()));
+      }
+    }
+  }
+
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
     return std::make_shared<WebGPUMemory>(size, ort_allocator_, ort_memory_info_);
   }


### PR DESCRIPTION
* Let EPs specify the device memory info through the DeviceInterface, instead of having EP-specific branching in EnsureDeviceOrtInit.
* Fix Debug build failure due to misnamed variable in QNN interface.
* This is a follow-up to PR #2105.