### PR TITLE
Support transformers v5 rope_parameters in model builder

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -392,8 +392,7 @@ class Model:
         if self.exclude_lm_head:
             del self.output_names["logits"]
 
-    @staticmethod
-    def get_rope_parameters(config):
+    def get_rope_parameters(self, config):
         """Return the RoPE parameters mapping from the model config.
 
         Transformers v5 standardizes RoPE settings under `rope_parameters`.

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -37,13 +37,16 @@ class Model:
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
         # Model attributes from config
         self.context_length = config.seq_length if hasattr(config, "seq_length") else config.max_position_embeddings
+        # Transformers v5 standardizes RoPE settings under `rope_parameters`; older
+        # versions used `rope_scaling` (kept as a backward-compatible alias in v5).
+        # Read whichever the installed transformers version provides.
+        rope_params = self.get_rope_parameters(config)
         self.original_context_length = (
             config.original_max_position_embeddings
             if hasattr(config, "original_max_position_embeddings")
-            else config.rope_scaling["original_max_position_embeddings"]
-            if hasattr(config, "rope_scaling")
-            and isinstance(config.rope_scaling, Mapping)
-            and "original_max_position_embeddings" in config.rope_scaling
+            else rope_params["original_max_position_embeddings"]
+            if isinstance(rope_params, Mapping)
+            and "original_max_position_embeddings" in rope_params
             else self.context_length
         )
         self.window_size = config.sliding_window if hasattr(config, "sliding_window") else -1  # default is -1 in GroupQueryAttention kernel
@@ -230,10 +233,8 @@ class Model:
             if hasattr(config, "rope_theta")
             else config.rope_embedding_base
             if hasattr(config, "rope_embedding_base")
-            else config.rope_scaling["rope_theta"]
-            if hasattr(config, "rope_scaling")
-            and isinstance(config.rope_scaling, Mapping)
-            and "rope_theta" in config.rope_scaling
+            else rope_params["rope_theta"]
+            if isinstance(rope_params, Mapping) and "rope_theta" in rope_params
             else 10000
         )
         self.rope_attrs = {
@@ -250,7 +251,7 @@ class Model:
             "mscale": 1,                                     # Magnitude scaling factor when scaling `emb.cos()/emb.sin()` in rotary embeddings
             "mscale_policy": "",                             # Magnitude scaling policy when scaling `emb.cos()/emb.sin()` in rotary embeddings
         }
-        if hasattr(config, "rope_scaling") and config.rope_scaling is not None:
+        if rope_params is not None:
             self.make_rope_init(config)
 
         # Attention-specific variables (MHA, GQA, GQA + Rot.Emb., etc.)
@@ -391,18 +392,30 @@ class Model:
         if self.exclude_lm_head:
             del self.output_names["logits"]
 
-    def make_rope_init(self, config):
-        if "beta_fast" in config.rope_scaling:
-            # For models that use YARN (e.g. OpenAI OS-minier, Ministral3)
-            factor = config.rope_scaling["factor"] if "factor" in config.rope_scaling else 0
-            beta_slow = config.rope_scaling["beta_slow"] if "beta_slow" in config.rope_scaling else 0
-            beta_fast = config.rope_scaling["beta_fast"] if "beta_fast" in config.rope_scaling else 0
+    @staticmethod
+    def get_rope_parameters(config):
+        """Return the RoPE parameters mapping from the model config.
 
-            self.rope_attrs["mscale_policy"] = config.rope_scaling["rope_type"]
+        Transformers v5 standardizes RoPE settings under `rope_parameters`.
+        Older versions (and the v5 backward-compatible alias) expose the same
+        data under `rope_scaling`. Prefer `rope_parameters` and fall back to
+        `rope_scaling` so the builder works across transformers versions.
+        """
+        return getattr(config, "rope_parameters", None) or getattr(config, "rope_scaling", None)
+
+    def make_rope_init(self, config):
+        rope_params = self.get_rope_parameters(config)
+        if "beta_fast" in rope_params:
+            # For models that use YARN (e.g. OpenAI OS-minier, Ministral3)
+            factor = rope_params["factor"] if "factor" in rope_params else 0
+            beta_slow = rope_params["beta_slow"] if "beta_slow" in rope_params else 0
+            beta_fast = rope_params["beta_fast"] if "beta_fast" in rope_params else 0
+
+            self.rope_attrs["mscale_policy"] = rope_params["rope_type"]
             self.rope_attrs["mscale"] = self.make_mscale(
-                config.rope_scaling["factor"],
-                config_mscale=config.rope_scaling.get("mscale", 0),
-                config_mscale_all_dim=config.rope_scaling.get("mscale_all_dim", 0),
+                rope_params["factor"],
+                config_mscale=rope_params.get("mscale", 0),
+                config_mscale_all_dim=rope_params.get("mscale_all_dim", 0),
             )
             self.rope_attrs["rescale_inv_freq"] = {
                 "factor": factor,
@@ -411,27 +424,27 @@ class Model:
             }
 
         elif (
-            config.rope_scaling.get("rope_type", config.rope_scaling.get("type")) == "linear"
-            and "factor" in config.rope_scaling
+            rope_params.get("rope_type", rope_params.get("type")) == "linear"
+            and "factor" in rope_params
         ):
             # Hugging Face: modeling_rope_utils._compute_linear_scaling_rope_parameters — inv_freq /= factor
             # Equivalent to inv_freq = 1 / (factor * theta ** (i / dim)) in make_rotary_embedding_caches_from_scratch.
-            factor = float(config.rope_scaling["factor"])
+            factor = float(rope_params["factor"])
             if factor <= 0:
                 raise ValueError(f"rope_scaling.factor must be positive for linear RoPE scaling, got {factor}")
             self.rope_attrs["rescale_factors"] = factor
 
-        elif "mrope_section" in config.rope_scaling:
+        elif "mrope_section" in rope_params:
             # For models that use MRoPE (e.g. Qwen 2.5 VL, Qwen 3 VL)
             self.rope_attrs["mrope"] = {
-                "sections": config.rope_scaling["mrope_section"],  # Sections for MRoPE
+                "sections": rope_params["mrope_section"],  # Sections for MRoPE
             }
 
-            # Some models (e.g. Qwen3-VL) store rope_theta inside rope_scaling
+            # Some models (e.g. Qwen3-VL) store rope_theta inside the rope parameters
             # instead of as a top-level config attribute. Override the default theta
-            # if rope_scaling provides one.
-            if "rope_theta" in config.rope_scaling:
-                self.rope_attrs["theta"] = config.rope_scaling["rope_theta"]
+            # if the rope parameters provide one.
+            if "rope_theta" in rope_params:
+                self.rope_attrs["theta"] = rope_params["rope_theta"]
 
     def is_gqa_supported(self) -> bool:
         valid_gqa_configurations = {

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -401,10 +401,15 @@ class Model:
         data under `rope_scaling`. Prefer `rope_parameters` and fall back to
         `rope_scaling` so the builder works across transformers versions.
         """
-        return getattr(config, "rope_parameters", None) or getattr(config, "rope_scaling", None)
+        rope_parameters = getattr(config, "rope_parameters", None)
+        if rope_parameters is not None:
+            return rope_parameters
+        return getattr(config, "rope_scaling", None)
 
     def make_rope_init(self, config):
         rope_params = self.get_rope_parameters(config)
+        if not isinstance(rope_params, Mapping):
+            return
         if "beta_fast" in rope_params:
             # For models that use YARN (e.g. OpenAI OS-minier, Ministral3)
             factor = rope_params["factor"] if "factor" in rope_params else 0

--- a/src/python/py/models/builders/hunyuan.py
+++ b/src/python/py/models/builders/hunyuan.py
@@ -31,7 +31,7 @@ class HunyuanDenseV1Model(Model):
         #   effective_theta ≈ 10000 * 1000^(128/126) ≈ 10,359,000
         # Transformers versions have used both rope_scaling and rope_parameters
         # for RoPE metadata, so accept either shape before passing config to the base builder.
-        rope_config = getattr(config, "rope_scaling", None) or getattr(config, "rope_parameters", None)
+        rope_config = self.get_rope_parameters(config)
         if rope_config is not None:
             base_theta = getattr(config, "rope_theta", None) or rope_config.get("rope_theta")
             if base_theta is not None:

--- a/src/python/py/models/builders/llama.py
+++ b/src/python/py/models/builders/llama.py
@@ -11,12 +11,13 @@ class LlamaModel(Model):
         super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
 
     def make_rope_init(self, config):
-        if "low_freq_factor" in config.rope_scaling:
+        rope_params = self.get_rope_parameters(config)
+        if "low_freq_factor" in rope_params:
             # For models that rescale `inv_freq` using `low_freq_factor` and `high_freq_factor` (e.g. LLaMA-3.1)
-            factor = config.rope_scaling["factor"] if "factor" in config.rope_scaling else 0
-            low_freq_factor = config.rope_scaling["low_freq_factor"] if "low_freq_factor" in config.rope_scaling else 0
+            factor = rope_params["factor"] if "factor" in rope_params else 0
+            low_freq_factor = rope_params["low_freq_factor"] if "low_freq_factor" in rope_params else 0
             high_freq_factor = (
-                config.rope_scaling["high_freq_factor"] if "high_freq_factor" in config.rope_scaling else 0
+                rope_params["high_freq_factor"] if "high_freq_factor" in rope_params else 0
             )
 
             self.rope_attrs["rescale_inv_freq"] = {

--- a/src/python/py/models/builders/llama.py
+++ b/src/python/py/models/builders/llama.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+from collections.abc import Mapping
+
 from .base import Model
 
 
@@ -12,6 +14,8 @@ class LlamaModel(Model):
 
     def make_rope_init(self, config):
         rope_params = self.get_rope_parameters(config)
+        if not isinstance(rope_params, Mapping):
+            return
         if "low_freq_factor" in rope_params:
             # For models that rescale `inv_freq` using `low_freq_factor` and `high_freq_factor` (e.g. LLaMA-3.1)
             factor = rope_params["factor"] if "factor" in rope_params else 0

--- a/src/python/py/models/builders/phi.py
+++ b/src/python/py/models/builders/phi.py
@@ -71,14 +71,15 @@ class Phi3MiniLongRoPEModel(Phi3MiniModel):
             self.position_ids_name = None
 
     def make_rope_init(self, config):
-        if "short_factor" in config.rope_scaling:
+        rope_params = self.get_rope_parameters(config)
+        if "short_factor" in rope_params:
             # For models with multiple rotary embedding caches (e.g. Phi-3 mini 128K)
-            self.rope_attrs["mscale_policy"] = config.rope_scaling["type"]
-            short_factor = torch.tensor(config.rope_scaling["short_factor"], dtype=torch.float32)
-            long_factor = torch.tensor(config.rope_scaling["long_factor"], dtype=torch.float32)
+            self.rope_attrs["mscale_policy"] = rope_params["type"]
+            short_factor = torch.tensor(rope_params["short_factor"], dtype=torch.float32)
+            long_factor = torch.tensor(rope_params["long_factor"], dtype=torch.float32)
 
-            short_mscale = config.rope_scaling["short_mscale"] if "short_mscale" in config.rope_scaling else 0
-            long_mscale = config.rope_scaling["long_mscale"] if "long_mscale" in config.rope_scaling else 0
+            short_mscale = rope_params["short_mscale"] if "short_mscale" in rope_params else 0
+            long_mscale = rope_params["long_mscale"] if "long_mscale" in rope_params else 0
             short_mscale = short_mscale if short_mscale > 0 else self.make_mscale(self.context_length / self.original_context_length)
             long_mscale = long_mscale if long_mscale > 0 else self.make_mscale(self.context_length / self.original_context_length)
 

--- a/src/python/py/models/builders/phi.py
+++ b/src/python/py/models/builders/phi.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 import onnx_ir as ir
 import torch
+from collections.abc import Mapping
 
 from .base import Model
 from .mistral import MistralModel
@@ -72,6 +73,8 @@ class Phi3MiniLongRoPEModel(Phi3MiniModel):
 
     def make_rope_init(self, config):
         rope_params = self.get_rope_parameters(config)
+        if not isinstance(rope_params, Mapping):
+            return
         if "short_factor" in rope_params:
             # For models with multiple rotary embedding caches (e.g. Phi-3 mini 128K)
             self.rope_attrs["mscale_policy"] = rope_params["type"]

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -76,7 +76,7 @@ class Qwen25VLTextModel(Model):
 
         self.mrope_sections = self.rope_attrs.get("mrope", {}).get("sections", [])
         if not self.mrope_sections:
-            raise ValueError("MRoPE sections not found in config.text_config.rope_scaling.mrope_section")
+            raise ValueError("MRoPE sections not found in text_config rope_parameters/rope_scaling mrope_section")
 
         # The HF logic is `mrope_section * 2`, not `[s * 2 for s in mrope_section]`.
         # This results in [16, 24, 24, 16, 24, 24]
@@ -1026,7 +1026,7 @@ class Qwen35TextModel(Model):
         # mRoPE config
         self.mrope_sections = self.rope_attrs.get("mrope", {}).get("sections", [])
         if not self.mrope_sections:
-            raise ValueError("MRoPE sections not found in config.text_config.rope_scaling.mrope_section")
+            raise ValueError("MRoPE sections not found in text_config rope_parameters/rope_scaling mrope_section")
         if len(self.mrope_sections) != 3:
             raise ValueError(
                 f"Expected 3 MRoPE sections [T, H, W], got {len(self.mrope_sections)}: {self.mrope_sections}"

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -61,8 +61,9 @@ class Qwen25VLTextModel(Model):
 
         # Check rope type since huggingface model supports yarn but that is not recommended as mentioned in model card. Example:
         #    "rope_scaling": {"type": "mrope", "mrope_section": [16, 24,24]}
-        if config.rope_scaling and "type" in config.rope_scaling:
-            assert config.rope_scaling["type"] in ["mrope", "default"]
+        rope_params = self.get_rope_parameters(config)
+        if rope_params and "type" in rope_params:
+            assert rope_params["type"] in ["mrope", "default"]
 
         # Qwen 2.5 VL applies RoPE manually before attention, not fused in the op
         self.attention_attrs["use_rope_in_attn"] = False
@@ -979,12 +980,13 @@ class Qwen35TextModel(Model):
                 if not hasattr(config, key) or getattr(config, key) is None:
                     setattr(config, key, getattr(text_config, key))
 
-        # rope_scaling contains the actual rope_theta for Qwen3.5
-        if hasattr(config, "rope_scaling") and config.rope_scaling is not None:
-            if "rope_theta" in config.rope_scaling:
-                config.rope_theta = config.rope_scaling["rope_theta"]
-            if "partial_rotary_factor" in config.rope_scaling:
-                config.partial_rotary_factor = config.rope_scaling["partial_rotary_factor"]
+        # rope parameters contain the actual rope_theta for Qwen3.5
+        rope_params = self.get_rope_parameters(config)
+        if rope_params is not None:
+            if "rope_theta" in rope_params:
+                config.rope_theta = rope_params["rope_theta"]
+            if "partial_rotary_factor" in rope_params:
+                config.partial_rotary_factor = rope_params["partial_rotary_factor"]
 
         # Parse layer types before super().__init__() because
         # make_int4_algo_config() is called from the base class init

--- a/test/python/models/test_yarn_rope_parity.py
+++ b/test/python/models/test_yarn_rope_parity.py
@@ -273,7 +273,7 @@ def _make_builder_cos_sin_rope_field(
         mock_kwargs["rope_theta"] = config_dict["rope_theta"]
     mock_config = types.SimpleNamespace(**mock_kwargs)
 
-    rope_params = Model.get_rope_parameters(mock_config)
+    rope_params = model.get_rope_parameters(mock_config)
 
     # original_context_length resolution (mirrors Model.__init__)
     if isinstance(rope_params, Mapping) and "original_max_position_embeddings" in rope_params:
@@ -688,30 +688,34 @@ class TestYarnRopeCacheParity:
     # -----------------------------------------------------------------------
     def test_get_rope_parameters_prefers_rope_parameters(self):
         """get_rope_parameters returns rope_parameters when present (transformers v5)."""
+        model = object.__new__(Model)
         config = types.SimpleNamespace(
             rope_parameters={"rope_type": "yarn", "factor": 32.0},
             rope_scaling={"rope_type": "linear", "factor": 8.0},
         )
-        assert Model.get_rope_parameters(config) == {"rope_type": "yarn", "factor": 32.0}
+        assert model.get_rope_parameters(config) == {"rope_type": "yarn", "factor": 32.0}
 
     def test_get_rope_parameters_empty_rope_parameters_not_overridden(self):
         """A present-but-empty rope_parameters ({}) must not fall back to rope_scaling."""
+        model = object.__new__(Model)
         config = types.SimpleNamespace(
             rope_parameters={},
             rope_scaling={"rope_type": "yarn", "factor": 32.0},
         )
-        assert Model.get_rope_parameters(config) == {}
+        assert model.get_rope_parameters(config) == {}
 
     def test_get_rope_parameters_falls_back_to_rope_scaling(self):
         """When rope_parameters is absent, fall back to rope_scaling (older transformers)."""
+        model = object.__new__(Model)
         config = types.SimpleNamespace(rope_scaling={"rope_type": "yarn", "factor": 32.0})
         assert not hasattr(config, "rope_parameters")
-        assert Model.get_rope_parameters(config) == {"rope_type": "yarn", "factor": 32.0}
+        assert model.get_rope_parameters(config) == {"rope_type": "yarn", "factor": 32.0}
 
     def test_get_rope_parameters_none_when_absent(self):
         """When neither field is present, get_rope_parameters returns None."""
+        model = object.__new__(Model)
         config = types.SimpleNamespace(max_position_embeddings=131072)
-        assert Model.get_rope_parameters(config) is None
+        assert model.get_rope_parameters(config) is None
 
     def test_make_rope_init_no_op_without_rope_params(self):
         """make_rope_init must not raise when no rope parameters are present."""
@@ -732,7 +736,8 @@ class TestYarnRopeCacheParity:
             rope_parameters=GPTOSS_20B_CONFIG["rope_scaling"],
         )
         assert not hasattr(mock, "rope_scaling")
-        assert Model.get_rope_parameters(mock) == GPTOSS_20B_CONFIG["rope_scaling"]
+        model = object.__new__(Model)
+        assert model.get_rope_parameters(mock) == GPTOSS_20B_CONFIG["rope_scaling"]
 
         hf_cos, hf_sin = _make_hf_reference_cos_sin(GPTOSS_20B_CONFIG, CACHE_LENGTH)
         params_cos, params_sin = _make_builder_cos_sin_rope_field(
@@ -773,11 +778,12 @@ class TestYarnRopeCacheParity:
 
     def test_rope_parameters_only_resolves_original_context_length(self):
         """original_context_length must come from rope_parameters when rope_scaling is absent."""
+        model = object.__new__(Model)
         mock = types.SimpleNamespace(
             max_position_embeddings=GPTOSS_20B_CONFIG["max_position_embeddings"],
             rope_parameters=GPTOSS_20B_CONFIG["rope_scaling"],
         )
-        rope_params = Model.get_rope_parameters(mock)
+        rope_params = model.get_rope_parameters(mock)
         assert isinstance(rope_params, Mapping)
         assert rope_params["original_max_position_embeddings"] == 4096
         # Guard against the regression where the extended length (131072) leaks in.

--- a/test/python/models/test_yarn_rope_parity.py
+++ b/test/python/models/test_yarn_rope_parity.py
@@ -246,6 +246,70 @@ def _make_builder_cos_sin(config_dict: dict, cache_length: int) -> tuple[np.ndar
     return cos_cache.numpy(), sin_cache.numpy()
 
 
+def _make_builder_cos_sin_rope_field(
+    config_dict: dict, cache_length: int, field: str = "rope_scaling"
+) -> tuple[np.ndarray, np.ndarray]:
+    """Drive the builder RoPE path with the rope dict under a chosen config field.
+
+    ``field`` selects where the rope settings live on the mock config:
+    ``"rope_scaling"`` (legacy transformers) or ``"rope_parameters"``
+    (transformers v5). Settings are resolved via ``Model.get_rope_parameters``,
+    mirroring the current builder ``__init__``, so both fields are exercised by
+    the real code path rather than hard-coding ``rope_scaling``.
+    """
+    rs = config_dict["rope_scaling"]
+    head_dim = config_dict["head_dim"]
+
+    model = object.__new__(Model)
+    model.head_size = head_dim
+    model.context_length = config_dict["max_position_embeddings"]
+
+    mock_kwargs = {
+        "head_dim": head_dim,
+        "max_position_embeddings": config_dict["max_position_embeddings"],
+        field: rs,
+    }
+    if "rope_theta" in config_dict:
+        mock_kwargs["rope_theta"] = config_dict["rope_theta"]
+    mock_config = types.SimpleNamespace(**mock_kwargs)
+
+    rope_params = Model.get_rope_parameters(mock_config)
+
+    # original_context_length resolution (mirrors Model.__init__)
+    if isinstance(rope_params, Mapping) and "original_max_position_embeddings" in rope_params:
+        model.original_context_length = rope_params["original_max_position_embeddings"]
+    else:
+        model.original_context_length = model.context_length
+
+    # rope_theta resolution (mirrors Model.__init__)
+    rope_theta = (
+        mock_config.rope_theta
+        if hasattr(mock_config, "rope_theta")
+        else rope_params["rope_theta"]
+        if isinstance(rope_params, Mapping) and "rope_theta" in rope_params
+        else 10000
+    )
+
+    model.rope_attrs = {
+        "create_caches": True,
+        "save_caches": False,
+        "cache_length": cache_length,
+        "theta": rope_theta,
+        "partial_rotary_factor": 1.0,
+        "interleaved": 0,
+        "rotary_embedding_dim": 0,
+        "rescale_factors": 1,
+        "t_dtype": torch.int64,
+        "position_scale": 1,
+        "mscale": 1.0,
+    }
+
+    model.make_rope_init(mock_config)
+
+    cos_cache, sin_cache = model.make_rotary_embedding_caches_from_scratch()
+    return cos_cache.numpy(), sin_cache.numpy()
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -618,3 +682,103 @@ class TestYarnRopeCacheParity:
         np.testing.assert_allclose(
             builder_sin, hf_sin, rtol=1e-5, atol=1e-5, err_msg="sin_cache mismatch for GPT-OSS-20B @ 2048"
         )
+
+    # -----------------------------------------------------------------------
+    # transformers v5 `rope_parameters` support (PR: rope_parameters)
+    # -----------------------------------------------------------------------
+    def test_get_rope_parameters_prefers_rope_parameters(self):
+        """get_rope_parameters returns rope_parameters when present (transformers v5)."""
+        config = types.SimpleNamespace(
+            rope_parameters={"rope_type": "yarn", "factor": 32.0},
+            rope_scaling={"rope_type": "linear", "factor": 8.0},
+        )
+        assert Model.get_rope_parameters(config) == {"rope_type": "yarn", "factor": 32.0}
+
+    def test_get_rope_parameters_empty_rope_parameters_not_overridden(self):
+        """A present-but-empty rope_parameters ({}) must not fall back to rope_scaling."""
+        config = types.SimpleNamespace(
+            rope_parameters={},
+            rope_scaling={"rope_type": "yarn", "factor": 32.0},
+        )
+        assert Model.get_rope_parameters(config) == {}
+
+    def test_get_rope_parameters_falls_back_to_rope_scaling(self):
+        """When rope_parameters is absent, fall back to rope_scaling (older transformers)."""
+        config = types.SimpleNamespace(rope_scaling={"rope_type": "yarn", "factor": 32.0})
+        assert not hasattr(config, "rope_parameters")
+        assert Model.get_rope_parameters(config) == {"rope_type": "yarn", "factor": 32.0}
+
+    def test_get_rope_parameters_none_when_absent(self):
+        """When neither field is present, get_rope_parameters returns None."""
+        config = types.SimpleNamespace(max_position_embeddings=131072)
+        assert Model.get_rope_parameters(config) is None
+
+    def test_make_rope_init_no_op_without_rope_params(self):
+        """make_rope_init must not raise when no rope parameters are present."""
+        model = object.__new__(Model)
+        model.rope_attrs = {}
+        config = types.SimpleNamespace(max_position_embeddings=131072)
+        model.make_rope_init(config)  # no-op, must not raise on `"beta_fast" in None`
+        assert "rescale_inv_freq" not in model.rope_attrs
+
+    def test_rope_parameters_only_config_matches_rope_scaling(self):
+        """A config exposing only rope_parameters (transformers v5) yields the same
+        caches as the legacy rope_scaling shape and matches the HF reference."""
+        # Sanity: rope_parameters-only mock has no rope_scaling attribute.
+        mock = types.SimpleNamespace(
+            head_dim=GPTOSS_20B_CONFIG["head_dim"],
+            max_position_embeddings=GPTOSS_20B_CONFIG["max_position_embeddings"],
+            rope_theta=GPTOSS_20B_CONFIG["rope_theta"],
+            rope_parameters=GPTOSS_20B_CONFIG["rope_scaling"],
+        )
+        assert not hasattr(mock, "rope_scaling")
+        assert Model.get_rope_parameters(mock) == GPTOSS_20B_CONFIG["rope_scaling"]
+
+        hf_cos, hf_sin = _make_hf_reference_cos_sin(GPTOSS_20B_CONFIG, CACHE_LENGTH)
+        params_cos, params_sin = _make_builder_cos_sin_rope_field(
+            GPTOSS_20B_CONFIG, CACHE_LENGTH, field="rope_parameters"
+        )
+        scaling_cos, scaling_sin = _make_builder_cos_sin_rope_field(
+            GPTOSS_20B_CONFIG, CACHE_LENGTH, field="rope_scaling"
+        )
+
+        np.testing.assert_allclose(
+            params_cos,
+            hf_cos,
+            rtol=1e-5,
+            atol=1e-5,
+            err_msg="rope_parameters-only cos_cache must match HF reference",
+        )
+        np.testing.assert_allclose(
+            params_sin,
+            hf_sin,
+            rtol=1e-5,
+            atol=1e-5,
+            err_msg="rope_parameters-only sin_cache must match HF reference",
+        )
+        np.testing.assert_allclose(
+            params_cos,
+            scaling_cos,
+            rtol=1e-6,
+            atol=1e-6,
+            err_msg="rope_parameters and rope_scaling must produce identical cos_cache",
+        )
+        np.testing.assert_allclose(
+            params_sin,
+            scaling_sin,
+            rtol=1e-6,
+            atol=1e-6,
+            err_msg="rope_parameters and rope_scaling must produce identical sin_cache",
+        )
+
+    def test_rope_parameters_only_resolves_original_context_length(self):
+        """original_context_length must come from rope_parameters when rope_scaling is absent."""
+        mock = types.SimpleNamespace(
+            max_position_embeddings=GPTOSS_20B_CONFIG["max_position_embeddings"],
+            rope_parameters=GPTOSS_20B_CONFIG["rope_scaling"],
+        )
+        rope_params = Model.get_rope_parameters(mock)
+        assert isinstance(rope_params, Mapping)
+        assert rope_params["original_max_position_embeddings"] == 4096
+        # Guard against the regression where the extended length (131072) leaks in.
+        assert rope_params["original_max_position_embeddings"] != mock.max_position_embeddings


### PR DESCRIPTION
## Summary

Make the ONNX model builder read RoPE settings from the config in a way that works across transformers versions. Transformers v5 standardizes RoPE metadata under `rope_parameters` (keeping `rope_scaling` only as a backward‑compatible alias), so the builder now reads whichever field the installed transformers version provides instead of relying solely on `rope_scaling`.

## Motivation

For models that carry their RoPE settings inside the config dict (e.g. GPT‑OSS YaRN, Llama‑3.1, Phi‑3 LongRoPE, Qwen MRoPE), transformers v5 moved those keys — including `original_max_position_embeddings`, `rope_theta`, `factor`, `beta_fast`/`beta_slow`, `mrope_section` — from `rope_scaling` into `rope_parameters`. The builder read them only via `config.rope_scaling`. If a config exposes only `rope_parameters` (or a future transformers drops the `rope_scaling` alias), `hasattr(config, "rope_scaling")` fails and the builder silently falls back to defaults:

- `original_context_length` falls back to the **extended** context length instead of the pretraining length. For GPT‑OSS YaRN this shifts the correction range and leaves rotary dimensions unscaled, degrading long‑context accuracy.
- `make_rope_init` is skipped, so `mscale`, YaRN `factor`, and `rope_theta` are never applied.

## Key Changes

Added a shared helper `Model.get_rope_parameters(config)` that prefers `rope_parameters` and falls back to `rope_scaling`, and routed every RoPE‑config read through it.

| File | Change |
|---|---|
| `base.py` | New `get_rope_parameters()` staticmethod; use it for `original_context_length`, `rope_theta`, the `make_rope_init` trigger, and the YaRN/linear/MRoPE branches in `make_rope_init`. |
| `llama.py` | `make_rope_init` reads `low_freq_factor`/`high_freq_factor` via the helper. |
| `phi.py` | `make_rope_init` (Phi‑3 LongRoPE short/long factors) via the helper. |
| `qwen.py` | Qwen2.5‑VL rope‑type check and Qwen3.5 `rope_theta`/`partial_rotary_factor` extraction via the helper. |
| `hunyuan.py` | Reuse the shared helper instead of an inline `getattr` fallback. |

No behavior change on older transformers (where `rope_scaling` is present); the helper resolves to the same dict.

## Testing Notes

- `python -m py_compile` and `lintrunner -a` pass clean on all five files.
- Verified with transformers 5.10.2 that the GPT‑OSS config resolves `original_context_length = 4096` (not `131072`).
- Verified the helper resolves correctly across three shapes: real config (`rope_parameters` + `rope_scaling` alias), `rope_parameters`‑only (future), and `rope_scaling`‑only (older transformers) — all yield the expected values.
