### PR TITLE
DML: allow opting out of graph capture via provider option

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1489,6 +1489,16 @@ bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options) {
         }
         return false;
       } else if (provider_options->name == "DML") {
+        // Graph capture defaults to ON for DML but can be opted out via the
+        // provider option "enable_graph_capture": "0". Captured-command-list
+        // replay computes wrong logits on some D3D12 devices (observed on the
+        // Xbox Series S Dev-Mode driver: deterministic garbage from the same
+        // model that is correct on CPU EP and on non-captured ORT sessions).
+        for (const auto& value : provider_options->options) {
+          if (value.first == "enable_graph_capture" && (value.second == "0" || value.second == "false")) {
+            return false;
+          }
+        }
         return true;
       } else if (provider_options->name == "WebGPU") {
         for (const auto& value : provider_options->options) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1495,8 +1495,13 @@ bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options) {
         // Xbox Series S Dev-Mode driver: deterministic garbage from the same
         // model that is correct on CPU EP and on non-captured ORT sessions).
         for (const auto& value : provider_options->options) {
-          if (value.first == "enable_graph_capture" && (value.second == "0" || value.second == "false")) {
-            return false;
+          if (value.first == "enable_graph_capture") {
+            std::string lower_value = value.second;
+            std::transform(lower_value.begin(), lower_value.end(), lower_value.begin(),
+                           [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); });
+            if (lower_value == "0" || lower_value == "false") {
+              return false;
+            }
           }
         }
         return true;

--- a/src/dml/session_options.cpp
+++ b/src/dml/session_options.cpp
@@ -35,10 +35,20 @@ DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
     InitDmlInterface(p_device_luid, p_device_index);
   }
 
+  // Graph capture can also be opted out per model via the provider option
+  // "enable_graph_capture": "0" — captured-command-list replay computes wrong
+  // logits on some D3D12 devices (see IsGraphCaptureEnabled in config.cpp).
+  bool graph_capture_opt_out = false;
+  for (const auto& [name, value] : provider_options.options) {
+    if (name == "enable_graph_capture" && (value == "0" || value == "false")) {
+      graph_capture_opt_out = true;
+    }
+  }
+
   // Non-decoder sessions (vision, speech, embedding) have control-flow nodes
   // that are incompatible with graph capture, so the caller sets
   // disable_graph_capture=true for those sessions.
-  if (!disable_graph_capture) {
+  if (!disable_graph_capture && !graph_capture_opt_out) {
     session_options.AddConfigEntry("ep.dml.enable_graph_capture", "1");
   }
 

--- a/src/dml/session_options.cpp
+++ b/src/dml/session_options.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <algorithm>
+#include <cctype>
+
 #include "session_options.h"
 #include "../models/session_options.h"
 
@@ -40,8 +43,13 @@ DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
   // logits on some D3D12 devices (see IsGraphCaptureEnabled in config.cpp).
   bool graph_capture_opt_out = false;
   for (const auto& [name, value] : provider_options.options) {
-    if (name == "enable_graph_capture" && (value == "0" || value == "false")) {
-      graph_capture_opt_out = true;
+    if (name == "enable_graph_capture") {
+      std::string lower_value = value;
+      std::transform(lower_value.begin(), lower_value.end(), lower_value.begin(),
+                     [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); });
+      if (lower_value == "0" || lower_value == "false") {
+        graph_capture_opt_out = true;
+      }
     }
   }
 

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -423,7 +423,11 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
       // total_length before every Run), but the DML allocator rejects
       // zero-sized buffers. Clamp the placeholder to one position so DML
       // decoder sessions without past_present_share_buffer can be created.
-      tensor_shape[2] = std::max<int64_t>(1, tensor_shape[2]);
+      // DML-only: on other EPs a zero-sized buffer needs no allocation, so
+      // clamping there would only add startup memory overhead.
+      if (Device().GetType() == DeviceType::DML) {
+        tensor_shape[2] = std::max<int64_t>(1, tensor_shape[2]);
+      }
 
       presents_.push_back(OrtValue::CreateTensor(Allocator(), tensor_shape, type_));
       if (Device().GetType() != DeviceType::WEBGPU) {

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -418,6 +418,13 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
         tensor_shape = layer_shapes_[i / 2];
       }
 
+      // Non-share-buffer caches start with a zero-length sequence dim; these
+      // tensors are placeholders (Update() reallocates presents_ at the real
+      // total_length before every Run), but the DML allocator rejects
+      // zero-sized buffers. Clamp the placeholder to one position so DML
+      // decoder sessions without past_present_share_buffer can be created.
+      tensor_shape[2] = std::max<int64_t>(1, tensor_shape[2]);
+
       presents_.push_back(OrtValue::CreateTensor(Allocator(), tensor_shape, type_));
       if (Device().GetType() != DeviceType::WEBGPU) {
         ByteWrapTensor(Device(), *presents_.back()).Zero();


### PR DESCRIPTION
## Motivation

Graph capture is currently hardcoded ON for every DML decoder session: `IsGraphCaptureEnabled` returns `true` unconditionally for the `DML` provider, and `AppendExecutionProvider` always sets `ep.dml.enable_graph_capture=1`. There is no way to reach it from `genai_config.json` (`provider_options.dml` only reads `luid`/`device_index`).

That matters because captured-command-list replay computes deterministically wrong logits on some D3D12 devices/drivers, and today the only workaround is rebuilding the library. We hit this on the Xbox Series S Dev-Mode driver: GQA and MHA decoder models (fp16 and int4) produce garbage logits via DML (NMSE ~1 vs the same weights on CPU EP; pure noise at seq_len=1), while non-captured plain-ORT sessions (an SD-Turbo UNet) are correct on the same device. Graph-level knobs (`ORT_DISABLE_ALL`, `ep.dml.disable_graph_fusion`) leave the output bit-identical, placing the issue below the graph layer. Related driver-side investigation: microsoft/onnxruntime#29739.

Being able to A/B capture on/off from config — without rebuilding — is useful for anyone debugging DML numerical issues, independent of our device.

## Changes

1. **`enable_graph_capture: "0"` (or `"false"`) in `provider_options.dml` is now respected** in both places that assume capture:
   - `IsGraphCaptureEnabled` (config.cpp) — the replay state machine;
   - `AppendExecutionProvider` (dml/session_options.cpp) — skips the `ep.dml.enable_graph_capture` session config entry.
2. **`DefaultKeyValueCache`: clamp the zero-length placeholder allocation** (kv_cache.cpp). With capture off, a DML decoder takes the non-share-buffer cache path, whose initial `presents_` tensors have a zero-length sequence dim. They are placeholders (`Update()` reallocates at the real length before every `Run`), but the DML allocator rejects zero-sized buffers, so session creation fails. Clamping the placeholder to one position makes the opt-out actually usable on DML; other EPs are unaffected (the placeholder is never read).

Default behavior is unchanged in both commits: capture stays on unless explicitly opted out, and the clamp only touches a never-read placeholder.

## Usage

```json
"model": { "decoder": { "session_options": { "provider_options": [ { "dml": { "enable_graph_capture": "0" } } ] } } }
```

## Testing

- Validated on hardware (Xbox Series S, Dev Mode, AMD RDNA2): with the opt-out, DML decoder sessions create and run through the non-captured path (an MHA SmolLM2-360M fp16 export runs end-to-end; without the kv_cache clamp, session creation fails on the zero-sized placeholder; without the opt-out, capture is unconditionally on).
- Desktop DML default path (no option set): behavior unchanged — the option is purely opt-in.