### PR TITLE
Fall back to the system D3D12 runtime when the Agility SDK device factory cannot create a device

### DIFF
--- a/src/dml/dml_helpers.cpp
+++ b/src/dml/dml_helpers.cpp
@@ -147,10 +147,10 @@ DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device
     if (SUCCEEDED(create_device_hr)) {
       agility_device_created = true;
     } else {
-      printf("Warning: Unable to create a device from version 1.614.0 of the DirectX 12 Agility SDK (HRESULT 0x%08X). Falling back to the system D3D12 runtime; some scenarios may not work.\n", static_cast<unsigned int>(create_device_hr));
+      printf("Warning: Unable to create a device from version 1.%u.0 of the DirectX 12 Agility SDK (HRESULT 0x%08X). Falling back to the system D3D12 runtime; some scenarios may not work.\n", agility_sdk_version, static_cast<unsigned int>(create_device_hr));
     }
   } else {
-    printf("Warning: Unable to create a device from version 1.614.0 of the DirectX 12 Agility SDK. You can still use this library, but some scenarios may not work.\n");
+    printf("Warning: Unable to create a device from version 1.%u.0 of the DirectX 12 Agility SDK. You can still use this library, but some scenarios may not work.\n", agility_sdk_version);
     printf("The given module path: %s\n", current_module_path.c_str());
   }
 

--- a/src/dml/dml_helpers.cpp
+++ b/src/dml/dml_helpers.cpp
@@ -135,12 +135,26 @@ DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device
   // Get the version from https://devblogs.microsoft.com/directx/directx12agility/. We are currently using 1.614.0.
   constexpr uint32_t agility_sdk_version = 614;
 
+  bool agility_device_created = false;
   if (SUCCEEDED(D3D12GetInterface(CLSID_D3D12SDKConfiguration, IID_PPV_ARGS(&d3d12_sdk_config))) &&
       SUCCEEDED(d3d12_sdk_config->CreateDeviceFactory(agility_sdk_version, current_module_path.c_str(), IID_PPV_ARGS(&d3d12_factory)))) {
-    THROW_IF_FAILED(d3d12_factory->CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&dml_objects.d3d12_device)));
+    // The Agility SDK device factory can fail even when the factory itself was created successfully.
+    // A known case is DXGI_ERROR_ALREADY_EXISTS (0x887A0036): the process already holds a D3D12 device
+    // created with the system runtime (e.g. the XAML/WinUI compositor in a packaged app), and devices
+    // from different D3D12 runtimes cannot coexist in one process. Fall back to the system runtime
+    // instead of failing model creation.
+    HRESULT create_device_hr = d3d12_factory->CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&dml_objects.d3d12_device));
+    if (SUCCEEDED(create_device_hr)) {
+      agility_device_created = true;
+    } else {
+      printf("Warning: Unable to create a device from version 1.614.0 of the DirectX 12 Agility SDK (HRESULT 0x%08X). Falling back to the system D3D12 runtime; some scenarios may not work.\n", static_cast<unsigned int>(create_device_hr));
+    }
   } else {
     printf("Warning: Unable to create a device from version 1.614.0 of the DirectX 12 Agility SDK. You can still use this library, but some scenarios may not work.\n");
     printf("The given module path: %s", current_module_path.c_str());
+  }
+
+  if (!agility_device_created) {
     THROW_IF_FAILED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&dml_objects.d3d12_device)));
   }
 

--- a/src/dml/dml_helpers.cpp
+++ b/src/dml/dml_helpers.cpp
@@ -151,7 +151,7 @@ DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device
     }
   } else {
     printf("Warning: Unable to create a device from version 1.614.0 of the DirectX 12 Agility SDK. You can still use this library, but some scenarios may not work.\n");
-    printf("The given module path: %s", current_module_path.c_str());
+    printf("The given module path: %s\n", current_module_path.c_str());
   }
 
   if (!agility_device_created) {


### PR DESCRIPTION
### Problem

`CreateDmlObjects` (`src/dml/dml_helpers.cpp`) tries the Agility SDK device factory first and **throws on any `CreateDevice` failure** instead of reaching the existing system-runtime fallback branch:

```cpp
if (SUCCEEDED(D3D12GetInterface(...)) && SUCCEEDED(sdk_config->CreateDeviceFactory(614, module_path, ...))) {
  THROW_IF_FAILED(d3d12_factory->CreateDevice(...));   // throws — fallback below is unreachable
} else {
  ...
  THROW_IF_FAILED(D3D12CreateDevice(...));
}
```

A known failure is `DXGI_ERROR_ALREADY_EXISTS` (0x887A0036): the process already holds a D3D12 device created with the system runtime — e.g. the XAML/WinUI compositor in a packaged app creates one at `Window.Activate()` — and devices from different D3D12 runtimes cannot coexist in one process. The plain `D3D12CreateDevice` branch handles exactly this situation, but is unreachable.

Whether this bites is **OS-dependent**: if the in-box D3D12 is older than the requested SDK version (614), `CreateDeviceFactory` itself fails and the fallback runs — an OS update silently flips the branch and breaks `OgaCreateModel` in XAML hosts.

### Fix

Treat a factory `CreateDevice` failure like a factory creation failure: log a warning with the HRESULT and fall back to `D3D12CreateDevice`.

No regression for #612 (which introduced the Agility path): the new fallback only runs when the in-box runtime is >= the requested SDK version — i.e. the system runtime already contains the fixes the Agility dependency was added for. Related: #1054 (the pre-existing fallback branch for factory-creation failure).

### Validation (real hardware)

Xbox Series S, Dev Mode UWP (OS 26100), ORT GenAI 0.13.2 DirectML + ORT 1.24.4, SmolLM2-360M INT4 (DML model built with the model builder):

| Scenario | vanilla DLL | patched DLL |
|---|---|---|
| XAML app + DML EP | `887A0036` at `OgaCreateModel` (reproduced 3x) | loads in 886 ms, weights resident on GPU (315 MB), full decode (739 tokens) |
| XAML app + CPU EP | works | works (67.2 tok/s, unchanged) |
| Headless (no compositor) + DML EP | works via Agility path | works via Agility path |
