### PR TITLE
test: cover DML graph capture opt-out

### DIFF
--- a/docs/model_package.md
+++ b/docs/model_package.md
@@ -148,6 +148,35 @@ The execution provider name accepts the short form used in `genai_config.json`
 (`"cuda"`, `"dml"`, `"openvino"`, ...) or the full ONNX Runtime name
 (`"CUDAExecutionProvider"`, `"DmlExecutionProvider"`, ...).
 
+### DML graph capture
+
+DirectML decoder sessions use graph capture by default. On devices or drivers where
+captured-command-list replay produces incorrect results, it can be disabled per model
+through the DML provider options:
+
+```json
+{
+  "model": {
+    "decoder": {
+      "session_options": {
+        "provider_options": [
+          { "dml": { "enable_graph_capture": "0" } }
+        ]
+      }
+    }
+  }
+}
+```
+
+The values `"0"` and `"false"` disable graph capture; the value comparison is
+case-insensitive. Any other value preserves the default enabled behavior. When the
+decoder uses the non-shared-buffer KV-cache path, DirectML allocates its initial
+zero-length placeholders with one position; the placeholders are replaced with the
+actual sequence length before inference. Other execution providers are unaffected.
+This setting is a GenAI-side workaround for device/driver-specific DML accuracy issues;
+the corresponding ONNX Runtime investigation is tracked in
+[microsoft/onnxruntime#29739](https://github.com/microsoft/onnxruntime/issues/29739).
+
 ### C API
 
 ```c

--- a/src/config.h
+++ b/src/config.h
@@ -4,6 +4,7 @@
 // Portions of this file consist of AI generated content.
 #pragma once
 #include "provider_options.h"
+#include "filesystem.h"
 
 #include <functional>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,7 +40,7 @@ target_include_directories(unit_tests PRIVATE
 
 target_link_directories(unit_tests PRIVATE ${ORT_LIB_DIR})
 target_link_libraries(unit_tests PRIVATE
-  onnxruntime-genai
+  onnxruntime-genai-obj
   onnxruntime_extensions
   GTest::gtest
 )

--- a/test/config_tests.cpp
+++ b/test/config_tests.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "config.h"
+
+namespace {
+
+Generators::Config::SessionOptions MakeSessionOptions(
+    std::string provider,
+    std::vector<Generators::NamedString> options = {}) {
+  Generators::Config::SessionOptions session_options;
+  session_options.providers.push_back(provider);
+  session_options.provider_options.push_back(
+      Generators::Config::ProviderOptions{std::move(provider), std::move(options), std::nullopt});
+  return session_options;
+}
+
+TEST(ConfigTests, DmlGraphCaptureIsEnabledByDefault) {
+  EXPECT_TRUE(Generators::IsGraphCaptureEnabled(MakeSessionOptions("DML")));
+}
+
+TEST(ConfigTests, DmlGraphCaptureOptOutAcceptsFalseValuesCaseInsensitively) {
+  for (const auto& value : {"0", "false", "False", "FALSE"}) {
+    SCOPED_TRACE(value);
+    EXPECT_FALSE(Generators::IsGraphCaptureEnabled(
+        MakeSessionOptions("DML", {{"enable_graph_capture", value}})));
+  }
+}
+
+TEST(ConfigTests, DmlGraphCaptureRemainsEnabledForNonOptOutValues) {
+  for (const auto& value : {"1", "true", "TRUE", "on", "unexpected"}) {
+    SCOPED_TRACE(value);
+    EXPECT_TRUE(Generators::IsGraphCaptureEnabled(
+        MakeSessionOptions("DML", {{"enable_graph_capture", value}})));
+  }
+}
+
+TEST(ConfigTests, UnrelatedDmlOptionsDoNotDisableGraphCapture) {
+  EXPECT_TRUE(Generators::IsGraphCaptureEnabled(
+      MakeSessionOptions("DML", {{"device_index", "0"}})));
+}
+
+TEST(ConfigTests, ProviderSpecificGraphCaptureOptionsRemainIndependent) {
+  EXPECT_TRUE(Generators::IsGraphCaptureEnabled(
+      MakeSessionOptions("NvTensorRtRtx", {{"enable_graph_capture", "false"},
+                                           {"enable_cuda_graph", "1"}})));
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Adds regression coverage and documentation for the DML graph-capture opt-out introduced by #2300.

This follow-up does not change the runtime behavior added by #2300. It makes the configuration logic executable in the portable unit-test suite, documents the model configuration, and makes `src/config.h` self-contained.

## Changes

- Add five unit tests covering:
  - DML graph capture enabled by default;
  - `0`, `false`, `False`, and `FALSE` opt-out values;
  - non-opt-out values preserving the default;
  - unrelated DML options;
  - independence from provider-specific CUDA graph options.
- Document `enable_graph_capture` in `docs/model_package.md` with a copyable `genai_config.json` example.
- Include `filesystem.h` directly from `config.h`, removing an include-order dependency exposed by the new tests.

## Context

The runtime workaround from #2300 is already merged in upstream `main` (merge commit `30c5673f`). The underlying device/driver-specific DirectML accuracy investigation remains open in [microsoft/onnxruntime#29739](https://github.com/microsoft/onnxruntime/issues/29739). This PR is related to that issue but does not claim to fix or close it.

## Validation

- Linux CPU build with `cmake --preset linux_gcc_cpu_release`.
- `./unit_tests --gtest_filter='ConfigTests.*'`: 5 passed.
- Full `unit_tests`: 87 tests, 66 passed, 21 skipped because optional models/EPs are unavailable in the environment.
- `git diff --check` passed.
- clang-format check passed for the new test.
