### PR TITLE
Fix new-delete-type-mismatch in C API opaque handle destroy functions

### DIFF
--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -47,6 +47,15 @@ struct OgaAbstract {
 // As the Oga* types are just typedefs, we can use them as the actual types in the C API.
 // We still need to cast from internal types to the external ones, but these definitions ensure that the types are correct.
 // But do not use reinterpret_cast!
+//
+// IMPORTANT: Objects handed out through these opaque handles are actually allocated as their
+// internal base type (see `ReturnUnique<OgaX>(std::make_unique<BaseX>(...))`). On some ABIs
+// (notably MSVC without `__declspec(empty_bases)`), the multiple-inheritance with `OgaAbstract`
+// makes `sizeof(OgaX) > sizeof(BaseX)`. If the corresponding `OgaDestroyX` function does
+// `delete p` on the `OgaX*`, C++17 sized-delete will pass `sizeof(OgaX)` to the allocator while
+// the object was actually allocated with `sizeof(BaseX)` — a new-delete-type-mismatch that
+// corrupts heap metadata. Every `OgaDestroyX` below MUST therefore delete through the base type,
+// i.e. `delete static_cast<BaseX*>(p)`, to match what was allocated.
 struct OgaAdapters : Generators::Adapters, OgaAbstract {};
 struct OgaAudios : Generators::Audios, OgaAbstract {};
 struct OgaConfig : Generators::Config, OgaAbstract {};
@@ -1093,23 +1102,29 @@ OgaResult* OGA_API_CALL OgaRequestGetOpaqueData(OgaRequest* request, void** data
   OGA_CATCH
 }
 
-void OGA_API_CALL OgaDestroyStringArray(OgaStringArray* string_array) { delete string_array; }
-void OGA_API_CALL OgaDestroyResult(OgaResult* p) { delete p; }
+// NOTE: Every `delete` below casts the Oga* handle back to the internal base type that was
+// actually allocated by the matching OgaCreate*/ReturnUnique call. Deleting through the Oga*
+// pointer directly would trigger a new-delete-type-mismatch (heap corruption) on ABIs where
+// sizeof(OgaX) > sizeof(BaseX) — e.g. MSVC does not apply empty-base optimization to the
+// `OgaAbstract` secondary base across multiple inheritance by default, so the C++17 sized-delete
+// would hand a mismatched allocation size to the allocator.
+void OGA_API_CALL OgaDestroyStringArray(OgaStringArray* string_array) { delete static_cast<std::vector<std::string>*>(string_array); }
+void OGA_API_CALL OgaDestroyResult(OgaResult* p) { delete static_cast<Generators::Result*>(p); }
 void OGA_API_CALL OgaDestroyString(const char* p) { delete[] p; }
-void OGA_API_CALL OgaDestroySequences(OgaSequences* p) { delete p; }
-void OGA_API_CALL OgaDestroyConfig(OgaConfig* p) { delete p; }
+void OGA_API_CALL OgaDestroySequences(OgaSequences* p) { delete static_cast<Generators::TokenSequences*>(p); }
+void OGA_API_CALL OgaDestroyConfig(OgaConfig* p) { delete static_cast<Generators::Config*>(p); }
 void OGA_API_CALL OgaDestroyModel(OgaModel* p) { p->ExternalRelease(); }
 void OGA_API_CALL OgaDestroyGeneratorParams(OgaGeneratorParams* p) { p->ExternalRelease(); }
-void OGA_API_CALL OgaDestroyGenerator(OgaGenerator* p) { delete p; }
+void OGA_API_CALL OgaDestroyGenerator(OgaGenerator* p) { delete static_cast<Generators::Generator*>(p); }
 void OGA_API_CALL OgaDestroyTokenizer(OgaTokenizer* p) { p->ExternalRelease(); }
-void OGA_API_CALL OgaDestroyTokenizerStream(OgaTokenizerStream* p) { delete p; }
+void OGA_API_CALL OgaDestroyTokenizerStream(OgaTokenizerStream* p) { delete static_cast<Generators::TokenizerStream*>(p); }
 void OGA_API_CALL OgaDestroyTensor(OgaTensor* p) { p->ExternalRelease(); }
 void OGA_API_CALL OgaDestroyMultiModalProcessor(OgaMultiModalProcessor* p) { p->ExternalRelease(); }
-void OGA_API_CALL OgaDestroyImages(OgaImages* p) { delete p; }
-void OGA_API_CALL OgaDestroyAudios(OgaAudios* p) { delete p; }
-void OGA_API_CALL OgaDestroyNamedTensors(OgaNamedTensors* p) { delete p; }
+void OGA_API_CALL OgaDestroyImages(OgaImages* p) { delete static_cast<Generators::Images*>(p); }
+void OGA_API_CALL OgaDestroyAudios(OgaAudios* p) { delete static_cast<Generators::Audios*>(p); }
+void OGA_API_CALL OgaDestroyNamedTensors(OgaNamedTensors* p) { delete static_cast<Generators::NamedTensors*>(p); }
 void OGA_API_CALL OgaDestroyAdapters(OgaAdapters* p) { p->ExternalRelease(); }
-void OGA_API_CALL OgaDestroyRuntimeSettings(OgaRuntimeSettings* p) { delete p; }
+void OGA_API_CALL OgaDestroyRuntimeSettings(OgaRuntimeSettings* p) { delete static_cast<Generators::RuntimeSettings*>(p); }
 void OGA_API_CALL OgaDestroyEngine(OgaEngine* p) { p->ExternalRelease(); }
 void OGA_API_CALL OgaDestroyRequest(OgaRequest* p) { p->ExternalRelease(); }
 
@@ -1153,7 +1168,7 @@ OgaResult* OGA_API_CALL OgaStreamingProcessorFlush(OgaStreamingProcessor* proces
   OGA_CATCH
 }
 
-void OGA_API_CALL OgaDestroyStreamingProcessor(OgaStreamingProcessor* p) { delete p; }
+void OGA_API_CALL OgaDestroyStreamingProcessor(OgaStreamingProcessor* p) { delete static_cast<Generators::StreamingProcessor*>(p); }
 
 OgaResult* OGA_API_CALL OgaStreamingProcessorSetOption(OgaStreamingProcessor* processor, const char* key, const char* value) {
   OGA_TRY


### PR DESCRIPTION
The Oga* opaque handle types in src/ort_genai_c.cpp are defined via multiple inheritance from the internal type and the empty `OgaAbstract` marker. On ABIs that do not apply empty-base optimization across multiple inheritance by default (notably MSVC without `__declspec(empty_bases)`), `sizeof(OgaX) > sizeof(BaseX)`. Objects are allocated as the internal base type (`new Generators::BaseX(...)` in the matching OgaCreate*/ReturnUnique helpers), so `delete p` on the `OgaX*` made the C++17 sized-delete operator pass a mismatched allocation size to the allocator, corrupting heap metadata (ASan:
new-delete-type-mismatch, e.g. 5128 vs 5136 bytes for OgaConfig).

Fix: every owning `OgaDestroy*` now deletes through the internal base type that was actually allocated:

    delete static_cast<Generators::BaseX*>(p);

so `operator new` and `operator delete` see the same size on every ABI. Applied to all 12 owning destroy paths: OgaDestroyResult, OgaDestroySequences, OgaDestroyConfig, OgaDestroyGenerator, OgaDestroyTokenizerStream, OgaDestroyImages, OgaDestroyAudios, OgaDestroyNamedTensors, OgaDestroyRuntimeSettings, OgaDestroyStringArray, and OgaDestroyStreamingProcessor. The ExternalRefCounted destroys (Model, Tokenizer, Tensor, MultiModalProcessor, Adapters, Engine, Request, GeneratorParams) are untouched because they call `ExternalRelease()` and never `delete`.

The struct definitions and `OgaAbstract` type are unchanged, so the public ABI is preserved and the accidental-construction type-safety protection is retained.