### PR TITLE
Detect model packages by manifest.json without a root genai_config.json

### DIFF
--- a/docs/model_package.md
+++ b/docs/model_package.md
@@ -168,6 +168,11 @@ When passed a package they auto-detect the execution provider; an ambiguous pack
 returns an error pointing at `OgaCreateConfigFromPackageEp`. The `FromPackageEp` entry
 point rejects flat directories.
 
+A directory is treated as a package when it has a top-level `manifest.json` and no
+top-level `genai_config.json`. A flat model directory always keeps `genai_config.json` at
+its root, so one that happens to carry an unrelated `manifest.json` is still loaded as a
+flat directory.
+
 Combining a model package with `OgaRuntimeSettings` is not supported and returns an
 error. Runtime settings work as before with flat directories via
 `OgaCreateModelWithRuntimeSettings`.

--- a/src/models/model_package.cpp
+++ b/src/models/model_package.cpp
@@ -59,12 +59,19 @@ std::unique_ptr<OrtSessionOptions> BuildSelectionSessionOptions(const std::strin
 
 bool IsModelPackage(const fs::path& path) {
   constexpr const char* kManifestFilename = "manifest.json";
+  constexpr const char* kGenaiConfigFilename = "genai_config.json";
   std::error_code ec;
   const std::filesystem::path root = AsStdPath(path);
-  if (!std::filesystem::is_directory(root, ec) || ec) {
+  if (!std::filesystem::is_directory(root, ec)) {
     return false;
   }
-  return std::filesystem::is_regular_file(root / kManifestFilename, ec) && !ec;
+  if (!std::filesystem::is_regular_file(root / kManifestFilename, ec)) {
+    return false;
+  }
+  // A model package keeps genai_config.json inside each variant directory, never at the root.
+  // A flat model directory keeps it at the root and may carry an unrelated manifest.json, so a
+  // root genai_config.json means this is a flat directory, not a package.
+  return !std::filesystem::is_regular_file(root / kGenaiConfigFilename, ec);
 }
 
 #if ORT_GENAI_HAS_MODEL_PACKAGE

--- a/src/models/model_package.cpp
+++ b/src/models/model_package.cpp
@@ -70,8 +70,14 @@ bool IsModelPackage(const fs::path& path) {
   }
   // A model package keeps genai_config.json inside each variant directory, never at the root.
   // A flat model directory keeps it at the root and may carry an unrelated manifest.json, so a
-  // root genai_config.json means this is a flat directory, not a package.
-  return !std::filesystem::is_regular_file(root / kGenaiConfigFilename, ec);
+  // root genai_config.json means this is a flat directory, not a package. Only a genuinely
+  // absent file (not a probe error like EACCES) counts as "no root genai_config.json".
+  const std::filesystem::file_status genai_config_status =
+      std::filesystem::status(root / kGenaiConfigFilename, ec);
+  if (std::filesystem::is_regular_file(genai_config_status)) {
+    return false;
+  }
+  return genai_config_status.type() == std::filesystem::file_type::not_found;
 }
 
 #if ORT_GENAI_HAS_MODEL_PACKAGE

--- a/src/models/model_package.h
+++ b/src/models/model_package.h
@@ -10,7 +10,8 @@
 
 namespace Generators {
 
-// True when `path` is a directory containing a top-level manifest.json.
+// True when `path` is a model package directory: it has a top-level manifest.json and no
+// top-level genai_config.json (a flat model directory keeps genai_config.json at its root).
 bool IsModelPackage(const fs::path& path);
 
 #if ORT_GENAI_HAS_MODEL_PACKAGE

--- a/test/model_package_test.cpp
+++ b/test/model_package_test.cpp
@@ -133,6 +133,25 @@ TEST(ModelPackage, RejectsFlatDirectory) {
   EXPECT_NE(message.find("is not a model package"), std::string::npos) << message;
 }
 
+TEST(ModelPackage, FlatDirectoryWithManifestIsNotAPackage) {
+  // A flat model directory may carry its own unrelated manifest.json. The root genai_config.json
+  // marks it as flat, so it must not be treated as a model package.
+  const auto root = MakeTempDir("flat_with_manifest");
+  WriteFile(root / "genai_config.json",
+            "{ \"model\": { \"type\": \"tiny-test-model\","
+            " \"vocab_size\": 16, \"context_length\": 32 }, \"search\": {} }");
+  WriteFile(root / "model.onnx", "placeholder");
+  WriteFile(root / "manifest.json", "{ \"unrelated\": true }");
+
+  // Passing an ep treats the path as a package; it must be rejected as a flat directory instead.
+  const std::string message = CaptureThrowMessage(
+      [&] { OgaConfig::CreateFromPackageEp(root.string().c_str(), "cpu"); });
+  EXPECT_NE(message.find("is not a model package"), std::string::npos) << message;
+
+  // Loading it as a flat directory (no ep) succeeds despite the manifest.json.
+  EXPECT_NO_THROW(OgaConfig::Create(root.string().c_str()));
+}
+
 TEST(ModelPackage, RejectsMissingPath) {
   EXPECT_THROW(OgaConfig::CreateFromPackageEp("/this/path/does/not/exist/12345", "cpu"),
                std::runtime_error);


### PR DESCRIPTION
## Summary

Some consumers keep a flat (non-package) model directory that carries its own unrelated `manifest.json`. The previous detection treated any directory with a `manifest.json` as an ONNX Runtime model package, so these flat directories were misclassified and failed to load.

A flat model directory always keeps `genai_config.json` at its root (that is what onnxruntime-genai parses to load it), while a model package keeps `genai_config.json` inside each variant directory and never at the root. This PR uses that as the discriminator.

## What changed

- `IsModelPackage` now returns true only when the directory has a top-level `manifest.json` **and no top-level `genai_config.json`**. A flat directory that happens to carry a `manifest.json` is still loaded as a flat directory.
- Added a test (`FlatDirectoryWithManifestIsNotAPackage`) covering a flat directory that contains both `genai_config.json` and an unrelated `manifest.json`.
- Documented the detection rule in `docs/model_package.md`.

## Testing

`unit_tests --gtest_filter='ModelPackage.*'`: 11 tests pass, including the new flat-directory-with-manifest case. Full unit suite (72 tests) passes.

Note: the detection uses the boolean result of `std::filesystem::is_regular_file` rather than its `error_code`, since that call sets the `error_code` to "no such file" when the file is absent, which would otherwise reject valid packages.
