### PR TITLE
for vlm model, add AppendInputs for multi-turn chat

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -557,6 +557,42 @@ void Generator::SetInputs(const NamedTensors& named_tensors) {
   }
 }
 
+void Generator::AppendInputs(const NamedTensors& named_tensors) {
+  if (model_->config_->model.type != "qwen3_5" && model_->config_->model.type != "qwen3_5_moe") {
+    if (search_->GetSequenceLength() == 0) {
+      SetInputs(named_tensors);
+      return;
+    }
+    throw std::runtime_error("AppendInputs after generation is currently only supported for qwen3_5 and qwen3_5_moe.");
+  }
+
+  cpu_span<int32_t> input_ids;
+  std::vector<ExtraInput> inputs_for_this_append;
+  for (const auto& [name, tensor] : named_tensors) {
+    if (name == Config::Defaults::InputIdsName) {
+      input_ids = cpu_span<int32_t>(tensor->ort_tensor_->GetTensorMutableData<int32_t>(),
+                                    tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetElementCount());
+    } else {
+      [[maybe_unused]] const auto [graph_name, found] = model_->config_->GetGraphName(name);
+      inputs_for_this_append.push_back({graph_name, tensor});
+    }
+  }
+
+  if (input_ids.size() == 0) {
+    throw std::runtime_error("AppendInputs requires input_ids.");
+  }
+
+  if (set_extra_inputs_) {
+    extra_inputs_.insert(extra_inputs_.end(), inputs_for_this_append.begin(), inputs_for_this_append.end());
+    state_->SetExtraInputs(extra_inputs_);
+    set_extra_inputs_ = false;
+  } else {
+    state_->SetExtraInputsForAppend(inputs_for_this_append, search_->GetSequenceLength());
+  }
+
+  AppendTokens(input_ids);
+}
+
 void Generator::ComputeLogits(DeviceSpan<int32_t> next_tokens) {
   if (computed_logits_)
     throw std::runtime_error("ComputeLogits called again without calling AppendTokens or GenerateNextToken first");

--- a/src/generators.h
+++ b/src/generators.h
@@ -106,6 +106,7 @@ struct Generator : LeakChecked<Generator> {
   bool IsDone();
   size_t TokenCount() const;
   void AppendTokens(cpu_span<const int32_t> input_ids);
+  void AppendInputs(const NamedTensors& inputs);
   void GenerateNextToken();
   void RewindToLength(size_t new_length);  // Rewind state to new_length
   DeviceSpan<float> GetLogits();

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -41,6 +41,11 @@ struct State {
   void SetRunOption(const char* key, const char* value);
   void SetRunOptions(const Config::RunOptions& config_run_options);
   virtual void SetExtraInputs(const std::vector<ExtraInput>& extra_inputs) {}
+  virtual void SetExtraInputsForAppend(const std::vector<ExtraInput>& extra_inputs, int64_t current_length) {
+    (void)extra_inputs;
+    (void)current_length;
+    throw std::runtime_error("AppendInputs is not supported for this model type.");
+  }
 
   void DumpInputs();
   void DumpOutputs();

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -638,6 +638,19 @@ void EmbeddingState::SetExtraInputs(const int64_t num_images, const int64_t num_
   }
 }
 
+void EmbeddingState::ResetImageInputs(const int64_t num_images, const int64_t num_image_tokens) {
+  num_image_tokens_ = num_image_tokens;
+  if (!image_features_) {
+    image_features_ = std::make_unique<MultiModalFeatures>(*this, MultiModalFeatures::Mode::Input,
+                                                           model_.config_->model.embedding.inputs.image_features,
+                                                           num_images, num_image_tokens_);
+    image_features_->Add();
+    return;
+  }
+
+  image_features_->Reset(num_images, num_image_tokens_);
+}
+
 void EmbeddingState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, bool is_prompt) {
   input_ids_.Update(next_tokens);
   if (model_.vision_session_) image_features_->Update(is_prompt);
@@ -778,6 +791,55 @@ void MultiModalPipelineState::SetExtraInputs(const std::vector<ExtraInput>& extr
   }
 }
 
+void MultiModalPipelineState::SetExtraInputsForAppend(const std::vector<ExtraInput>& extra_inputs, int64_t current_length) {
+  if (model_.config_->model.type != "qwen3_5" && model_.config_->model.type != "qwen3_5_moe") {
+    throw std::runtime_error("AppendInputs with images is currently only supported for qwen3_5 and qwen3_5_moe.");
+  }
+  if (params_->search.batch_size != 1 || params_->search.num_beams != 1) {
+    throw std::runtime_error("AppendInputs with images currently supports only batch_size=1 and num_beams=1.");
+  }
+
+  num_image_tokens_ = GetNumImageTokens(extra_inputs);
+  num_audio_tokens_ = GetNumAudioTokens(extra_inputs, model_.config_->model.speech.inputs.audio_sizes);
+  num_images_ = GetImageFeatureBatchSize(extra_inputs);
+
+  if (num_audio_tokens_ > 0) {
+    throw std::runtime_error("AppendInputs with audio is not supported.");
+  }
+
+  if (num_image_tokens_ <= 0) {
+    pending_multimodal_append_ = false;
+    return;
+  }
+
+  if (!model_.vision_session_) {
+    throw std::runtime_error("AppendInputs received image inputs but the model has no vision session.");
+  }
+
+  vision_state_ = CreateVisionState(model_, *params_);
+  vision_state_->SetExtraInputs(extra_inputs, num_images_, num_image_tokens_);
+  embedding_state_->ResetImageInputs(num_images_, num_image_tokens_);
+
+  if (auto* qwen_pos_inputs = dynamic_cast<Qwen2VLPositionInputs*>(decoder_state_->position_inputs_.get())) {
+    std::shared_ptr<Tensor> img_grid, vid_grid, sec_grid;
+
+    for (const auto& input : extra_inputs) {
+      if (input.name == Config::Defaults::ImageGridThwName) {
+        img_grid = input.tensor;
+      } else if (input.name == "video_grid_thw") {
+        vid_grid = input.tensor;
+      } else if (input.name == "second_per_grid_ts") {
+        sec_grid = input.tensor;
+      }
+    }
+
+    qwen_pos_inputs->SetGridTensors(img_grid, vid_grid, sec_grid);
+    qwen_pos_inputs->PrepareMultimodalAppend(current_length);
+  }
+
+  pending_multimodal_append_ = true;
+}
+
 DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices) {
   // Pipeline state defines the pipeline of the execution of the models
   // Prompt stage:
@@ -789,10 +851,12 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
   //   - input_ids, image_features, audio_features -> |embeddings_model| -> inputs_embeds
   //   - inputs_embeds -> |decoder_model| -> logits
 
-  embedding_state_->UpdateInputsOutputs(next_tokens, is_prompt_);
+  const bool run_multimodal_prefill = is_prompt_ || pending_multimodal_append_;
+
+  embedding_state_->UpdateInputsOutputs(next_tokens, run_multimodal_prefill);
   decoder_state_->UpdateInputsOutputs(next_tokens, current_length, next_indices);
 
-  if (is_prompt_) {
+  if (run_multimodal_prefill) {
     if (num_image_tokens_ > 0 && vision_state_) {
       vision_state_->Run(current_length, next_tokens, next_indices);
     }
@@ -824,6 +888,7 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
     auto logits = decoder_state_->Run(current_length, next_tokens, next_indices);
 
     is_prompt_ = false;
+    pending_multimodal_append_ = false;
     if (vision_state_) vision_state_.reset();  // The vision state is no longer needed in generation stage
     if (speech_state_) speech_state_.reset();  // The speech state is no longer needed in generation stage
 

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -110,6 +110,7 @@ struct EmbeddingState : State {
   EmbeddingState& operator=(const EmbeddingState&) = delete;
 
   void SetExtraInputs(const int64_t num_images_, const int64_t num_image_tokens_, const int64_t num_audio_tokens_);
+  void ResetImageInputs(const int64_t num_images, const int64_t num_image_tokens);
   DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices = {});
 
  private:
@@ -161,6 +162,7 @@ struct MultiModalPipelineState : State {
   MultiModalPipelineState& operator=(const MultiModalPipelineState&) = delete;
 
   void SetExtraInputs(const std::vector<ExtraInput>& extra_inputs) override;
+  void SetExtraInputsForAppend(const std::vector<ExtraInput>& extra_inputs, int64_t current_length) override;
 
   DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens,
                         DeviceSpan<int32_t> next_indices) override;
@@ -183,6 +185,7 @@ struct MultiModalPipelineState : State {
   std::unique_ptr<DecoderState> decoder_state_;
   std::shared_ptr<Adapters> adapters_;
   bool is_prompt_{true};
+  bool pending_multimodal_append_{false};
 
   const std::string vision_adapter_name_{"vision"};
   const std::string speech_adapter_name_{"speech"};

--- a/src/models/multi_modal_features.cpp
+++ b/src/models/multi_modal_features.cpp
@@ -14,18 +14,7 @@ MultiModalFeatures::MultiModalFeatures(State& state, MultiModalFeatures::Mode mo
                 : model_.session_info_.GetOutputDataType(name)},
       mode_{mode},
       name_{name} {
-  const auto dims = mode_ == MultiModalFeatures::Mode::Input
-                        ? model_.session_info_.GetInputSymbolicShape(name).size()
-                        : model_.session_info_.GetOutputSymbolicShape(name).size();
-
-  // If the model expects 3 dimensions, add a batch dimension
-  // batch_size <= 0 signals "skip batch dim even if model has 3D output"
-  if (dims == 3 && batch_size > 0) {
-    shape_.push_back(batch_size);
-  }
-
-  shape_.push_back(num_feature_tokens);
-  shape_.push_back(model_.config_->model.decoder.hidden_size);
+  SetShape(batch_size, num_feature_tokens);
 
   // There are four cases for MultiModalFeatures:
   // 1) Created as an output for vision or speech model (num_feature_tokens > 0)
@@ -40,6 +29,38 @@ MultiModalFeatures::MultiModalFeatures(State& state, MultiModalFeatures::Mode mo
   //    The tensor does not need to be pre-allocated because it will be created during (2).
   if (mode == MultiModalFeatures::Mode::Output) {
     features_ = OrtValue::CreateTensor(model_.p_device_->GetAllocator(), shape_, type_);
+  }
+}
+
+void MultiModalFeatures::SetShape(int64_t batch_size, int64_t num_feature_tokens) {
+  const auto dims = mode_ == MultiModalFeatures::Mode::Input
+                        ? model_.session_info_.GetInputSymbolicShape(name_).size()
+                        : model_.session_info_.GetOutputSymbolicShape(name_).size();
+
+  shape_.clear();
+  // If the model expects 3 dimensions, add a batch dimension
+  // batch_size <= 0 signals "skip batch dim even if model has 3D output"
+  if (dims == 3 && batch_size > 0) {
+    shape_.push_back(batch_size);
+  }
+
+  shape_.push_back(num_feature_tokens);
+  shape_.push_back(model_.config_->model.decoder.hidden_size);
+}
+
+void MultiModalFeatures::Reset(int64_t batch_size, int64_t num_feature_tokens) {
+  SetShape(batch_size, num_feature_tokens);
+
+  if (mode_ == MultiModalFeatures::Mode::Output) {
+    features_ = OrtValue::CreateTensor(model_.p_device_->GetAllocator(), shape_, type_);
+    if (index_ != ~0U) {
+      state_.outputs_[index_] = features_.get();
+    }
+  } else {
+    features_.reset();
+    if (index_ != ~0U) {
+      state_.inputs_[index_] = nullptr;
+    }
   }
 }
 

--- a/src/models/multi_modal_features.h
+++ b/src/models/multi_modal_features.h
@@ -18,6 +18,7 @@ struct MultiModalFeatures {
   void Add();
   void Update(bool is_prompt);
   void ReuseFeaturesBuffer(MultiModalFeatures& other);
+  void Reset(int64_t batch_size, int64_t num_feature_tokens);
 
   // Pre-allocate an empty features tensor for Input mode when no source session provides one.
   // Used when the embedding model requires an input (e.g., audio_features) but no corresponding
@@ -31,6 +32,8 @@ struct MultiModalFeatures {
   OrtValue* Get() { return features_.get(); }
 
  private:
+  void SetShape(int64_t batch_size, int64_t num_feature_tokens);
+
   State& state_;
   const Model& model_{state_.model_};
 

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -653,6 +653,11 @@ void Qwen2VLPositionInputs::SetGridTensors(const std::shared_ptr<Tensor>& image_
   second_per_grid_ts_ = second_per_grid_ts;
 }
 
+void Qwen2VLPositionInputs::PrepareMultimodalAppend(int64_t position_offset) {
+  force_multimodal_update_ = true;
+  position_offset_ = position_offset;
+}
+
 void Qwen2VLPositionInputs::Add() {
   if (has_posid_input_) {
     AddPositionIDs();
@@ -804,9 +809,9 @@ void Qwen2VLPositionInputs::CreateAndInitialize3DPositionIDs(DeviceSpan<int32_t>
           position_data[1 * batch_size * seq_len + b * seq_len + current_token_idx] = 0;
           position_data[2 * batch_size * seq_len + b * seq_len + current_token_idx] = 0;
         } else {
-          position_data[0 * batch_size * seq_len + b * seq_len + current_token_idx] = current_pos;
-          position_data[1 * batch_size * seq_len + b * seq_len + current_token_idx] = current_pos;
-          position_data[2 * batch_size * seq_len + b * seq_len + current_token_idx] = current_pos;
+          position_data[0 * batch_size * seq_len + b * seq_len + current_token_idx] = static_cast<T>(position_offset_ + current_pos);
+          position_data[1 * batch_size * seq_len + b * seq_len + current_token_idx] = static_cast<T>(position_offset_ + current_pos);
+          position_data[2 * batch_size * seq_len + b * seq_len + current_token_idx] = static_cast<T>(position_offset_ + current_pos);
           max_pos_for_batch = current_pos;
           current_pos++;  // Only increment position for non-pad tokens
         }
@@ -828,9 +833,9 @@ void Qwen2VLPositionInputs::CreateAndInitialize3DPositionIDs(DeviceSpan<int32_t>
         T w_pos = static_cast<T>(gw) + st_idx;
 
         // Vision tokens are guaranteed not to be padding
-        position_data[0 * batch_size * seq_len + b * seq_len + (ed + s)] = t_pos;
-        position_data[1 * batch_size * seq_len + b * seq_len + (ed + s)] = h_pos;
-        position_data[2 * batch_size * seq_len + b * seq_len + (ed + s)] = w_pos;
+        position_data[0 * batch_size * seq_len + b * seq_len + (ed + s)] = static_cast<T>(position_offset_ + t_pos);
+        position_data[1 * batch_size * seq_len + b * seq_len + (ed + s)] = static_cast<T>(position_offset_ + h_pos);
+        position_data[2 * batch_size * seq_len + b * seq_len + (ed + s)] = static_cast<T>(position_offset_ + w_pos);
         max_pos_for_batch = std::max({max_pos_for_batch, t_pos, h_pos, w_pos});
       }
       st = ed + vision_len;  // New start is after the vision tokens
@@ -848,9 +853,9 @@ void Qwen2VLPositionInputs::CreateAndInitialize3DPositionIDs(DeviceSpan<int32_t>
           position_data[1 * batch_size * seq_len + b * seq_len + current_token_idx] = 0;
           position_data[2 * batch_size * seq_len + b * seq_len + current_token_idx] = 0;
         } else {
-          position_data[0 * batch_size * seq_len + b * seq_len + current_token_idx] = current_pos;
-          position_data[1 * batch_size * seq_len + b * seq_len + current_token_idx] = current_pos;
-          position_data[2 * batch_size * seq_len + b * seq_len + current_token_idx] = current_pos;
+          position_data[0 * batch_size * seq_len + b * seq_len + current_token_idx] = static_cast<T>(position_offset_ + current_pos);
+          position_data[1 * batch_size * seq_len + b * seq_len + current_token_idx] = static_cast<T>(position_offset_ + current_pos);
+          position_data[2 * batch_size * seq_len + b * seq_len + current_token_idx] = static_cast<T>(position_offset_ + current_pos);
           max_pos_for_batch = current_pos;
           current_pos++;  // Only increment position for non-pad tokens
         }
@@ -926,7 +931,7 @@ void Qwen2VLPositionInputs::UpdateAttentionMask() {
 void Qwen2VLPositionInputs::Update(DeviceSpan<int32_t> next_tokens, int total_length, int new_length) {
   if (has_posid_input_) {
     position_ids_shape_[2] = new_length;
-    if (is_first_update_) {
+    if (is_first_update_ || force_multimodal_update_) {
       DispatchOnType(type_, InitPositionIdsFunctor{this, next_tokens, position_ids_shape_});
     } else {
       Update3DPositionIDs(total_length - new_length);
@@ -944,6 +949,8 @@ void Qwen2VLPositionInputs::Update(DeviceSpan<int32_t> next_tokens, int total_le
   }
 
   is_first_update_ = false;
+  force_multimodal_update_ = false;
+  position_offset_ = 0;
 }
 
 void Qwen2VLPositionInputs::RewindTo(size_t index) {

--- a/src/models/position_inputs.h
+++ b/src/models/position_inputs.h
@@ -124,6 +124,8 @@ struct Qwen2VLPositionInputs : PositionInputs {
   void Update(DeviceSpan<int32_t> next_tokens, int total_length, int new_length) override;
   void RewindTo(size_t index) override;
 
+  void PrepareMultimodalAppend(int64_t position_offset);
+
   void SetGridTensors(const std::shared_ptr<Tensor>& image_grid_thw,
                       const std::shared_ptr<Tensor>& video_grid_thw,
                       const std::shared_ptr<Tensor>& second_per_grid_ts);
@@ -162,6 +164,8 @@ struct Qwen2VLPositionInputs : PositionInputs {
   std::unique_ptr<Tensor> attention_mask_;
 
   bool is_first_update_{true};
+  bool force_multimodal_update_{false};
+  int64_t position_offset_{0};
 
   // Cached data from processor
   std::shared_ptr<Tensor> image_grid_thw_;

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -471,6 +471,10 @@ struct OgaGenerator : OgaAbstract {
     OgaCheckResult(OgaGenerator_SetInputs(this, &named_tensors));
   }
 
+  void AppendInputs(OgaNamedTensors& named_tensors) {
+    OgaCheckResult(OgaGenerator_AppendInputs(this, &named_tensors));
+  }
+
   void AppendTokenSequences(const OgaSequences& sequences) {
     OgaCheckResult(OgaGenerator_AppendTokenSequences(this, &sequences));
   }

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -473,6 +473,13 @@ OgaResult* OGA_API_CALL OgaGenerator_SetInputs(OgaGenerator* generator, const Og
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaGenerator_AppendInputs(OgaGenerator* generator, const OgaNamedTensors* p_named_tensors) {
+  OGA_TRY
+  generator->AppendInputs(*p_named_tensors);
+  return nullptr;
+  OGA_CATCH
+}
+
 OgaResult* OGA_API_CALL OgaGenerator_AppendTokenSequences(OgaGenerator* generator, const OgaSequences* sequences) {
   OGA_TRY
 

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -535,6 +535,14 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_SetModelInput(OgaGenerator* gene
 OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_SetInputs(OgaGenerator* generator, const OgaNamedTensors* named_tensors);
 
 /**
+ * \brief Appends processed model inputs to the generator. For multimodal models, the named tensors should be produced by
+ * a MultiModalProcessor and include input_ids plus any image/audio tensors needed for the appended prompt chunk.
+ * \param[in] generator The generator to add the inputs to.
+ * \param[in] named_tensors The named tensors to append.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaGenerator_AppendInputs(OgaGenerator* generator, const OgaNamedTensors* named_tensors);
+
+/**
  * \brief Adds the input ids to the generator. The input ids are used to seed the generation.
  * \param[in] generator The generator to add the input ids to.
  * \param[in] p_sequences The input id sequences.

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -250,6 +250,10 @@ struct PyGenerator {
     generator_->SetInputs(named_tensors);
   }
 
+  void AppendInputs(OgaNamedTensors& named_tensors) {
+    generator_->AppendInputs(named_tensors);
+  }
+
   void AppendTokens(OgaTensor& tokens) {
     generator_->AppendTokens(ToSpan<int32_t>(tokens));
   }
@@ -494,6 +498,7 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def("get_input", &PyGenerator::GetInput)
       .def("get_output", &PyGenerator::GetOutput)
       .def("set_inputs", &PyGenerator::SetInputs)
+      .def("append_inputs", &PyGenerator::AppendInputs)
       .def("set_model_input", &PyGenerator::SetModelInput)
       .def("append_tokens", pybind11::overload_cast<pybind11::array_t<int32_t>&>(&PyGenerator::AppendTokens))
       .def("append_tokens", pybind11::overload_cast<OgaTensor&>(&PyGenerator::AppendTokens))


### PR DESCRIPTION
For current oga, for vlm model, the image input is only allowed in first-turn conversation via SetInputs.
In following chat, only text message is allowed to input via the function of AppendTokens().
But this is not the limitation of vlm model, but the oga platform.

This PR extend the oga function by adding new API of AppendInputs similar to AppendTokens but allow input images in following chat.  
Currently, it only supports qwen 3.5 vl model (other vlm model not test yet)

