### PR TITLE
Fix C# native bool marshaling

### DIFF
--- a/src/csharp/NativeMethods.cs
+++ b/src/csharp/NativeMethods.cs
@@ -29,7 +29,8 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         public static extern IntPtr /* const char* */ OgaResultGetError(IntPtr /* const OgaResult* */ result);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
-        public static extern IntPtr /* OgaResult */ OgaSetLogBool(byte[] /* const char* */ name, bool value);
+        public static extern IntPtr /* OgaResult */ OgaSetLogBool(byte[] /* const char* */ name,
+                                                                  [MarshalAs(UnmanagedType.I1)] bool value);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult */ OgaSetLogString(byte[] /* const char* */ name, byte[] /* const char* */ value);
@@ -112,12 +113,12 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaGeneratorParamsSetSearchBool(IntPtr /* OgaGeneratorParams* */ generatorParams,
                                                                                      byte[] /* const char* */ searchOption,
-                                                                                     bool value);
+                                                                                     [MarshalAs(UnmanagedType.I1)] bool value);
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaGeneratorParamsSetGuidance(IntPtr /* OgaGeneratorParams* */ generatorParams,
                                                                                    byte[] /* const char* */ type,
                                                                                    byte[] /* const char* */ data,
-                                                                                   bool /* boolean */ enable_ff_tokens);
+                                                                                   [MarshalAs(UnmanagedType.I1)] bool /* boolean */ enable_ff_tokens);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaGeneratorParamsGetSearchNumber(IntPtr /* OgaGeneratorParams* */ generatorParams,
@@ -127,7 +128,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaGeneratorParamsGetSearchBool(IntPtr /* OgaGeneratorParams* */ generatorParams,
                                                                                      byte[] /* const char* */ searchOption,
-                                                                                     out bool /* const bool* */ value);
+                                                                                     [MarshalAs(UnmanagedType.I1)] out bool /* const bool* */ value);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]
         public static extern IntPtr /* OgaResult* */ OgaCreateGenerator(IntPtr /* const OgaModel* */ model,
@@ -286,7 +287,7 @@ namespace Microsoft.ML.OnnxRuntimeGenAI
                                                                                    byte[] /* const char* */ template_string,
                                                                                    byte[] /* const char* */ message,
                                                                                    byte[] /* const char* */ tool_calls,
-                                                                                   bool /* bool */ add_gen_prompt,
+                                                                                   [MarshalAs(UnmanagedType.I1)] bool /* bool */ add_gen_prompt,
                                                                                    out IntPtr /* const char** */ outStr);
 
         [DllImport(NativeLib.DllName, CallingConvention = CallingConvention.Winapi)]

--- a/test/csharp/NativeMethodsMarshallingTests.cs
+++ b/test/csharp/NativeMethodsMarshallingTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Microsoft.ML.OnnxRuntimeGenAI.Tests
+{
+    public class NativeMethodsMarshallingTests
+    {
+        [Fact]
+        public void NativeBoolParametersUseOneByteMarshalling()
+        {
+            Type nativeMethods = typeof(Utils).Assembly.GetType(
+                "Microsoft.ML.OnnxRuntimeGenAI.NativeMethods",
+                throwOnError: true)!;
+
+            Type boolType = typeof(bool);
+            Type boolByRefType = boolType.MakeByRefType();
+            ParameterInfo[] boolParameters = nativeMethods
+                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .SelectMany(method => method.GetParameters())
+                .Where(parameter =>
+                    parameter.ParameterType == boolType ||
+                    parameter.ParameterType == boolByRefType)
+                .ToArray();
+
+            Assert.NotEmpty(boolParameters);
+            foreach (ParameterInfo parameter in boolParameters)
+            {
+                MarshalAsAttribute marshalAs = parameter.GetCustomAttribute<MarshalAsAttribute>();
+                Assert.NotNull(marshalAs);
+                Assert.Equal(UnmanagedType.I1, marshalAs.Value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- marshal every existing C# P/Invoke parameter/output backed by native C/C++ `bool` as one-byte `UnmanagedType.I1`
- keep the existing `byte` representation for the native `OgaGenerator_IsDone` bool return
- add a reflection regression test that requires explicit `I1` metadata for every `bool` and `out bool` parameter in `NativeMethods`

## Why

.NET P/Invoke marshals an unannotated `System.Boolean` as the four-byte Win32 `BOOL` type. ONNX Runtime GenAI's C API uses lowercase C/C++ `bool`, which has a one-byte ABI on the supported native toolchains. Explicit `I1` annotations remove the ABI ambiguity for both input and output parameters.

## Validation

- `dotnet build src/csharp/Microsoft.ML.OnnxRuntimeGenAI.csproj --configuration Release`
- `dotnet test test/csharp/Microsoft.ML.OnnxRuntimeGenAI.Tests.csproj --configuration Release --filter FullyQualifiedName~NativeMethodsMarshallingTests`
- reflected the built assembly and confirmed all five bool parameters/outputs emit `MarshalAs=I1`
