### PR TITLE
LFM2: add shared-buffer KV cache support to LFM2Cache

### DIFF
--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+// Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "../generators.h"
 #include "model.h"
@@ -737,10 +738,41 @@ LFM2Cache::LFM2Cache(State& state)
     }
 
     kv_type_ = model_.session_info_.GetInputDataType(kv_input_name_strings_[0]);
-    kv_empty_past_ = OrtValue::CreateTensor(Allocator(), kv_shape_, kv_type_);
 
-    for (int i = 0; i < kv_layer_count_ * 2; ++i) {
-      kv_presents_.push_back(OrtValue::CreateTensor(Allocator(), kv_shape_, kv_type_));
+    // Shared KV cache: same policy as DefaultKeyValueCache. Start from the genai
+    // search option, then let DetectAndConfigureFixedKvShape force share-buffer when
+    // the ONNX graph fixes the kv seq_len (e.g. RyzenAI fusion). The buffer is sized
+    // to that fixed dim when present, otherwise to search.max_length for symbolic
+    // graphs. (LFM2 attention on the NPU/GQO requires past==present shared buffer.)
+    kv_share_buffer_ = state_.params_->IsPastPresentShareBufferEnabled(model_.config_->model.type);
+    const int64_t fixed_kv_seq_len = DetectAndConfigureFixedKvShape(
+        model_.session_info_, kv_input_name_strings_, kv_layer_count_,
+        state_.params_->search, kv_share_buffer_);
+    if (g_log.enabled && g_log.warning && kv_share_buffer_ != state_.params_->search.past_present_share_buffer)
+      Log("warning", "past_present_share_buffer search option set to true, but has been disabled due to the current configuration. See https://aka.ms/generate_config for details");
+
+    if (kv_share_buffer_) {
+      const int64_t seq_cap = fixed_kv_seq_len > 0
+                                  ? fixed_kv_seq_len
+                                  : static_cast<int64_t>(state_.params_->search.max_length);
+      if (seq_cap <= 0) {
+        throw std::runtime_error(
+            "LFM2Cache: past_present_share_buffer requires a fixed kv seq_len in the "
+            "model or search.max_length > 0 (set max_length or model.context_length "
+            "in genai_config.json).");
+      }
+      kv_shape_[2] = seq_cap;
+      for (int i = 0; i < kv_layer_count_ * 2; ++i) {
+        kv_presents_.push_back(OrtValue::CreateTensor(Allocator(), kv_shape_, kv_type_));
+        if (Device().GetType() != DeviceType::WEBGPU) {
+          ByteWrapTensor(Device(), *kv_presents_.back()).Zero();
+        }
+      }
+    } else {
+      kv_empty_past_ = OrtValue::CreateTensor(Allocator(), kv_shape_, kv_type_);
+      for (int i = 0; i < kv_layer_count_ * 2; ++i) {
+        kv_presents_.push_back(OrtValue::CreateTensor(Allocator(), kv_shape_, kv_type_));
+      }
     }
   }
 
@@ -779,10 +811,11 @@ LFM2Cache::LFM2Cache(State& state)
 }
 
 void LFM2Cache::Add() {
-  // Add KV cache inputs/outputs
+  // Add KV cache inputs/outputs. In shared-buffer mode past == present (same fixed
+  // buffer), so the input is bound to the present tensor and never changes.
   kv_input_index_ = state_.inputs_.size();
   for (int i = 0; i < kv_layer_count_ * 2; ++i) {
-    state_.inputs_.push_back(kv_empty_past_.get());
+    state_.inputs_.push_back(kv_share_buffer_ ? kv_presents_[i].get() : kv_empty_past_.get());
     state_.input_names_.push_back(kv_input_name_strings_[i].c_str());
   }
   kv_output_index_ = state_.outputs_.size();
@@ -806,23 +839,28 @@ void LFM2Cache::Add() {
 
 void LFM2Cache::Update(DeviceSpan<int32_t> beam_indices, int total_length) {
   // --- Update KV cache (attention layers) ---
-  if (!kv_is_first_update_) {
-    for (int i = 0; i < kv_layer_count_ * 2; i++) {
-      if (beam_indices.empty()) {
-        kv_pasts_[i] = std::move(kv_presents_[i]);
-      } else {
-        PickPastState(beam_indices, i);
+  // In shared-buffer mode the past/present KV buffers are fixed and reused in place
+  // (the session writes new tokens into the same buffer), so there is nothing to
+  // grow or swap here. Only the dynamic/growing path needs updating.
+  if (!kv_share_buffer_) {
+    if (!kv_is_first_update_) {
+      for (int i = 0; i < kv_layer_count_ * 2; i++) {
+        if (beam_indices.empty()) {
+          kv_pasts_[i] = std::move(kv_presents_[i]);
+        } else {
+          PickPastState(beam_indices, i);
+        }
+        state_.inputs_[kv_input_index_ + i] = kv_pasts_[i].get();
       }
-      state_.inputs_[kv_input_index_ + i] = kv_pasts_[i].get();
     }
-  }
 
-  kv_shape_[2] = total_length;
-  for (int i = 0; i < kv_layer_count_ * 2; i++) {
-    kv_presents_[i] = OrtValue::CreateTensor(Allocator(), kv_shape_, kv_type_);
-    state_.outputs_[kv_output_index_ + i] = kv_presents_[i].get();
+    kv_shape_[2] = total_length;
+    for (int i = 0; i < kv_layer_count_ * 2; i++) {
+      kv_presents_[i] = OrtValue::CreateTensor(Allocator(), kv_shape_, kv_type_);
+      state_.outputs_[kv_output_index_ + i] = kv_presents_[i].get();
+    }
+    kv_is_first_update_ = false;
   }
-  kv_is_first_update_ = false;
 
   // --- Update conv state cache ---
   if (!conv_is_first_update_) {

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -181,7 +181,8 @@ int64_t DetectAndConfigureFixedKvShape(const SessionInfo& session_info,
                                        const std::vector<std::string>& input_name_strings,
                                        int layer_count,
                                        const Config::Search& search,
-                                       bool& past_present_share_buffer) {
+                                       bool& past_present_share_buffer,
+                                       const char* cache_name) {
   if (layer_count <= 0) return 0;
 
   // input_name_strings stores [past_key.0, past_value.0, past_key.1, past_value.1, ...].
@@ -206,7 +207,7 @@ int64_t DetectAndConfigureFixedKvShape(const SessionInfo& session_info,
   }
   past_present_share_buffer = true;
   if (g_log.enabled) {
-    Log("info", "DefaultKeyValueCache: auto-detected fixed kv-cache seq_len=" +
+    Log("info", std::string(cache_name) + ": auto-detected fixed kv-cache seq_len=" +
                     std::to_string(common_seq_len) +
                     "; allocating shared past/present buffer to that size.");
   }
@@ -341,7 +342,7 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
 
   const int64_t fixed_kv_seq_len = DetectAndConfigureFixedKvShape(
       model_.session_info_, input_name_strings_, layer_count_,
-      state_.params_->search, past_present_share_buffer_);
+      state_.params_->search, past_present_share_buffer_, "DefaultKeyValueCache");
 
   if (state_.params_->use_graph_capture && !past_present_share_buffer_) {
     // share buffer is a precondition for graph capture
@@ -746,9 +747,12 @@ LFM2Cache::LFM2Cache(State& state)
     kv_share_buffer_ = state_.params_->IsPastPresentShareBufferEnabled(model_.config_->model.type);
     const int64_t fixed_kv_seq_len = DetectAndConfigureFixedKvShape(
         model_.session_info_, kv_input_name_strings_, kv_layer_count_,
-        state_.params_->search, kv_share_buffer_);
-    if (g_log.enabled && g_log.warning && kv_share_buffer_ != state_.params_->search.past_present_share_buffer)
+        state_.params_->search, kv_share_buffer_, "LFM2Cache");
+    if (g_log.enabled && g_log.warning && state_.params_->search.past_present_share_buffer && !kv_share_buffer_) {
       Log("warning", "past_present_share_buffer search option set to true, but has been disabled due to the current configuration. See https://aka.ms/generate_config for details");
+    } else if (g_log.enabled && !state_.params_->search.past_present_share_buffer && kv_share_buffer_) {
+      Log("info", "LFM2Cache: past_present_share_buffer was forced on due to a fixed kv-cache shape in the model graph.");
+    }
 
     if (kv_share_buffer_) {
       const int64_t seq_cap = fixed_kv_seq_len > 0

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -741,9 +741,8 @@ LFM2Cache::LFM2Cache(State& state)
 
     // Shared KV cache: same policy as DefaultKeyValueCache. Start from the genai
     // search option, then let DetectAndConfigureFixedKvShape force share-buffer when
-    // the ONNX graph fixes the kv seq_len (e.g. RyzenAI fusion). The buffer is sized
-    // to that fixed dim when present, otherwise to search.max_length for symbolic
-    // graphs. (LFM2 attention on the NPU/GQO requires past==present shared buffer.)
+    // the ONNX graph fixes the kv seq_len. The buffer is sized to that fixed dim when
+    // present, otherwise to search.max_length for symbolic graphs.
     kv_share_buffer_ = state_.params_->IsPastPresentShareBufferEnabled(model_.config_->model.type);
     const int64_t fixed_kv_seq_len = DetectAndConfigureFixedKvShape(
         model_.session_info_, kv_input_name_strings_, kv_layer_count_,

--- a/src/models/kv_cache.h
+++ b/src/models/kv_cache.h
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+// Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #pragma once
 
@@ -180,6 +181,12 @@ struct LFM2Cache : KeyValueCache {
   std::vector<std::string> kv_input_name_strings_, kv_output_name_strings_;
   size_t kv_input_index_{~0U}, kv_output_index_{~0U};
   bool kv_is_first_update_{true};
+  // When true, attention KV uses one fixed-size buffer for past and present (same OrtValue
+  // bound to both). Enabled the same way as DefaultKeyValueCache: via
+  // IsPastPresentShareBufferEnabled (genai search options) and/or a fixed kv seq_len
+  // detected in the model graph by DetectAndConfigureFixedKvShape. Sequence capacity is
+  // the detected fixed dim when present, else search.max_length.
+  bool kv_share_buffer_{false};
 
   // Conv state cache (only for conv layers)
   int conv_layer_count_{};

--- a/src/python/py/models/builders/lfm2.py
+++ b/src/python/py/models/builders/lfm2.py
@@ -276,9 +276,5 @@ class LFM2Model(Model):
         decoder["inputs"]["past_conv_names"] = "past_conv.%d"
         decoder["outputs"]["present_conv_names"] = "present_conv.%d"
 
-        # past_present_share_buffer: LFM2Cache pre-allocates KV to search.max_length when
-        # IsPastPresentShareBufferEnabled is true. Do not force the flag off here — the base
-        # class sets it from model layout; overriding broke shared-KV execution paths.
-
         with open(config_path, "w") as f:
             json.dump(genai_config, f, indent=4)

--- a/src/python/py/models/builders/lfm2.py
+++ b/src/python/py/models/builders/lfm2.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.  All rights reserved.
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
+# Modifications Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # --------------------------------------------------------------------------
 import json
 import os
@@ -275,8 +276,9 @@ class LFM2Model(Model):
         decoder["inputs"]["past_conv_names"] = "past_conv.%d"
         decoder["outputs"]["present_conv_names"] = "present_conv.%d"
 
-        # Hybrid models don't support shared past/present buffer
-        genai_config["search"]["past_present_share_buffer"] = False
+        # past_present_share_buffer: LFM2Cache pre-allocates KV to search.max_length when
+        # IsPastPresentShareBufferEnabled is true. Do not force the flag off here — the base
+        # class sets it from model layout; overriding broke shared-KV execution paths.
 
         with open(config_path, "w") as f:
             json.dump(genai_config, f, indent=4)

--- a/test/python/_test_utils.py
+++ b/test/python/_test_utils.py
@@ -153,6 +153,8 @@ def get_model_paths():
         "phi-4-mini": ("microsoft/Phi-4-mini-instruct", True, False),
         "qwen-2.5-0.5b": ("Qwen/Qwen2.5-0.5B-Instruct", False, False),
         "qwen-2.5-0.5b-graph": ("Qwen/Qwen2.5-0.5B-Instruct", False, True),
+        "lfm2.5-350m": ("LiquidAI/LFM2.5-350M", False, False),
+        "lfm2.5-1.2b": ("LiquidAI/LFM2.5-1.2B-Instruct", False, False),
     }
 
     ci_data_path = os.path.join(get_ci_data_path(), "pytorch")

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -7,4 +7,4 @@ sympy
 pytest
 onnx
 onnx_ir>=0.1.3
-transformers<5.0.0
+transformers>=5.0.0


### PR DESCRIPTION
## LFM2: support shared-buffer (fixed-size) KV cache in `LFM2Cache`

### Summary
Adds a shared (pre-allocated, fixed-size) KV-cache mode to `LFM2Cache`, mirroring
`DefaultKeyValueCache`. This lets LFM2 use `past_present_share_buffer`, where the
past and present KV alias a single fixed-size buffer — a layout some execution
providers/kernels require.

### Problem
LFM2 is a hybrid (attention + conv) model and uses a dedicated `LFM2Cache`. That
class only implemented a **dynamic / growing** KV cache: it allocated `seq=0`, fed
an empty past, and reallocated/swapped the present tensors every step. In addition,
the LFM2 model builder hard-forced `past_present_share_buffer = False` in the
generated `genai_config.json`, so the shared-buffer path could never be selected —
even for backends that only support a fixed, shared past/present buffer.

### Changes
- Add `kv_share_buffer_` to `LFM2Cache`, gated the same way as
  `DefaultKeyValueCache` (via `IsPastPresentShareBufferEnabled` and
  `DetectAndConfigureFixedKvShape`).
- In shared-buffer mode: pre-allocate the KV buffer once (sized to the model's fixed
  kv `seq_len` when the graph pins it, otherwise to `search.max_length`), bind
  past == present (the same `OrtValue`), and make `Update()` a no-op for KV (no
  grow/swap).
- Preserve the existing dynamic/growing path unchanged when share-buffer is off.
- Stop overriding `past_present_share_buffer` to `False` in the LFM2 model builder,
  so the runtime can enable the shared-KV path when appropriate.

### Testing
- Exported **LFM2.5-350M** and **LFM2.5-1.2B-Instruct** via Olive using the OGA
  model builder; verified `past_present_share_buffer: true` in the generated
  `genai_config.json`.
- Ran inference across a range of prompt lengths; generation is stable and outputs
  remain coherent.