### PR TITLE
Roll onnxruntime-extensions to pick up Gemma4LogMel OOB fix (#1092)

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -14,7 +14,7 @@ pybind11;https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.zip;f78029
 googletest;https://github.com/google/googletest/archive/530d5c8c84abd2a46f38583ee817743c9b3a42b4.zip;5e3a61db2aa975cfd0f97ba92c818744e7fa7034
 microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.zip;e4a542a323c070376f7c2d1973d0f7ddbc1d2fa5
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
-onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;05b2c1ac7d58fd31a05c9cb4f28bf04b9366c128
+onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;fe4e13f46b19fb490c90b09fe280277308bd5bb7
 
 # These two dependencies are for the optional constrained decoding feature (USE_GUIDANCE)
 llguidance;https://github.com/microsoft/llguidance.git;94fa39128ef184ffeda33845f6d333f332a34b4d


### PR DESCRIPTION
Bumps the pinned `onnxruntime-extensions` dependency in `cmake/deps.txt` from `05b2c1a` to `fe4e13f`.

This picks up microsoft/onnxruntime-extensions#1092 (*Fix OOB heap read in Gemma4LogMel per-bin normalization*), which adds a size-invariant check between `feature_size_` and the per-bin normalization vectors, rejecting malformed configs instead of reading out of bounds.

**Change**
- `cmake/deps.txt`: onnxruntime_extensions SHA `05b2c1ac7d58fd31a05c9cb4f28bf04b9366c128` -> `fe4e13f46b19fb490c90b09fe280277308bd5bb7` (dependency roll only, no source changes).