### PR TITLE
Contain enable_profiling path to model directory (path traversal hardening)

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -53,6 +53,33 @@ namespace {
 constexpr const char* kOrtSessionOptionsModelExternalInitializersFileFolderPath =
     "session.model_external_initializers_file_folder_path";
 
+// Validates that a path-like string from the (untrusted) model config stays
+// within the model directory, then resolves it relative to that directory.
+// Rejects absolute paths and any parent-directory ("..") component to prevent
+// path traversal / arbitrary file writes (CWE-22).
+fs::path ResolveContainedConfigPath(const fs::path& model_dir, const std::string& value, const char* field_name) {
+  fs::path candidate{value};
+  if (!candidate.is_relative()) {
+    throw std::runtime_error(std::string(field_name) + " (" + value +
+                             ") must be a relative path contained within the model directory");
+  }
+
+  size_t start = 0;
+  while (start <= value.size()) {
+    size_t sep = value.find_first_of("/\\", start);
+    const std::string component = value.substr(start, sep == std::string::npos ? std::string::npos : sep - start);
+    if (component == "..") {
+      throw std::runtime_error(std::string(field_name) + " (" + value +
+                               ") must not contain parent-directory (\"..\") components");
+    }
+    if (sep == std::string::npos)
+      break;
+    start = sep + 1;
+  }
+
+  return model_dir / value;
+}
+
 }  // namespace
 
 State::State(const GeneratorParams& params, const Model& model)
@@ -655,7 +682,10 @@ void Model::CreateSessionOptionsFromConfig(const Config::SessionOptions& config_
   }
 
   if (config_session_options.enable_profiling.has_value()) {
-    fs::path profile_file_prefix{config_session_options.enable_profiling.value()};
+    // The profiling path comes from the (untrusted) model config, so contain it
+    // to the model directory to prevent path traversal / arbitrary file writes.
+    fs::path profile_file_prefix = ResolveContainedConfigPath(
+        config_->config_path, config_session_options.enable_profiling.value(), "enable_profiling");
     session_options.EnableProfiling(profile_file_prefix.c_str());
   }
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -55,8 +55,9 @@ constexpr const char* kOrtSessionOptionsModelExternalInitializersFileFolderPath 
 
 // Validates that a path-like string from the (untrusted) model config stays
 // within the model directory, then resolves it relative to that directory.
-// Rejects absolute paths and any parent-directory ("..") component to prevent
-// path traversal / arbitrary file writes (CWE-22).
+// Rejects absolute paths and any current/parent-directory (".", "..") component
+// -- including Windows trailing dot/space variants -- to prevent path traversal
+// / arbitrary file writes (CWE-22).
 fs::path ResolveContainedConfigPath(const fs::path& model_dir, const std::string& value, const char* field_name) {
   fs::path candidate{value};
   if (!candidate.is_relative()) {
@@ -68,9 +69,15 @@ fs::path ResolveContainedConfigPath(const fs::path& model_dir, const std::string
   while (start <= value.size()) {
     size_t sep = value.find_first_of("/\\", start);
     const std::string component = value.substr(start, sep == std::string::npos ? std::string::npos : sep - start);
-    if (component == "..") {
+    // Windows trims trailing '.' and ' ' from path components, so values like
+    // ".. ", "..." or ". " can be interpreted by the OS as a current/parent
+    // directory reference and bypass a naive component == ".." check. Reject any
+    // component that, after stripping trailing dots/spaces, collapses to nothing
+    // while still containing a '.' (covers ".", "..", "...", ".. ", etc.).
+    const size_t last_significant = component.find_last_not_of(". ");
+    if (last_significant == std::string::npos && component.find('.') != std::string::npos) {
       throw std::runtime_error(std::string(field_name) + " (" + value +
-                               ") must not contain parent-directory (\"..\") components");
+                               ") must not contain current- or parent-directory (\".\"/\"..\") components");
     }
     if (sep == std::string::npos)
       break;

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -561,3 +561,37 @@ TEST(ValidationTests, WindowIndexRejectsTotalSizeOverflow) {
   // Each dim individually <= kMaxElements, but grid_t * padded_h * padded_w > kMaxElements
   EXPECT_THROW(Generators::ValidateWindowIndexParams(1000, 2000000, 2000000, 2, 14, 112), std::runtime_error);
 }
+
+// Regression test: enable_profiling from genai_config.json must not be able to
+// escape the model directory via path traversal (CWE-22). Loading a model whose
+// config sets a traversing profiling path should be rejected.
+TEST(ModelTests, EnableProfilingRejectsPathTraversal) {
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->Overlay(R"({ "model": { "decoder": { "session_options": { "enable_profiling": "../../../../evil_profile" } } } })");
+
+  try {
+    OgaModel::Create(*config);
+    FAIL() << "Expected std::runtime_error for traversing enable_profiling path";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find("enable_profiling"), std::string::npos)
+        << "Unexpected error message: " << e.what();
+  }
+}
+
+// An absolute enable_profiling path must also be rejected.
+TEST(ModelTests, EnableProfilingRejectsAbsolutePath) {
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+#ifdef _WIN32
+  config->Overlay(R"({ "model": { "decoder": { "session_options": { "enable_profiling": "C:\\Windows\\Temp\\evil_profile" } } } })");
+#else
+  config->Overlay(R"({ "model": { "decoder": { "session_options": { "enable_profiling": "/tmp/evil_profile" } } } })");
+#endif
+
+  try {
+    OgaModel::Create(*config);
+    FAIL() << "Expected std::runtime_error for absolute enable_profiling path";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find("enable_profiling"), std::string::npos)
+        << "Unexpected error message: " << e.what();
+  }
+}

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -595,3 +595,19 @@ TEST(ModelTests, EnableProfilingRejectsAbsolutePath) {
         << "Unexpected error message: " << e.what();
   }
 }
+
+// A parent-directory component with a trailing dot/space (".. ") must be
+// rejected too: Windows trims trailing dots/spaces, so such a component can be
+// interpreted by the OS as "..", bypassing a naive lexical check.
+TEST(ModelTests, EnableProfilingRejectsTrailingDotSpaceTraversal) {
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->Overlay(R"({ "model": { "decoder": { "session_options": { "enable_profiling": ".. /evil_profile" } } } })");
+
+  try {
+    OgaModel::Create(*config);
+    FAIL() << "Expected std::runtime_error for trailing-dot/space traversal path";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find("enable_profiling"), std::string::npos)
+        << "Unexpected error message: " << e.what();
+  }
+}


### PR DESCRIPTION
## Summary

Hardens the `enable_profiling` field of `genai_config.json` against path traversal (CWE-22).

The field was read from the (untrusted) model config and passed **verbatim** to OnnxRuntime's `EnableProfiling()`:

```cpp
// src/models/model.cpp
fs::path profile_file_prefix{config_session_options.enable_profiling.value()};
session_options.EnableProfiling(profile_file_prefix.c_str());  // honored verbatim
```

ORT writes a `<prefix>_<timestamp>.json` profiling file when the session closes. A malicious model package could set e.g. `"enable_profiling": "../../../../etc/cron.d/ort"` (Linux) or a `...\Startup\evil` path (Windows) to write to arbitrary locations.

## Fix

- **`src/models/model.cpp`**: add `ResolveContainedConfigPath`, which rejects absolute paths and any parent-directory (`..`) component, then resolves the profiling prefix relative to the model directory (`config_->config_path`). Applied at the `enable_profiling` sink.
- **`test/model_tests.cpp`**: add `EnableProfilingRejectsPathTraversal` and `EnableProfilingRejectsAbsolutePath`.

The custom `fs::path` in this repo has no canonicalization primitives, so containment is enforced lexically (reject absolute + `..`), which is sufficient to keep the resolved path within the model directory subtree.

## Notes / scope

- The **host-controlled** runtime option (`SetRuntimeOption("enable_profiling", ...)`, `model.cpp` / `State::SetRunOption`) is intentionally left unchanged — that path is not attacker-controlled.
- Behavior change: config-sourced relative profiling paths now resolve relative to the model directory (previously the process CWD). This matches how other config paths (e.g. `custom_ops_library`) resolve and is the contained/expected default.
- As the reporter notes, the co-located `custom_ops_library` field is a higher-value target but reflects the documented model-package trust boundary; this PR scopes to the `enable_profiling` hardening.

## Testing

New regression tests use the existing `OgaConfig::Overlay` pattern on `tiny-random-gpt2-fp32`. Local build isn't available in my environment (root-owned build dir / jiafa-dev container needed); relying on CI to build and run the C++ unit tests.