### PR TITLE
Enable re-init after OgaShutdown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,19 @@ if(MSVC)
     "$<$<COMPILE_LANGUAGE:C>:/WX>"
     "$<$<COMPILE_LANGUAGE:CXX>:/WX>"
   )
+
+  # MSVC 19.50+ (VS 2026) introduced C4875: non-string literal argument to [[gsl::suppress]] is
+  # deprecated. The GSL version used by onnxruntime_extensions (and other deps) hasn't adopted
+  # string-literal syntax yet. Suppress globally so third-party headers build cleanly.
+  # Also silence the STL1011 static assertion for <experimental/coroutine> being deprecated
+  # (ocos_operators in onnxruntime_extensions still uses it; the fix is upstream).
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.50")
+    add_compile_options(
+      "$<$<COMPILE_LANGUAGE:C>:/wd4875>"
+      "$<$<COMPILE_LANGUAGE:CXX>:/wd4875>"
+    )
+    add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+  endif()
 endif()
 
 include(cmake/ortlib.cmake)
@@ -155,8 +168,22 @@ endif()
 
 find_package(Threads REQUIRED)
 
+# genai is split into an OBJECT library (all sources + their compile/link usage requirements) and
+# the SHARED library that ships it. White-box test binaries (e.g. reinit_tests) link the object
+# library directly to reach internal symbols; the shipped DLL and every other consumer keep linking
+# the SHARED onnxruntime-genai target. Usage requirements are PUBLIC on the object library so both
+# the shared library and such tests inherit them. The shared library links the object library
+# PRIVATE, so DLL consumers (python / java / benchmark / unit_tests) do not inherit genai's private
+# dependencies -- they just link the shared onnxruntime-genai library directly.
+add_library(onnxruntime-genai-obj OBJECT ${generator_srcs})
+target_include_directories(onnxruntime-genai-obj PUBLIC ${ORT_HEADER_DIR})
+target_include_directories(onnxruntime-genai-obj PUBLIC ${onnxruntime_extensions_SOURCE_DIR}/shared/api)
+target_link_libraries(onnxruntime-genai-obj PUBLIC onnxruntime_extensions)
+target_link_directories(onnxruntime-genai-obj PUBLIC ${ORT_LIB_DIR})
+target_link_libraries(onnxruntime-genai-obj PUBLIC Threads::Threads)
+
 if(WIN32)
-  add_library(onnxruntime-genai SHARED ${generator_srcs} "${GENERATORS_ROOT}/dll/onnxruntime-genai.rc")
+  add_library(onnxruntime-genai SHARED "${GENERATORS_ROOT}/dll/onnxruntime-genai.rc")
   target_compile_definitions(onnxruntime-genai PRIVATE VERSION_INFO=\"${VERSION_INFO}\")
   target_compile_definitions(onnxruntime-genai PRIVATE VERSION_MAJOR=${VERSION_MAJOR})
   target_compile_definitions(onnxruntime-genai PRIVATE VERSION_MINOR=${VERSION_MINOR})
@@ -164,14 +191,16 @@ if(WIN32)
   target_compile_definitions(onnxruntime-genai PRIVATE VERSION_SUFFIX=${VERSION_SUFFIX})
   target_compile_definitions(onnxruntime-genai PRIVATE FILE_NAME=\"onnxruntime-genai.dll\")
 else()
-  add_library(onnxruntime-genai SHARED ${generator_srcs})
+  add_library(onnxruntime-genai SHARED)
 endif()
+# Bring in the object library's compiled objects and its (PUBLIC) usage requirements. PRIVATE so
+# the requirements are not re-exported to consumers of the shared library.
+target_link_libraries(onnxruntime-genai PRIVATE onnxruntime-genai-obj)
 
-target_include_directories(onnxruntime-genai PRIVATE ${ORT_HEADER_DIR})
-target_include_directories(onnxruntime-genai PRIVATE ${onnxruntime_extensions_SOURCE_DIR}/shared/api)
-target_link_libraries(onnxruntime-genai PRIVATE onnxruntime_extensions)
-target_link_directories(onnxruntime-genai PRIVATE ${ORT_LIB_DIR})
-target_link_libraries(onnxruntime-genai PRIVATE Threads::Threads)
+# Group the genai library targets under one Visual Studio solution folder so the object library and
+# the shared library it produces appear together rather than as loose entries at the solution root.
+# Cosmetic only (IDE generators); no effect on the build.
+set_target_properties(onnxruntime-genai-obj onnxruntime-genai PROPERTIES FOLDER "GenAI")
 
 # The genai library itself is always embedded in the shared library
 list(APPEND ortgenai_embed_libs "$<TARGET_FILE:onnxruntime-genai>")
@@ -181,14 +210,14 @@ list(APPEND ortgenai_embed_libs "$<TARGET_FILE:onnxruntime-genai>")
 if(CMAKE_SYSTEM_NAME STREQUAL "Android" OR CMAKE_SYSTEM_NAME STREQUAL "Linux" OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND (NOT BUILD_APPLE_FRAMEWORK) AND (NOT MAC_CATALYST)))
   add_compile_definitions(_ORT_GENAI_USE_DLOPEN)
 else()
-  target_link_libraries(onnxruntime-genai PRIVATE ${ONNXRUNTIME_LIB})
+  target_link_libraries(onnxruntime-genai-obj PUBLIC ${ONNXRUNTIME_LIB})
   if(USE_WINML)
     target_link_options(onnxruntime-genai PRIVATE "/DELAYLOAD:${ONNXRUNTIME_LIB}")
   endif()
 endif()
 
 if(APPLE)
-target_link_libraries(onnxruntime-genai PRIVATE "-framework Foundation" "-framework CoreML")
+target_link_libraries(onnxruntime-genai-obj PUBLIC "-framework Foundation" "-framework CoreML")
 endif()
 
 
@@ -227,6 +256,7 @@ if((USE_CUDA OR USE_TRT_RTX) AND CMAKE_CUDA_COMPILER)
   target_include_directories(onnxruntime-genai-cuda PRIVATE ${GENERATORS_ROOT})
   target_link_libraries(onnxruntime-genai-cuda PRIVATE cublasLt cublas curand cufft cudart)
   set_target_properties(onnxruntime-genai-cuda PROPERTIES LINKER_LANGUAGE CUDA)
+  set_target_properties(onnxruntime-genai-cuda PROPERTIES FOLDER "GenAI")
   add_dependencies(onnxruntime-genai onnxruntime-genai-cuda)
   source_group(TREE ${GENERATORS_ROOT}/cuda FILES ${generator_cudalib_srcs})
   list(APPEND ortgenai_embed_libs "$<TARGET_FILE:onnxruntime-genai-cuda>")
@@ -243,11 +273,11 @@ endif()
 
 
 if(USE_GUIDANCE)
-  target_include_directories(onnxruntime-genai PUBLIC ${llguidance_SOURCE_DIR}/parser/)
-  target_link_libraries(onnxruntime-genai PRIVATE llguidance)
+  target_include_directories(onnxruntime-genai-obj PUBLIC ${llguidance_SOURCE_DIR}/parser/)
+  target_link_libraries(onnxruntime-genai-obj PUBLIC llguidance)
   if (WIN32)
     # bcrypt is needed for the rust std lib
-    target_link_libraries(onnxruntime-genai PRIVATE bcrypt)
+    target_link_libraries(onnxruntime-genai-obj PUBLIC bcrypt)
   endif()
   if(MSVC)
     # The Rust llguidance static library is always compiled against the release MSVC CRT
@@ -260,12 +290,14 @@ if(USE_GUIDANCE)
     # Fix: explicitly add the debug CRT import libraries in Debug builds. Explicitly specified
     # libraries are not affected by /NODEFAULTLIB directives (those only suppress /DEFAULTLIB
     # auto-linking). Also suppress the conflicting release CRT to avoid LNK4098 warnings.
-    target_link_libraries(onnxruntime-genai PRIVATE
+    # PUBLIC/INTERFACE so any binary linking the object library (the shared lib and white-box tests)
+    # gets the same fixups.
+    target_link_libraries(onnxruntime-genai-obj PUBLIC
       $<$<CONFIG:Debug>:msvcrtd.lib>
       $<$<CONFIG:Debug>:ucrtd.lib>
       $<$<CONFIG:Debug>:vcruntimed.lib>
     )
-    target_link_options(onnxruntime-genai PRIVATE
+    target_link_options(onnxruntime-genai-obj INTERFACE
       $<$<CONFIG:Debug>:/NODEFAULTLIB:msvcrt.lib>
       $<$<CONFIG:Debug>:/NODEFAULTLIB:ucrt.lib>
       $<$<CONFIG:Debug>:/NODEFAULTLIB:vcruntime.lib>
@@ -277,24 +309,24 @@ if(USE_GUIDANCE)
 endif()
 
 if(CMAKE_GENERATOR_TOOLSET MATCHES "Visual Studio")
-  target_compile_options(onnxruntime-genai PRIVATE "/sdl")
+  target_compile_options(onnxruntime-genai-obj PRIVATE "/sdl")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set_target_properties(onnxruntime-genai PROPERTIES POSITION_INDEPENDENT_CODE ON)
-  target_link_libraries(onnxruntime-genai PUBLIC dl)  # For dlopen & co
+  set_target_properties(onnxruntime-genai-obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_link_libraries(onnxruntime-genai-obj PUBLIC dl)  # For dlopen & co
 endif()
 
 if(USE_DML)
   list(APPEND ortgenai_embed_libs "${D3D12_LIB_DIR}/D3D12Core.dll")
-  target_include_directories(onnxruntime-genai PRIVATE $<TARGET_PROPERTY:${WIL_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
-  target_include_directories(onnxruntime-genai PRIVATE $<TARGET_PROPERTY:${DIRECTX_HEADERS_TARGET},INTERFACE_INCLUDE_DIRECTORIES>/directx)
-  target_include_directories(onnxruntime-genai PRIVATE $<TARGET_PROPERTY:${DIRECTX_HEADERS_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
-  target_include_directories(onnxruntime-genai PRIVATE ${DML_HEADER_DIR})
-  target_include_directories(onnxruntime-genai PRIVATE ${D3D12_HEADER_DIR})
-  target_link_directories(onnxruntime-genai PRIVATE ${DML_LIB_DIR})
-  target_link_directories(onnxruntime-genai PRIVATE ${D3D12_LIB_DIR})
-  target_link_libraries(onnxruntime-genai PRIVATE d3d12.lib dxcore.lib dxguid.lib dxgi.lib)
+  target_include_directories(onnxruntime-genai-obj PRIVATE $<TARGET_PROPERTY:${WIL_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
+  target_include_directories(onnxruntime-genai-obj PRIVATE $<TARGET_PROPERTY:${DIRECTX_HEADERS_TARGET},INTERFACE_INCLUDE_DIRECTORIES>/directx)
+  target_include_directories(onnxruntime-genai-obj PRIVATE $<TARGET_PROPERTY:${DIRECTX_HEADERS_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
+  target_include_directories(onnxruntime-genai-obj PRIVATE ${DML_HEADER_DIR})
+  target_include_directories(onnxruntime-genai-obj PRIVATE ${D3D12_HEADER_DIR})
+  target_link_directories(onnxruntime-genai-obj PUBLIC ${DML_LIB_DIR})
+  target_link_directories(onnxruntime-genai-obj PUBLIC ${D3D12_LIB_DIR})
+  target_link_libraries(onnxruntime-genai-obj PUBLIC d3d12.lib dxcore.lib dxguid.lib dxgi.lib)
 
   get_filename_component(PACKAGES_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps ABSOLUTE)
   set(DXC_PACKAGE_DIR ${PACKAGES_DIR}/Microsoft.Direct3D.DXC.1.7.2308.12)
@@ -318,7 +350,7 @@ if(USE_DML)
   )
 
   add_dependencies(RESTORE_PACKAGES nuget)
-  add_dependencies(onnxruntime-genai RESTORE_PACKAGES)
+  add_dependencies(onnxruntime-genai-obj RESTORE_PACKAGES)
 endif()
 
 if(ANDROID)

--- a/docs/EnableReinitAfterOgaShutdown.md
+++ b/docs/EnableReinitAfterOgaShutdown.md
@@ -1,0 +1,172 @@
+# Plan: Clean `OgaShutdown` and re-initialization
+
+`OgaShutdown` returns genai to a *just-loaded* state. It tears down all of
+genai's ONNX Runtime-derived global state -- the `OrtEnv`, the device
+interfaces, the genai add-on libraries, and the trivial-session allocators --
+and a subsequent genai call transparently re-initializes with a fresh `OrtEnv`.
+This lets a host that recreates its wrapper in-process (for example Foundry
+Local's `Manager`) get a clean environment -- fresh logging and env
+configuration -- without restarting the process.
+
+## Background
+
+`OrtEnv` is a process-wide, refcounted singleton. genai holds one reference to
+it inside its global state (`OrtGlobals`). Previously that state was created
+once via a function-static and never rebuilt, so after `OgaShutdown` reset it
+genai could not be used again in the same process. The changes here move all
+env-scoped state into a single owner (`OrtGlobals`) that is destroyed on
+shutdown and rebuilt on demand.
+
+## `OrtGlobals` owns all env-scoped state
+
+`OrtGlobals` (`src/generators.cpp`, `src/generators.h`) is the single owner of
+everything whose lifetime is tied to the `OrtEnv`:
+
+- `env_` -- the `OrtEnv`.
+- `owned_interfaces_` -- the in-process `DeviceInterface` instances (CPU,
+  WebGPU, QNN, OpenVINO, RyzenAI), owned directly.
+- `cuda_library_` -- the genai CUDA add-on library handle (see below).
+- `device_interfaces_` -- a non-owning `DeviceType -> DeviceInterface*` lookup
+  that indexes the owners above (and the module-owned DML interface).
+- `device_allocators_` -- the trivial-session allocators (`{session, allocator}`
+  per device type) that bootstrap the non-CPU device allocators.
+- `graph_session_cache_` -- cached dynamically-built sessions (Cast, TopK, ...).
+
+Because all of this lives in one object, tearing genai down is a single
+`OrtGlobals` destruction and re-initialization is a single `OrtGlobals`
+construction.
+
+## Re-creatable globals
+
+`g_ort_globals` is a `std::unique_ptr<OrtGlobals>` that `GetOrtGlobals()` builds
+on demand:
+
+- `GetOrtGlobals()` lazily (re)creates the globals whenever they are null, so
+  the first call after `OgaShutdown` rebuilds them with a fresh `OrtEnv`.
+- Creation is guarded by a mutex rather than `std::call_once` (which is
+  process-once and would prevent re-init), so concurrent first-use -- or
+  first-use after a shutdown -- cannot double-construct the globals.
+- A process-exit guard, `g_process_exiting`, is set by the `EnsureShutdown`
+  static destructor so `GetOrtGlobals()` cannot resurrect the globals during
+  static destruction.
+- `Shutdown()` (behind `OgaShutdown`) simply resets `g_ort_globals`;
+  `~OrtGlobals` performs all of the teardown.
+
+The `OrtGlobals` constructor bootstraps the CPU interface through a member call
+(`this->GetDeviceInterface(DeviceType::CPU)`) rather than the free
+`GetDeviceInterface()` -> `GetOrtGlobals()` path, so it does not re-enter
+`GetOrtGlobals()` while still being constructed.
+
+## Device interface ownership
+
+Each in-process EP exposes a `CreateXInterface()` factory that returns a
+`std::unique_ptr<DeviceInterface>`. `OrtGlobals::GetDeviceInterface()` creates
+the interface on first use (under a lock), stores it in `owned_interfaces_`, and
+caches a raw pointer in `device_interfaces_`. This replaces the previous per-EP
+`GetXInterface()` accessors that held the interface in a function/namespace
+static (and, for RyzenAI, a `std::call_once`), none of which could be rebuilt
+after a shutdown. Because the interfaces are now owned by `OrtGlobals`,
+`~OrtGlobals` drops them all, and the hard-coded `RyzenAIInterface::Shutdown()`
+that `Shutdown()` used to call is gone.
+
+## CUDA add-on library
+
+The genai CUDA add-on library (`onnxruntime-genai-cuda`) provides its
+`DeviceInterface` from inside the DLL (`g_cuda_device`), along with the CUDA
+stream and a file-static allocator pointer. `OrtGlobals` owns the loaded library
+handle (`cuda_library_`) and holds only a non-owning pointer to the interface in
+`device_interfaces_`. Unloading the library at teardown runs the add-on's static
+destructors, so the interface, the stream, and the file-static allocator all
+cease to exist between cycles -- genai returns to a just-loaded state with no
+cached add-on state.
+
+## Teardown order
+
+`~OrtGlobals` destroys state in the reverse of construction order, so everything
+that uses env-owned resources is gone before the env itself:
+
+1. `graph_session_cache_` -- genai-side session caches of dynamically created models for pre/post processing.
+2. `device_interfaces_` (the non-owning index), then `owned_interfaces_`, then
+   `cuda_library_` -- the device interfaces and the CUDA add-on library.
+3. `device_allocators_` -- the trivial-session allocators. Each entry bundles its
+   own dedicated dummy `OrtSession`; the allocator wraps that bundled session (not
+   any session in `graph_session_cache_`), so the relative order of steps 1 and 3
+   is not a correctness constraint. Within each entry the `OrtSession` is declared
+   before the `Ort::Allocator`, so the allocator is destroyed before its session.
+4. `env_` -- the `OrtEnv`. If genai held the last reference, ORT destroys the
+   environment here.
+
+Ending all allocator use before the env is destroyed keeps teardown correct even
+if a future interface or buffer were to dereference a cached allocator in its own
+destructor.
+
+## CPU allocator
+
+The CPU interface allocates through ONNX Runtime's process-global default
+allocator (`Ort::Allocator::GetWithDefaultOptions()`), not an env-scoped one, so
+nothing genai caches for CPU dangles when the env is destroyed. The only change
+CPU needs for re-init is that its `InitOrt` is idempotent: `OrtGlobals` re-runs
+`CreateAndRegisterAllocator` on the new env and calls `InitOrt` again with the
+same process-global allocator each cycle, so the previous
+`assert(!ort_allocator_)` is removed.
+
+## DML
+
+DML is a deliberate exception to the ownership model above, for two reasons:
+
+1. Its interface is built from the model's `luid` / `device_index` provider
+   options (parsed in `src/dml/session_options.cpp` and passed to
+   `InitDmlInterface`), which the generic `GetDeviceInterface(DeviceType::DML)`
+   cannot supply.
+2. DML objects launch background threads that must be released promptly, so
+   `Model::~Model` tears the DML interface down per-`Model` via
+   `CloseDmlInterface()`.
+
+Because DML is destroyed per-`Model`, `OrtGlobals::GetDeviceInterface` must
+**not** cache the DML interface -- a cached pointer would dangle after the first
+DML model is freed and be handed to a later one. The `#if USE_DML` arm therefore
+returns the live `GetDmlInterface()` instead of memoizing it (all other EPs,
+which live for the env cycle, are cached). DML is already re-init-safe through
+this per-`Model` teardown: after the last DML model is destroyed, no DML
+interface or `Dml::` static survives into the next env cycle.
+
+## RyzenAI
+
+RyzenAI is owned by `OrtGlobals` like the other in-process EPs (created via
+`CreateRyzenAIInterface(env)`), and the hard-coded `RyzenAIInterface::Shutdown()`
+is removed -- teardown now happens when `~OrtGlobals` drops the interface. EP-library
+registration is per-`OrtEnv` (ORT keys it by registration name), so on each env cycle
+the interface registers the RyzenAI EP library on the fresh env even when the EP module
+is already resident in the process from an earlier cycle. Because an `OrtEnv` can outlive
+an `OgaShutdown` when the host holds its own reference, the registration call tolerates
+ORT's "library is already registered" status for that env rather than skipping
+registration up front, so RyzenAI is re-init-safe in both cases.
+
+Teardown of the EP module itself (the `RyzenAI_Shutdown` call in the interface destructor)
+is gated on genai having loaded it: each interface records at construction, before it
+registers/loads the EP, whether the module was already resident. genai calls
+`RyzenAI_Shutdown` only when it was not -- i.e. genai's own registration loaded it. If an
+external owner had already loaded it, genai never shuts it down, so it cannot tear down EP
+state another owner still relies on. ORT unloads the EP library when the interface's env is
+torn down, so the next re-init cycle re-evaluates this against a freshly unloaded module.
+
+## Lifetime contract
+
+No `Model`, `Generator`, `Tokenizer`, `OgaTensor`, `Engine`, `Request`, or any
+object that holds device memory may outlive `OgaShutdown`. The caller must
+destroy every such object before calling `OgaShutdown`; doing otherwise is
+undefined behavior (typically a crash when the buffer is freed through a
+now-invalid allocator). Debug builds report any leaked genai objects at shutdown.
+
+## Testing
+
+Re-initialization is covered by a dedicated `reinit_tests` executable, kept
+separate from `unit_tests` because it calls `OgaShutdown`, which resets
+process-global state and so must not share a process with the public-API suite.
+`reinit_tests` links the genai object library (`onnxruntime-genai-obj`) rather
+than the shared library, giving white-box access to `GetDeviceInterface` so it
+can force each available device interface to be created and torn down directly
+across repeated shutdown -> re-init cycles (no model load required). The
+object-library split -- the shipped shared library and the white-box tests both
+consume `onnxruntime-genai-obj` -- lets the tests reach internal symbols without
+exporting them from the shipped DLL.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1416,13 +1416,27 @@ static std::string EscapeJsonString(std::string_view s) {
   result.reserve(s.size());
   for (char c : s) {
     switch (c) {
-      case '"':  result += "\\\""; break;
-      case '\\': result += "\\\\"; break;
-      case '\b': result += "\\b";  break;
-      case '\f': result += "\\f";  break;
-      case '\n': result += "\\n";  break;
-      case '\r': result += "\\r";  break;
-      case '\t': result += "\\t";  break;
+      case '"':
+        result += "\\\"";
+        break;
+      case '\\':
+        result += "\\\\";
+        break;
+      case '\b':
+        result += "\\b";
+        break;
+      case '\f':
+        result += "\\f";
+        break;
+      case '\n':
+        result += "\\n";
+        break;
+      case '\r':
+        result += "\\r";
+        break;
+      case '\t':
+        result += "\\t";
+        break;
       default:
         if (static_cast<unsigned char>(c) < 0x20) {
           throw std::runtime_error(

--- a/src/cpu/interface.cpp
+++ b/src/cpu/interface.cpp
@@ -49,7 +49,9 @@ struct CpuInterface : DeviceInterface {
   DeviceType GetType() const override { return DeviceType::CPU; }
 
   void InitOrt(const OrtApi& /*api*/, Ort::Allocator& allocator) override {
-    assert(!ort_allocator_);
+    // Idempotent: on re-initialization this is called again with the same process-global default
+    // allocator (CpuMemory allocates through Ort::Allocator::GetWithDefaultOptions(), which is not
+    // env-scoped), so re-assigning the same pointer is harmless.
     ort_allocator_ = &allocator;
   }
 
@@ -166,9 +168,8 @@ struct CpuInterface : DeviceInterface {
   void Synchronize() override {}  // Nothing to do as CPU is always in sync with itself
 };
 
-DeviceInterface* GetCpuInterface() {
-  static std::unique_ptr<CpuInterface> g_cpu = std::make_unique<CpuInterface>();
-  return g_cpu.get();
+std::unique_ptr<DeviceInterface> CreateCpuInterface() {
+  return std::make_unique<CpuInterface>();
 }
 
 }  // namespace Generators

--- a/src/cpu/interface.h
+++ b/src/cpu/interface.h
@@ -3,6 +3,7 @@
 
 namespace Generators {
 
-DeviceInterface* GetCpuInterface();
+// Creates a fresh CPU DeviceInterface instance. Ownership is taken by OrtGlobals.
+std::unique_ptr<DeviceInterface> CreateCpuInterface();
 
 }

--- a/src/cpu/interface.h
+++ b/src/cpu/interface.h
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#pragma once
+
+#include <memory>
 
 namespace Generators {
 

--- a/src/cpu/interface.h
+++ b/src/cpu/interface.h
@@ -9,4 +9,4 @@ namespace Generators {
 // Creates a fresh CPU DeviceInterface instance. Ownership is taken by OrtGlobals.
 std::unique_ptr<DeviceInterface> CreateCpuInterface();
 
-}
+}  // namespace Generators

--- a/src/dll_load_error.cpp
+++ b/src/dll_load_error.cpp
@@ -30,9 +30,14 @@ std::string DetermineLoadLibraryError(const char* filename) {
       return error;
     }
 
-    // Get the address of the Import Directory
+    // Get the address of the Import Directory.
+    // NOTE: MappedAsImage must be TRUE here: LoadLibraryEx maps the module as an image (section
+    // alignment, not file alignment), so the import descriptors and their Name RVAs are relative to
+    // the image base. Passing FALSE makes ImageDirectoryEntryToData apply file-offset math to an
+    // image-mapped module and return a bogus pointer, which then reads garbage as the dependency
+    // name. (This matches ONNX Runtime's core/platform/windows/dll_load_error.cc.)
     ULONG size{};
-    IMAGE_IMPORT_DESCRIPTOR* import_desc = reinterpret_cast<IMAGE_IMPORT_DESCRIPTOR*>(ImageDirectoryEntryToData(hModule.get(), FALSE, IMAGE_DIRECTORY_ENTRY_IMPORT, &size));
+    IMAGE_IMPORT_DESCRIPTOR* import_desc = reinterpret_cast<IMAGE_IMPORT_DESCRIPTOR*>(ImageDirectoryEntryToData(hModule.get(), TRUE, IMAGE_DIRECTORY_ENTRY_IMPORT, &size));
     if (!import_desc) {
       error += " No import directory found.";  // This is unexpected, and I'm not sure how it could happen but we handle it just in case.
       return error;
@@ -53,6 +58,54 @@ std::string DetermineLoadLibraryError(const char* filename) {
   }
   error += " But no dependency issue could be determined.";
   return error;
+}
+
+bool CanLoadLibrary(const char* filename) {
+  // Fully load the library (runs its DllMain and resolves imports), with the library's own
+  // directory searched first for co-located native dependencies (LOAD_WITH_ALTERED_SEARCH_PATH),
+  // matching how ONNX Runtime resolves an EP's private dependencies. If the provider or any native
+  // dependency fails to initialize (e.g. an NVIDIA runtime on a machine whose GPU was removed), the
+  // load fails here and the caller can skip the EP instead of handing it to ORT.
+  HMODULE hModule = LoadLibraryExA(filename, nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+  if (!hModule)
+    return false;
+  FreeLibrary(hModule);
+  return true;
+}
+
+#else
+
+// Non-Windows (Linux / macOS / Android): ONNX Runtime has no import-table dependency walk on these
+// platforms -- its loader (core/platform/posix/env.cc LoadDynamicLibrary) just uses dlopen() /
+// dlerror(), and the dynamic linker's error already names the missing dependency (for example
+// "libcuda.so.1: cannot open shared object file: No such file or directory"). We reuse that same
+// mechanism here so the pre-flight and its error message stay consistent with ORT.
+#include <dlfcn.h>
+#include <string>
+
+std::string DetermineLoadLibraryError(const char* filename) {
+  dlerror();  // clear any stale error
+  void* handle = dlopen(filename, RTLD_NOW | RTLD_LOCAL);
+  if (!handle) {
+    const char* err = dlerror();
+    return std::string("Error loading \"") + (filename ? filename : "") + "\": " +
+           (err ? err : "unknown error");
+  }
+  dlclose(handle);  // Loaded successfully on this attempt (not expected on the error path).
+  return std::string("Error loading \"") + (filename ? filename : "") + "\".";
+}
+
+bool CanLoadLibrary(const char* filename) {
+  // Pre-flight the load the same way ORT's POSIX loader does: RTLD_NOW resolves all symbols, so a
+  // missing native dependency (e.g. an absent CUDA runtime) fails here. Note: on Linux a hardware
+  // EP whose GPU was removed may still dlopen successfully and only fail at first use; that case is
+  // surfaced at model-load time rather than here.
+  dlerror();
+  void* handle = dlopen(filename, RTLD_NOW | RTLD_LOCAL);
+  if (!handle)
+    return false;
+  dlclose(handle);
+  return true;
 }
 
 #endif

--- a/src/dll_load_error.h
+++ b/src/dll_load_error.h
@@ -1,10 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#pragma once
+
+#include <string>
+
 std::string DetermineLoadLibraryError(const char* filename);
 
 // Returns true if `filename` (and its native dependencies) can actually be loaded. Used to
 // pre-flight an execution provider library before registering it with ONNX Runtime: a provider
 // whose native runtime is unavailable (e.g. a removed or disabled GPU) is then rejected cleanly
 // instead of leaving ONNX Runtime with a half-registered library that crashes at environment
-// teardown. On non-Windows platforms this pre-flight is a no-op that returns true.
+// teardown. On Windows this fully loads the library (LoadLibraryEx) to verify it and its native
+// dependencies resolve; on non-Windows platforms it does the equivalent dlopen(RTLD_NOW) check.
 bool CanLoadLibrary(const char* filename);

--- a/src/dll_load_error.h
+++ b/src/dll_load_error.h
@@ -1,3 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 std::string DetermineLoadLibraryError(const char* filename);
+
+// Returns true if `filename` (and its native dependencies) can actually be loaded. Used to
+// pre-flight an execution provider library before registering it with ONNX Runtime: a provider
+// whose native runtime is unavailable (e.g. a removed or disabled GPU) is then rejected cleanly
+// instead of leaving ONNX Runtime with a half-registered library that crashes at environment
+// teardown. On non-Windows platforms this pre-flight is a no-op that returns true.
+bool CanLoadLibrary(const char* filename);

--- a/src/dml/interface.cpp
+++ b/src/dml/interface.cpp
@@ -4,7 +4,6 @@
 #include "../generators.h"
 #include "../search.h"
 #include "../models/utils.h"
-#include "../cpu/interface.h"
 #include "interface.h"
 #include <cstdarg>
 
@@ -147,11 +146,11 @@ struct InterfaceImpl : DeviceInterface {
   }
 
   std::unique_ptr<Search> CreateGreedy(const GeneratorParams& params) override {
-    return GetCpuInterface()->CreateGreedy(params);
+    return GetDeviceInterface(DeviceType::CPU)->CreateGreedy(params);
   }
 
   std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override {
-    return GetCpuInterface()->CreateBeam(params);
+    return GetDeviceInterface(DeviceType::CPU)->CreateBeam(params);
   }
 
 #if 0

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -77,6 +77,11 @@ OrtGlobals::OrtGlobals()
 // The single genai global. Lazily (re)created by GetOrtGlobals() and reset by Shutdown(), so that
 // genai can be torn down and re-initialized in-process (e.g. a host recreating its wrapper).
 static std::unique_ptr<OrtGlobals> g_ort_globals;
+// Guards lazy (re)creation and teardown of g_ort_globals so concurrent first-use (or first-use
+// after a shutdown) cannot double-construct the globals, and a concurrent Shutdown() cannot race
+// creation. Re-init after shutdown must remain possible, so this is a plain mutex rather than
+// std::call_once (which is process-once).
+static std::mutex g_ort_globals_mutex;
 // Set by the process-exit EnsureShutdown destructor to prevent GetOrtGlobals() from resurrecting
 // the globals during static destruction.
 static bool g_process_exiting = false;
@@ -94,14 +99,11 @@ std::unique_ptr<OrtGlobals>& GetOrtGlobals() {
   // Registered once; its destructor runs at process exit (before g_ort_globals is destroyed) and
   // performs the final Shutdown().
   static EnsureShutdown ensure_shutdown;
-  // Guard lazy (re)creation so concurrent first-use (or first-use after a shutdown) cannot
-  // double-construct the globals. Re-init after shutdown must remain possible, so this is a plain
-  // mutex rather than std::call_once (which is process-once). The OrtGlobals constructor does not
-  // re-enter GetOrtGlobals() (it bootstraps the CPU interface via the OrtGlobals member accessor),
-  // so acquiring this lock here cannot deadlock. The lock is released before the returned
-  // reference is dereferenced by callers, so it does not nest with device_interfaces_mutex_.
-  static std::mutex creation_mutex;
-  std::scoped_lock lock{creation_mutex};
+  // The OrtGlobals constructor does not re-enter GetOrtGlobals() (it bootstraps the CPU interface
+  // via the OrtGlobals member accessor), so acquiring this lock here cannot deadlock. The lock is
+  // released before the returned reference is dereferenced by callers, so it does not nest with
+  // device_interfaces_mutex_.
+  std::scoped_lock lock{g_ort_globals_mutex};
   if (!g_ort_globals && !g_process_exiting)
     g_ort_globals = std::make_unique<OrtGlobals>();
 
@@ -137,9 +139,12 @@ void Shutdown() {
     std::cerr << "    Please see the documentation for the API being used to ensure proper cleanup." << std::endl;
   }
 
-  // Delete now because on process exit is too late. ~OrtGlobals tears down the device interfaces
-  // (including the RyzenAI EP shutdown) and unloads the genai add-on libraries.
-  GetOrtGlobals().reset();
+  // Reset g_ort_globals directly (rather than through GetOrtGlobals(), which would lazily construct
+  // the globals just to immediately tear them down). If genai was never initialized there is nothing
+  // to do. Delete now because on process exit is too late. ~OrtGlobals tears down the device
+  // interfaces (including the RyzenAI EP shutdown) and unloads the genai add-on libraries.
+  std::scoped_lock lock{g_ort_globals_mutex};
+  g_ort_globals.reset();
 }
 
 OrtEnv& GetOrtEnv() {

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -89,8 +89,18 @@ static bool g_process_exiting = false;
 // Ensure Shutdown() has been called before process exit
 struct EnsureShutdown {
   ~EnsureShutdown() {
-    g_process_exiting = true;
-    if (g_ort_globals)
+    // Set the process-exit flag under the mutex so GetOrtGlobals() (which reads it under the same
+    // lock) can never race with this write. Capture whether teardown is needed while holding the
+    // lock, then call Shutdown() outside it -- Shutdown() re-acquires the mutex, so holding it here
+    // would self-deadlock (the mutex is non-recursive).
+    bool needs_shutdown = false;
+    {
+      std::scoped_lock lock{g_ort_globals_mutex};
+      g_process_exiting = true;
+      needs_shutdown = static_cast<bool>(g_ort_globals);
+    }
+
+    if (needs_shutdown)
       Shutdown();
   }
 };

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -70,24 +70,42 @@ OrtGlobals::OrtGlobals()
   Ort::Allocator& allocator_cpu{Ort::Allocator::GetWithDefaultOptions()};
   env_->CreateAndRegisterAllocator(allocator_cpu.GetInfo(), *arena_config);
 
-  // Init the CPU device (special case because it always exists, and its allocator is special
+  // Init the CPU device (special case because it always exists, and its allocator is special).
   GetDeviceInterface(DeviceType::CPU)->InitOrt(*Ort::api, allocator_cpu);
 }
+
+// The single genai global. Lazily (re)created by GetOrtGlobals() and reset by Shutdown(), so that
+// genai can be torn down and re-initialized in-process (e.g. a host recreating its wrapper).
+static std::unique_ptr<OrtGlobals> g_ort_globals;
+// Set by the process-exit EnsureShutdown destructor to prevent GetOrtGlobals() from resurrecting
+// the globals during static destruction.
+static bool g_process_exiting = false;
 
 // Ensure Shutdown() has been called before process exit
 struct EnsureShutdown {
   ~EnsureShutdown() {
-    if (GetOrtGlobals()) {
+    g_process_exiting = true;
+    if (g_ort_globals)
       Shutdown();
-    }
   }
 };
 
-std::unique_ptr<OrtGlobals>&
-GetOrtGlobals() {
-  static auto globals = std::make_unique<OrtGlobals>();
-  static auto validate = std::make_unique<EnsureShutdown>();  // Must be after the above line so the destructor runs before the above destructor
-  return globals;
+std::unique_ptr<OrtGlobals>& GetOrtGlobals() {
+  // Registered once; its destructor runs at process exit (before g_ort_globals is destroyed) and
+  // performs the final Shutdown().
+  static EnsureShutdown ensure_shutdown;
+  // Guard lazy (re)creation so concurrent first-use (or first-use after a shutdown) cannot
+  // double-construct the globals. Re-init after shutdown must remain possible, so this is a plain
+  // mutex rather than std::call_once (which is process-once). The OrtGlobals constructor does not
+  // re-enter GetOrtGlobals() (it bootstraps the CPU interface via the OrtGlobals member accessor),
+  // so acquiring this lock here cannot deadlock. The lock is released before the returned
+  // reference is dereferenced by callers, so it does not nest with device_interfaces_mutex_.
+  static std::mutex creation_mutex;
+  std::scoped_lock lock{creation_mutex};
+  if (!g_ort_globals && !g_process_exiting)
+    g_ort_globals = std::make_unique<OrtGlobals>();
+
+  return g_ort_globals;
 }
 
 // Used by Shutdown() to display the counts and types of any leaked objects.
@@ -119,9 +137,9 @@ void Shutdown() {
     std::cerr << "    Please see the documentation for the API being used to ensure proper cleanup." << std::endl;
   }
 
-  GetOrtGlobals().reset();  // Delete now because on process exit is too late
-
-  RyzenAIInterface::Shutdown();
+  // Delete now because on process exit is too late. ~OrtGlobals tears down the device interfaces
+  // (including the RyzenAI EP shutdown) and unloads the genai add-on libraries.
+  GetOrtGlobals().reset();
 }
 
 OrtEnv& GetOrtEnv() {
@@ -212,28 +230,104 @@ struct LibraryHandle {
 };
 #endif
 
-DeviceInterface* GetCudaInterface(DeviceType type) {
+OrtGlobals::~OrtGlobals() {
+  // Teardown is the reverse of construction: destroy everything that uses env-owned resources
+  // (the trivial-session allocators and registered EP libraries) BEFORE the env that owns them.
+  // Ending all allocator usage before the env is destroyed keeps this correct even if a future
+  // interface or buffer dereferences a cached allocator during its own destruction — we do not
+  // rely on "nothing happens to deref it today". Shutdown is single-threaded, so no locks.
+
+  // 1. Sessions that hold env / EP state directly. Models (which own these indirectly) are already
+  //    gone per the lifetime contract; drop the genai-side session caches here.
+  graph_session_cache_.sessions_.clear();
+
+  // 2. Device interfaces + the CUDA add-on library. Interfaces cache the trivial-session allocator
+  //    (via device_allocators_), and the CUDA add-on interface lives inside cuda_library_. Destroy
+  //    them here so all allocator usage ends before the env. device_interfaces_ is only a
+  //    non-owning index (cleared first); owned_interfaces_ and cuda_library_ are the real owners.
+  device_interfaces_.clear();
+  owned_interfaces_.clear();
+  cuda_library_.reset();
+
+  // 3. The trivial-session env-derived allocators, now unreferenced by any interface. Within each
+  //    entry session_ is declared before allocator_, so ~allocator_ runs first.
+  for (auto& a : device_allocators_) a = {};
+
+  // 4. Finally the env. If genai held the last reference, ORT destroys the environment here,
+  //    unregistering / unloading any still-registered EP libraries — by now nothing references them.
+  env_.reset();
+}
+
+DeviceInterface* OrtGlobals::LoadCudaInterface(DeviceType type) {
   assert(type == DeviceType::NvTensorRtRtx || type == DeviceType::CUDA);
   try {
+    if (!cuda_library_) {
 #if defined(_WIN32)
-    static LibraryHandle library{"onnxruntime-genai-cuda.dll"};
+      cuda_library_ = std::make_unique<LibraryHandle>("onnxruntime-genai-cuda.dll");
 #elif defined(__linux__) && !defined(__ANDROID__)
-    static LibraryHandle library{"libonnxruntime-genai-cuda.so"};
+      cuda_library_ = std::make_unique<LibraryHandle>("libonnxruntime-genai-cuda.so");
 #else
-    static LibraryHandle library{""};
+      cuda_library_ = std::make_unique<LibraryHandle>("");
 #endif
-    if (!library)
+    }
+    if (!*cuda_library_)
       throw std::runtime_error("Shared library load failure (see first error)");
 
     Generators::DeviceInterface* GetInterface(GenaiInterface * p_genai, const char* deviceType);
-    static DeviceInterface* cuda_interface =
-        reinterpret_cast<decltype(&GetInterface)>(
-            library.GetSymbol("GetInterface"))(&g_genai, to_string(type).c_str());
-
-    return cuda_interface;
+    return reinterpret_cast<decltype(&GetInterface)>(
+        cuda_library_->GetSymbol("GetInterface"))(&g_genai, to_string(type).c_str());
   } catch (const std::exception& e) {
     throw std::runtime_error("Cuda interface not available: " + std::string(e.what()));
   }
+}
+
+DeviceInterface* OrtGlobals::GetDeviceInterface(DeviceType type) {
+  std::scoped_lock lock{device_interfaces_mutex_};
+
+#if USE_DML
+  // DML is deliberately NOT cached in device_interfaces_. Its interface (g_dml_device) is created
+  // lazily by dml/session_options.cpp (it needs the LUID / device_index from the model's provider
+  // options) and destroyed per-Model in Model::~Model via CloseDmlInterface() to release DML's
+  // background-thread hardware resources promptly. Caching the pointer here would dangle after a
+  // DML model is freed (a later DML model would get the stale pointer), so always fetch the current
+  // instance instead.
+  if (type == DeviceType::DML)
+    return GetDmlInterface();
+#endif
+
+  auto& slot = device_interfaces_[type];
+  if (slot)
+    return slot;
+
+  switch (type) {
+    case DeviceType::CUDA:
+    case DeviceType::NvTensorRtRtx:
+      slot = LoadCudaInterface(type);  // Non-owning; the interface is owned by cuda_library_.
+      break;
+    case DeviceType::WEBGPU:
+      owned_interfaces_.push_back(CreateWebGPUInterface());
+      slot = owned_interfaces_.back().get();
+      break;
+    case DeviceType::QnnHtp:
+    case DeviceType::QnnGpu:
+      owned_interfaces_.push_back(CreateQNNInterface(type));
+      slot = owned_interfaces_.back().get();
+      break;
+    case DeviceType::OpenVINO:
+      owned_interfaces_.push_back(CreateOpenVINOInterface());
+      slot = owned_interfaces_.back().get();
+      break;
+    case DeviceType::RyzenAI:
+      owned_interfaces_.push_back(CreateRyzenAIInterface(*env_));
+      slot = owned_interfaces_.back().get();
+      break;
+    case DeviceType::CPU:
+    default:
+      owned_interfaces_.push_back(CreateCpuInterface());
+      slot = owned_interfaces_.back().get();
+      break;
+  }
+  return slot;
 }
 
 std::string to_string(DeviceType device_type) {
@@ -261,27 +355,7 @@ std::string to_string(DeviceType device_type) {
 }
 
 DeviceInterface* GetDeviceInterface(DeviceType type) {
-  switch (type) {
-    default:
-    case DeviceType::CPU:
-      return GetCpuInterface();
-    case DeviceType::CUDA:
-    case DeviceType::NvTensorRtRtx:
-      return GetCudaInterface(type);
-#if USE_DML
-    case DeviceType::DML:
-      return GetDmlInterface();
-#endif
-    case DeviceType::WEBGPU:
-      return GetWebGPUInterface();
-    case DeviceType::QnnHtp:
-    case DeviceType::QnnGpu:
-      return GetQNNInterface(type);
-    case DeviceType::OpenVINO:
-      return GetOpenVINOInterface();
-    case DeviceType::RyzenAI:
-      return GetRyzenAIInterface();
-  }
+  return GetOrtGlobals()->GetDeviceInterface(type);
 }
 
 GeneratorParams::GeneratorParams(const Config& config)

--- a/src/generators.h
+++ b/src/generators.h
@@ -145,10 +145,20 @@ struct Generator : LeakChecked<Generator> {
   void InitializePhi3RopeThreshold(const GeneratorParams& params);
 };
 
+// Defined in generators.cpp; owned by OrtGlobals so genai add-on libraries (e.g. the CUDA
+// add-on) are unloaded on teardown.
+struct LibraryHandle;
+
 struct OrtGlobals {
   OrtGlobals();
+  ~OrtGlobals();
 
   std::unique_ptr<OrtEnv> env_;
+
+  // Get-or-create the DeviceInterface for a device type. The interface is owned by this
+  // OrtGlobals instance (in-process EPs) or by a genai add-on library it holds (CUDA), so every
+  // interface is rebuilt on re-initialization after a shutdown. Thread-safe.
+  DeviceInterface* GetDeviceInterface(DeviceType type);
 
   struct Allocator {
     // Field order matters here. The OrtAllocator returned by OrtApi::CreateAllocator (called via
@@ -173,6 +183,19 @@ struct OrtGlobals {
  private:
   OrtGlobals(const OrtGlobals&) = delete;
   void operator=(const OrtGlobals&) = delete;
+
+  DeviceInterface* LoadCudaInterface(DeviceType type);
+
+  std::mutex device_interfaces_mutex_;
+  // Non-owning cache: values point into owned_interfaces_, the CUDA add-on library, or a
+  // module-owned interface (DML). Rebuilt each env cycle.
+  std::unordered_map<DeviceType, DeviceInterface*> device_interfaces_;
+  // In-process interfaces owned directly by genai (CPU / WebGPU / QNN / OpenVINO / RyzenAI).
+  std::vector<std::unique_ptr<DeviceInterface>> owned_interfaces_;
+  // The genai CUDA add-on library (onnxruntime-genai-cuda). Holds the loaded library so that
+  // unloading it (on teardown) runs the add-on's static destructors. The interface pointer it
+  // provides is non-owning and lives in device_interfaces_.
+  std::unique_ptr<LibraryHandle> cuda_library_;
 };
 
 std::unique_ptr<OrtGlobals>& GetOrtGlobals();

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -446,6 +446,7 @@ void EnsureDeviceOrtInit(DeviceInterface& device, const Config& config) {
       user_provider_options_it != user_provider_options_list.end() ? &*user_provider_options_it : nullptr;
   if (user_provider_options)
     init_session_provider_options.device_filtering_options = user_provider_options->device_filtering_options;
+
   device.ShapeInitSessionProviderOptions(init_session_provider_options, user_provider_options);
 
   provider_options_list.emplace_back(std::move(init_session_provider_options));

--- a/src/openvino/interface.cpp
+++ b/src/openvino/interface.cpp
@@ -4,7 +4,6 @@
 #include "../generators.h"
 #include "../search.h"
 #include "interface.h"
-#include "../cpu/interface.h"
 #include "../models/model.h"
 
 namespace Generators {
@@ -16,21 +15,22 @@ struct InterfaceImpl : DeviceInterface {
 
   DeviceType GetType() const override { return DeviceType::OpenVINO; }
 
-  void InitOrt(const OrtApi& /*api*/, Ort::Allocator& allocator) override {
-    // since we use the CPU interface for allocation (right now), InitOrt should not be getting called.
+  void InitOrt(const OrtApi& /*api*/, Ort::Allocator& /*allocator*/) override {
+    // Since we use the CPU interface for allocation (right now), InitOrt should not be getting
+    // called (EnsureDeviceOrtInit early-returns for OpenVINO).
     assert(false);
   }
 
   Ort::Allocator& GetAllocator() override {
-    return GetCpuInterface()->GetAllocator();
+    return GetDeviceInterface(DeviceType::CPU)->GetAllocator();
   }
 
   std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
-    return GetCpuInterface()->AllocateBase(size);
+    return GetDeviceInterface(DeviceType::CPU)->AllocateBase(size);
   }
 
   std::shared_ptr<DeviceBuffer> WrapMemoryBase(void* p, size_t size) override {
-    return GetCpuInterface()->WrapMemoryBase(p, size);
+    return GetDeviceInterface(DeviceType::CPU)->WrapMemoryBase(p, size);
   }
 
   std::unique_ptr<Search> CreateGreedy(const GeneratorParams& params) override { return std::make_unique<GreedySearch_Cpu>(params); }
@@ -41,9 +41,8 @@ struct InterfaceImpl : DeviceInterface {
 
 }  // namespace OpenVINO
 
-DeviceInterface* GetOpenVINOInterface() {
-  static std::unique_ptr<DeviceInterface> g_device = std::make_unique<OpenVINO::InterfaceImpl>();
-  return g_device.get();
+std::unique_ptr<DeviceInterface> CreateOpenVINOInterface() {
+  return std::make_unique<OpenVINO::InterfaceImpl>();
 }
 
 bool IsOpenVINOStatefulModel(const Model& model) {

--- a/src/openvino/interface.h
+++ b/src/openvino/interface.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <memory>
+
 #include "../config.h"
 namespace Generators {
 

--- a/src/openvino/interface.h
+++ b/src/openvino/interface.h
@@ -5,7 +5,8 @@
 #include "../config.h"
 namespace Generators {
 
-DeviceInterface* GetOpenVINOInterface();
+// Creates a fresh OpenVINO DeviceInterface instance. Ownership is taken by OrtGlobals.
+std::unique_ptr<DeviceInterface> CreateOpenVINOInterface();
 
 struct Model;
 bool IsOpenVINOStatefulModel(const Model& model);

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -19,6 +19,7 @@
 #include "models/parakeet.h"
 #include "models/silero_vad.h"
 #include "models/model_package.h"
+#include "dll_load_error.h"
 
 namespace Generators {
 
@@ -1145,9 +1146,31 @@ void OGA_API_CALL OgaDestroyRuntimeSettings(OgaRuntimeSettings* p) { delete stat
 void OGA_API_CALL OgaDestroyEngine(OgaEngine* p) { p->ExternalRelease(); }
 void OGA_API_CALL OgaDestroyRequest(OgaRequest* p) { p->ExternalRelease(); }
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+// C4297: this extern "C" entry point is assumed non-throwing under /EHc, but it intentionally
+// throws to report a registration failure to the caller -- exactly as the ORT registration call it
+// wraps already does (that throw is simply not visible to the compiler because it is in another
+// translation unit). The exception propagates and is caught by callers normally.
+#pragma warning(disable : 4297)
+#endif
 void OGA_API_CALL OgaRegisterExecutionProviderLibrary(const char* registration_name, const char* library_path) {
+  // Pre-flight the provider library before registering it. A failed ORT registration (e.g. a
+  // hardware EP whose native runtime cannot initialize because the GPU was removed or disabled) can
+  // leave ONNX Runtime with a half-registered library that crashes at environment teardown. By
+  // verifying the library and its native dependencies load first, a broken EP fails cleanly here
+  // with a descriptive error instead of destabilizing the process (see CanLoadLibrary).
+  if (!CanLoadLibrary(library_path))
+    throw std::runtime_error("Failed to register execution provider library '" + std::string(registration_name) +
+                             "'. " + DetermineLoadLibraryError(library_path) +
+                             " The required hardware or driver may be unavailable (for example, a GPU that has been "
+                             "removed or disabled).");
+
   Ort::RegisterExecutionProviderLibrary(&(Generators::GetOrtEnv()), registration_name, fs::path(library_path).c_str());
 }
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 void OGA_API_CALL OgaUnregisterExecutionProviderLibrary(const char* registration_name) {
   Ort::UnregisterExecutionProviderLibrary(&(Generators::GetOrtEnv()), registration_name);

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -96,8 +96,17 @@ typedef struct OgaStreamingProcessor OgaStreamingProcessor;
  * \note C++ callers should prefer the OgaHandle RAII wrapper in ort_genai.h; C# callers should prefer the
  *       OgaHandle IDisposable wrapper. Both invoke OgaShutdown() on destruction.
  *
- * \note Must be the last GenAI call in the process. Any OgaModel / OgaGenerator / OgaTokenizer / etc. handles owned
- *       by the caller must be released first.
+ * \note Lifetime contract: no OgaModel / OgaGenerator / OgaTokenizer / OgaTensor / OgaEngine / OgaRequest, or any
+ *       object that holds device memory, may outlive OgaShutdown(). The caller MUST destroy every such object before
+ *       calling OgaShutdown(). Calling OgaShutdown() with such objects still alive is undefined behavior (typically a
+ *       crash when the buffer is freed through a now-invalid allocator).
+ *
+ * \note Re-initialization: OgaShutdown() is a full teardown -- it destroys GenAI's ONNX Runtime environment and unloads
+ *       GenAI's add-on libraries. GenAI may be used again after OgaShutdown(); the next GenAI call re-initializes with a
+ *       fresh environment.
+ *
+ * \note If a host registered execution provider libraries directly on its own OrtEnv reference, it should unregister
+ *       them (on that reference) and release the reference after OgaShutdown(), once all GenAI usage is finished.
  */
 OGA_EXPORT void OGA_API_CALL OgaShutdown();
 

--- a/src/qnn/interface.cpp
+++ b/src/qnn/interface.cpp
@@ -80,9 +80,11 @@ struct HtpInterfaceImpl : QnnInterfaceBase {
     //             "enable_dx12_shared_memory_allocator" in `GpuInterfaceImpl::ShapeInitSessionProviderOptions`.
     //         2.) Oga keeps one global allocator for HTP and one for GPU, each of which is created once. Because each device
     //             only supports once allocator, the fact that each device's chosen allocator is sticky is ok.
-    for (const auto& opt : user_options->options) {
-      if (opt.first == "enable_htp_shared_memory_allocator") {
-        init_options.options.emplace_back(opt);
+    if (user_options) {
+      for (const auto& opt : user_options->options) {
+        if (opt.first == "enable_htp_shared_memory_allocator") {
+          init_options.options.emplace_back(opt);
+        }
       }
     }
 
@@ -96,9 +98,11 @@ struct GpuInterfaceImpl : QnnInterfaceBase {
 
   void ShapeInitSessionProviderOptions(Config::ProviderOptions& init_options,
                                        const Config::ProviderOptions* user_options) const override {
-    for (const auto& opt : user_options->options) {
-      if (opt.first == "enable_dx12_shared_memory_allocator") {
-        init_options.options.emplace_back(opt);
+    if (user_options) {
+      for (const auto& opt : user_options->options) {
+        if (opt.first == "enable_dx12_shared_memory_allocator") {
+          init_options.options.emplace_back(opt);
+        }
       }
     }
 
@@ -108,16 +112,12 @@ struct GpuInterfaceImpl : QnnInterfaceBase {
 
 }  // namespace QNN
 
-DeviceInterface* GetQNNInterface(DeviceType device_type) {
-  assert(type == DeviceType::QnnHtp || type == DeviceType::QnnGpu);
-
-  static std::unique_ptr<DeviceInterface> g_htp_device = std::make_unique<QNN::HtpInterfaceImpl>();
-  static std::unique_ptr<DeviceInterface> g_gpu_device = std::make_unique<QNN::GpuInterfaceImpl>();
+std::unique_ptr<DeviceInterface> CreateQNNInterface(DeviceType device_type) {
   switch (device_type) {
     case DeviceType::QnnHtp:
-      return g_htp_device.get();
+      return std::make_unique<QNN::HtpInterfaceImpl>();
     case DeviceType::QnnGpu:
-      return g_gpu_device.get();
+      return std::make_unique<QNN::GpuInterfaceImpl>();
     default:
       return nullptr;
   }

--- a/src/qnn/interface.cpp
+++ b/src/qnn/interface.cpp
@@ -113,6 +113,8 @@ struct GpuInterfaceImpl : QnnInterfaceBase {
 }  // namespace QNN
 
 std::unique_ptr<DeviceInterface> CreateQNNInterface(DeviceType device_type) {
+  assert(type == DeviceType::QnnHtp || type == DeviceType::QnnGpu);
+
   switch (device_type) {
     case DeviceType::QnnHtp:
       return std::make_unique<QNN::HtpInterfaceImpl>();

--- a/src/qnn/interface.h
+++ b/src/qnn/interface.h
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#pragma once
+
 #include <memory>
 
 namespace Generators {

--- a/src/qnn/interface.h
+++ b/src/qnn/interface.h
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <memory>
+
 namespace Generators {
 
 struct Config;
@@ -8,7 +10,8 @@ struct DeviceInterface;
 enum struct DeviceType;
 struct Model;
 
-DeviceInterface* GetQNNInterface(DeviceType device_type);
+// Creates a fresh QNN DeviceInterface instance. Ownership is taken by OrtGlobals.
+std::unique_ptr<DeviceInterface> CreateQNNInterface(DeviceType device_type);
 
 bool IsQNNStatefulModel(const Model& model);
 

--- a/src/ryzenai/interface.cpp
+++ b/src/ryzenai/interface.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <span>
+#include <unordered_map>
 
 namespace Generators {
 namespace RyzenAI {
@@ -120,9 +121,10 @@ struct Interface : RyzenAIInterface {
     // Register on this env, tolerating the case where it is already registered. An OrtEnv can outlive
     // a genai OgaShutdown (the host may hold a reference), so on re-init the same env may already have
     // the library; ORT reports that as "library is already registered under ...", which is benign here.
-    if (auto status = std::unique_ptr<OrtStatus>{
-            Ort::api->RegisterExecutionProviderLibrary(&env_, ep_name_, ep_path_.native().c_str())}) {
-      const std::string message = status->GetErrorMessage();
+    try {
+      Ort::RegisterExecutionProviderLibrary(&env_, ep_name_, ep_path_.native().c_str());
+    } catch (const Ort::Exception& e) {
+      const std::string message = e.what();
       if (message.find("already registered") == std::string::npos)
         throw std::runtime_error("Failed to register RyzenAI execution provider library: " + message);
     }
@@ -153,33 +155,24 @@ struct Interface : RyzenAIInterface {
       const OrtEpDevice* const* devices = nullptr;
       size_t ndevices = 0;
 
-      Ort::ThrowOnError(Ort::api->GetEpDevices(&env_, &devices, &ndevices));
+      Ort::GetEpDevices(&env_, &devices, &ndevices);
 
       for (const auto& device : std::span{devices, ndevices})
-        if (std::string_view{ep_name_} == Ort::api->EpDevice_EpName(device) &&
-            OrtHardwareDeviceType_NPU == Ort::api->HardwareDevice_Type(Ort::api->EpDevice_Device(device)))
+        if (std::string_view{ep_name_} == device->Name() &&
+            OrtHardwareDeviceType_NPU == device->Device()->Type())
           supported_devices.push_back(device);
     }
 
     if (supported_devices.empty())
       throw std::runtime_error{"No RyzenAI devices detected"};
 
-    {
-      std::vector<const char*> ep_keys, ep_values;
+    // this call merges provider_options into session_options
+    std::unordered_map<std::string, std::string> ep_options;
+    for (const auto& option : provider_options)
+      ep_options.emplace(option.first, option.second);
+    session_options.AppendExecutionProvider_V2(env_, supported_devices, ep_options);
 
-      for (auto& option : provider_options) {
-        ep_keys.emplace_back(option.first.c_str());
-        ep_values.emplace_back(option.second.c_str());
-      }
-
-      // this call merges provider_options into session_options
-      Ort::ThrowOnError(Ort::api->SessionOptionsAppendExecutionProvider_V2(&session_options,
-                                                                           &env_, supported_devices.data(),
-                                                                           supported_devices.size(),
-                                                                           ep_keys.data(), ep_values.data(), ep_keys.size()));
-    }
-
-    Ort::ThrowOnError(Ort::api->RegisterCustomOpsLibrary_V2(&session_options, ep_path_.native().c_str()));
+    session_options.RegisterCustomOpsLibrary(ep_path_.native().c_str());
   }
 
   DeviceType GetType() const override { return DeviceType::RyzenAI; }

--- a/src/ryzenai/interface.cpp
+++ b/src/ryzenai/interface.cpp
@@ -55,6 +55,7 @@ struct Memory : DeviceBuffer {
 
   bool owned_;
 };
+
 struct Interface : RyzenAIInterface {
   Interface(OrtEnv& env) : env_{env} {
 #if defined(_WIN32)
@@ -128,6 +129,11 @@ struct Interface : RyzenAIInterface {
   }
 
   ~Interface() {
+    // Clear the process-global allocator pointer so a subsequent re-init (new interface on a fresh
+    // env) starts from a clean state: InitOrt()'s assert holds again and no Memory allocation can
+    // dangle against this env's now-destroyed session allocator.
+    ort_allocator_ = nullptr;
+
     // TODO: make it linux compatible
 #if defined(_WIN32)
     // Only shut the EP down if genai loaded the module. If it was already resident when this interface

--- a/src/ryzenai/interface.cpp
+++ b/src/ryzenai/interface.cpp
@@ -5,12 +5,9 @@
 #include "../models/model.h"
 #include "interface.h"
 #include <filesystem>
+#include <memory>
 #include <mutex>
 #include <span>
-
-#if !defined(_WIN32)
-#include <dlfcn.h>
-#endif
 
 namespace Generators {
 namespace RyzenAI {
@@ -58,19 +55,21 @@ struct Memory : DeviceBuffer {
 
   bool owned_;
 };
-
 struct Interface : RyzenAIInterface {
-  Interface() {
-    ep_path_ = ep_filename_;
-    // If already loaded then nothing to do
+  Interface(OrtEnv& env) : env_{env} {
 #if defined(_WIN32)
-    if (GetModuleHandleA(ep_filename_))
-      return;
-#else
-    if (dlopen(ep_filename_, RTLD_NOLOAD | RTLD_NOW))
-      return;
+    // Record whether the EP module is already resident, before our registration below loads it. If it
+    // was not resident, our registration loads it and genai owns shutting it down in the destructor;
+    // if it was already resident (loaded by the host outside genai), another owner is responsible.
+    // ORT unloads the EP library when this interface's env is torn down, so each fresh interface
+    // re-evaluates this against a genuinely unloaded module on the next re-init cycle.
+    owns_ep_module_ = (GetModuleHandleA(ep_filename_) == nullptr);
 #endif
 
+    // Resolve the EP library path (SetupProvider also needs it for RegisterCustomOpsLibrary_V2) and
+    // register it on env_ below. The EP module may already be resident -- from an earlier env cycle or
+    // loaded by the host outside genai -- but ORT keys EP-library registration per-OrtEnv, so a fresh
+    // env still needs the library registered on it.
     std::error_code ec;
 
     ep_path_ = GetEnv(ep_path_env_key_);
@@ -98,8 +97,8 @@ struct Interface : RyzenAIInterface {
     };
 
     if (ep_path_.empty())
-      // check next to onnxruntime-genai.dll
-      if (const auto hmod = get_hmod_for_method(GetRyzenAIInterface))
+      // check next to onnxruntime-genai.dll (use CreateRyzenAIInterface as module-address marker)
+      if (const auto hmod = get_hmod_for_method(CreateRyzenAIInterface))
         ep_path_ = find_next_to_module(hmod);
 
     if (ep_path_.empty())
@@ -117,15 +116,27 @@ struct Interface : RyzenAIInterface {
       // fallback to current working directory
       ep_path_ = std::filesystem::current_path(ec) / ep_filename_;
 
-    Ort::ThrowOnError(Ort::api->RegisterExecutionProviderLibrary(GetOrtGlobals()->env_.get(), ep_name_, ep_path_.native().c_str()));
+    // Register on this env, tolerating the case where it is already registered. An OrtEnv can outlive
+    // a genai OgaShutdown (the host may hold a reference), so on re-init the same env may already have
+    // the library; ORT reports that as "library is already registered under ...", which is benign here.
+    if (auto status = std::unique_ptr<OrtStatus>{
+            Ort::api->RegisterExecutionProviderLibrary(&env_, ep_name_, ep_path_.native().c_str())}) {
+      const std::string message = status->GetErrorMessage();
+      if (message.find("already registered") == std::string::npos)
+        throw std::runtime_error("Failed to register RyzenAI execution provider library: " + message);
+    }
   }
 
   ~Interface() {
     // TODO: make it linux compatible
 #if defined(_WIN32)
-    if (const auto mod = GetModuleHandleA(ep_filename_))
-      if (const auto func = reinterpret_cast<void (*)()>(GetProcAddress(mod, func_shutdown_)))
-        func();
+    // Only shut the EP down if genai loaded the module. If it was already resident when this interface
+    // was constructed, another owner is responsible for it and shutting it down here could pull state
+    // out from under them.
+    if (owns_ep_module_)
+      if (const auto mod = GetModuleHandleA(ep_filename_))
+        if (const auto func = reinterpret_cast<void (*)()>(GetProcAddress(mod, func_shutdown_)))
+          func();
 #endif  // _WIN32
   }
 
@@ -136,7 +147,7 @@ struct Interface : RyzenAIInterface {
       const OrtEpDevice* const* devices = nullptr;
       size_t ndevices = 0;
 
-      Ort::ThrowOnError(Ort::api->GetEpDevices(&GetOrtEnv(), &devices, &ndevices));
+      Ort::ThrowOnError(Ort::api->GetEpDevices(&env_, &devices, &ndevices));
 
       for (const auto& device : std::span{devices, ndevices})
         if (std::string_view{ep_name_} == Ort::api->EpDevice_EpName(device) &&
@@ -157,7 +168,8 @@ struct Interface : RyzenAIInterface {
 
       // this call merges provider_options into session_options
       Ort::ThrowOnError(Ort::api->SessionOptionsAppendExecutionProvider_V2(&session_options,
-                                                                           &GetOrtEnv(), supported_devices.data(), supported_devices.size(),
+                                                                           &env_, supported_devices.data(),
+                                                                           supported_devices.size(),
                                                                            ep_keys.data(), ep_values.data(), ep_keys.size()));
     }
 
@@ -189,25 +201,17 @@ struct Interface : RyzenAIInterface {
   void Synchronize() override {}
 
  private:
+  OrtEnv& env_;  // The env this interface belongs to; valid until OrtGlobals tears this interface down.
   std::filesystem::path ep_path_;
+#if defined(_WIN32)
+  bool owns_ep_module_{false};  // True if genai's registration loaded the EP module, so genai shuts it down.
+#endif
 };
-
-static std::unique_ptr<Interface> interface_;
 
 }  // namespace RyzenAI
 
-void RyzenAIInterface::Shutdown() {
-  RyzenAI::interface_.reset();
-}
-
-RyzenAIInterface* GetRyzenAIInterface() {
-  static std::once_flag once;
-
-  std::call_once(once, []() {
-    RyzenAI::interface_ = std::make_unique<RyzenAI::Interface>();
-  });
-
-  return RyzenAI::interface_.get();
+std::unique_ptr<DeviceInterface> CreateRyzenAIInterface(OrtEnv& env) {
+  return std::make_unique<RyzenAI::Interface>(env);
 }
 
 }  // namespace Generators

--- a/src/ryzenai/interface.h
+++ b/src/ryzenai/interface.h
@@ -9,10 +9,11 @@ struct RyzenAIInterface : DeviceInterface {
   using ProviderOptions = std::vector<std::pair<std::string, std::string>>;
 
   virtual void SetupProvider(OrtSessionOptions&, const ProviderOptions&) = 0;
-
-  static void Shutdown();
 };
 
-RyzenAIInterface* GetRyzenAIInterface();
+// Creates a fresh RyzenAI DeviceInterface instance. Ownership is taken by OrtGlobals.
+// `env` is the OrtGlobals env this interface belongs to (created before the interface and
+// destroyed after it, per the reverse-order teardown).
+std::unique_ptr<DeviceInterface> CreateRyzenAIInterface(OrtEnv& env);
 
 }  // namespace Generators

--- a/src/ryzenai/interface.h
+++ b/src/ryzenai/interface.h
@@ -2,6 +2,11 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace Generators {
 
 // Note: memory allocated through RyzenAI interface is host/cpu accessible

--- a/src/ryzenai/session_options.cpp
+++ b/src/ryzenai/session_options.cpp
@@ -12,7 +12,7 @@ DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
                                          bool /*disable_graph_capture*/) {
   auto device = GetDeviceInterface(DeviceType::RyzenAI);
   session_options.AddConfigEntry("model_root", config.config_path.string().c_str());
-  GetRyzenAIInterface()->SetupProvider(session_options, provider_options.options);
+  static_cast<RyzenAIInterface*>(device)->SetupProvider(session_options, provider_options.options);
 
   return device;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2,7 +2,6 @@
 #include "softmax.h"
 #include "search.h"
 #include "beam_search_scorer.h"
-#include "cpu/interface.h"
 #include <queue>
 #include <algorithm>
 #include <limits>
@@ -11,7 +10,7 @@ namespace Generators {
 
 Search_Cpu::Search_Cpu(const GeneratorParams& params)
     : Search{params},
-      cpu_device_{*GetCpuInterface()} {
+      cpu_device_{*GetDeviceInterface(DeviceType::CPU)} {
   auto batch_beam_size = params.BatchBeamSize();
 
   sequence_lengths_ = cpu_device_.Allocate<int32_t>(batch_beam_size);

--- a/src/webgpu/interface.cpp
+++ b/src/webgpu/interface.cpp
@@ -300,9 +300,8 @@ struct InterfaceImpl : DeviceInterface {
 
 }  // namespace WebGPU
 
-DeviceInterface* GetWebGPUInterface() {
-  static std::unique_ptr<DeviceInterface> g_device = std::make_unique<WebGPU::InterfaceImpl>();
-  return g_device.get();
+std::unique_ptr<DeviceInterface> CreateWebGPUInterface() {
+  return std::make_unique<WebGPU::InterfaceImpl>();
 }
 
 }  // namespace Generators

--- a/src/webgpu/interface.h
+++ b/src/webgpu/interface.h
@@ -3,6 +3,7 @@
 
 namespace Generators {
 
-DeviceInterface* GetWebGPUInterface();
+// Creates a fresh WebGPU DeviceInterface instance. Ownership is taken by OrtGlobals.
+std::unique_ptr<DeviceInterface> CreateWebGPUInterface();
 
 }  // namespace Generators

--- a/src/webgpu/interface.h
+++ b/src/webgpu/interface.h
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#pragma once
+
+#include <memory>
 
 namespace Generators {
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,10 @@ file(GLOB test_srcs CONFIGURE_DEPENDS
   "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
 )
 
+# reinit_tests.cpp is a standalone executable (it calls OgaShutdown() to exercise re-initialization
+# and has its own main()), so keep it out of the unit_tests sources.
+list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/reinit_tests.cpp")
+
 if(USE_CUDA AND CMAKE_CUDA_COMPILER AND ENABLE_CUDA_KERNEL_TESTS)
   message(STATUS "Including CUDA kernel tests in the build.")
   file(GLOB cuda_kernel_test_srcs CONFIGURE_DEPENDS
@@ -68,3 +72,34 @@ if (NOT MSVC)
 endif()
 
 add_test(NAME UnitTests COMMAND unit_tests)
+
+# Standalone shutdown / re-initialization tests. Isolated in their own executable because they call
+# OgaShutdown(), which resets process-global GenAI state (env, device interfaces, add-on libraries,
+# registered plugin EPs). Keeping them out of unit_tests avoids any coupling to test order. This
+# binary links the genai OBJECT library (not the shared DLL) so it can call internal genai symbols
+# (e.g. GetDeviceInterface) directly for white-box coverage; unit_tests deliberately stays on the
+# public API via the shared library.
+add_executable(reinit_tests "${CMAKE_CURRENT_SOURCE_DIR}/reinit_tests.cpp")
+target_include_directories(reinit_tests PRIVATE
+  ${ORT_HEADER_DIR}
+  ${onnxruntime_extensions_SOURCE_DIR}/shared/api
+  ${CMAKE_SOURCE_DIR}/src
+)
+# onnxruntime-genai-obj provides genai's objects and its PUBLIC usage requirements (ORT + extensions
+# include dirs; extensions / ORT / Threads link libs), so those are inherited here.
+target_link_libraries(reinit_tests PRIVATE
+  onnxruntime-genai-obj
+  GTest::gtest
+)
+# The shared library stages the ORT runtime (onnxruntime.dll) and the CUDA add-on next to itself;
+# depend on it so those are present in reinit_tests' output directory at run time.
+add_dependencies(reinit_tests onnxruntime-genai)
+set_target_properties(reinit_tests PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "$<TARGET_FILE_DIR:onnxruntime-genai>"
+    FOLDER "Tests"
+)
+if (NOT MSVC)
+  target_compile_options(reinit_tests PRIVATE "-fvisibility=hidden")
+endif()
+
+add_test(NAME ReInitTests COMMAND reinit_tests)

--- a/test/ep_registration.h
+++ b/test/ep_registration.h
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Test-only, header-only helpers for discovering and registering ONNX Runtime execution-provider
+// plugin libraries at test time -- from an explicit directory (--ep_dir) and/or WinML-installed EP
+// packages. Shared by the unit_tests and reinit_tests binaries. This is NOT part of the shipping
+// library; it only uses the public Oga* C API to register EPs.
+
+#pragma once
+
+#include <array>
+#include <cstdio>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "ort_genai.h"
+
+namespace test_ep {
+
+namespace fs = std::filesystem;
+
+// Platform-specific file-name prefix/suffix of an ORT execution provider plugin library,
+// e.g. "onnxruntime_providers_webgpu.dll" or "libonnxruntime_providers_webgpu.so".
+#if defined(_WIN32)
+inline constexpr const char* kProviderPrefix = "";
+inline constexpr const char* kProviderSuffix = ".dll";
+#elif defined(__APPLE__)
+inline constexpr const char* kProviderPrefix = "lib";
+inline constexpr const char* kProviderSuffix = ".dylib";
+#else
+inline constexpr const char* kProviderPrefix = "lib";
+inline constexpr const char* kProviderSuffix = ".so";
+#endif
+
+// A plugin EP genai can load at test time.
+//   registration_name : arbitrary handle passed to OgaRegisterExecutionProviderLibrary. It is NOT
+//                       the EP name (the ".GenAI" suffix makes that obvious); it is also the key
+//                       used to dedupe an EP that ships under multiple candidate library names.
+//   library_stem      : platform-independent stem; the file is "<prefix><stem><suffix>".
+//   provider_name     : genai config provider name (OgaConfig::AppendProvider), or empty if none.
+struct EpLibrary {
+  std::string_view registration_name;
+  std::string_view library_stem;
+  std::string_view provider_name;
+};
+
+// A single EP may ship under more than one library file name across ORT versions (e.g. CUDA); list
+// each candidate under the same registration_name. The NvTensorRtRtx library name is confirmed from
+// the WinML TRT-RTX EP package.
+inline constexpr std::array<EpLibrary, 5> kPluginEpLibraries = {{
+    {"WebGPU.GenAI", "onnxruntime_providers_webgpu", "WebGPU"},
+    {"CUDA.GenAI", "onnxruntime_providers_cuda", "cuda"},
+    {"CUDA.GenAI", "onnxruntime_providers_cuda_plugin", "cuda"},
+    {"OpenVINO.GenAI", "onnxruntime_providers_openvino_plugin", "OpenVINO"},
+    {"NvTensorRtRtx.GenAI", "onnxruntime_providers_nv_tensorrt_rtx", "NvTensorRtRtx"},
+}};
+
+inline std::string EpLibraryFileName(std::string_view stem) {
+  return std::string(kProviderPrefix) + std::string(stem) + kProviderSuffix;
+}
+
+// Discovers plugin EP libraries (from directories and/or WinML packages) and registers them with
+// genai. Discovery is separated from registration so callers that tear genai down and re-initialize
+// (the reinit tests) can re-register the same discovered libraries on each fresh env.
+class EpRegistrar {
+ public:
+  // Records every known EP plugin library found under `ep_dir` (recursive, so a flat --ep_dir and
+  // nested WinML MSIX package layouts both work). Deduped by registration handle.
+  void DiscoverFromDirectory(const fs::path& ep_dir) {
+    std::error_code ec;
+    if (ep_dir.empty()) return;
+    if (!fs::is_directory(ep_dir, ec)) {
+      std::cerr << "Warning: EP directory '" << ep_dir.string() << "' is not a directory." << std::endl;
+      return;
+    }
+    for (fs::recursive_directory_iterator it{ep_dir, fs::directory_options::skip_permission_denied, ec}, end;
+         it != end && !ec; it.increment(ec)) {
+      if (!it->is_regular_file(ec)) continue;
+      const std::string fname = it->path().filename().string();
+      for (const auto& ep : kPluginEpLibraries)
+        if (fname == EpLibraryFileName(ep.library_stem))
+          AddFound(ep, it->path());
+    }
+  }
+
+#if defined(_WIN32)
+  // Discovers EPs from all WinML-installed EP packages. WinML packages follow the naming convention
+  // "*.EP.*" and ship the provider DLL(s) under their MSIX InstallLocation.
+  void DiscoverWinML() {
+    for (const auto& location : GetWinMLEpInstallLocations()) {
+      std::cout << "Scanning WinML EP package: " << location.string() << std::endl;
+      DiscoverFromDirectory(location);
+    }
+  }
+#endif
+
+  // Registers all discovered EP libraries on genai's current env. Safe to call again after
+  // OgaShutdown() (re-registers on the freshly created env). Recomputes and returns the genai
+  // provider names (OgaConfig::AppendProvider) that registered successfully.
+  const std::vector<std::string>& RegisterAll() {
+    providers_.clear();
+    registered_handles_.clear();
+    for (const auto& f : found_) {
+      try {
+        std::cout << "Registering execution provider library '" << f.registration_name << "' -> "
+                  << f.path.string() << std::endl;
+        OgaRegisterExecutionProviderLibrary(f.registration_name.c_str(), f.path.string().c_str());
+        registered_handles_.push_back(f.registration_name);
+        if (!f.provider_name.empty())
+          providers_.push_back(f.provider_name);
+      } catch (const std::exception& e) {
+        std::cerr << "Warning: failed to register execution provider library '" << f.registration_name
+                  << "': " << e.what() << std::endl;
+      }
+    }
+    return providers_;
+  }
+
+  // True if the given registration handle registered successfully in the most recent RegisterAll().
+  bool IsRegistered(std::string_view registration_name) const {
+    for (const auto& h : registered_handles_)
+      if (h == registration_name) return true;
+    return false;
+  }
+
+  // genai provider names available from the most recent RegisterAll().
+  const std::vector<std::string>& Providers() const { return providers_; }
+
+ private:
+  struct Found {
+    std::string registration_name;
+    std::string provider_name;
+    fs::path path;
+  };
+
+  void AddFound(const EpLibrary& ep, const fs::path& path) {
+    for (const auto& f : found_)
+      if (f.registration_name == ep.registration_name) return;  // dedupe by handle
+    found_.push_back({std::string(ep.registration_name), std::string(ep.provider_name), path});
+  }
+
+#if defined(_WIN32)
+  // Queries WinML EP package install locations. The command string is a fixed literal (no external
+  // input interpolated), so there is no command-injection surface.
+  static std::vector<fs::path> GetWinMLEpInstallLocations() {
+    std::vector<fs::path> locations;
+    FILE* pipe = _popen(
+        "powershell -NoProfile -NonInteractive -Command "
+        "\"Get-AppxPackage '*.EP.*' | Select-Object -ExpandProperty InstallLocation\"",
+        "r");
+    if (!pipe) {
+      std::cerr << "Warning: failed to query WinML EP packages via Get-AppxPackage." << std::endl;
+      return locations;
+    }
+    char buffer[1024];
+    while (std::fgets(buffer, sizeof(buffer), pipe)) {
+      std::string line{buffer};
+      while (!line.empty() && (line.back() == '\n' || line.back() == '\r' || line.back() == ' '))
+        line.pop_back();
+      if (!line.empty()) locations.emplace_back(line);
+    }
+    _pclose(pipe);
+    return locations;
+  }
+#endif
+
+  std::vector<Found> found_;
+  std::vector<std::string> providers_;
+  std::vector<std::string> registered_handles_;
+};
+
+}  // namespace test_ep

--- a/test/ep_registration.h
+++ b/test/ep_registration.h
@@ -68,7 +68,8 @@ inline std::string EpLibraryFileName(std::string_view stem) {
 class EpRegistrar {
  public:
   // Records every known EP plugin library found under `ep_dir` (recursive, so a flat --ep_dir and
-  // nested WinML MSIX package layouts both work). Deduped by registration handle.
+  // nested WinML MSIX package layouts both work). Distinct candidate libraries for the same handle
+  // are all kept (see AddFound) so RegisterAll() can fall back across them.
   void DiscoverFromDirectory(const fs::path& ep_dir) {
     std::error_code ec;
     if (ep_dir.empty()) return;
@@ -97,13 +98,19 @@ class EpRegistrar {
   }
 #endif
 
-  // Registers all discovered EP libraries on genai's current env. Safe to call again after
-  // OgaShutdown() (re-registers on the freshly created env). Recomputes and returns the genai
-  // provider names (OgaConfig::AppendProvider) that registered successfully.
+  // Registers discovered EP libraries on genai's current env. Safe to call again after
+  // OgaShutdown() (re-registers on the freshly created env). For a registration handle with more
+  // than one candidate library name, the candidates are tried in discovery order and the first that
+  // registers wins; the remaining candidates for that handle are skipped. Recomputes and returns
+  // the genai provider names (OgaConfig::AppendProvider) that registered successfully.
   const std::vector<std::string>& RegisterAll() {
     providers_.clear();
     registered_handles_.clear();
     for (const auto& f : found_) {
+      // An earlier candidate for this handle already registered; skip the alternative library names.
+      if (IsRegistered(f.registration_name))
+        continue;
+
       try {
         std::cout << "Registering execution provider library '" << f.registration_name << "' -> "
                   << f.path.string() << std::endl;
@@ -112,6 +119,7 @@ class EpRegistrar {
         if (!f.provider_name.empty())
           providers_.push_back(f.provider_name);
       } catch (const std::exception& e) {
+        // Fall through to try the next candidate library (if any) for this handle.
         std::cerr << "Warning: failed to register execution provider library '" << f.registration_name
                   << "': " << e.what() << std::endl;
       }
@@ -137,8 +145,12 @@ class EpRegistrar {
   };
 
   void AddFound(const EpLibrary& ep, const fs::path& path) {
+    // Keep every distinct candidate library for a handle (an EP may ship under multiple file names
+    // across ORT versions) so RegisterAll() can fall back to an alternative if the first fails to
+    // register. Only skip an exact duplicate (same handle and same path) to avoid re-adding the
+    // same file discovered twice (e.g. overlapping --ep_dir and WinML scans).
     for (const auto& f : found_)
-      if (f.registration_name == ep.registration_name) return;  // dedupe by handle
+      if (f.registration_name == ep.registration_name && f.path == path) return;  // exact dupe
     found_.push_back({std::string(ep.registration_name), std::string(ep.provider_name), path});
   }
 

--- a/test/reinit_tests.cpp
+++ b/test/reinit_tests.cpp
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Dedicated test binary for GenAI shutdown / re-initialization.
+//
+// These tests call OgaShutdown() to prove GenAI can be torn down and re-initialized in-process
+// (for example a host such as Foundry Local's `Manager` that recreates its wrapper in-process).
+// They live in their OWN executable rather than in unit_tests because OgaShutdown() resets
+// process-global GenAI state (the ORT environment, the device interfaces, the genai add-on
+// libraries, and any registered plugin EP libraries). Running them inside the shared suite would
+// couple every other test to their teardown and depend on test ordering; isolating them removes
+// that fragility. This binary deliberately does not register any plugin EPs — re-init is exercised
+// on the always-present CPU path.
+
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "ort_genai.h"
+#include "generators.h"  // Generators::GetDeviceInterface / DeviceType (from the genai object library)
+#if USE_DML
+#include "dml/interface.h"  // Generators::InitDmlInterface / CloseDmlInterface / GetDmlInterface
+#endif
+
+#include <gtest/gtest.h>
+
+#include "ep_registration.h"
+#include "test_utils.h"
+
+// Plugin EPs discovered at startup (WinML packages by default, plus any --ep_dir). Registered on
+// genai's env at the start of each re-init cycle by the test below, so their device interfaces are
+// created and then torn down by OgaShutdown() each cycle. (generators.h defines a global `fs` type,
+// so this file qualifies std::filesystem explicitly rather than adding its own alias.)
+test_ep::EpRegistrar g_ep_registrar;
+
+namespace {
+
+// Runs a minimal CPU generate workload and validates the output. Every GenAI object is destroyed
+// before returning, honoring the lifetime contract that no object holding device memory may
+// outlive a subsequent OgaShutdown().
+void RunCpuWorkload() {
+  std::vector<int32_t> input_ids{0, 0, 0, 52, 0, 0, 195, 731};
+  std::vector<int32_t> expected_output{
+      0, 0, 0, 52, 204, 204, 204, 204, 204, 204,
+      0, 0, 195, 731, 731, 114, 114, 114, 114, 114};
+  const int batch_size = 2;
+  const int max_length = 10;
+
+  auto model = OgaModel::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", max_length);
+  params->SetSearchOption("batch_size", batch_size);
+  auto generator = OgaGenerator::Create(*model, *params);
+  generator->AppendTokens(input_ids.data(), input_ids.size());
+  while (!generator->IsDone())
+    generator->GenerateNextToken();
+
+  for (int i = 0; i < batch_size; ++i) {
+    const auto sequence_length = generator->GetSequenceCount(i);
+    const auto* sequence_data = generator->GetSequenceData(i);
+    ASSERT_LE(sequence_length, static_cast<size_t>(max_length));
+    EXPECT_TRUE(0 == std::memcmp(&expected_output[i * max_length], sequence_data,
+                                 sequence_length * sizeof(int32_t)));
+  }
+}
+
+// Loads the tiny model (optionally forced onto `provider` via the genai config) and runs a short
+// generate, destroying every GenAI object before returning. `provider` empty => the model's
+// configured default (CPU for the test model). Throws if the provider is not built in / unavailable.
+void RunGenerateOnce(const char* provider) {
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  if (provider && *provider) {
+    config->ClearProviders();
+    config->AppendProvider(provider);
+  }
+
+  std::vector<int32_t> input_ids{0, 0, 0, 52};
+  auto model = OgaModel::Create(*config);
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 10);
+  params->SetSearchOption("batch_size", 1);
+  auto generator = OgaGenerator::Create(*model, *params);
+  generator->AppendTokens(input_ids.data(), input_ids.size());
+  while (!generator->IsDone())
+    generator->GenerateNextToken();
+  ASSERT_GT(generator->GetSequenceCount(0), 0u);
+}
+
+// Forces creation of the DeviceInterface for `provider` directly via genai's internal
+// GetDeviceInterface (no model load), so the create -> teardown -> recreate path is exercised across
+// re-init cycles (for the CUDA add-on this also loads and later unloads the add-on library).
+// The created interface is owned by OrtGlobals, so the subsequent OgaShutdown() tears it down.
+void ExerciseDeviceInterface(const std::string& provider) {
+  Generators::DeviceType device_type;
+  if (provider == "WebGPU") {
+    device_type = Generators::DeviceType::WEBGPU;
+  } else if (provider == "cuda") {
+    device_type = Generators::DeviceType::CUDA;
+  } else if (provider == "OpenVINO") {
+    device_type = Generators::DeviceType::OpenVINO;
+  } else if (provider == "NvTensorRtRtx") {
+    device_type = Generators::DeviceType::NvTensorRtRtx;
+  } else {
+    return;  // no genai DeviceInterface mapping for this provider
+  }
+
+  // Creating the interface registers it with OrtGlobals (so OgaShutdown tears it down / unloads the
+  // CUDA add-on). It may throw if the EP/add-on is not usable on this machine (e.g. the CUDA add-on
+  // library is absent), which the caller treats as skip.
+  Generators::GetDeviceInterface(device_type);
+}
+
+}  // namespace
+
+// Primary driver: after OgaShutdown() GenAI returns to a just-loaded state and the next
+// GenAI call re-initializes cleanly with a fresh OrtEnv. Each cycle registers the discovered plugin
+// EPs (on the fresh env), runs a CPU workload plus a workload per available provider (to create and
+// then tear down each EP's device interface), and calls OgaShutdown(). Repeating this proves that
+// repeated register -> use -> shutdown -> re-init is stable, including reloading the CUDA add-on.
+TEST(ReInitTests, ShutdownReInitCycle) {
+  const int kCycles = 3;
+  for (int cycle = 0; cycle < kCycles; ++cycle) {
+    SCOPED_TRACE("re-init cycle " + std::to_string(cycle));
+
+    // Register discovered plugin EPs on the current (fresh, after the previous OgaShutdown) env.
+    const std::vector<std::string>& providers = g_ep_registrar.RegisterAll();
+
+    RunCpuWorkload();  // always-present CPU path (full model/session/generator teardown)
+
+    // Force creation + teardown of each available EP's device interface. Best-effort: an EP's genai
+    // add-on may be absent (e.g. CUDA without onnxruntime-genai-cuda) or its allocator unavailable,
+    // so a failure just skips that provider this cycle.
+    for (const std::string& provider : providers) {
+      try {
+        ExerciseDeviceInterface(provider);
+        std::cout << "cycle " << cycle << ": exercised device interface for '" << provider << "'"
+                  << std::endl;
+      } catch (const std::exception& e) {
+        std::cout << "cycle " << cycle << ": skipped provider '" << provider << "': " << e.what()
+                  << std::endl;
+      }
+    }
+
+    OgaShutdown();  // full teardown: env + all created device interfaces + add-on libraries
+  }
+}
+
+// Regression guard for the DeviceInterface cache in OrtGlobals::GetDeviceInterface. Creating a
+// model, destroying it, then creating another model within the SAME env cycle (no OgaShutdown
+// between) must hand the second model a live DeviceInterface, not a dangling one.
+//
+// The CPU path exercises the real model create -> free -> create seam on every build. DML is the
+// case that actually motivated the OrtGlobals no-cache fix, but the tiny CPU test model cannot run
+// on DML (DML forces graph capture, which requires full DML partitioning), so DML is validated
+// directly at the interface level in the DmlInterfaceNotCachedAcrossReload test below.
+TEST(ReInitTests, SequentialModelLoads) {
+  RunGenerateOnce("");  // first load (default provider == CPU for the test model)
+  RunGenerateOnce("");  // second load after the first was fully destroyed -- must not dangle
+
+  OgaShutdown();  // leave process-global state clean for any following test
+}
+
+#if USE_DML
+// Deterministic white-box guard for the DML branch of OrtGlobals::GetDeviceInterface. DML's
+// interface (g_dml_device) is destroyed per-Model in Model::~Model via CloseDmlInterface(), so
+// OrtGlobals must NOT cache the DML interface pointer -- a cached pointer would dangle after the
+// first DML model is freed and be handed to the next DML model (use-after-free). This drives the
+// same lifecycle directly (create -> GetDeviceInterface -> CloseDmlInterface -> recreate) with no
+// ORT session/model, so it needs only a D3D12 device (not a DML-partitionable model). This mirrors
+// the DML branch of OrtGlobals::GetDeviceInterface in generators.cpp.
+TEST(ReInitTests, DmlInterfaceNotCachedAcrossReload) {
+  // First "model load": create the DML interface. Skips if no DML/D3D12 device is available.
+  try {
+    Generators::InitDmlInterface(nullptr, nullptr);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "DML device not available: " << e.what();
+  }
+
+  // Populate the OrtGlobals DeviceInterface lookup for DML (this is where the buggy version would
+  // memoize the pointer).
+  Generators::DeviceInterface* dml_first = Generators::GetDeviceInterface(Generators::DeviceType::DML);
+  ASSERT_NE(dml_first, nullptr);
+  ASSERT_EQ(dml_first, Generators::GetDmlInterface());
+
+  // First "model free": Model::~Model calls CloseDmlInterface(), destroying the interface.
+  Generators::CloseDmlInterface();
+  ASSERT_EQ(Generators::GetDmlInterface(), nullptr);
+
+  // Second "model load": a fresh DML interface is created.
+  Generators::InitDmlInterface(nullptr, nullptr);
+  Generators::DeviceInterface* live = Generators::GetDmlInterface();
+  ASSERT_NE(live, nullptr);
+
+  // The guard: GetDeviceInterface(DML) must return the LIVE interface, not the freed first one.
+  // Without the no-cache fix it returns the stale memoized pointer (which differs from the live
+  // GetDmlInterface()), so this comparison fails.
+  ASSERT_EQ(Generators::GetDeviceInterface(Generators::DeviceType::DML), live);
+
+  Generators::CloseDmlInterface();
+  OgaShutdown();  // reset process-global state for isolation
+}
+#endif  // USE_DML
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // --ep_dir <dir>: also register plugin EP libraries found under <dir> (recursive).
+  std::filesystem::path ep_dir;
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--ep_dir" && i + 1 < argc)
+      ep_dir = argv[++i];
+  }
+
+  // Register any WinML-installed EP packages by default (Windows) so re-init is exercised with real
+  // device interfaces where available, plus any --ep_dir. Discovery is filesystem/PowerShell only
+  // (no genai env); the test registers these on genai's env at the start of each cycle.
+#if defined(_WIN32)
+  g_ep_registrar.DiscoverWinML();
+#endif
+  g_ep_registrar.DiscoverFromDirectory(ep_dir);
+
+  const int result = RUN_ALL_TESTS();
+  OgaShutdown();
+  return result;
+}

--- a/test/reinit_tests.cpp
+++ b/test/reinit_tests.cpp
@@ -9,8 +9,9 @@
 // process-global GenAI state (the ORT environment, the device interfaces, the genai add-on
 // libraries, and any registered plugin EP libraries). Running them inside the shared suite would
 // couple every other test to their teardown and depend on test ordering; isolating them removes
-// that fragility. This binary deliberately does not register any plugin EPs — re-init is exercised
-// on the always-present CPU path.
+// that fragility. Re-init is always exercised on the always-present CPU path; if plugin EPs are
+// discovered (WinML packages and/or --ep_dir) they are additionally registered and torn down each
+// cycle.
 
 #include <cstring>
 #include <filesystem>


### PR DESCRIPTION
Enable re-init after OgaShutdown. State returns to 'just loaded' post-OgaShutdown.
Allows user to control lifetime of the OrtEnv instance that is pinned in OgaGlobals.

See the plan document for details.

Adds some additional library load validation/diagnostic info (copied from ORT) so we stay in a clean state if an EP can't be loaded.