### PR TITLE
Fix use-after-free by making GeneratorParams co-own its Model

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -290,7 +290,8 @@ GeneratorParams::GeneratorParams(const Config& config)
 }
 
 GeneratorParams::GeneratorParams(const Model& model)
-    : config{*model.config_.get()},
+    : model_owner_{model.shared_from_this()},
+      config{*model_owner_->config_.get()},
       use_graph_capture{IsGraphCaptureEnabled(model.config_->model.decoder.session_options)},
       use_multi_profile{IsMultiProfileEnabled(model.config_->model.decoder.session_options)},
       p_device{model.p_device_scoring_} {

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -290,8 +290,8 @@ GeneratorParams::GeneratorParams(const Config& config)
 }
 
 GeneratorParams::GeneratorParams(const Model& model)
-    : model_owner_{model.shared_from_this()},
-      config{*model_owner_->config_.get()},
+    : model_{model.shared_from_this()},
+      config{*model_->config_.get()},
       use_graph_capture{IsGraphCaptureEnabled(model.config_->model.decoder.session_options)},
       use_multi_profile{IsMultiProfileEnabled(model.config_->model.decoder.session_options)},
       p_device{model.p_device_scoring_} {

--- a/src/generators.h
+++ b/src/generators.h
@@ -73,7 +73,10 @@ struct GeneratorParams : std::enable_shared_from_this<GeneratorParams>, LeakChec
   GeneratorParams(const Config& config);  // This constructor is only used for internal generator benchmarks
   GeneratorParams(const Model& model);
 
-  const Config& config;                  // The model outlives the GeneratorParams
+  // Co-owns the model so the aliased Config below cannot be freed while this
+  // params object is alive. Null for the benchmark-only Config constructor.
+  std::shared_ptr<const Model> model_owner_;
+  const Config& config;                  // Aliases model-owned Config; kept alive by model_owner_
   Config::Search search{config.search};  // Copy of the search parameters from the config
 
   // Query the params to get the value set for a param

--- a/src/generators.h
+++ b/src/generators.h
@@ -75,8 +75,8 @@ struct GeneratorParams : std::enable_shared_from_this<GeneratorParams>, LeakChec
 
   // Co-owns the model so the aliased Config below cannot be freed while this
   // params object is alive. Null for the benchmark-only Config constructor.
-  std::shared_ptr<const Model> model_owner_;
-  const Config& config;                  // Aliases model-owned Config; kept alive by model_owner_
+  std::shared_ptr<const Model> model_;
+  const Config& config;                  // Aliases model-owned Config; kept alive by model_
   Config::Search search{config.search};  // Copy of the search parameters from the config
 
   // Query the params to get the value set for a param

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -1195,8 +1195,11 @@ TEST(CAPITests, CreateGeneratorAfterDestroyModel) {
   ASSERT_EQ(OgaCreateGeneratorParams(model, &params), nullptr);
   ASSERT_NE(params, nullptr);
 
-  // Drop the external reference to the model. The params must keep the
-  // underlying model (and its Config) alive, so the handle stays usable.
+  // Drop the external reference to the model by destroying its handle. Because
+  // params co-owns the underlying Model (and its Config) via shared ownership,
+  // the object itself stays alive, so dereferencing the raw model pointer below
+  // remains valid. This does NOT imply the handle is generally usable after
+  // OgaDestroyModel; it is valid here only because another owner keeps it alive.
   OgaDestroyModel(model);
 
   OgaGenerator* generator = nullptr;

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -1182,6 +1182,31 @@ TEST(CAPITests, TopKTopPExceedsVocabSizeThrows) {
   }
 }
 
+// Regression test: a GeneratorParams created from a model must keep that model
+// alive, so destroying the model handle before creating the generator does not
+// cause a use-after-free (GeneratorParams aliases the model-owned Config, and
+// Generator::Generator calls model.shared_from_this()).
+TEST(CAPITests, CreateGeneratorAfterDestroyModel) {
+  OgaModel* model = nullptr;
+  ASSERT_EQ(OgaCreateModel(PHI2_PATH, &model), nullptr);
+  ASSERT_NE(model, nullptr);
+
+  OgaGeneratorParams* params = nullptr;
+  ASSERT_EQ(OgaCreateGeneratorParams(model, &params), nullptr);
+  ASSERT_NE(params, nullptr);
+
+  // Drop the external reference to the model. The params must keep the
+  // underlying model (and its Config) alive, so the handle stays usable.
+  OgaDestroyModel(model);
+
+  OgaGenerator* generator = nullptr;
+  ASSERT_EQ(OgaCreateGenerator(model, params, &generator), nullptr);
+  ASSERT_NE(generator, nullptr);
+
+  OgaDestroyGenerator(generator);
+  OgaDestroyGeneratorParams(params);
+}
+
 TEST(CAPITests, AdaptersTest) {
 #ifdef USE_CUDA
   using OutputType = Ort::Float16_t;


### PR DESCRIPTION
## Summary

Fixes a use-after-free (CWE-416) reachable through the public C ABI.

`GeneratorParams` stored only a bare `const Config&` aliasing the model-owned `Config` (`src/generators.h`), relying on the documented-but-unenforced assumption that "the model outlives the GeneratorParams". It did **not** take co-ownership of the model. The following ordinary C API sequence therefore triggers a UAF:

1. `OgaCreateModel` — allocates the `Model` and its `std::unique_ptr<Config> config_`.
2. `OgaCreateGeneratorParams` — binds `config{*model.config_.get()}`, a bare reference; the model's refcount is unchanged.
3. `OgaDestroyModel` — `ExternalRelease` drops the last owner and frees the `Model` and its `Config`.
4. `OgaCreateGenerator(model, params)` — `Generator::Generator` runs `model_{model.shared_from_this()}` on the **freed** model → heap-use-after-free read.

`Generator` already co-owns the model via `std::shared_ptr<const Model> model_`; `GeneratorParams` did not follow the same discipline, leaving the window open.

## Fix

- **`src/generators.h`**: add `std::shared_ptr<const Model> model_owner_` to `GeneratorParams`, declared **before** the `config` reference so it is initialized first.
- **`src/generators.cpp`**: initialize `model_owner_{model.shared_from_this()}` and bind `config{*model_owner_->config_.get()}`. Now the model (and its `Config`) cannot be freed while a params handle is live, and a generator can never be constructed from a freed model. The benchmark-only `GeneratorParams(const Config&)` path leaves `model_owner_` null by design.
- **`test/c_api_tests.cpp`**: add `CreateGeneratorAfterDestroyModel`, reproducing the PoC ordering (destroy model handle, then create generator) and asserting success without a UAF.

## Testing

Local build isn't available in my environment (root-owned build dir / needs the jiafa-dev container); relying on CI to build and run the C++ unit tests, ideally under ASan.