### PR TITLE
Merge pipeline config overlays by model ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ target_link_directories(onnxruntime-genai-obj PUBLIC ${ORT_LIB_DIR})
 target_link_libraries(onnxruntime-genai-obj PUBLIC Threads::Threads)
 
 if(WIN32)
+  target_compile_definitions(onnxruntime-genai-obj PRIVATE BUILDING_ORT_GENAI_INTERNALS)
   add_library(onnxruntime-genai SHARED "${GENERATORS_ROOT}/dll/onnxruntime-genai.rc")
   target_compile_definitions(onnxruntime-genai PRIVATE VERSION_INFO=\"${VERSION_INFO}\")
   target_compile_definitions(onnxruntime-genai PRIVATE VERSION_MAJOR=${VERSION_MAJOR})

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -458,7 +458,9 @@ struct PipelineModel_Element : JSON::Element {
 
   JSON::Element& OnObject(std::string_view name) override {
     if (name == "session_options") {
-      v_.session_options = Config::SessionOptions{};
+      if (!v_.session_options) {
+        v_.session_options.emplace();
+      }
       session_options_ = std::make_unique<SessionOptions_Element>(*v_.session_options);
       return *session_options_;
     }
@@ -491,19 +493,32 @@ struct PipelineModel_Element : JSON::Element {
   StringStringMap_Element output_names_forwarder_{v_.output_names_forwarder};
 };
 
+template <typename PipelineModel>
+PipelineModel& GetOrCreatePipelineModel(std::vector<PipelineModel>& models, std::string_view model_id) {
+  auto model = std::find_if(models.begin(), models.end(),
+                            [model_id](const auto& model) { return model.model_id == model_id; });
+  if (model != models.end()) {
+    return *model;
+  }
+
+  auto& new_model = models.emplace_back();
+  new_model.model_id = model_id;
+  return new_model;
+}
+
 struct PipelineModelObject_Element : JSON::Element {
   explicit PipelineModelObject_Element(std::vector<Config::Model::Decoder::PipelineModel>& v) : v_{v} {}
 
   Element& OnObject(std::string_view name) override {
-    auto& model = v_.emplace_back();
-    model.model_id = name;
-    pipeline_model_elements_.emplace_back(model);
-    return pipeline_model_elements_.back();
+    pipeline_model_element_.reset();  // Appending below may reallocate v_.
+    auto& model = GetOrCreatePipelineModel(v_, name);
+    pipeline_model_element_ = std::make_unique<PipelineModel_Element>(model);
+    return *pipeline_model_element_;
   }
 
  private:
   std::vector<Config::Model::Decoder::PipelineModel>& v_;
-  std::vector<PipelineModel_Element> pipeline_model_elements_;
+  std::unique_ptr<PipelineModel_Element> pipeline_model_element_;
 };
 
 struct Pipeline_Element : JSON::Element {
@@ -729,7 +744,9 @@ struct VisionPipelineModel_Element : JSON::Element {
 
   Element& OnObject(std::string_view name) override {
     if (name == "session_options") {
-      v_.session_options = Config::SessionOptions{};
+      if (!v_.session_options) {
+        v_.session_options.emplace();
+      }
       session_options_ = std::make_unique<SessionOptions_Element>(*v_.session_options);
       return *session_options_;
     }
@@ -763,15 +780,15 @@ struct VisionPipelineModelObject_Element : JSON::Element {
   explicit VisionPipelineModelObject_Element(std::vector<Config::Model::Vision::PipelineModel>& v) : v_{v} {}
 
   Element& OnObject(std::string_view name) override {
-    auto& model = v_.emplace_back();
-    model.model_id = name;
-    elements_.emplace_back(model);
-    return elements_.back();
+    element_.reset();  // Appending below may reallocate v_.
+    auto& model = GetOrCreatePipelineModel(v_, name);
+    element_ = std::make_unique<VisionPipelineModel_Element>(model);
+    return *element_;
   }
 
  private:
   std::vector<Config::Model::Vision::PipelineModel>& v_;
-  std::vector<VisionPipelineModel_Element> elements_;
+  std::unique_ptr<VisionPipelineModel_Element> element_;
 };
 
 struct VisionPipeline_Element : JSON::Element {

--- a/src/config.h
+++ b/src/config.h
@@ -7,6 +7,16 @@
 
 #include <functional>
 
+#if defined(_WIN32)
+#if defined(BUILDING_ORT_GENAI_INTERNALS)
+#define OGA_INTERNAL_EXPORT __declspec(dllexport)
+#else
+#define OGA_INTERNAL_EXPORT __declspec(dllimport)
+#endif
+#else
+#define OGA_INTERNAL_EXPORT
+#endif
+
 namespace Generators {
 
 struct RuntimeSettings;
@@ -464,7 +474,7 @@ void SetSearchNumber(Config::Search& search, std::string_view name, double value
 void SetSearchBool(Config::Search& search, std::string_view name, bool value);
 void ClearProviders(Config& config);
 void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value);
-void OverlayConfig(Config& config, std::string_view json);
+OGA_INTERNAL_EXPORT void OverlayConfig(Config& config, std::string_view json);
 int SafeDoubleToInt(double x, std::string_view name);
 
 bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options);
@@ -478,3 +488,5 @@ void ClearDecoderProviderOptionsHardwareDeviceId(Config& config, std::string_vie
 void ClearDecoderProviderOptionsHardwareVendorId(Config& config, std::string_view provider_name);
 
 }  // namespace Generators
+
+#undef OGA_INTERNAL_EXPORT

--- a/test/config_tests.cpp
+++ b/test/config_tests.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include "filesystem.h"
+#include "config.h"
+
+namespace Generators {
+namespace {
+
+template <typename PipelineModels>
+void ExpectPipelineOverlayMerged(const PipelineModels& pipeline) {
+  ASSERT_EQ(pipeline.size(), 3U);
+
+  const auto& untouched_model = pipeline[0];
+  EXPECT_EQ(untouched_model.model_id, "untouched_model");
+  EXPECT_EQ(untouched_model.filename, "untouched.onnx");
+  ASSERT_TRUE(untouched_model.session_options);
+  ASSERT_TRUE(untouched_model.session_options->log_id);
+  EXPECT_EQ(*untouched_model.session_options->log_id, "untouched");
+  EXPECT_FALSE(untouched_model.session_options->enable_profiling);
+
+  const auto& existing_model = pipeline[1];
+  EXPECT_EQ(existing_model.model_id, "existing_model");
+  EXPECT_EQ(existing_model.filename, "existing.onnx");
+  ASSERT_TRUE(existing_model.session_options);
+  ASSERT_TRUE(existing_model.session_options->log_id);
+  EXPECT_EQ(*existing_model.session_options->log_id, "original");
+  ASSERT_TRUE(existing_model.session_options->enable_profiling);
+  EXPECT_EQ(*existing_model.session_options->enable_profiling, "profile");
+  ASSERT_EQ(existing_model.session_options->provider_options.size(), 1U);
+  EXPECT_EQ(existing_model.session_options->provider_options[0].name, "CPU");
+
+  const auto& new_model = pipeline[2];
+  EXPECT_EQ(new_model.model_id, "new_model");
+  EXPECT_EQ(new_model.filename, "new.onnx");
+}
+
+TEST(ConfigTests, PipelineOverlayMergesByModelId) {
+  Config config;
+  OverlayConfig(config, R"({
+    "model": {
+      "decoder": {
+        "pipeline": [{
+          "untouched_model": {
+            "filename": "untouched.onnx",
+            "session_options": {"log_id": "untouched"}
+          },
+          "existing_model": {
+            "filename": "existing.onnx",
+            "session_options": {
+              "log_id": "original",
+              "provider_options": [{"CPU": {}}]
+            }
+          }
+        }]
+      },
+      "vision": {
+        "pipeline": [{
+          "untouched_model": {
+            "filename": "untouched.onnx",
+            "session_options": {"log_id": "untouched"}
+          },
+          "existing_model": {
+            "filename": "existing.onnx",
+            "session_options": {
+              "log_id": "original",
+              "provider_options": [{"CPU": {}}]
+            }
+          }
+        }]
+      }
+    }
+  })");
+
+  OverlayConfig(config, R"({
+    "model": {
+      "decoder": {
+        "pipeline": [{
+          "existing_model": {
+            "session_options": {"enable_profiling": "profile"}
+          },
+          "new_model": {"filename": "new.onnx"}
+        }]
+      },
+      "vision": {
+        "pipeline": [{
+          "existing_model": {
+            "session_options": {"enable_profiling": "profile"}
+          },
+          "new_model": {"filename": "new.onnx"}
+        }]
+      }
+    }
+  })");
+
+  ExpectPipelineOverlayMerged(config.model.decoder.pipeline);
+  ExpectPipelineOverlayMerged(config.model.vision.pipeline);
+}
+
+}  // namespace
+}  // namespace Generators


### PR DESCRIPTION
## Description

Fixes #2004.

`Config::overlay()` currently appends decoder and vision pipeline entries even when an entry with the same `model_id` already exists. A partial component overlay can therefore create a duplicate entry with an empty `filename`, causing model loading to fail.

This change:
- reuses the matching pipeline entry and only appends unknown model IDs;
- preserves existing component filenames and `session_options` while applying a partial overlay;
- resets the active parser element before an append can reallocate the pipeline vector;
- applies the same semantics to decoder and vision pipelines.

The existing replacement behavior for `run_options` is unchanged.

## Testing

- Added `ConfigTests.PipelineOverlayMergesByModelId`, covering:
  - two existing IDs, with only the second targeted;
  - preservation of the untouched entry, filename, log ID, and provider options;
  - addition of a new ID;
  - decoder and vision pipelines.
- Confirmed the regression test fails against current `main` (four entries instead of three) and passes with this change.
- Built the CPU `RelWithDebInfo` targets and ran the full CTest suite: 100% passed.
- Verified end to end with the Python binding: the existing ID now creates one profiled session, while a new ID still adds a second session.
- `clang-format`, lintrunner, and `git diff --check` pass.

## AI assistance

OpenAI Codex (GPT-5) was used to assist with investigation, implementation, review, and testing. The resulting behavior was validated against current `main` with both unit and end-to-end tests.