### PR TITLE
Reject shared_embeddings=true for untied models in model builder

### DIFF
--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -269,7 +269,7 @@ Note that this is the same as outputting embeddings since the last hidden states
 
 #### Enable Shared Embeddings
 
-This scenario is for when you want to enable weight sharing between the embedding layer and the language modeling head. This reduces model size and can improve memory efficiency, especially useful for models with tied embeddings (where `tie_word_embeddings=true` in config.json). Shared embeddings are automatically enabled if `tie_word_embeddings=true` in the model's config.json (can be overridden with `shared_embeddings=false`), but cannot be used with `exclude_embeds=true` or `exclude_lm_head=true`. 
+This scenario is for when you want to enable weight sharing between the embedding layer and the language modeling head. This reduces model size and can improve memory efficiency, especially useful for models with tied embeddings (where `tie_word_embeddings=true` in config.json). Shared embeddings are only valid for models with tied embeddings; setting `shared_embeddings=true` for a model with `tie_word_embeddings=false` will raise a `ValueError`. Shared embeddings are automatically enabled if `tie_word_embeddings=true` in the model's config.json (can be overridden with `shared_embeddings=false`), but cannot be used with `exclude_embeds=true` or `exclude_lm_head=true`.
 
 ##### Example 1: INT4 weights + INT4 embeddings (for RTN and K-Quant)
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -532,6 +532,8 @@ def get_args():
                 shared_embeddings = Enable weight sharing between embedding and LM head layers. Default is false.
                     Use this option to share weights and reduce model size by eliminating duplicate weights.
                     Shares quantized weights using GatherBlockQuantized and shares unquantized weights using Gather.
+                    Only valid for models that tie their input and output embeddings (tie_word_embeddings=true in
+                    config.json). Setting shared_embeddings=true for a model with tie_word_embeddings=false raises a ValueError.
                 enable_cuda_graph = Enable CUDA graph capture during inference. Default is false.
                     If enabled, all nodes being placed on the CUDA EP is the prerequisite for the CUDA graph to be used correctly.
                     It is not guaranteed that CUDA graph be enabled as it depends on the model and the graph structure.

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -256,6 +256,20 @@ def create_model(
         )
         config.update(peft_config.__dict__)
 
+    # Weight sharing (shared_embeddings=true) reuses a single matrix for both the input
+    # embedding and the LM head. That is only valid when the model actually ties them. For an
+    # untied model (config.tie_word_embeddings is False) the token embedding and LM head are
+    # distinct weights, so tying them would make the embedding read from the wrong matrix and
+    # silently export a broken model (e.g. gpt-oss-20b generating gibberish). Reject the
+    # combination up front instead of producing a corrupt model.
+    if extra_options.get("shared_embeddings", False) and getattr(config, "tie_word_embeddings", None) is False:
+        raise ValueError(
+            "shared_embeddings=true requires a model that ties its input and output embeddings, "
+            "but this model's config has tie_word_embeddings=false (the token embedding and LM head "
+            "are separate weights). Sharing them would corrupt the exported model. Remove "
+            "shared_embeddings=true from --extra_options for this model."
+        )
+
     # Set input/output precision of ONNX model
     io_dtype = set_io_dtype(precision, execution_provider, extra_options)
     onnx_dtype = set_onnx_dtype(precision, extra_options)


### PR DESCRIPTION
The model builder silently honored shared_embeddings=true even when the model config sets tie_word_embeddings=false. For untied models (e.g. gpt-oss-20b and DeepSeek-R1-Distill-Qwen-1.5B), the token embedding and LM head are separate weights, so tying them made the embedding read from the wrong matrix and exported a broken model: gibberish generation, finite-but-flat logits, and near-random benchmark accuracy -- with no error or warning.

Raises a clear ValueError in create_model() when shared_embeddings=true for a model whose config has tie_word_embeddings=false, before any conversion work runs. Genuinely tied models (tie_word_embeddings=true) are unaffected.

Fixes #2306