### PR TITLE
Add int8 precision support to model builder

### DIFF
--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -349,7 +349,7 @@ python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p pr
 
 #### Quantization Options
 
-These options apply when exporting quantized models (for example `-p int4`).
+These options apply when exporting weight-only quantized models (`-p int4` for 4-bit weights or `-p int8` for 8-bit weights). Both precisions produce `MatMulNBits` ops and share the `int4_*` options below; the `-p int8` build simply runs the final `MatMulNBits` quantization pass with 8-bit weights.
 
 ##### Accuracy Level
 
@@ -448,6 +448,8 @@ python -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o pa
 # From source:
 python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p precision -e execution_provider -c cache_dir_to_store_temp_files --extra_options use_qdq=true
 ```
+
+This option is not supported with `-p int8` because 8-bit `MatMulNBits` is QOperator-only.
 
 ##### Use 8 Bits Quantization in QMoE
 

--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -275,30 +275,30 @@ This scenario is for when you want to enable weight sharing between the embeddin
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true int4_algo_config=k_quant
+python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true algo_config=k_quant
 
 # From source:
-python builder.py -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true int4_algo_config=k_quant
+python builder.py -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true algo_config=k_quant
 ```
 
 ##### Example 2: INT4 weights + INT8 embeddings (for RTN Last and K-Quant Last)
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true int4_algo_config=k_quant_last
+python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true algo_config=k_quant_last
 
 # From source:
-python builder.py -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true int4_algo_config=k_quant_last
+python builder.py -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true algo_config=k_quant_last
 ```
 
 ##### Example 3: INT4 weights + FP16 embeddings
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true int4_algo_config=rtn int4_nodes_to_exclude=/lm_head/MatMul
+python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true algo_config=rtn nodes_to_exclude=/lm_head/MatMul
 
 # From source:
-python builder.py -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true int4_algo_config=rtn int4_nodes_to_exclude=/lm_head/MatMul
+python builder.py -m model_name -o path_to_output_folder -p int4 -e cuda --extra_options shared_embeddings=true algo_config=rtn nodes_to_exclude=/lm_head/MatMul
 ```
 
 ##### Example 4: FP16 weights + FP16 embeddings
@@ -349,7 +349,7 @@ python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p pr
 
 #### Quantization Options
 
-These options apply when exporting weight-only quantized models (`-p int4` for 4-bit weights or `-p int8` for 8-bit weights). Both precisions produce `MatMulNBits` ops and share the `int4_*` options below; the `-p int8` build simply runs the final `MatMulNBits` quantization pass with 8-bit weights.
+These options apply when exporting weight-only quantized models (`-p int4` for 4-bit weights or `-p int8` for 8-bit weights). Both precisions produce `MatMulNBits` ops and share the quantization options below; the `-p int8` build simply runs the final `MatMulNBits` quantization pass with 8-bit weights.
 
 ##### Accuracy Level
 
@@ -357,10 +357,10 @@ This scenario is for when you want to control the accuracy level used for MatMul
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_accuracy_level=4
+python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options accuracy_level=4
 
 # From source:
-python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_accuracy_level=4
+python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options accuracy_level=4
 ```
 
 ##### MatMul Block Size
@@ -369,10 +369,10 @@ This scenario is for when you want to set the block size for MatMul quantization
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_block_size=32
+python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options block_size=32
 
 # From source:
-python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_block_size=32
+python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options block_size=32
 ```
 
 ##### QMoE Block Size
@@ -393,10 +393,10 @@ This scenario is for when you want to choose symmetric (`int4`) or asymmetric (`
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_is_symmetric=false
+python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options is_symmetric=false
 
 # From source:
-python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_is_symmetric=false
+python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options is_symmetric=false
 ```
 
 ##### Op Types To Quantize
@@ -405,10 +405,10 @@ This scenario is for when you want to target specific operator types for quantiz
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_op_types_to_quantize=MatMul/Gather
+python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options op_types_to_quantize=MatMul/Gather
 
 # From source:
-python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_op_types_to_quantize=MatMul/Gather
+python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options op_types_to_quantize=MatMul/Gather
 ```
 
 ##### Nodes To Exclude
@@ -417,10 +417,10 @@ This scenario is for when you want to skip quantizing specific nodes.
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_nodes_to_exclude=/lm_head/MatMul,/model/embed_tokens/Gather
+python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options nodes_to_exclude=/lm_head/MatMul,/model/embed_tokens/Gather
 
 # From source:
-python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_nodes_to_exclude=/lm_head/MatMul,/model/embed_tokens/Gather
+python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options nodes_to_exclude=/lm_head/MatMul,/model/embed_tokens/Gather
 ```
 
 ##### Algo Config
@@ -429,10 +429,10 @@ This scenario is for when you want to select the quantization algorithm mode.
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_algo_config=default
+python -m onnxruntime_genai.models.builder -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options algo_config=default
 
 # From source:
-python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options int4_algo_config=default
+python builder.py -m model_name -o path_to_output_folder -p int4 -e execution_provider --extra_options algo_config=default
 ```
 
 Supported values are: `default`, `rtn`, `rtn_last`, `k_quant`, `k_quant_mixed`, `k_quant_last`, `k_quant_linear`.

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -57,10 +57,43 @@ from transformers import (
 )
 
 
+# Soft-deprecated extra_options names, kept as aliases for backward compatibility
+# so existing consumers (e.g. Olive recipes) that still pass the old `int4_*`
+# names keep working. Maps old name -> new name. Remove after consumers migrate.
+_DEPRECATED_EXTRA_OPTION_ALIASES = {
+    "int4_accuracy_level": "accuracy_level",
+    "int4_block_size": "block_size",
+    "int4_is_symmetric": "is_symmetric",
+    "int4_op_types_to_quantize": "op_types_to_quantize",
+    "int4_nodes_to_exclude": "nodes_to_exclude",
+    "int4_algo_config": "algo_config",
+}
+
+
+def apply_deprecated_extra_option_aliases(kv_pairs):
+    """
+    Rename any deprecated extra_options keys to their new names in-place.
+
+    If both the old and new names are provided, the new name wins. Emits a
+    deprecation warning for each old name encountered.
+    """
+    for old_name, new_name in _DEPRECATED_EXTRA_OPTION_ALIASES.items():
+        if old_name not in kv_pairs:
+            continue
+        print(
+            f"WARNING: extra_option '{old_name}' is deprecated and will be removed in a future release. "
+            f"Please use '{new_name}' instead."
+        )
+        kv_pairs.setdefault(new_name, kv_pairs[old_name])
+        del kv_pairs[old_name]
+
+
 def check_extra_options(kv_pairs, precision, execution_provider):
     """
     Check key-value pairs and set values correctly
     """
+    apply_deprecated_extra_option_aliases(kv_pairs)
+
     bools = [
         "is_symmetric",
         "exclude_embeds",
@@ -194,6 +227,10 @@ def create_model(
     if execution_provider == "NvTensorRtRtx":
         execution_provider = "trt-rtx"
         extra_options["use_qdq"] = True
+
+    # Normalize any deprecated extra_options names for direct API callers (the CLI
+    # path already handles this in check_extra_options).
+    apply_deprecated_extra_option_aliases(extra_options)
 
     # Create cache and output directories
     os.makedirs(output_dir, exist_ok=True)
@@ -422,6 +459,7 @@ def get_args():
         help=textwrap.dedent("""\
             Key value pairs for various options. Currently supports:
                 The options below control weight-only MatMulNBits quantization for both `--precision int4` and `--precision int8`.
+                    (The former `int4_`-prefixed names, e.g. `int4_algo_config`, are deprecated aliases that still work but will be removed in a future release.)
                 accuracy_level = 1/2/3/4: Specify the minimum accuracy level for activation of MatMul in int4/int8 weight-only (MatMulNBits) quantization.
                     4 is int8, which means input A of int4 quantized MatMul is quantized to int8 and input B is upcasted to int8 for computation.
                     3 is bf16.

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -167,7 +167,8 @@ def set_onnx_dtype(precision: str, extra_options: dict[str, Any]) -> ir.DataType
         return ir.DataType.INT4 if extra_options.get("int4_is_symmetric", True) else ir.DataType.UINT4
 
     if precision == "int8":
-        return ir.DataType.INT8 if extra_options.get("int4_is_symmetric", True) else ir.DataType.UINT8
+        # int8 keeps FP32 weights; 8-bit quantization happens in the final MatMulNBits pass.
+        return ir.DataType.FLOAT
 
     to_onnx_dtype = {
         "fp32": ir.DataType.FLOAT,
@@ -221,6 +222,12 @@ def create_model(
     io_dtype = set_io_dtype(precision, execution_provider, extra_options)
     onnx_dtype = set_onnx_dtype(precision, extra_options)
     config_only = "config_only" in extra_options
+
+    if precision == "int8":
+        # 8-bit MatMulNBits is only supported in QOperator format, not QDQ.
+        if extra_options.get("use_qdq", False):
+            raise NotImplementedError("int8 precision does not support the QDQ format (use_qdq). Use QOperator (the default).")
+        extra_options["use_8bit_matmul_weights"] = True
 
     # List architecture options in alphabetical order
     if config.architectures[0] == "ChatGLMForConditionalGeneration" or config.architectures[0] == "ChatGLMModel":
@@ -417,32 +424,33 @@ def get_args():
         nargs="+",
         help=textwrap.dedent("""\
             Key value pairs for various options. Currently supports:
-                int4_accuracy_level = 1/2/3/4: Specify the minimum accuracy level for activation of MatMul in int4 quantization.
+                The int4_* options below control weight-only MatMulNBits quantization for both `--precision int4` and `--precision int8`.
+                int4_accuracy_level = 1/2/3/4: Specify the minimum accuracy level for activation of MatMul in int4/int8 weight-only (MatMulNBits) quantization.
                     4 is int8, which means input A of int4 quantized MatMul is quantized to int8 and input B is upcasted to int8 for computation.
                     3 is bf16.
                     2 is fp16.
                     1 is fp32.
                     Default is 4 for the CPU EP and 0 for non-CPU EPs.
-                int4_block_size = 16/32/64/128/256: Specify the block size for int4 quantization (MatMulNBits).
+                int4_block_size = 16/32/64/128/256: Specify the block size for int4/int8 weight-only (MatMulNBits) quantization.
                     Default value is 32.
                 qmoe_block_size = 16/32/64/128/256: Specify the block size for QMoE expert weights quantization.
                     Default is 128 for CUDA and TRT-RTX, 32 for others. Supported EPs: CPU, CUDA, WebGPU, TRT-RTX.
                 int4_is_symmetric = Quantize the weights symmetrically. Default is true.
                     If true, quantization uses signed ints (int4/int8). If false, it uses unsigned ints (uint4/uint8).
-                int4_op_types_to_quantize = MatMul/Gather: Specify op types to target for int4 quantization.
+                int4_op_types_to_quantize = MatMul/Gather: Specify op types to target for int4/int8 weight-only quantization.
                     Use this option when you want to quantize specific ops.
                     Separate the op types with a '/' when passing them here (e.g. int4_op_types_to_quantize=MatMul/Gather)
-                int4_nodes_to_exclude = Specify nodes to exclude from int4 quantization.
+                int4_nodes_to_exclude = Specify nodes to exclude from int4/int8 weight-only quantization.
                     Use this option when you want to exclude certain nodes from being quantized.
                     Separate the node names with a ',' when passing them here (e.g. int4_nodes_to_exclude=/lm_head/MatMul,/model/embed_tokens/Gather)
-                int4_algo_config = Method for int4 quantization. Default is 'default'.
+                int4_algo_config = Method for int4/int8 weight-only quantization. Default is 'default'.
                     Currently supported options are: 'default', 'rtn', 'rtn_last', 'k_quant', 'k_quant_mixed', 'k_quant_last', 'k_quant_linear'.
-                    default = algo_config passed to MatMulNBitsQuantizer is None. Quantizer uses default RTN algorithm. All MatMuls are quantized as int4. Uses different node naming conventions to `rtn`.
-                    rtn = RTN algorithm for int4 quantization.
-                    rtn_last = RTN algorithm where only the last MatMul (/lm_head/MatMul) is quantized as int8. Other MatMuls are quantized as int4.
-                    k_quant = k_quant algorithm for int4 quantization.
+                    default = algo_config passed to MatMulNBitsQuantizer is None. Quantizer uses default RTN algorithm. All MatMuls are quantized to the requested bit width. Uses different node naming conventions to `rtn`.
+                    rtn = RTN algorithm for weight-only quantization.
+                    rtn_last = RTN algorithm where only the last MatMul (/lm_head/MatMul) is quantized as int8. Other MatMuls use the requested bit width.
+                    k_quant = k_quant algorithm for weight-only quantization.
                     k_quant_mixed = k_quant algorithm with mixed precision (int4 + int8).
-                    k_quant_last = k_quant algorithm where only the last MatMul (/lm_head/MatMul) is quantized as int8. Other MatMuls are quantized as int4.
+                    k_quant_last = k_quant algorithm where only the last MatMul (/lm_head/MatMul) is quantized as int8. Other MatMuls use the requested bit width.
                     k_quant_linear = k_quant algorithm with linear attention layer projections and MLPs promoted to int8 (for hybrid attention models like Qwen3.5).
                 num_hidden_layers = Manually specify the number of layers in your ONNX model.
                     Used for unit testing purposes.
@@ -485,8 +493,10 @@ def get_args():
                     This affects attention mask reformatting and position IDs handling.
                 use_qdq = Use the QDQ decomposition for ops.
                     Use this option when you want to use quantize-dequantize ops. For example, you will have a quantized MatMul op instead of the MatMulNBits op.
+                    Not supported with `--precision int8` (8-bit MatMulNBits is QOperator-only).
                 use_8bits_moe = Use 8-bit quantization for MoE layers. Default is false.
                     If true, the QMoE op will use 8-bit quantization. If false, the QMoE op will use 4-bit quantization.
+                    Always true for `--precision int8`, which quantizes MoE experts to 8-bit to match the dense weights.
                 disable_qkv_fusion = Disable QKV fusion in the model. Default is false.
                     If true, the model will not fuse the Q, K, and V projections. Automatically assumed for certain EPs.
                 use_webgpu_fp32 = Use FP32 I/O precision for WebGPU EP.

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -62,7 +62,7 @@ def check_extra_options(kv_pairs, execution_provider):
     Check key-value pairs and set values correctly
     """
     bools = [
-        "int4_is_symmetric",
+        "is_symmetric",
         "exclude_embeds",
         "exclude_lm_head",
         "include_hidden_states",
@@ -89,14 +89,14 @@ def check_extra_options(kv_pairs, execution_provider):
     if "hf_token" in kv_pairs:
         kv_pairs["hf_token"] = parse_hf_token(kv_pairs["hf_token"])
 
-    if "int4_op_types_to_quantize" in kv_pairs:
+    if "op_types_to_quantize" in kv_pairs:
         op_types_to_quantize = ()
-        for op_type in kv_pairs["int4_op_types_to_quantize"].split("/"):
+        for op_type in kv_pairs["op_types_to_quantize"].split("/"):
             op_types_to_quantize += (op_type,)
-        kv_pairs["int4_op_types_to_quantize"] = op_types_to_quantize
+        kv_pairs["op_types_to_quantize"] = op_types_to_quantize
 
-    if "int4_nodes_to_exclude" in kv_pairs:
-        kv_pairs["int4_nodes_to_exclude"] = kv_pairs["int4_nodes_to_exclude"].split(",")
+    if "nodes_to_exclude" in kv_pairs:
+        kv_pairs["nodes_to_exclude"] = kv_pairs["nodes_to_exclude"].split(",")
 
     if "exclude_lm_head" in kv_pairs and "include_hidden_states" in kv_pairs:
         # 'exclude_lm_head' is for when 'hidden_states' are outputted and 'logits' are not outputted
@@ -164,7 +164,7 @@ def set_io_dtype(precision, execution_provider, extra_options) -> ir.DataType:
 
 def set_onnx_dtype(precision: str, extra_options: dict[str, Any]) -> ir.DataType:
     if precision == "int4":
-        return ir.DataType.INT4 if extra_options.get("int4_is_symmetric", True) else ir.DataType.UINT4
+        return ir.DataType.INT4 if extra_options.get("is_symmetric", True) else ir.DataType.UINT4
 
     if precision == "int8":
         # int8 keeps FP32 weights; 8-bit quantization happens in the final MatMulNBits pass.
@@ -224,7 +224,6 @@ def create_model(
     config_only = "config_only" in extra_options
 
     if precision == "int8":
-        # 8-bit MatMulNBits is only supported in QOperator format, not QDQ.
         if extra_options.get("use_qdq", False):
             raise NotImplementedError("int8 precision does not support the QDQ format (use_qdq). Use QOperator (the default).")
         extra_options["use_8bit_matmul_weights"] = True
@@ -424,26 +423,26 @@ def get_args():
         nargs="+",
         help=textwrap.dedent("""\
             Key value pairs for various options. Currently supports:
-                The int4_* options below control weight-only MatMulNBits quantization for both `--precision int4` and `--precision int8`.
-                int4_accuracy_level = 1/2/3/4: Specify the minimum accuracy level for activation of MatMul in int4/int8 weight-only (MatMulNBits) quantization.
+                The options below control weight-only MatMulNBits quantization for both `--precision int4` and `--precision int8`.
+                accuracy_level = 1/2/3/4: Specify the minimum accuracy level for activation of MatMul in int4/int8 weight-only (MatMulNBits) quantization.
                     4 is int8, which means input A of int4 quantized MatMul is quantized to int8 and input B is upcasted to int8 for computation.
                     3 is bf16.
                     2 is fp16.
                     1 is fp32.
                     Default is 4 for the CPU EP and 0 for non-CPU EPs.
-                int4_block_size = 16/32/64/128/256: Specify the block size for int4/int8 weight-only (MatMulNBits) quantization.
+                block_size = 16/32/64/128/256: Specify the block size for int4/int8 weight-only (MatMulNBits) quantization.
                     Default value is 32.
                 qmoe_block_size = 16/32/64/128/256: Specify the block size for QMoE expert weights quantization.
                     Default is 128 for CUDA and TRT-RTX, 32 for others. Supported EPs: CPU, CUDA, WebGPU, TRT-RTX.
-                int4_is_symmetric = Quantize the weights symmetrically. Default is true.
+                is_symmetric = Quantize the weights symmetrically. Default is true.
                     If true, quantization uses signed ints (int4/int8). If false, it uses unsigned ints (uint4/uint8).
-                int4_op_types_to_quantize = MatMul/Gather: Specify op types to target for int4/int8 weight-only quantization.
+                op_types_to_quantize = MatMul/Gather: Specify op types to target for int4/int8 weight-only quantization.
                     Use this option when you want to quantize specific ops.
-                    Separate the op types with a '/' when passing them here (e.g. int4_op_types_to_quantize=MatMul/Gather)
-                int4_nodes_to_exclude = Specify nodes to exclude from int4/int8 weight-only quantization.
+                    Separate the op types with a '/' when passing them here (e.g. op_types_to_quantize=MatMul/Gather)
+                nodes_to_exclude = Specify nodes to exclude from int4/int8 weight-only quantization.
                     Use this option when you want to exclude certain nodes from being quantized.
-                    Separate the node names with a ',' when passing them here (e.g. int4_nodes_to_exclude=/lm_head/MatMul,/model/embed_tokens/Gather)
-                int4_algo_config = Method for int4/int8 weight-only quantization. Default is 'default'.
+                    Separate the node names with a ',' when passing them here (e.g. nodes_to_exclude=/lm_head/MatMul,/model/embed_tokens/Gather)
+                algo_config = Method for int4/int8 weight-only quantization. Default is 'default'.
                     Currently supported options are: 'default', 'rtn', 'rtn_last', 'k_quant', 'k_quant_mixed', 'k_quant_last', 'k_quant_linear'.
                     default = algo_config passed to MatMulNBitsQuantizer is None. Quantizer uses default RTN algorithm. All MatMuls are quantized to the requested bit width. Uses different node naming conventions to `rtn`.
                     rtn = RTN algorithm for weight-only quantization.

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -166,6 +166,9 @@ def set_onnx_dtype(precision: str, extra_options: dict[str, Any]) -> ir.DataType
     if precision == "int4":
         return ir.DataType.INT4 if extra_options.get("int4_is_symmetric", True) else ir.DataType.UINT4
 
+    if precision == "int8":
+        return ir.DataType.INT8 if extra_options.get("int4_is_symmetric", True) else ir.DataType.UINT8
+
     to_onnx_dtype = {
         "fp32": ir.DataType.FLOAT,
         "fp16": ir.DataType.FLOAT16,
@@ -386,7 +389,7 @@ def get_args():
         "-p",
         "--precision",
         required=True,
-        choices=["int4", "bf16", "fp16", "fp32"],
+        choices=["int4", "int8", "bf16", "fp16", "fp32"],
         help="Precision of model",
     )
 
@@ -395,7 +398,7 @@ def get_args():
         "--execution_provider",
         required=True,
         choices=["cpu", "cuda", "dml", "webgpu", "NvTensorRtRtx"],
-        help="Execution provider to target with precision of model (e.g. FP16 CUDA, INT4 CPU, INT4 WebGPU)",
+        help="Execution provider to target with precision of model (e.g. FP16 CUDA, INT4 CPU, INT4/INT8 WebGPU)",
     )
 
     parser.add_argument(
@@ -425,7 +428,7 @@ def get_args():
                 qmoe_block_size = 16/32/64/128/256: Specify the block size for QMoE expert weights quantization.
                     Default is 128 for CUDA and TRT-RTX, 32 for others. Supported EPs: CPU, CUDA, WebGPU, TRT-RTX.
                 int4_is_symmetric = Quantize the weights symmetrically. Default is true.
-                    If true, quantization is done to int4. If false, quantization is done to uint4.
+                    If true, quantization uses signed ints (int4/int8). If false, it uses unsigned ints (uint4/uint8).
                 int4_op_types_to_quantize = MatMul/Gather: Specify op types to target for int4 quantization.
                     Use this option when you want to quantize specific ops.
                     Separate the op types with a '/' when passing them here (e.g. int4_op_types_to_quantize=MatMul/Gather)
@@ -497,7 +500,7 @@ def get_args():
 
     args = parser.parse_args()
     print(
-        "Valid precision + execution provider combinations are: FP32 CPU, FP32 CUDA, FP16 CUDA, FP16 DML, BF16 CUDA, FP16 TRT-RTX, BF16 TRT-RTX, INT4 CPU, INT4 CUDA, INT4 DML, INT4 WebGPU"
+        "Valid precision + execution provider combinations are: FP32 CPU, FP32 CUDA, FP16 CUDA, FP16 DML, BF16 CUDA, FP16 TRT-RTX, BF16 TRT-RTX, INT4 CPU, INT4 CUDA, INT4 DML, INT4 WebGPU, INT8 CPU, INT8 WebGPU"
     )
     return args
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -57,27 +57,25 @@ from transformers import (
 )
 
 
-# Soft-deprecated extra_options names, kept as aliases for backward compatibility
-# so existing consumers (e.g. Olive recipes) that still pass the old `int4_*`
-# names keep working. Maps old name -> new name. Remove after consumers migrate.
-_DEPRECATED_EXTRA_OPTION_ALIASES = {
-    "int4_accuracy_level": "accuracy_level",
-    "int4_block_size": "block_size",
-    "int4_is_symmetric": "is_symmetric",
-    "int4_op_types_to_quantize": "op_types_to_quantize",
-    "int4_nodes_to_exclude": "nodes_to_exclude",
-    "int4_algo_config": "algo_config",
-}
-
-
 def apply_deprecated_extra_option_aliases(kv_pairs):
     """
     Rename any deprecated extra_options keys to their new names in-place.
 
-    If both the old and new names are provided, the new name wins. Emits a
-    deprecation warning for each old name encountered.
+    Kept for backward compatibility so existing consumers (e.g. Olive recipes) that
+    still pass the old `int4_`-prefixed names keep working. If both the old and new
+    names are provided, the new name wins. Emits a deprecation warning for each old
+    name encountered. Remove this method (and its call sites) once consumers migrate.
     """
-    for old_name, new_name in _DEPRECATED_EXTRA_OPTION_ALIASES.items():
+    # Maps deprecated old name -> new name.
+    deprecated_aliases = {
+        "int4_accuracy_level": "accuracy_level",
+        "int4_block_size": "block_size",
+        "int4_is_symmetric": "is_symmetric",
+        "int4_op_types_to_quantize": "op_types_to_quantize",
+        "int4_nodes_to_exclude": "nodes_to_exclude",
+        "int4_algo_config": "algo_config",
+    }
+    for old_name, new_name in deprecated_aliases.items():
         if old_name not in kv_pairs:
             continue
         print(

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -57,7 +57,7 @@ from transformers import (
 )
 
 
-def check_extra_options(kv_pairs, execution_provider):
+def check_extra_options(kv_pairs, precision, execution_provider):
     """
     Check key-value pairs and set values correctly
     """
@@ -111,8 +111,12 @@ def check_extra_options(kv_pairs, execution_provider):
         )
         kv_pairs["enable_webgpu_graph"] = False
 
+    if precision == "int8" and kv_pairs.get("use_qdq", False):
+        # 8-bit MatMulNBits is only supported in QOperator format, not QDQ.
+        raise NotImplementedError("int8 precision does not support the QDQ format (use_qdq). Use QOperator (the default).")
 
-def parse_extra_options(kv_items, execution_provider):
+
+def parse_extra_options(kv_items, precision, execution_provider):
     """
     Parse key-value pairs that are separated by '='
     """
@@ -124,7 +128,7 @@ def parse_extra_options(kv_items, execution_provider):
             kv_pairs[kv[0].strip()] = kv[1].strip()
 
     print(f"Extra options: {kv_pairs}")
-    check_extra_options(kv_pairs, execution_provider)
+    check_extra_options(kv_pairs, precision, execution_provider)
     return kv_pairs
 
 
@@ -146,11 +150,11 @@ def parse_hf_token(hf_token):
 
 
 def set_io_dtype(precision, execution_provider, extra_options) -> ir.DataType:
-    int4_cpu = precision == "int4" and execution_provider == "cpu"
+    cpu_quant = precision in {"int4", "int8"} and execution_provider == "cpu"
     fp32_webgpu = execution_provider == "webgpu" and extra_options.get("use_webgpu_fp32", False)
     bf16_cuda = precision == "int4" and execution_provider in {"cuda", "trt-rtx"} and extra_options.get("use_cuda_bf16", False)
 
-    if precision in {"int8", "fp32"} or int4_cpu or fp32_webgpu:
+    if precision == "fp32" or cpu_quant or fp32_webgpu:
         # FP32 precision
         return ir.DataType.FLOAT
 
@@ -167,8 +171,7 @@ def set_onnx_dtype(precision: str, extra_options: dict[str, Any]) -> ir.DataType
         return ir.DataType.INT4 if extra_options.get("is_symmetric", True) else ir.DataType.UINT4
 
     if precision == "int8":
-        # int8 keeps FP32 weights; 8-bit quantization happens in the final MatMulNBits pass.
-        return ir.DataType.FLOAT
+        return ir.DataType.INT8 if extra_options.get("is_symmetric", True) else ir.DataType.UINT8
 
     to_onnx_dtype = {
         "fp32": ir.DataType.FLOAT,
@@ -222,11 +225,6 @@ def create_model(
     io_dtype = set_io_dtype(precision, execution_provider, extra_options)
     onnx_dtype = set_onnx_dtype(precision, extra_options)
     config_only = "config_only" in extra_options
-
-    if precision == "int8":
-        if extra_options.get("use_qdq", False):
-            raise NotImplementedError("int8 precision does not support the QDQ format (use_qdq). Use QOperator (the default).")
-        extra_options["use_8bit_matmul_weights"] = True
 
     # List architecture options in alphabetical order
     if config.architectures[0] == "ChatGLMForConditionalGeneration" or config.architectures[0] == "ChatGLMModel":
@@ -404,7 +402,7 @@ def get_args():
         "--execution_provider",
         required=True,
         choices=["cpu", "cuda", "dml", "webgpu", "NvTensorRtRtx"],
-        help="Execution provider to target with precision of model (e.g. FP16 CUDA, INT4 CPU, INT4/INT8 WebGPU)",
+        help="Execution provider to target with precision of model (e.g. FP16 CUDA, INT4 CPU, INT4 WebGPU, INT8 WebGPU)",
     )
 
     parser.add_argument(
@@ -516,7 +514,7 @@ def get_args():
 
 if __name__ == "__main__":
     args = get_args()
-    extra_options = parse_extra_options(args.extra_options, args.execution_provider)
+    extra_options = parse_extra_options(args.extra_options, args.precision, args.execution_provider)
     create_model(
         args.model_name,
         args.input,

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -285,11 +285,8 @@ class Model:
             "use_fc": False,                                 # Use fully-connected style for MLP (FC1/FC2)
         }
 
-        # int8 precision requests 8-bit weight-only quantization; INT4/UINT4 onnx_dtype forces 4-bit.
-        quantize_to_8bits = (
-            bool(extra_options.get("use_8bit_matmul_weights", False))
-            and self.onnx_dtype not in {ir.DataType.INT4, ir.DataType.UINT4}
-        )
+        # int8 precision (onnx_dtype INT8/UINT8) builds a float graph and quantizes weights to 8-bit at save time.
+        quantize_to_8bits = self.onnx_dtype in {ir.DataType.INT8, ir.DataType.UINT8}
 
         # MoE-specific variables
         moe_op_type = "QMoE" if (self.onnx_dtype == ir.DataType.INT4 or quantize_to_8bits) else "MoE"
@@ -523,8 +520,8 @@ class Model:
 
         # Determine if embeddings and lm_head will be quantized or not.
         # Embeddings use Gather/GatherBlockQuantized, which only supports 4-bit (INT4/UINT4).
-        # The lm_head MatMul is quantized for INT4/UINT4 or for int8 precision (bits == 8).
-        matmul_is_quantized = self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4} or self.quant_attrs["bits"] == 8
+        # The lm_head MatMul is quantized for INT4/UINT4 (4-bit) or INT8/UINT8 (8-bit).
+        matmul_is_quantized = self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4, ir.DataType.INT8, ir.DataType.UINT8}
         quantized_embeds = (
             self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}
             and "Gather" in self.quant_attrs["op_types_to_quantize"]
@@ -813,7 +810,7 @@ class Model:
 
         # Skip quantizing `MatMul` in `DequantizeLinear --> Transpose --> MatMul` path
         already_quantized_in_qdq_format = self.quant_type is not None and self.quant_attrs["use_qdq"]
-        if (self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4} or self.quant_attrs["bits"] == 8) and not already_quantized_in_qdq_format:
+        if self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4, ir.DataType.INT8, ir.DataType.UINT8} and not already_quantized_in_qdq_format:
             model = self.to_nbits()
         else:
             model = self.model
@@ -1179,8 +1176,8 @@ class Model:
             # For regular `MatMul`
             return self.make_matmul_op(matmul, basename, root_input, **kwargs)
 
-    def make_matmul_op(self, matmul, basename, root_input, **kwargs):
-        if self.onnx_dtype in {ir.DataType.FLOAT16, ir.DataType.BFLOAT16, ir.DataType.FLOAT}:
+    def make_matmul_op(self, matmul, basename, root_input, **kwargs):        # INT8/UINT8 build a float graph and are quantized to 8-bit MatMulNBits at save time.
+        if self.onnx_dtype in {ir.DataType.FLOAT16, ir.DataType.BFLOAT16, ir.DataType.FLOAT, ir.DataType.INT8, ir.DataType.UINT8}:
             return self.make_matmul_float(matmul, basename, root_input, **kwargs)
         elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}:
             if self.quant_attrs["use_qdq"]:
@@ -1369,7 +1366,7 @@ class Model:
         return add_name
 
     def make_packed_matmul(self, q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs):
-        if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16}:
+        if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16, ir.DataType.INT8, ir.DataType.UINT8}:
             return self.make_packed_matmul_float(q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs)
         elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}:
             return self.make_packed_matmul_int4(q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs)
@@ -1377,7 +1374,7 @@ class Model:
             raise NotImplementedError(f"The {self.onnx_dtype} precision is not currently supported.")
 
     def make_packed_matmul_class(self, q_matmul, k_matmul, v_matmul):
-        if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16}:
+        if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16, ir.DataType.INT8, ir.DataType.UINT8}:
             return self.make_packed_matmul_float_class(q_matmul, k_matmul, v_matmul)
         elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}:
             return self.make_packed_matmul_int4_class(q_matmul, k_matmul, v_matmul)

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -285,11 +285,17 @@ class Model:
             "use_fc": False,                                 # Use fully-connected style for MLP (FC1/FC2)
         }
 
+        # int8 precision requests 8-bit weight-only quantization; INT4/UINT4 onnx_dtype forces 4-bit.
+        quantize_to_8bits = (
+            bool(extra_options.get("use_8bit_matmul_weights", False))
+            and self.onnx_dtype not in {ir.DataType.INT4, ir.DataType.UINT4}
+        )
+
         # MoE-specific variables
-        moe_op_type = "QMoE" if self.onnx_dtype == ir.DataType.INT4 else "MoE"
+        moe_op_type = "QMoE" if (self.onnx_dtype == ir.DataType.INT4 or quantize_to_8bits) else "MoE"
         num_experts = config.num_local_experts if hasattr(config, "num_local_experts") else 0
         top_k_experts = config.num_experts_per_tok if hasattr(config, "num_experts_per_tok") else 0
-        expert_weight_bits = 8 if extra_options.get("use_8bits_moe", False) else 4
+        expert_weight_bits = 8 if (quantize_to_8bits or extra_options.get("use_8bits_moe", False)) else 4
         swiglu_limit = config.swiglu_limit if hasattr(config, "swiglu_limit") else None
         self.moe_attrs = {
             "op_type": moe_op_type,                          # MoE op to use
@@ -322,8 +328,7 @@ class Model:
             "accuracy_level": int(extra_options.get("int4_accuracy_level", 4 if self.ep in ["cpu", "webgpu"] else 0)),
             "qmoe_block_size": int(self.qmoe_block_size),
             "qdq_block_size": int(self.matmul_block_size),
-            # onnx_dtype INT8/UINT8 selects 8-bit MatMulNBits weights; INT4/UINT4 selects 4-bit.
-            "bits": 8 if self.onnx_dtype in {ir.DataType.INT8, ir.DataType.UINT8} else 4,
+            "bits": 8 if quantize_to_8bits else 4,
             "is_symmetric": extra_options.get("int4_is_symmetric", True),
             "op_types_to_quantize": extra_options.get("int4_op_types_to_quantize", ("MatMul",)),
             "nodes_to_exclude": extra_options.get("int4_nodes_to_exclude", []),
@@ -516,14 +521,17 @@ class Model:
             and not self.prune_lm_head
         )
 
-        # Determine if embeddings and lm_head will be quantized or not
+        # Determine if embeddings and lm_head will be quantized or not.
+        # Embeddings use Gather/GatherBlockQuantized, which only supports 4-bit (INT4/UINT4).
+        # The lm_head MatMul is quantized for INT4/UINT4 or for int8 precision (bits == 8).
+        matmul_is_quantized = self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4} or self.quant_attrs["bits"] == 8
         quantized_embeds = (
             self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}
             and "Gather" in self.quant_attrs["op_types_to_quantize"]
             and "/model/embed_tokens/Gather" not in self.quant_attrs["nodes_to_exclude"]
         )
         quantized_lm_head = (
-            self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}
+            matmul_is_quantized
             and "MatMul" in self.quant_attrs["op_types_to_quantize"]
             and "/lm_head/MatMul" not in self.quant_attrs["nodes_to_exclude"]
         )
@@ -786,8 +794,6 @@ class Model:
         return algo_config
 
     def to_nbits(self) -> ir.Model:
-        # Quantize the model's MatMul weights to N-bit MatMulNBits ops, where N is
-        # self.quant_attrs["bits"] (4 for INT4/UINT4, 8 for INT8/UINT8 precision).
         quant = MatMulNBitsQuantizer(
             model=ir.to_proto(self.model),
             bits=self.quant_attrs["bits"],
@@ -807,8 +813,8 @@ class Model:
 
         # Skip quantizing `MatMul` in `DequantizeLinear --> Transpose --> MatMul` path
         already_quantized_in_qdq_format = self.quant_type is not None and self.quant_attrs["use_qdq"]
-        # INT4/UINT4 and INT8/UINT8 precisions are quantized to 4-bit/8-bit MatMulNBits ops respectively.
-        if self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4, ir.DataType.INT8, ir.DataType.UINT8} and not already_quantized_in_qdq_format:
+        # Quantize INT4/UINT4 (4-bit) and int8 (bits == 8) weights to MatMulNBits.
+        if (self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4} or self.quant_attrs["bits"] == 8) and not already_quantized_in_qdq_format:
             model = self.to_nbits()
         else:
             model = self.model

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -322,6 +322,8 @@ class Model:
             "accuracy_level": int(extra_options.get("int4_accuracy_level", 4 if self.ep in ["cpu", "webgpu"] else 0)),
             "qmoe_block_size": int(self.qmoe_block_size),
             "qdq_block_size": int(self.matmul_block_size),
+            # onnx_dtype INT8/UINT8 selects 8-bit MatMulNBits weights; INT4/UINT4 selects 4-bit.
+            "bits": 8 if self.onnx_dtype in {ir.DataType.INT8, ir.DataType.UINT8} else 4,
             "is_symmetric": extra_options.get("int4_is_symmetric", True),
             "op_types_to_quantize": extra_options.get("int4_op_types_to_quantize", ("MatMul",)),
             "nodes_to_exclude": extra_options.get("int4_nodes_to_exclude", []),
@@ -783,9 +785,12 @@ class Model:
 
         return algo_config
 
-    def to_int4(self) -> ir.Model:
+    def to_nbits(self) -> ir.Model:
+        # Quantize the model's MatMul weights to N-bit MatMulNBits ops, where N is
+        # self.quant_attrs["bits"] (4 for INT4/UINT4, 8 for INT8/UINT8 precision).
         quant = MatMulNBitsQuantizer(
             model=ir.to_proto(self.model),
+            bits=self.quant_attrs["bits"],
             block_size=self.quant_attrs["qdq_block_size"],
             is_symmetric=self.quant_attrs["is_symmetric"],
             accuracy_level=self.quant_attrs["accuracy_level"],
@@ -802,8 +807,9 @@ class Model:
 
         # Skip quantizing `MatMul` in `DequantizeLinear --> Transpose --> MatMul` path
         already_quantized_in_qdq_format = self.quant_type is not None and self.quant_attrs["use_qdq"]
-        if self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4} and not already_quantized_in_qdq_format:
-            model = self.to_int4()
+        # INT4/UINT4 and INT8/UINT8 precisions are quantized to 4-bit/8-bit MatMulNBits ops respectively.
+        if self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4, ir.DataType.INT8, ir.DataType.UINT8} and not already_quantized_in_qdq_format:
+            model = self.to_nbits()
         else:
             model = self.model
 

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1176,14 +1176,14 @@ class Model:
             # For regular `MatMul`
             return self.make_matmul_op(matmul, basename, root_input, **kwargs)
 
-    def make_matmul_op(self, matmul, basename, root_input, **kwargs):        # INT8/UINT8 build a float graph and are quantized to 8-bit MatMulNBits at save time.
-        if self.onnx_dtype in {ir.DataType.FLOAT16, ir.DataType.BFLOAT16, ir.DataType.FLOAT, ir.DataType.INT8, ir.DataType.UINT8}:
+    def make_matmul_op(self, matmul, basename, root_input, **kwargs):
+        if self.onnx_dtype in {ir.DataType.FLOAT16, ir.DataType.BFLOAT16, ir.DataType.FLOAT}:
             return self.make_matmul_float(matmul, basename, root_input, **kwargs)
-        elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}:
+        elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4, ir.DataType.INT8, ir.DataType.UINT8}:
             if self.quant_attrs["use_qdq"]:
-                return self.make_matmul_int4_qdq(matmul, basename, root_input, **kwargs)
+                return self.make_matmul_nbits_qdq(matmul, basename, root_input, **kwargs)
             else:
-                return self.make_matmul_int4(matmul, basename, root_input, **kwargs)
+                return self.make_matmul_nbits(matmul, basename, root_input, **kwargs)
         else:
             raise NotImplementedError(f"The {self.onnx_dtype} precision is not currently supported.")
 
@@ -1199,7 +1199,7 @@ class Model:
 
         return name
 
-    def make_matmul_int4(self, matmul, basename, root_input, **kwargs):
+    def make_matmul_nbits(self, matmul, basename, root_input, **kwargs):
         if not hasattr(matmul, "qweight"):
             # TODO: quantize weights, then save new MatMul weights for onnx model
             # print(f"Quantizing to {self.onnx_dtype} on-the-fly is not currently supported.")
@@ -1293,7 +1293,7 @@ class Model:
 
         return dequantize_output
 
-    def make_matmul_int4_qdq(self, matmul, matmul_name, root_input, **kwargs):
+    def make_matmul_nbits_qdq(self, matmul, matmul_name, root_input, **kwargs):
         if not hasattr(matmul, "qweight"):
             # TODO: quantize weights, then save new MatMul weights for onnx model
             # print(f"Quantizing to {self.onnx_dtype} on-the-fly is not currently supported.")
@@ -1366,18 +1366,18 @@ class Model:
         return add_name
 
     def make_packed_matmul(self, q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs):
-        if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16, ir.DataType.INT8, ir.DataType.UINT8}:
+        if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16}:
             return self.make_packed_matmul_float(q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs)
-        elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}:
-            return self.make_packed_matmul_int4(q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs)
+        elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4, ir.DataType.INT8, ir.DataType.UINT8}:
+            return self.make_packed_matmul_nbits(q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs)
         else:
             raise NotImplementedError(f"The {self.onnx_dtype} precision is not currently supported.")
 
     def make_packed_matmul_class(self, q_matmul, k_matmul, v_matmul):
-        if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16, ir.DataType.INT8, ir.DataType.UINT8}:
+        if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16}:
             return self.make_packed_matmul_float_class(q_matmul, k_matmul, v_matmul)
-        elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}:
-            return self.make_packed_matmul_int4_class(q_matmul, k_matmul, v_matmul)
+        elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4, ir.DataType.INT8, ir.DataType.UINT8}:
+            return self.make_packed_matmul_nbits_class(q_matmul, k_matmul, v_matmul)
         else:
             raise NotImplementedError(f"The {self.onnx_dtype} precision is not currently supported.")
 
@@ -1400,7 +1400,7 @@ class Model:
         matmul = PackedMatMul()
         return matmul
     
-    def make_packed_matmul_int4_class(self, q_matmul, k_matmul, v_matmul):
+    def make_packed_matmul_nbits_class(self, q_matmul, k_matmul, v_matmul):
         if not hasattr(q_matmul, "qweight"):
             return self.make_packed_matmul_float_class(q_matmul, k_matmul, v_matmul)
 
@@ -1429,15 +1429,15 @@ class Model:
         new_name = self.make_matmul(matmul, basename, root_input, **kwargs)
         return new_name
 
-    def make_packed_matmul_int4(self, q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs):
+    def make_packed_matmul_nbits(self, q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs):
         if not hasattr(q_matmul, "qweight"):
             # TODO: quantize weights, then save new MatMul weights for onnx model
             # print(f"Quantizing to {self.onnx_dtype} on-the-fly is not currently supported.")
             # print(f"Saving as {self.io_dtype} on-the-fly and quantizing to {self.onnx_dtype} at the end.")
             return self.make_packed_matmul_float(q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs)
 
-        matmul = self.make_packed_matmul_int4_class(q_matmul, k_matmul, v_matmul)
-        new_name = self.make_matmul_int4(matmul, basename, root_input, **kwargs)
+        matmul = self.make_packed_matmul_nbits_class(q_matmul, k_matmul, v_matmul)
+        new_name = self.make_matmul_nbits(matmul, basename, root_input, **kwargs)
         return new_name
 
     def make_add_bias(self, add, name, root_input, **kwargs):

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -321,17 +321,17 @@ class Model:
         self.make_lm_head_init(config)
 
         # Quantization-specific variables (INT4, INT8, etc.)
-        self.algo_config_name = extra_options.get("int4_algo_config", "default")
-        self.matmul_block_size = int(extra_options.get("int4_block_size", 32))
+        self.algo_config_name = extra_options.get("algo_config", "default")
+        self.matmul_block_size = int(extra_options.get("block_size", 32))
         self.qmoe_block_size = int(extra_options.get("qmoe_block_size", 128 if self.ep in {"cuda", "trt-rtx"} else 32))
         self.quant_attrs = {
-            "accuracy_level": int(extra_options.get("int4_accuracy_level", 4 if self.ep in ["cpu", "webgpu"] else 0)),
+            "accuracy_level": int(extra_options.get("accuracy_level", 4 if self.ep in ["cpu", "webgpu"] else 0)),
             "qmoe_block_size": int(self.qmoe_block_size),
             "qdq_block_size": int(self.matmul_block_size),
             "bits": 8 if quantize_to_8bits else 4,
-            "is_symmetric": extra_options.get("int4_is_symmetric", True),
-            "op_types_to_quantize": extra_options.get("int4_op_types_to_quantize", ("MatMul",)),
-            "nodes_to_exclude": extra_options.get("int4_nodes_to_exclude", []),
+            "is_symmetric": extra_options.get("is_symmetric", True),
+            "op_types_to_quantize": extra_options.get("op_types_to_quantize", ("MatMul",)),
+            "nodes_to_exclude": extra_options.get("nodes_to_exclude", []),
             "algo_config": self.make_algo_config(),
             "use_qdq": extra_options.get("use_qdq", False),
         }
@@ -813,7 +813,6 @@ class Model:
 
         # Skip quantizing `MatMul` in `DequantizeLinear --> Transpose --> MatMul` path
         already_quantized_in_qdq_format = self.quant_type is not None and self.quant_attrs["use_qdq"]
-        # Quantize INT4/UINT4 (4-bit) and int8 (bits == 8) weights to MatMulNBits.
         if (self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4} or self.quant_attrs["bits"] == 8) and not already_quantized_in_qdq_format:
             model = self.to_nbits()
         else:

--- a/test/python/_test_utils.py
+++ b/test/python/_test_utils.py
@@ -208,7 +208,7 @@ def download_model(model_name, input_path, output_path, precision, device, one_l
 
     extra_options = ["--extra_options", "include_hidden_states=1", "hf_token=0", "hf_remote=0"]
     if device == "cpu" and precision == "int4":
-        extra_options += ["int4_accuracy_level=4"]
+        extra_options += ["accuracy_level=4"]
     if one_layer:
         extra_options += ["num_hidden_layers=1"]
     # Graph capture is a generic model option and maps to EP-specific builder flags.

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -54,21 +54,21 @@ Model = base_module.Model
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("int4_is_symmetric", [True, False, None])
-def test_int8_onnx_dtype_stays_float(int4_is_symmetric):
-    extra_options = {} if int4_is_symmetric is None else {"int4_is_symmetric": int4_is_symmetric}
+@pytest.mark.parametrize("is_symmetric", [True, False, None])
+def test_int8_onnx_dtype_stays_float(is_symmetric):
+    extra_options = {} if is_symmetric is None else {"is_symmetric": is_symmetric}
     assert builder_module.set_onnx_dtype("int8", extra_options) == ir.DataType.FLOAT
 
 
 @pytest.mark.parametrize(
-    "int4_is_symmetric, expected",
+    "is_symmetric, expected",
     [
         (True, ir.DataType.INT4),
         (False, ir.DataType.UINT4),
     ],
 )
-def test_int4_onnx_dtype_is_still_int4(int4_is_symmetric, expected):
-    assert builder_module.set_onnx_dtype("int4", {"int4_is_symmetric": int4_is_symmetric}) == expected
+def test_int4_onnx_dtype_is_still_int4(is_symmetric, expected):
+    assert builder_module.set_onnx_dtype("int4", {"is_symmetric": is_symmetric}) == expected
 
 
 def test_int8_io_dtype_is_fp32():

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -180,3 +180,42 @@ def test_int4_with_qdq_is_allowed():
     # QDQ is only rejected for int8; int4 still supports it.
     builder_module.check_extra_options({"use_qdq": "true"}, "int4", "cpu")
 
+
+# ---------------------------------------------------------------------------
+# Deprecated `int4_*` extra_option names still work as soft-deprecated aliases.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "old_name, new_name",
+    [
+        ("int4_accuracy_level", "accuracy_level"),
+        ("int4_block_size", "block_size"),
+        ("int4_is_symmetric", "is_symmetric"),
+        ("int4_op_types_to_quantize", "op_types_to_quantize"),
+        ("int4_nodes_to_exclude", "nodes_to_exclude"),
+        ("int4_algo_config", "algo_config"),
+    ],
+)
+def test_deprecated_alias_is_renamed_to_new_name(old_name, new_name):
+    kv_pairs = {old_name: "value"}
+    builder_module.apply_deprecated_extra_option_aliases(kv_pairs)
+    assert old_name not in kv_pairs
+    assert kv_pairs[new_name] == "value"
+
+
+def test_new_name_wins_when_both_provided():
+    kv_pairs = {"int4_algo_config": "old", "algo_config": "new"}
+    builder_module.apply_deprecated_extra_option_aliases(kv_pairs)
+    assert kv_pairs == {"algo_config": "new"}
+
+
+def test_check_extra_options_applies_deprecated_aliases():
+    # Old name flows through check_extra_options and is parsed like the new one.
+    kv_pairs = {"int4_is_symmetric": "false", "int4_op_types_to_quantize": "MatMul/Gather"}
+    builder_module.check_extra_options(kv_pairs, "int4", "cpu")
+    assert "int4_is_symmetric" not in kv_pairs
+    assert kv_pairs["is_symmetric"] is False
+    assert kv_pairs["op_types_to_quantize"] == ("MatMul", "Gather")
+
+

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -49,15 +49,19 @@ Model = base_module.Model
 
 
 # ---------------------------------------------------------------------------
-# int8 keeps FP32 weights + I/O so graph construction avoids the INT8/UINT8
-# `NotImplementedError` branches.
+# int8 precision maps onnx_dtype to INT8/UINT8 (like int4 -> INT4/UINT4).
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("is_symmetric", [True, False, None])
-def test_int8_onnx_dtype_stays_float(is_symmetric):
-    extra_options = {} if is_symmetric is None else {"is_symmetric": is_symmetric}
-    assert builder_module.set_onnx_dtype("int8", extra_options) == ir.DataType.FLOAT
+@pytest.mark.parametrize(
+    "is_symmetric, expected",
+    [
+        (True, ir.DataType.INT8),
+        (False, ir.DataType.UINT8),
+    ],
+)
+def test_int8_onnx_dtype_is_int8(is_symmetric, expected):
+    assert builder_module.set_onnx_dtype("int8", {"is_symmetric": is_symmetric}) == expected
 
 
 @pytest.mark.parametrize(
@@ -71,12 +75,21 @@ def test_int4_onnx_dtype_is_still_int4(is_symmetric, expected):
     assert builder_module.set_onnx_dtype("int4", {"is_symmetric": is_symmetric}) == expected
 
 
-def test_int8_io_dtype_is_fp32():
-    assert builder_module.set_io_dtype("int8", "cpu", {}) == ir.DataType.FLOAT
+@pytest.mark.parametrize(
+    "execution_provider, expected",
+    [
+        ("cpu", ir.DataType.FLOAT),
+        ("cuda", ir.DataType.FLOAT16),
+        ("webgpu", ir.DataType.FLOAT16),
+    ],
+)
+def test_int8_io_dtype_is_not_forced_to_fp32(execution_provider, expected):
+    # int8 must not assume FP32 I/O: GPU/WebGPU use FP16, only CPU uses FP32.
+    assert builder_module.set_io_dtype("int8", execution_provider, {}) == expected
 
 
 # ---------------------------------------------------------------------------
-# int8's FP32 onnx_dtype routes to the float MatMul builders (no NotImplementedError).
+# int8's INT8/UINT8 onnx_dtype routes to the float MatMul builders.
 # ---------------------------------------------------------------------------
 
 
@@ -87,16 +100,18 @@ def _make_bare_model(onnx_dtype, quant_attrs=None):
     return model
 
 
-def test_make_matmul_op_float_path_for_int8_dtype(monkeypatch):
-    model = _make_bare_model(ir.DataType.FLOAT)
+@pytest.mark.parametrize("onnx_dtype", [ir.DataType.INT8, ir.DataType.UINT8])
+def test_make_matmul_op_float_path_for_int8_dtype(monkeypatch, onnx_dtype):
+    model = _make_bare_model(onnx_dtype)
     sentinel = object()
     monkeypatch.setattr(model, "make_matmul_float", lambda *a, **k: sentinel)
 
     assert model.make_matmul_op(object(), "/lm_head/MatMul", "root") is sentinel
 
 
-def test_make_packed_matmul_float_path_for_int8_dtype(monkeypatch):
-    model = _make_bare_model(ir.DataType.FLOAT)
+@pytest.mark.parametrize("onnx_dtype", [ir.DataType.INT8, ir.DataType.UINT8])
+def test_make_packed_matmul_float_path_for_int8_dtype(monkeypatch, onnx_dtype):
+    model = _make_bare_model(onnx_dtype)
     sentinel = object()
     monkeypatch.setattr(model, "make_packed_matmul_float", lambda *a, **k: sentinel)
 
@@ -155,18 +170,12 @@ def test_to_nbits_forwards_requested_bits(monkeypatch, bits):
 # ---------------------------------------------------------------------------
 
 
-def test_int8_with_qdq_is_rejected(monkeypatch):
-    config = types.SimpleNamespace(architectures=["LlamaForCausalLM"])
-    monkeypatch.setattr(builder_module.AutoConfig, "from_pretrained", lambda *a, **k: config)
-
+def test_int8_with_qdq_is_rejected():
     with pytest.raises(NotImplementedError, match="QDQ"):
-        builder_module.create_model(
-            model_name="dummy",
-            input_path="",
-            output_dir=".",
-            precision="int8",
-            execution_provider="cpu",
-            cache_dir=".",
-            use_qdq=True,
-        )
+        builder_module.check_extra_options({"use_qdq": "true"}, "int8", "cpu")
+
+
+def test_int4_with_qdq_is_allowed():
+    # QDQ is only rejected for int8; int4 still supports it.
+    builder_module.check_extra_options({"use_qdq": "true"}, "int4", "cpu")
 

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -89,7 +89,8 @@ def test_int8_io_dtype_is_not_forced_to_fp32(execution_provider, expected):
 
 
 # ---------------------------------------------------------------------------
-# int8's INT8/UINT8 onnx_dtype routes to the float MatMul builders.
+# int8's INT8/UINT8 onnx_dtype routes through the MatMulNBits builders, which
+# fall back to a float MatMul when the source model is not already quantized.
 # ---------------------------------------------------------------------------
 
 
@@ -101,7 +102,7 @@ def _make_bare_model(onnx_dtype, quant_attrs=None):
 
 
 @pytest.mark.parametrize("onnx_dtype", [ir.DataType.INT8, ir.DataType.UINT8])
-def test_make_matmul_op_float_path_for_int8_dtype(monkeypatch, onnx_dtype):
+def test_make_matmul_op_int8_falls_back_to_float_when_not_quantized(monkeypatch, onnx_dtype):
     model = _make_bare_model(onnx_dtype)
     sentinel = object()
     monkeypatch.setattr(model, "make_matmul_float", lambda *a, **k: sentinel)
@@ -110,7 +111,7 @@ def test_make_matmul_op_float_path_for_int8_dtype(monkeypatch, onnx_dtype):
 
 
 @pytest.mark.parametrize("onnx_dtype", [ir.DataType.INT8, ir.DataType.UINT8])
-def test_make_packed_matmul_float_path_for_int8_dtype(monkeypatch, onnx_dtype):
+def test_make_packed_matmul_int8_falls_back_to_float_when_not_quantized(monkeypatch, onnx_dtype):
     model = _make_bare_model(onnx_dtype)
     sentinel = object()
     monkeypatch.setattr(model, "make_packed_matmul_float", lambda *a, **k: sentinel)

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import onnx_ir as ir
+import pytest
+
+MODELS_DIR = Path(__file__).parents[3] / "src" / "python" / "py" / "models"
+BUILDERS_DIR = MODELS_DIR / "builders"
+sys.path.insert(0, str(BUILDERS_DIR.parents[1]))
+
+
+def _load_base_module():
+    sys.modules.setdefault("models", types.ModuleType("models"))
+    builders_package = sys.modules.setdefault("models.builders", types.ModuleType("models.builders"))
+    builders_package.__path__ = [str(BUILDERS_DIR)]
+
+    spec = importlib.util.spec_from_file_location("models.builders.base", BUILDERS_DIR / "base.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["models.builders.base"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_builder_entrypoint_module():
+    # `builder.py` imports the concrete model classes via `from builders import (...)`.
+    # Provide a stub `builders` module so we can import the lightweight precision helpers
+    # (`set_onnx_dtype` / `set_io_dtype`) without pulling in every model builder.
+    builders_stub = types.ModuleType("builders")
+
+    def __getattr__(name):  # PEP 562: satisfies `from builders import <ModelClass>`
+        return type(name, (), {})
+
+    builders_stub.__getattr__ = __getattr__
+    sys.modules["builders"] = builders_stub
+
+    spec = importlib.util.spec_from_file_location("models_builder_entrypoint", MODELS_DIR / "builder.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+base_module = _load_base_module()
+builder_module = _load_builder_entrypoint_module()
+Model = base_module.Model
+
+
+# ---------------------------------------------------------------------------
+# int8 keeps FP32 weights + I/O so graph construction avoids the INT8/UINT8
+# `NotImplementedError` branches.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("int4_is_symmetric", [True, False, None])
+def test_int8_onnx_dtype_stays_float(int4_is_symmetric):
+    extra_options = {} if int4_is_symmetric is None else {"int4_is_symmetric": int4_is_symmetric}
+    assert builder_module.set_onnx_dtype("int8", extra_options) == ir.DataType.FLOAT
+
+
+@pytest.mark.parametrize(
+    "int4_is_symmetric, expected",
+    [
+        (True, ir.DataType.INT4),
+        (False, ir.DataType.UINT4),
+    ],
+)
+def test_int4_onnx_dtype_is_still_int4(int4_is_symmetric, expected):
+    assert builder_module.set_onnx_dtype("int4", {"int4_is_symmetric": int4_is_symmetric}) == expected
+
+
+def test_int8_io_dtype_is_fp32():
+    assert builder_module.set_io_dtype("int8", "cpu", {}) == ir.DataType.FLOAT
+
+
+# ---------------------------------------------------------------------------
+# int8's FP32 onnx_dtype routes to the float MatMul builders (no NotImplementedError).
+# ---------------------------------------------------------------------------
+
+
+def _make_bare_model(onnx_dtype, quant_attrs=None):
+    model = Model.__new__(Model)
+    model.onnx_dtype = onnx_dtype
+    model.quant_attrs = quant_attrs if quant_attrs is not None else {"use_qdq": False}
+    return model
+
+
+def test_make_matmul_op_float_path_for_int8_dtype(monkeypatch):
+    model = _make_bare_model(ir.DataType.FLOAT)
+    sentinel = object()
+    monkeypatch.setattr(model, "make_matmul_float", lambda *a, **k: sentinel)
+
+    assert model.make_matmul_op(object(), "/lm_head/MatMul", "root") is sentinel
+
+
+def test_make_packed_matmul_float_path_for_int8_dtype(monkeypatch):
+    model = _make_bare_model(ir.DataType.FLOAT)
+    sentinel = object()
+    monkeypatch.setattr(model, "make_packed_matmul_float", lambda *a, **k: sentinel)
+
+    assert model.make_packed_matmul(object(), object(), object(), "/attn/qkv/MatMul", "root") is sentinel
+
+
+# ---------------------------------------------------------------------------
+# `to_nbits` forwards the requested weight bit width to `MatMulNBitsQuantizer`.
+# ---------------------------------------------------------------------------
+
+
+def _make_quant_model(bits):
+    model = Model.__new__(Model)
+    model.model = object()
+    model.quant_attrs = {
+        "bits": bits,
+        "qdq_block_size": 32,
+        "is_symmetric": True,
+        "accuracy_level": 4,
+        "nodes_to_exclude": [],
+        "use_qdq": False,
+        "op_types_to_quantize": ("MatMul",),
+        "algo_config": None,
+    }
+    return model
+
+
+class _FakeQuantizer:
+    captured = None
+
+    def __init__(self, **kwargs):
+        type(self).captured = kwargs
+        self.model = types.SimpleNamespace(model="quantized-proto")
+
+    def process(self):
+        pass
+
+
+@pytest.mark.parametrize("bits", [4, 8])
+def test_to_nbits_forwards_requested_bits(monkeypatch, bits):
+    _FakeQuantizer.captured = None
+    monkeypatch.setattr(base_module, "MatMulNBitsQuantizer", _FakeQuantizer)
+    monkeypatch.setattr(base_module.ir, "to_proto", lambda m: m)
+    monkeypatch.setattr(base_module.ir, "from_proto", lambda p: p)
+
+    model = _make_quant_model(bits)
+    result = model.to_nbits()
+
+    assert _FakeQuantizer.captured is not None
+    assert _FakeQuantizer.captured["bits"] == bits
+    assert result == "quantized-proto"
+
+
+# ---------------------------------------------------------------------------
+# int8 rejects the unsupported QDQ format (8-bit MatMulNBits is QOperator-only).
+# ---------------------------------------------------------------------------
+
+
+def test_int8_with_qdq_is_rejected(monkeypatch):
+    config = types.SimpleNamespace(architectures=["LlamaForCausalLM"])
+    monkeypatch.setattr(builder_module.AutoConfig, "from_pretrained", lambda *a, **k: config)
+
+    with pytest.raises(NotImplementedError, match="QDQ"):
+        builder_module.create_model(
+            model_name="dummy",
+            input_path="",
+            output_dir=".",
+            precision="int8",
+            execution_provider="cpu",
+            cache_dir=".",
+            use_qdq=True,
+        )
+

--- a/test/python/builder/test_tied_embeddings.py
+++ b/test/python/builder/test_tied_embeddings.py
@@ -39,6 +39,7 @@ def _make_model_for_tied_embeddings(
     exclude_lm_head=False,
     prune_lm_head=False,
     int4_algo_config="default",
+    bits=4,
 ):
     model = Model.__new__(Model)
     model.extra_options = {"int4_algo_config": int4_algo_config}
@@ -48,6 +49,7 @@ def _make_model_for_tied_embeddings(
     model.quant_attrs = {
         "op_types_to_quantize": op_types,
         "nodes_to_exclude": list(nodes_to_exclude),
+        "bits": bits,
     }
     model.exclude_embeds = exclude_embeds
     model.exclude_lm_head = exclude_lm_head
@@ -170,6 +172,38 @@ def test_tied_unquantized_embeddings_can_be_true_in_int4_mode_when_both_quant_pa
         op_types=op_types,
         nodes_to_exclude=nodes_to_exclude,
         int4_algo_config="rtn",
+    )
+
+    assert model.tied_quantized_embeddings is False
+    assert model.tied_unquantized_embeddings is True
+
+
+def test_int8_lm_head_is_quantized_so_shared_embeddings_are_not_tied():
+    # int8 keeps onnx_dtype FLOAT but quantizes the lm_head MatMul to 8-bit (bits == 8),
+    # while embeddings (Gather) stay unquantized (Gather only supports 4-bit). A quantized
+    # lm_head cannot be tied to an unquantized embedding, so neither tying path is selected.
+    model = _make_model_for_tied_embeddings(
+        shared_embeddings=True,
+        tie_word_embeddings=False,
+        onnx_dtype=ir.DataType.FLOAT,
+        op_types=("MatMul", "Gather"),
+        bits=8,
+    )
+
+    assert model.tied_quantized_embeddings is False
+    assert model.tied_unquantized_embeddings is False
+
+
+def test_int8_with_lm_head_excluded_allows_unquantized_tying():
+    # Excluding the lm_head MatMul leaves both layers unquantized, so int8 can share the
+    # unquantized embedding weights.
+    model = _make_model_for_tied_embeddings(
+        shared_embeddings=True,
+        tie_word_embeddings=False,
+        onnx_dtype=ir.DataType.FLOAT,
+        op_types=("MatMul", "Gather"),
+        nodes_to_exclude=("/lm_head/MatMul",),
+        bits=8,
     )
 
     assert model.tied_quantized_embeddings is False

--- a/test/python/builder/test_tied_embeddings.py
+++ b/test/python/builder/test_tied_embeddings.py
@@ -38,11 +38,11 @@ def _make_model_for_tied_embeddings(
     exclude_embeds=False,
     exclude_lm_head=False,
     prune_lm_head=False,
-    int4_algo_config="default",
+    algo_config="default",
     bits=4,
 ):
     model = Model.__new__(Model)
-    model.extra_options = {"int4_algo_config": int4_algo_config}
+    model.extra_options = {"algo_config": algo_config}
     if shared_embeddings is not None:
         model.extra_options["shared_embeddings"] = shared_embeddings
     model.onnx_dtype = onnx_dtype
@@ -108,7 +108,7 @@ def test_shared_embeddings_are_disabled_when_embeddings_or_lm_head_are_excluded(
 
 
 @pytest.mark.parametrize(
-    "onnx_dtype, op_types, nodes_to_exclude, exclude_embeds, exclude_lm_head, prune_lm_head, int4_algo_config, expected_tied_quantized, expected_tied_unquantized",
+    "onnx_dtype, op_types, nodes_to_exclude, exclude_embeds, exclude_lm_head, prune_lm_head, algo_config, expected_tied_quantized, expected_tied_unquantized",
     [
         (ir.DataType.INT4, ("MatMul", "Gather"), (), False, False, False, "default", True, False),
         (ir.DataType.INT4, ("MatMul", "Gather"), (), False, False, False, "rtn", True, False),
@@ -131,7 +131,7 @@ def test_tied_embedding_path_selection_matches_current_base_logic(
     exclude_embeds,
     exclude_lm_head,
     prune_lm_head,
-    int4_algo_config,
+    algo_config,
     expected_tied_quantized,
     expected_tied_unquantized,
 ):
@@ -144,7 +144,7 @@ def test_tied_embedding_path_selection_matches_current_base_logic(
         exclude_embeds=exclude_embeds,
         exclude_lm_head=exclude_lm_head,
         prune_lm_head=prune_lm_head,
-        int4_algo_config=int4_algo_config,
+        algo_config=algo_config,
     )
 
     assert model.tied_quantized_embeddings is expected_tied_quantized
@@ -171,7 +171,7 @@ def test_tied_unquantized_embeddings_can_be_true_in_int4_mode_when_both_quant_pa
         onnx_dtype=onnx_dtype,
         op_types=op_types,
         nodes_to_exclude=nodes_to_exclude,
-        int4_algo_config="rtn",
+        algo_config="rtn",
     )
 
     assert model.tied_quantized_embeddings is False
@@ -211,7 +211,7 @@ def test_int8_with_lm_head_excluded_allows_unquantized_tying():
 
 
 @pytest.mark.parametrize(
-    "quantized_embeds, quantized_lm_head, int4_algo_config, expected_tied_quantized, expected_tied_unquantized",
+    "quantized_embeds, quantized_lm_head, algo_config, expected_tied_quantized, expected_tied_unquantized",
     [
         (True, True, "default", True, False),
         (True, True, "rtn", True, False),
@@ -228,7 +228,7 @@ def test_int8_with_lm_head_excluded_allows_unquantized_tying():
 def test_shared_embeddings_prefers_quantized_path_only_when_both_layers_are_quantized(
     quantized_embeds,
     quantized_lm_head,
-    int4_algo_config,
+    algo_config,
     expected_tied_quantized,
     expected_tied_unquantized,
 ):
@@ -238,7 +238,7 @@ def test_shared_embeddings_prefers_quantized_path_only_when_both_layers_are_quan
         tie_word_embeddings=False,
         onnx_dtype=ir.DataType.INT4,
         op_types=op_types,
-        int4_algo_config=int4_algo_config,
+        algo_config=algo_config,
     )
 
     assert model.tied_quantized_embeddings is expected_tied_quantized
@@ -246,7 +246,7 @@ def test_shared_embeddings_prefers_quantized_path_only_when_both_layers_are_quan
 
 
 @pytest.mark.parametrize(
-    "int4_algo_config, matmul_block_size, is_symmetric, expected_bits, expected_weight, expected_scale, expected_zp",
+    "algo_config, matmul_block_size, is_symmetric, expected_bits, expected_weight, expected_scale, expected_zp",
     [
         ("default", 32, True, 4, "lm_head.MatMul.weight_Q4", "lm_head.MatMul.weight_scales", ""),
         ("default", 32, False, 4, "lm_head.MatMul.weight", "", ""),
@@ -265,7 +265,7 @@ def test_shared_embeddings_prefers_quantized_path_only_when_both_layers_are_quan
     ],
 )
 def test_tied_quantized_embedding_weight_names_cover_all_supported_algorithms(
-    int4_algo_config,
+    algo_config,
     matmul_block_size,
     is_symmetric,
     expected_bits,
@@ -274,8 +274,8 @@ def test_tied_quantized_embedding_weight_names_cover_all_supported_algorithms(
     expected_zp,
 ):
     model = Model.__new__(Model)
-    model.extra_options = {"int4_algo_config": int4_algo_config}
-    model.algo_config_name = int4_algo_config
+    model.extra_options = {"algo_config": algo_config}
+    model.algo_config_name = algo_config
     model.matmul_block_size = matmul_block_size
     model.quant_attrs = {"is_symmetric": is_symmetric}
 
@@ -289,7 +289,7 @@ def test_tied_quantized_embedding_weight_names_cover_all_supported_algorithms(
 
 def test_tied_quantized_embedding_weight_names_raise_for_unknown_algorithm():
     model = Model.__new__(Model)
-    model.extra_options = {"int4_algo_config": "unexpected"}
+    model.extra_options = {"algo_config": "unexpected"}
     model.algo_config_name = "unexpected"
     model.matmul_block_size = 32
     model.quant_attrs = {"is_symmetric": True}
@@ -298,10 +298,10 @@ def test_tied_quantized_embedding_weight_names_raise_for_unknown_algorithm():
         model.make_tied_quantized_embedding_input_names()
 
 
-def _make_minimal_model_for_quantized_tied_embedding(*, int4_algo_config, is_symmetric=True, quant_type=None):
+def _make_minimal_model_for_quantized_tied_embedding(*, algo_config, is_symmetric=True, quant_type=None):
     model = Model.__new__(Model)
-    model.extra_options = {"int4_algo_config": int4_algo_config}
-    model.algo_config_name = int4_algo_config
+    model.extra_options = {"algo_config": algo_config}
+    model.algo_config_name = algo_config
     model.matmul_block_size = 32
     model.hidden_size = 64
     model.vocab_size = 32000
@@ -338,7 +338,7 @@ def _make_minimal_model_for_quantized_tied_embedding(*, int4_algo_config, is_sym
 
 
 @pytest.mark.parametrize(
-    "int4_algo_config, is_symmetric, quant_type, expected_weight_name, expected_scale_name, expected_zp_name, expect_zp_input",
+    "algo_config, is_symmetric, quant_type, expected_weight_name, expected_scale_name, expected_zp_name, expect_zp_input",
     [
         ("default", True, None, "lm_head.MatMul.weight_Q4", "lm_head.MatMul.weight_scales", None, False),
         ("default", False, None, "lm_head.MatMul.weight", "", None, False),
@@ -349,7 +349,7 @@ def _make_minimal_model_for_quantized_tied_embedding(*, int4_algo_config, is_sym
     ],
 )
 def test_make_embedding_uses_algo_specific_lm_head_initializer_names_for_tied_quantized_embeddings(
-    int4_algo_config,
+    algo_config,
     is_symmetric,
     quant_type,
     expected_weight_name,
@@ -358,7 +358,7 @@ def test_make_embedding_uses_algo_specific_lm_head_initializer_names_for_tied_qu
     expect_zp_input,
 ):
     model = _make_minimal_model_for_quantized_tied_embedding(
-        int4_algo_config=int4_algo_config,
+        algo_config=algo_config,
         is_symmetric=is_symmetric,
         quant_type=quant_type,
     )

--- a/test/python/builder/test_tied_embeddings.py
+++ b/test/python/builder/test_tied_embeddings.py
@@ -494,7 +494,7 @@ def test_int4_matmul_uses_float_fallback_when_model_not_already_quantized():
     model = _make_minimal_model_for_int4_matmul()
 
     matmul = types.SimpleNamespace(weight=object())
-    result = model.make_matmul_int4(matmul, "/lm_head/MatMul", "hidden_states")
+    result = model.make_matmul_nbits(matmul, "/lm_head/MatMul", "hidden_states")
 
     assert result == "float_fallback"
     assert model._float_called is True
@@ -514,7 +514,7 @@ def test_int4_matmul_emits_matmul_nbits_when_model_already_quantized():
         in_features=64,
         out_features=128,
     )
-    result = model.make_matmul_int4(matmul, "/lm_head/MatMul", "hidden_states")
+    result = model.make_matmul_nbits(matmul, "/lm_head/MatMul", "hidden_states")
 
     assert result == "/lm_head/MatMulNBits"
     assert model._float_called is False

--- a/test/python/builder/test_tied_embeddings.py
+++ b/test/python/builder/test_tied_embeddings.py
@@ -39,7 +39,6 @@ def _make_model_for_tied_embeddings(
     exclude_lm_head=False,
     prune_lm_head=False,
     algo_config="default",
-    bits=4,
 ):
     model = Model.__new__(Model)
     model.extra_options = {"algo_config": algo_config}
@@ -49,7 +48,6 @@ def _make_model_for_tied_embeddings(
     model.quant_attrs = {
         "op_types_to_quantize": op_types,
         "nodes_to_exclude": list(nodes_to_exclude),
-        "bits": bits,
     }
     model.exclude_embeds = exclude_embeds
     model.exclude_lm_head = exclude_lm_head
@@ -179,15 +177,14 @@ def test_tied_unquantized_embeddings_can_be_true_in_int4_mode_when_both_quant_pa
 
 
 def test_int8_lm_head_is_quantized_so_shared_embeddings_are_not_tied():
-    # int8 keeps onnx_dtype FLOAT but quantizes the lm_head MatMul to 8-bit (bits == 8),
-    # while embeddings (Gather) stay unquantized (Gather only supports 4-bit). A quantized
-    # lm_head cannot be tied to an unquantized embedding, so neither tying path is selected.
+    # int8 quantizes the lm_head MatMul to 8-bit (onnx_dtype INT8), while embeddings
+    # (Gather) stay unquantized (Gather only supports 4-bit). A quantized lm_head cannot
+    # be tied to an unquantized embedding, so neither tying path is selected.
     model = _make_model_for_tied_embeddings(
         shared_embeddings=True,
         tie_word_embeddings=False,
-        onnx_dtype=ir.DataType.FLOAT,
+        onnx_dtype=ir.DataType.INT8,
         op_types=("MatMul", "Gather"),
-        bits=8,
     )
 
     assert model.tied_quantized_embeddings is False
@@ -200,10 +197,9 @@ def test_int8_with_lm_head_excluded_allows_unquantized_tying():
     model = _make_model_for_tied_embeddings(
         shared_embeddings=True,
         tie_word_embeddings=False,
-        onnx_dtype=ir.DataType.FLOAT,
+        onnx_dtype=ir.DataType.INT8,
         op_types=("MatMul", "Gather"),
         nodes_to_exclude=("/lm_head/MatMul",),
-        bits=8,
     )
 
     assert model.tied_quantized_embeddings is False


### PR DESCRIPTION
The model builder currently supports the following precisions for weight quantization: int4, bf16, fp16, fp32

This change adds support for int8.