### PR TITLE
Add regression tests for top_k exceeding vocab_size

### DIFF
--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -1122,6 +1122,37 @@ INSTANTIATE_TEST_SUITE_P(TopKCAPITest,
                          ParametrizedTopKTopPCAPITestsTests,
                          ::testing::Values(false, true));
 
+// Regression test: a top_k value larger than the model's vocab_size must be
+// rejected at generator creation time instead of triggering an out-of-bounds
+// read/write in std::partial_sort inside SampleTopK/SampleTopKTopP.
+TEST(CAPITests, TopKExceedsVocabSizeThrows) {
+  Phi2Test test;
+
+  // vocab_size for any real model is far below this, so the value is guaranteed
+  // to exceed it regardless of the specific test model.
+  constexpr int kTopKAboveVocabSize = 1'000'000;
+
+  test.params_->SetSearchOptionBool("do_sample", true);
+  test.params_->SetSearchOption("top_k", kTopKAboveVocabSize);
+  test.params_->SetSearchOption("temperature", 0.6f);
+
+  EXPECT_THROW(OgaGenerator::Create(*test.model_, *test.params_), std::exception);
+}
+
+// Regression test for the combined Top-K + Top-P sampling path.
+TEST(CAPITests, TopKTopPExceedsVocabSizeThrows) {
+  Phi2Test test;
+
+  constexpr int kTopKAboveVocabSize = 1'000'000;
+
+  test.params_->SetSearchOptionBool("do_sample", true);
+  test.params_->SetSearchOption("top_k", kTopKAboveVocabSize);
+  test.params_->SetSearchOption("top_p", 0.6f);
+  test.params_->SetSearchOption("temperature", 0.6f);
+
+  EXPECT_THROW(OgaGenerator::Create(*test.model_, *test.params_), std::exception);
+}
+
 TEST(CAPITests, AdaptersTest) {
 #ifdef USE_CUDA
   using OutputType = Ort::Float16_t;

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -1128,15 +1128,21 @@ INSTANTIATE_TEST_SUITE_P(TopKCAPITest,
 TEST(CAPITests, TopKExceedsVocabSizeThrows) {
   Phi2Test test;
 
-  // vocab_size for any real model is far below this, so the value is guaranteed
-  // to exceed it regardless of the specific test model.
+  // Chosen to sit well above typical vocabulary sizes (and above Phi-2's known
+  // vocab_size) so it reliably exceeds the model's vocab_size.
   constexpr int kTopKAboveVocabSize = 1'000'000;
 
   test.params_->SetSearchOptionBool("do_sample", true);
   test.params_->SetSearchOption("top_k", kTopKAboveVocabSize);
   test.params_->SetSearchOption("temperature", 0.6f);
 
-  EXPECT_THROW(OgaGenerator::Create(*test.model_, *test.params_), std::exception);
+  try {
+    OgaGenerator::Create(*test.model_, *test.params_);
+    FAIL() << "Expected std::runtime_error for top_k > vocab_size";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find("vocab_size"), std::string::npos)
+        << "Unexpected error message: " << e.what();
+  }
 }
 
 // Regression test for the combined Top-K + Top-P sampling path.
@@ -1150,7 +1156,13 @@ TEST(CAPITests, TopKTopPExceedsVocabSizeThrows) {
   test.params_->SetSearchOption("top_p", 0.6f);
   test.params_->SetSearchOption("temperature", 0.6f);
 
-  EXPECT_THROW(OgaGenerator::Create(*test.model_, *test.params_), std::exception);
+  try {
+    OgaGenerator::Create(*test.model_, *test.params_);
+    FAIL() << "Expected std::runtime_error for top_k > vocab_size";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find("vocab_size"), std::string::npos)
+        << "Unexpected error message: " << e.what();
+  }
 }
 
 TEST(CAPITests, AdaptersTest) {


### PR DESCRIPTION
## Summary

Adds C API regression tests guarding against an out-of-bounds (heap OOB) access that could previously be triggered when `top_k` exceeded the model's `vocab_size` (reported via MSRC).

## Background

A heap OOB in `GreedySearch_Cpu::SampleTopK()` / `SampleTopKTopP()` (`src/search.cpp`): when `top_k > vocab_size`, `std::partial_sort(indices.begin(), indices.begin() + k, indices.end(), ...)` reads/writes past the `indices` allocation.

Investigation shows the vulnerability is **already fixed** on `main`:
- `src/generators.cpp` (`InitializeSamplingMethod`) rejects both `top_k < 0` and `top_k > vocab_size` with a clear error at generator creation.
- `SampleTopK` / `SampleTopKTopP` clamp `k = std::min(k, vocab_size)`.
- The CUDA sampling path (`src/cuda/cuda_sampling.cu`) clamps `k` to `vocab_size`.

However, there was **no test** guarding this behavior. This PR adds that coverage.

## Changes

- `test/c_api_tests.cpp`: add `TopKExceedsVocabSizeThrows` and `TopKTopPExceedsVocabSizeThrows`, which set `top_k` well above any `vocab_size` and assert that `OgaGenerator::Create` throws instead of proceeding to an OOB access.

## Testing

Tests follow the existing `Phi2Test` C API test pattern. Local build isn't available in my environment; relying on CI to build and run the C++ unit tests.