### PR TITLE
Add standard-Quark uint2 -> MatMulNBits (bits=2, float zero-point)

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -147,10 +147,11 @@ def parse_hf_token(hf_token):
 
 def set_io_dtype(precision, execution_provider, extra_options) -> ir.DataType:
     int4_cpu = precision == "int4" and execution_provider == "cpu"
+    int2_cpu = precision == "int2" and execution_provider == "cpu"
     fp32_webgpu = execution_provider == "webgpu" and extra_options.get("use_webgpu_fp32", False)
     bf16_cuda = precision == "int4" and execution_provider in {"cuda", "trt-rtx"} and extra_options.get("use_cuda_bf16", False)
 
-    if precision in {"int8", "fp32"} or int4_cpu or fp32_webgpu:
+    if precision in {"int8", "fp32"} or int4_cpu or int2_cpu or fp32_webgpu:
         # FP32 precision
         return ir.DataType.FLOAT
 
@@ -165,6 +166,11 @@ def set_io_dtype(precision, execution_provider, extra_options) -> ir.DataType:
 def set_onnx_dtype(precision: str, extra_options: dict[str, Any]) -> ir.DataType:
     if precision == "int4":
         return ir.DataType.INT4 if extra_options.get("int4_is_symmetric", True) else ir.DataType.UINT4
+
+    if precision == "int2":
+        # 2-bit quantized weights are emitted as MatMulNBits (bits=2); non-quantized
+        # ops follow io_dtype, so onnx_dtype tracks the FLOAT io_dtype used on CPU.
+        return ir.DataType.FLOAT
 
     to_onnx_dtype = {
         "fp32": ir.DataType.FLOAT,
@@ -386,7 +392,7 @@ def get_args():
         "-p",
         "--precision",
         required=True,
-        choices=["int4", "bf16", "fp16", "fp32"],
+        choices=["int2", "int4", "bf16", "fp16", "fp32"],
         help="Precision of model",
     )
 

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1169,6 +1169,10 @@ class Model:
             return self.make_matmul_op(matmul, basename, root_input, **kwargs)
 
     def make_matmul_op(self, matmul, basename, root_input, **kwargs):
+        # 2-bit Quark weights are emitted as MatMulNBits even when the io/onnx dtype is
+        # float (ORT runs the float zero-point 2-bit MatMulNBits on CPU/MLAS).
+        if hasattr(matmul, "qweight") and matmul.qweight is not None and getattr(matmul, "bits", None) == 2:
+            return self.make_matmul_int4(matmul, basename, root_input, **kwargs)
         if self.onnx_dtype in {ir.DataType.FLOAT16, ir.DataType.BFLOAT16, ir.DataType.FLOAT}:
             return self.make_matmul_float(matmul, basename, root_input, **kwargs)
         elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}:
@@ -1210,7 +1214,12 @@ class Model:
 
         if hasattr(matmul, "qzeros") and matmul.qzeros is not None:
             zeros = name[1:].replace("/", ".") + ".qzeros"
-            self.make_initializer(matmul.qzeros, zeros)
+            # Float zero-points (e.g. 2-bit Quark) must match the scales' dtype; integer
+            # zero-points are emitted in their packed integer form.
+            if torch.is_floating_point(matmul.qzeros):
+                self.make_initializer(matmul.qzeros, zeros, to=self.io_dtype)
+            else:
+                self.make_initializer(matmul.qzeros, zeros)
             inputs.append(zeros)
 
         if hasattr(matmul, "g_idx") and matmul.g_idx is not None:
@@ -1358,6 +1367,10 @@ class Model:
         return add_name
 
     def make_packed_matmul(self, q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs):
+        # 2-bit Quark weights use the (bits-generic) NBits packed path even when the
+        # io/onnx dtype is float.
+        if hasattr(q_matmul, "qweight") and q_matmul.qweight is not None and getattr(q_matmul, "bits", None) == 2:
+            return self.make_packed_matmul_int4(q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs)
         if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16}:
             return self.make_packed_matmul_float(q_matmul, k_matmul, v_matmul, basename, root_input, **kwargs)
         elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}:
@@ -1366,6 +1379,8 @@ class Model:
             raise NotImplementedError(f"The {self.onnx_dtype} precision is not currently supported.")
 
     def make_packed_matmul_class(self, q_matmul, k_matmul, v_matmul):
+        if hasattr(q_matmul, "qweight") and q_matmul.qweight is not None and getattr(q_matmul, "bits", None) == 2:
+            return self.make_packed_matmul_int4_class(q_matmul, k_matmul, v_matmul)
         if self.onnx_dtype in {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16}:
             return self.make_packed_matmul_float_class(q_matmul, k_matmul, v_matmul)
         elif self.onnx_dtype in {ir.DataType.INT4, ir.DataType.UINT4}:

--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -501,8 +501,8 @@ class QuantizedModel:
                                 tensor_map["self_attn.v_proj.qweight"] = tensor[q_size + kv_size :, :]
                             else:
                                 # AWQ/GPTQ/Quark: (in_features, out_features), split on dim=1
-                                q_dim = q_size // (32 // local_bits) if quant_type in {"awq", "quark"} else q_size
-                                kv_dim = kv_size // (32 // local_bits) if quant_type in {"awq", "quark"} else kv_size
+                                q_dim = q_size // self._packed_out_factor(tensor, local_bits) if quant_type in {"awq", "quark"} else q_size
+                                kv_dim = kv_size // self._packed_out_factor(tensor, local_bits) if quant_type in {"awq", "quark"} else kv_size
                                 tensor_map["self_attn.q_proj.qweight"] = tensor[:, :q_dim]
                                 tensor_map["self_attn.k_proj.qweight"] = tensor[:, q_dim : q_dim + kv_dim]
                                 tensor_map["self_attn.v_proj.qweight"] = tensor[:, q_dim + kv_dim :]
@@ -546,12 +546,12 @@ class QuantizedModel:
                             else:
                                 # AWQ/GPTQ/Quark: int32 packing, split on dim=1
                                 q_dim = (
-                                    q_size // (32 // local_bits)
+                                    q_size // self._packed_out_factor(tensor, local_bits)
                                     if quant_type in {"awq", "gptq", "quark"}
                                     else q_size
                                 )
                                 kv_dim = (
-                                    kv_size // (32 // local_bits)
+                                    kv_size // self._packed_out_factor(tensor, local_bits)
                                     if quant_type in {"awq", "gptq", "quark"}
                                     else kv_size
                                 )
@@ -592,7 +592,7 @@ class QuantizedModel:
                             else:
                                 # AWQ/GPTQ/Quark: (in_features, out_features), split on dim=1
                                 intermediate_dim = (
-                                    intermediate_size // (32 // local_bits)
+                                    intermediate_size // self._packed_out_factor(tensor, local_bits)
                                     if quant_type in {"awq", "quark"}
                                     else intermediate_size
                                 )
@@ -634,7 +634,7 @@ class QuantizedModel:
                             else:
                                 # AWQ/GPTQ/Quark: int32 packing, split on dim=1
                                 intermediate_dim = (
-                                    intermediate_size // (32 // local_bits)
+                                    intermediate_size // self._packed_out_factor(tensor, local_bits)
                                     if quant_type in {"awq", "gptq", "quark"}
                                     else intermediate_size
                                 )
@@ -905,6 +905,18 @@ class QuantizedModel:
         Return list of modules in quantized model in order of appearance in the model
         """
         return [self.embedding] + self.layers + [self.final_norm, self.lm_head]
+
+    @staticmethod
+    def _packed_out_factor(tensor, bits):
+        """Number of logical output channels stored per element along the packed
+        (column) axis: 8//bits for uint8 packing (Quark native uint2/uint4),
+        32//bits for int32 packing (AWQ/GPTQ style), and 1 for unpacked floating
+        tensors (per-group float scales / float zero-points)."""
+        if tensor.dtype == torch.uint8:
+            return 8 // bits
+        if tensor.dtype == torch.int32:
+            return 32 // bits
+        return 1
 
     def unpack(self, module):
         """
@@ -1468,6 +1480,8 @@ class QuarkModel(QuantizedModel):
         dtype_bits_maps = {
             "uint4": 4,
             "int4": 4,
+            "uint2": 2,
+            "int2": 2,
         }
 
         if global_dtype not in dtype_bits_maps:
@@ -1483,6 +1497,8 @@ class QuarkModel(QuantizedModel):
             dtype_bits_maps = {
                 "uint4": 4,
                 "int4": 4,
+                "uint2": 2,
+                "int2": 2,
             }
             if local_dtype not in dtype_bits_maps:
                 raise ValueError(f"Unexpected dtype: {local_dtype}.")
@@ -1495,6 +1511,31 @@ class QuarkModel(QuantizedModel):
             layer_quant_config = self._quant_attrs["config"]["layer_quant_config"][name]["weight"]
             return layer_quant_config["group_size"]
         return self.global_group_size
+
+    def unpack(self, module):
+        """
+        Unpack a Quark ``QuantizedTensorModule`` into the standard int-code layout.
+
+        Standard Quark native uint2 stores weights as uint8 ``[in, out/4]`` packed
+        MSB-first along the output axis, with per-group float ``scales`` and a float
+        ``zero_point`` (e.g. a constant 1.5). These are unpacked + dequantized here so
+        the shared ``repack``/``pack_ort_format`` pipeline can emit MatMulNBits-ready
+        tensors (same packing as the 4-bit path). Other bit-widths use the base
+        (int32-packed, AWQ-reorder) path.
+        """
+        if module.bits == 2:
+            module.qweight = self._unpack_uint2_msb_first(module.qweight)
+            self.dequant_weight(module)
+        else:
+            super().unpack(module)
+
+    @staticmethod
+    def _unpack_uint2_msb_first(packed):
+        """Unpack uint8 ``[rows, cols/4]`` (4x 2-bit codes per byte, MSB-first along
+        columns) into int codes ``[rows, cols]``."""
+        shifts = torch.tensor([6, 4, 2, 0], dtype=torch.int32, device=packed.device)
+        codes = (packed.to(torch.int32).unsqueeze(-1) >> shifts.view(1, 1, -1)) & 0x3
+        return codes.reshape(packed.shape[0], -1)
 
     def unpack_qweight(self, module):
         """


### PR DESCRIPTION
Enables loading standard-Quark native uint2 exports (uint8 MSB-first packing, per-group float scales, float zero-point) and building them as ORT MatMulNBits with bits=2 on CPU/MLAS.

- builder.py: add int2 precision (FLOAT io/onnx dtype on CPU).
- quantized_model.py: uint2/int2 in Quark dtype maps; dtype-aware fused-split factor (_packed_out_factor: uint8 8//bits, int32 32//bits, float 1); QuarkModel.unpack override that unpacks uint8 MSB-first uint2 then dequantizes (reusing the shared repack/pack pipeline).
- base.py: route bits==2 quantized matmuls to MatMulNBits even when io dtype is float; emit float zero-points in io_dtype.