### PR TITLE
Fix UAF in adapter lifecycle: serialize Adapters ops with a mutex

### DIFF
--- a/src/models/adapters.cpp
+++ b/src/models/adapters.cpp
@@ -10,14 +10,14 @@ Adapter::Adapter(const char* adapter_file_path, Ort::Allocator* allocator)
     : adapter_{OrtLoraAdapter::Create(fs::path(adapter_file_path).c_str(), *allocator)} {}
 
 const OrtLoraAdapter* Adapter::AcquireRef() {
-  // Caller (Adapters::AcquireAdapter) holds Adapters::mutex_, which
-  // serializes all access to ref_count_.
+  // Private; only callable by Adapters (friend), which holds Adapters::mutex_
+  // and therefore serializes all access to ref_count_.
   ref_count_++;
   return adapter_.get();
 }
 
 void Adapter::ReleaseRef() {
-  // Caller (Adapters::ReleaseAdapter) holds Adapters::mutex_.
+  // Private; only callable by Adapters (friend), which holds Adapters::mutex_.
   ref_count_--;
   if (ref_count_ < 0) {
     // Restore invariant so a caller catching the exception doesn't leave the
@@ -28,7 +28,7 @@ void Adapter::ReleaseRef() {
 }
 
 int32_t Adapter::RefCount() const {
-  // Caller (Adapters::UnloadAdapter) holds Adapters::mutex_.
+  // Private; only callable by Adapters (friend), which holds Adapters::mutex_.
   return ref_count_;
 }
 

--- a/src/models/adapters.cpp
+++ b/src/models/adapters.cpp
@@ -10,25 +10,32 @@ Adapter::Adapter(const char* adapter_file_path, Ort::Allocator* allocator)
     : adapter_{OrtLoraAdapter::Create(fs::path(adapter_file_path).c_str(), *allocator)} {}
 
 const OrtLoraAdapter* Adapter::AcquireRef() {
+  // Caller (Adapters::AcquireAdapter) holds Adapters::mutex_, which
+  // serializes all access to ref_count_.
   ref_count_++;
-
   return adapter_.get();
 }
 
 void Adapter::ReleaseRef() {
+  // Caller (Adapters::ReleaseAdapter) holds Adapters::mutex_.
   ref_count_--;
   if (ref_count_ < 0) {
+    // Restore invariant so a caller catching the exception doesn't leave the
+    // counter in a negative state that would trip later releases too.
+    ref_count_++;
     throw std::runtime_error("Adapter ref count went negative.");
   }
 }
 
 int32_t Adapter::RefCount() const {
+  // Caller (Adapters::UnloadAdapter) holds Adapters::mutex_.
   return ref_count_;
 }
 
 Adapters::Adapters(const Model* model) : model_{model} {}
 
 void Adapters::LoadAdapter(const char* adapter_file_path, const std::string& adapter_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
   if (adapters_.find(adapter_name) != adapters_.end()) {
     throw std::runtime_error("Adapter already loaded: " + std::string{adapter_name});
   }
@@ -40,11 +47,16 @@ void Adapters::LoadAdapter(const char* adapter_file_path, const std::string& ada
 }
 
 void Adapters::UnloadAdapter(const std::string& adapter_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
   auto adapter = adapters_.find(adapter_name);
   if (adapter == adapters_.end()) {
     throw std::runtime_error("Adapter not found: " + std::string{adapter_name});
   }
 
+  // Check-and-erase must happen atomically with respect to AcquireAdapter /
+  // ReleaseAdapter, which also acquire mutex_. This closes the TOCTOU window
+  // where another thread could AcquireRef() between the RefCount() check and
+  // the erase(), producing a use-after-free.
   if (adapter->second->RefCount() > 0) {
     throw std::runtime_error("Adapter still in use: " + std::string{adapter_name});
   }
@@ -53,6 +65,7 @@ void Adapters::UnloadAdapter(const std::string& adapter_name) {
 }
 
 const OrtLoraAdapter* Adapters::AcquireAdapter(const std::string& adapter_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
   auto adapter = adapters_.find(adapter_name);
   if (adapter == adapters_.end()) {
     throw std::runtime_error("Adapter not found: " + std::string{adapter_name});
@@ -62,6 +75,7 @@ const OrtLoraAdapter* Adapters::AcquireAdapter(const std::string& adapter_name) 
 }
 
 void Adapters::ReleaseAdapter(const std::string& adapter_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
   auto adapter = adapters_.find(adapter_name);
   if (adapter == adapters_.end()) {
     throw std::runtime_error("Adapter not found: " + std::string{adapter_name});

--- a/src/models/adapters.h
+++ b/src/models/adapters.h
@@ -13,17 +13,21 @@ struct Adapter {
 
   Adapter(const char* adapter_file_path, Ort::Allocator* allocator);
 
+ private:
+  // AcquireRef/ReleaseRef/RefCount are intentionally private so that all
+  // access to ref_count_ is funneled through Adapters, which holds
+  // Adapters::mutex_. Exposing them publicly would make it easy for future
+  // call sites to bypass the mutex and reintroduce the data race / TOCTOU
+  // window between RefCount() and container erasure in
+  // Adapters::UnloadAdapter().
+  friend struct Adapters;
+
   const OrtLoraAdapter* AcquireRef();
 
   void ReleaseRef();
 
   int32_t RefCount() const;
 
- private:
-  // All access to ref_count_ is serialized by Adapters::mutex_, which is the
-  // sole entry point for AcquireRef/ReleaseRef/RefCount. This closes both the
-  // data race on the counter and the TOCTOU window between RefCount() and
-  // container erasure in Adapters::UnloadAdapter().
   int32_t ref_count_{};
   std::unique_ptr<OrtLoraAdapter> adapter_;
 };

--- a/src/models/adapters.h
+++ b/src/models/adapters.h
@@ -20,6 +20,10 @@ struct Adapter {
   int32_t RefCount() const;
 
  private:
+  // All access to ref_count_ is serialized by Adapters::mutex_, which is the
+  // sole entry point for AcquireRef/ReleaseRef/RefCount. This closes both the
+  // data race on the counter and the TOCTOU window between RefCount() and
+  // container erasure in Adapters::UnloadAdapter().
   int32_t ref_count_{};
   std::unique_ptr<OrtLoraAdapter> adapter_;
 };
@@ -41,6 +45,11 @@ struct Adapters : std::enable_shared_from_this<Adapters>, ExternalRefCounted<Ada
 
  private:
   const Model* model_;
+  // Serializes all access to adapters_ and to per-Adapter ref counts so that
+  // load/unload/acquire/release cannot race. Without this, the check-then-erase
+  // pattern in UnloadAdapter (and concurrent std::unordered_map mutation) is a
+  // use-after-free hazard.
+  mutable std::mutex mutex_;
   std::unordered_map<std::string, std::unique_ptr<Adapter>> adapters_;
 };
 

--- a/test/c_api_tests.cpp
+++ b/test/c_api_tests.cpp
@@ -1243,6 +1243,70 @@ TEST(CAPITests, AdaptersTestMultipleAdapters) {
   adapters->UnloadAdapter("adapter_a");
   adapters->UnloadAdapter("adapter_b");
 }
+
+// Regression test for the concurrency use-after-free / data race in the
+// adapter lifecycle. Prior to serializing Adapters ops with a mutex,
+// concurrent LoadAdapter/UnloadAdapter/SetActiveAdapter calls could race on
+// Adapter::ref_count_ and on the underlying unordered_map, producing lost
+// updates and a TOCTOU window where UnloadAdapter would erase an adapter
+// that another thread had just acquired.
+//
+// This test hammers the Adapters API from multiple threads. It is not
+// deterministic about which operations succeed (a concurrent UnloadAdapter
+// may legitimately throw "Adapter still in use" or "Adapter not found",
+// and a concurrent LoadAdapter of the same name may throw "already loaded")
+// but under TSAN/ASAN and in stress mode it reliably catches the pre-fix
+// races. Here we simply assert that no thread crashes or leaves the
+// Adapters map in an inconsistent state.
+TEST(CAPITests, AdaptersConcurrentLoadUnload) {
+  auto model = OgaModel::Create(MODEL_PATH "multiple_adapters");
+  auto adapters = OgaAdapters::Create(*model);
+
+  constexpr int kIterations = 50;
+  constexpr int kThreadsPerRole = 4;
+
+  const char* adapter_path_a = MODEL_PATH "multiple_adapters/adapter_0.onnx_adapter";
+  const char* adapter_path_b = MODEL_PATH "multiple_adapters/adapter_1.onnx_adapter";
+
+  auto swallow = [](auto&& fn) {
+    try {
+      fn();
+    } catch (const std::exception&) {
+      // Concurrent load/unload can legitimately throw (already loaded /
+      // not found / still in use). We only care that state stays consistent.
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreadsPerRole * 2);
+
+  for (int t = 0; t < kThreadsPerRole; ++t) {
+    threads.emplace_back([&] {
+      for (int i = 0; i < kIterations; ++i) {
+        swallow([&] { adapters->LoadAdapter(adapter_path_a, "adapter_a"); });
+        swallow([&] { adapters->LoadAdapter(adapter_path_b, "adapter_b"); });
+      }
+    });
+    threads.emplace_back([&] {
+      for (int i = 0; i < kIterations; ++i) {
+        swallow([&] { adapters->UnloadAdapter("adapter_a"); });
+        swallow([&] { adapters->UnloadAdapter("adapter_b"); });
+      }
+    });
+  }
+
+  for (auto& th : threads) th.join();
+
+  // Drain any adapters left loaded so we end in a known state. These may
+  // throw "not found" depending on which thread won the last unload; that's
+  // fine, we just want to prove the API remains usable and consistent.
+  swallow([&] { adapters->UnloadAdapter("adapter_a"); });
+  swallow([&] { adapters->UnloadAdapter("adapter_b"); });
+
+  // After draining, a fresh load/unload cycle must still succeed cleanly.
+  adapters->LoadAdapter(adapter_path_a, "adapter_a");
+  adapters->UnloadAdapter("adapter_a");
+}
 #endif  // TEST_PHI2 && !USE_DML
 
 void CheckResult(OgaResult* result) {


### PR DESCRIPTION
The Adapter::ref_count_ field was a plain int32_t modified without

synchronization, and Adapters::UnloadAdapter() performed a check-then-erase

on the underlying std::unordered_map without a lock. Concurrent

OgaSetActiveAdapter / OgaUnloadAdapter calls could therefore:

  * race on ref_count_ (data race, undefined behavior, lost updates), and

  * pass the RefCount() > 0 guard in UnloadAdapter while another thread

    was mid-AcquireRef(), destroying the adapter while a reference was

    still held (use-after-free).

Add a mutex to Adapters and take it in Load/Unload/Acquire/ReleaseAdapter.

Since AcquireRef/ReleaseRef/RefCount on Adapter are only reachable through

these Adapters entry points, the single mutex now serializes both map

mutation and per-adapter ref counting, closing the TOCTOU window and the

data race in one place. ReleaseRef also restores the counter before

throwing so a caught exception does not leave it in a negative state.