### PR TITLE
Reject vocab_size < 2 for beam search to fix OOB in BeamSearch_Cpu::SelectTop

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -398,6 +398,12 @@ Generator::Generator(const Model& model, const GeneratorParams& params) : model_
     throw std::runtime_error("num_beams (" + std::to_string(params.search.num_beams) + ") must be in [1, " + std::to_string(max_num_beams) + "]");
   if (params.config.model.vocab_size < 1)
     throw std::runtime_error("vocab_size must be 1 or greater, is " + std::to_string(params.config.model.vocab_size));
+  // Beam search selects the top 2*num_beams (beam, token) candidates out of
+  // num_beams*vocab_size entries in BeamSearch_Cpu::SelectTop, which requires
+  // num_beams*vocab_size >= 2*num_beams, i.e. vocab_size >= 2. A smaller
+  // vocabulary would drive an out-of-bounds partial_sort.
+  if (params.search.num_beams > 1 && params.config.model.vocab_size < 2)
+    throw std::runtime_error("vocab_size (" + std::to_string(params.config.model.vocab_size) + ") must be 2 or greater when using beam search (num_beams=" + std::to_string(params.search.num_beams) + ")");
 
   search_ = CreateSearch(params);
   state_ = model.CreateState(search_->GetSequenceLengths(), params);    // Search sequence lengths set when creating state

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -117,7 +117,12 @@ void BeamSearch_Cpu::SelectTop() {
   // Use partial_sort to find only the top 2*num_beams elements per batch,
   // instead of heapifying the entire vocab*beams array via priority_queue.
   const size_t total_elements = static_cast<size_t>(params_->search.num_beams) * params_->config.model.vocab_size;
-  assert(total_elements >= top_k);
+  // Defense-in-depth: a plain assert() is compiled out under NDEBUG (release
+  // builds), so enforce the invariant that partial_sort relies on at runtime.
+  // This is normally guaranteed by the vocab_size >= 2 validation for beam
+  // search in Generator::Generator.
+  if (total_elements < top_k)
+    throw std::runtime_error("Beam search requires num_beams * vocab_size (" + std::to_string(total_elements) + ") to be at least 2 * num_beams (" + std::to_string(top_k) + "); vocab_size is too small");
 
   // Reuse class member to avoid re-allocating on every call (size is constant).
   select_top_idx_.resize(total_elements);

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -81,6 +81,27 @@ TEST(SamplingTests, BatchedSamplingTopKCpu) {
   }
 }
 
+// Regression test: beam search with a vocab_size too small to supply
+// 2*num_beams candidates must be rejected at generator creation instead of
+// driving an out-of-bounds partial_sort in BeamSearch_Cpu::SelectTop.
+TEST(SamplingTests, BeamSearchVocabSizeTooSmallThrowsCpu) {
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->Overlay(R"({ "model": { "vocab_size" : 1 } })");
+
+  auto model = OgaModel::Create(*config);
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 10);
+  params->SetSearchOption("num_beams", 2);
+
+  try {
+    OgaGenerator::Create(*model, *params);
+    FAIL() << "Expected std::runtime_error for beam search with vocab_size < 2";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find("vocab_size"), std::string::npos)
+        << "Unexpected error message: " << e.what();
+  }
+}
+
 TEST(SamplingTests, BatchedSamplingTopPAndKCpu) {
   std::vector<int32_t> input_ids{0, 1, 2, 3};
   std::vector<float> logits_cpu{2.0f, 1.5f, 1.25f, 0.25f, 0.25f,


### PR DESCRIPTION
## Summary

Fixes a heap out-of-bounds read/write (CWE-787 / CWE-125) reachable from a malicious `genai_config.json`.

`BeamSearch_Cpu::SelectTop` builds an index array of `total_elements = num_beams * vocab_size` entries and `partial_sort`s it to surface the top `top_k = 2 * num_beams` candidates:

```cpp
const size_t top_k = 2 * params_->search.num_beams;
const size_t total_elements = num_beams * vocab_size;
assert(total_elements >= top_k);              // compiled out under NDEBUG
select_top_idx_.resize(total_elements);
std::partial_sort(begin, begin + top_k, end, ...);  // middle past end when top_k > total_elements
```

When `vocab_size == 1` (and `num_beams >= 2`), `total_elements = num_beams < top_k = 2*num_beams`, so `begin + top_k` points past the end of `select_top_idx_`. `std::partial_sort` heapifies `[begin, begin+top_k)`, reading and move-writing slots beyond the allocation. The only guard was an `assert`, which is compiled out in the shipped release builds (`NDEBUG`). The path is reached from the normal generation loop (`GenerateNextToken` -> `SelectTop`).

## Fix

- **`src/generators.cpp`**: reject beam search (`num_beams > 1`) with `vocab_size < 2` in the `Generator::Generator` validator (primary fix, at creation). `total_elements >= top_k` reduces exactly to `vocab_size >= 2`.
- **`src/search.cpp`**: replace the compiled-out `assert(total_elements >= top_k)` with a runtime check that throws, so release builds are protected as defense-in-depth.
- **`test/sampling_tests.cpp`**: add `BeamSearchVocabSizeTooSmallThrowsCpu`, overlaying `vocab_size = 1` with `num_beams = 2` and asserting `OgaGenerator::Create` throws.

Note: the greedy path (`GreedySearch_Cpu::SelectTop`, `num_beams == 1`) uses `std::max_element` and is unaffected.

## Testing

New regression test follows the existing `SamplingTests` overlay pattern. Local build isn't available in my environment (root-owned build dir / jiafa-dev container needed); relying on CI to build and run the C++ unit tests.