### PR TITLE
Clean up config path validation: free function in config.cpp, tests via C API

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -7,6 +7,7 @@
 #include "runtime_settings.h"
 #include "json.h"
 #include <algorithm>
+#include <cctype>
 #include <fstream>
 #include <sstream>
 #include <limits>
@@ -1716,34 +1717,74 @@ fs::path Config::ResolvePath(std::string_view value) const {
 // Validates every config-driven filename/path field after parsing so downstream code
 // (model/processor/adapter loading) can rely on paths being safe. Centralising the checks
 // here keeps individual model families free of path-validation calls.
-static void ValidateModelPaths(const Config& config) {
-  const auto& m = config.model;
-  Config::ValidatePath(m.encoder.filename, "model.encoder.filename");
-  Config::ValidatePath(m.embedding.filename, "model.embedding.filename");
+namespace {
 
-  Config::ValidatePath(m.vision.filename, "model.vision.filename");
-  Config::ValidatePath(m.vision.config_filename, "model.vision.config_filename");
-  if (m.vision.adapter_filename.has_value()) {
-    Config::ValidatePath(*m.vision.adapter_filename, "model.vision.adapter_filename");
+// Validates that a config-specified filename/path stays inside the model directory.
+// Throws std::runtime_error if the path is absolute, contains a Windows drive/UNC root,
+// or contains a ".." path traversal component. Empty paths are allowed (no-op). The
+// optional context label is prepended to error messages so callers can identify which
+// config field caused the failure.
+void ValidateConfigPath(const std::string& path, std::string_view context = {}) {
+  if (path.empty()) return;
+
+  auto make_error = [&](const std::string& msg) -> std::string {
+    return context.empty() ? msg : (std::string{context} + ": " + msg);
+  };
+
+  // Reject absolute paths: Unix "/" or Windows drive letters "C:" / "C:\" or UNC "\\"
+  if (path[0] == '/' || path[0] == '\\') {
+    throw std::runtime_error(make_error("Config path must be a relative path under the model directory, got: " + path));
   }
-  for (const auto& stage : m.vision.pipeline) {
-    Config::ValidatePath(stage.filename, "model.vision.pipeline.filename");
+#ifdef _WIN32
+  if (path.size() >= 2 && std::isalpha(static_cast<unsigned char>(path[0])) && path[1] == ':') {
+    throw std::runtime_error(make_error("Config path must be a relative path under the model directory, got: " + path));
   }
+#endif
 
-  Config::ValidatePath(m.speech.filename, "model.speech.filename");
-  Config::ValidatePath(m.speech.config_filename, "model.speech.config_filename");
-  if (m.speech.adapter_filename.has_value()) {
-    Config::ValidatePath(*m.speech.adapter_filename, "model.speech.adapter_filename");
-  }
-
-  Config::ValidatePath(m.joiner.filename, "model.joiner.filename");
-  Config::ValidatePath(m.vad.filename, "model.vad.filename");
-
-  Config::ValidatePath(m.decoder.filename, "model.decoder.filename");
-  for (const auto& stage : m.decoder.pipeline) {
-    Config::ValidatePath(stage.filename, "model.decoder.pipeline.filename");
+  // Reject path traversal ".." components. Split on '/' and '\\' and check each component.
+  std::string component;
+  for (size_t i = 0; i <= path.size(); ++i) {
+    if (i == path.size() || path[i] == '/' || path[i] == '\\') {
+      if (component == "..") {
+        throw std::runtime_error(make_error("Config path must not contain path traversal (..): " + path));
+      }
+      component.clear();
+    } else {
+      component += path[i];
+    }
   }
 }
+
+void ValidateModelPaths(const Config& config) {
+  const auto& m = config.model;
+  ValidateConfigPath(m.encoder.filename, "model.encoder.filename");
+  ValidateConfigPath(m.embedding.filename, "model.embedding.filename");
+
+  ValidateConfigPath(m.vision.filename, "model.vision.filename");
+  ValidateConfigPath(m.vision.config_filename, "model.vision.config_filename");
+  if (m.vision.adapter_filename.has_value()) {
+    ValidateConfigPath(*m.vision.adapter_filename, "model.vision.adapter_filename");
+  }
+  for (const auto& stage : m.vision.pipeline) {
+    ValidateConfigPath(stage.filename, "model.vision.pipeline.filename");
+  }
+
+  ValidateConfigPath(m.speech.filename, "model.speech.filename");
+  ValidateConfigPath(m.speech.config_filename, "model.speech.config_filename");
+  if (m.speech.adapter_filename.has_value()) {
+    ValidateConfigPath(*m.speech.adapter_filename, "model.speech.adapter_filename");
+  }
+
+  ValidateConfigPath(m.joiner.filename, "model.joiner.filename");
+  ValidateConfigPath(m.vad.filename, "model.vad.filename");
+
+  ValidateConfigPath(m.decoder.filename, "model.decoder.filename");
+  for (const auto& stage : m.decoder.pipeline) {
+    ValidateConfigPath(stage.filename, "model.decoder.pipeline.filename");
+  }
+}
+
+}  // namespace
 
 Config::Config(const fs::path& path, std::string_view json_overlay) : config_path{path} {
   ParseConfig(path / "genai_config.json", json_overlay, *this);

--- a/src/config.h
+++ b/src/config.h
@@ -6,9 +6,7 @@
 #include "filesystem.h"
 #include "provider_options.h"
 
-#include <cctype>
 #include <functional>
-#include <stdexcept>
 
 namespace Generators {
 
@@ -103,46 +101,6 @@ struct Config {
   // from a package, delegates to package_resolver (sha256: shared assets, relative paths);
   // otherwise the value is joined with config_path.
   fs::path ResolvePath(std::string_view value) const;
-
-  // Validates that a config-specified filename/path stays inside the model directory.
-  // Throws std::runtime_error if the path is absolute, contains a Windows drive/UNC root,
-  // or contains a ".." path traversal component. Empty paths are allowed (no-op).
-  // The optional context label is prepended to error messages to identify which config
-  // field caused the failure.
-  //
-  // Defined inline so that binaries that consume this header (including tests that link
-  // the shared onnxruntime-genai library without importing internal symbols) can call it
-  // without requiring a DLL export.
-  static void ValidatePath(const std::string& path, std::string_view context = {}) {
-    if (path.empty()) return;
-
-    auto make_error = [&](const std::string& msg) -> std::string {
-      return context.empty() ? msg : (std::string{context} + ": " + msg);
-    };
-
-    // Reject absolute paths: Unix "/" or Windows drive letters "C:" / "C:\" or UNC "\\"
-    if (path[0] == '/' || path[0] == '\\') {
-      throw std::runtime_error(make_error("Config path must be a relative path under the model directory, got: " + path));
-    }
-#ifdef _WIN32
-    if (path.size() >= 2 && std::isalpha(static_cast<unsigned char>(path[0])) && path[1] == ':') {
-      throw std::runtime_error(make_error("Config path must be a relative path under the model directory, got: " + path));
-    }
-#endif
-
-    // Reject path traversal ".." components. Split on '/' and '\\' and check each component.
-    std::string component;
-    for (size_t i = 0; i <= path.size(); ++i) {
-      if (i == path.size() || path[i] == '/' || path[i] == '\\') {
-        if (component == "..") {
-          throw std::runtime_error(make_error("Config path must not contain path traversal (..): " + path));
-        }
-        component.clear();
-      } else {
-        component += path[i];
-      }
-    }
-  }
 
   using NamedString = Generators::NamedString;
   using DeviceFilteringOptions = Generators::DeviceFilteringOptions;

--- a/test/validate_config_path_test.cpp
+++ b/test/validate_config_path_test.cpp
@@ -1,48 +1,144 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "config.h"
+// End-to-end tests for config path validation. These exercise the check through the
+// public C API boundary (OgaConfig::Create) rather than reaching into an internal helper,
+// so the tests keep working regardless of where the validation logic lives inside the
+// library.
+
+#include <filesystem>
+#include <fstream>
+#include <string>
 
 #include <gtest/gtest.h>
 
+#include "ort_genai.h"
+
 namespace Generators::test {
+namespace {
+
+namespace fs_std = std::filesystem;
+
+// Creates a fresh, empty per-test directory under the build's temp area.
+fs_std::path MakeTempDir(const std::string& suffix) {
+  static int counter = 0;
+  ++counter;
+  const auto dir = fs_std::temp_directory_path() /
+                   ("ortgenai_vcp_test_" + suffix + "_" + std::to_string(counter));
+  std::error_code ec;
+  fs_std::remove_all(dir, ec);
+  fs_std::create_directories(dir);
+  return dir;
+}
+
+void WriteFile(const fs_std::path& path, const std::string& contents) {
+  fs_std::create_directories(path.parent_path());
+  std::ofstream out(path, std::ios::binary);
+  out << contents;
+}
+
+// Builds a minimal genai_config.json that sets `decoder.filename` to `path`, wraps it in a
+// fresh temp directory, and returns the directory path. `decoder.filename` is used as a
+// representative config path field — all path fields share the same validation.
+fs_std::path WriteConfigWithDecoderFilename(const std::string& suffix, const std::string& path) {
+  const auto root = MakeTempDir(suffix);
+  // JSON-escape backslashes so Windows paths like "C:\\..." survive parsing.
+  std::string escaped;
+  escaped.reserve(path.size());
+  for (char c : path) {
+    if (c == '\\' || c == '"') escaped.push_back('\\');
+    escaped.push_back(c);
+  }
+  const std::string config =
+      "{ \"model\": { \"type\": \"tiny-test-model\","
+      " \"vocab_size\": 16, \"context_length\": 32,"
+      " \"decoder\": { \"filename\": \"" +
+      escaped +
+      "\" } },"
+      " \"search\": {} }";
+  WriteFile(root / "genai_config.json", config);
+  return root;
+}
+
+// Runs `fn`, expecting it to throw, and returns the exception message. Returns an empty
+// string when nothing was thrown.
+template <typename Fn>
+std::string CaptureThrowMessage(Fn&& fn) {
+  try {
+    fn();
+  } catch (const std::exception& e) {
+    return e.what();
+  }
+  return {};
+}
+
+}  // namespace
 
 TEST(ValidateConfigPathTest, AcceptsSimpleFilename) {
-  EXPECT_NO_THROW(Config::ValidatePath("model.onnx"));
+  const auto root = WriteConfigWithDecoderFilename("simple", "model.onnx");
+  EXPECT_NO_THROW(OgaConfig::Create(root.string().c_str()));
 }
 
 TEST(ValidateConfigPathTest, AcceptsRelativeSubdirectory) {
-  EXPECT_NO_THROW(Config::ValidatePath("subdir/model.onnx"));
+  const auto root = WriteConfigWithDecoderFilename("subdir", "subdir/model.onnx");
+  EXPECT_NO_THROW(OgaConfig::Create(root.string().c_str()));
+}
+
+TEST(ValidateConfigPathTest, AcceptsSingleDot) {
+  const auto root = WriteConfigWithDecoderFilename("dot", "./model.onnx");
+  EXPECT_NO_THROW(OgaConfig::Create(root.string().c_str()));
 }
 
 TEST(ValidateConfigPathTest, RejectsAbsolutePathUnix) {
-  EXPECT_THROW(Config::ValidatePath("/etc/passwd"), std::runtime_error);
+  const auto root = WriteConfigWithDecoderFilename("abs_unix", "/etc/passwd");
+  const std::string message =
+      CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
+  EXPECT_NE(message.find("model.decoder.filename"), std::string::npos) << message;
+  EXPECT_NE(message.find("relative path"), std::string::npos) << message;
 }
 
 #if defined(_WIN32)
 TEST(ValidateConfigPathTest, RejectsAbsolutePathWindows) {
-  EXPECT_THROW(Config::ValidatePath("C:\\Windows\\System32\\evil.dll"), std::runtime_error);
+  const auto root =
+      WriteConfigWithDecoderFilename("abs_win", "C:\\Windows\\System32\\evil.dll");
+  const std::string message =
+      CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
+  EXPECT_NE(message.find("model.decoder.filename"), std::string::npos) << message;
+  EXPECT_NE(message.find("relative path"), std::string::npos) << message;
 }
 
 TEST(ValidateConfigPathTest, RejectsDriveRelativePathWindows) {
-  EXPECT_THROW(Config::ValidatePath("C:Windows\\System32\\evil.dll"), std::runtime_error);
+  const auto root =
+      WriteConfigWithDecoderFilename("drive_win", "C:Windows\\System32\\evil.dll");
+  const std::string message =
+      CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
+  EXPECT_NE(message.find("model.decoder.filename"), std::string::npos) << message;
+  EXPECT_NE(message.find("relative path"), std::string::npos) << message;
 }
 #endif
 
 TEST(ValidateConfigPathTest, RejectsParentTraversal) {
-  EXPECT_THROW(Config::ValidatePath("../../../etc/passwd"), std::runtime_error);
+  const auto root = WriteConfigWithDecoderFilename("traversal", "../../../etc/passwd");
+  const std::string message =
+      CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
+  EXPECT_NE(message.find("model.decoder.filename"), std::string::npos) << message;
+  EXPECT_NE(message.find("path traversal"), std::string::npos) << message;
 }
 
 TEST(ValidateConfigPathTest, RejectsEmbeddedParentTraversal) {
-  EXPECT_THROW(Config::ValidatePath("subdir/../../etc/passwd"), std::runtime_error);
+  const auto root = WriteConfigWithDecoderFilename("embedded", "subdir/../../etc/passwd");
+  const std::string message =
+      CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
+  EXPECT_NE(message.find("model.decoder.filename"), std::string::npos) << message;
+  EXPECT_NE(message.find("path traversal"), std::string::npos) << message;
 }
 
 TEST(ValidateConfigPathTest, RejectsSingleDotDot) {
-  EXPECT_THROW(Config::ValidatePath(".."), std::runtime_error);
-}
-
-TEST(ValidateConfigPathTest, AcceptsSingleDot) {
-  EXPECT_NO_THROW(Config::ValidatePath("./model.onnx"));
+  const auto root = WriteConfigWithDecoderFilename("dotdot", "..");
+  const std::string message =
+      CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
+  EXPECT_NE(message.find("model.decoder.filename"), std::string::npos) << message;
+  EXPECT_NE(message.find("path traversal"), std::string::npos) << message;
 }
 
 }  // namespace Generators::test


### PR DESCRIPTION
This pull request refactors the config path validation logic to improve encapsulation and maintainability, and updates the associated tests to use the public API instead of internal helpers. The most important changes are summarized below.

**Config Path Validation Refactor:**

* The path validation logic (`ValidatePath`) was moved from the `Config` struct in `config.h` to an internal, anonymous namespace in `config.cpp`, and is now named `ValidateConfigPath`. This makes the validation logic internal to the implementation, reducing the public API surface and avoiding unnecessary exports. [[1]](diffhunk://#diff-6b2f0a449fdefd8930e23ef0dcd752beec69242e1303d77653f047c5e0766385L1719-R1788) [[2]](diffhunk://#diff-c24f78b3519d763901eb9f67b864f01d802d803df1b24faaf154019cf812bf95L107-L146)
* The implementation of path validation remains unchanged, but all config-driven path fields now use the new internal function.
* Unused includes for `<cctype>` and `<stdexcept>` were removed from `config.h` since path validation is no longer defined there.

**Testing Improvements:**

* The unit tests in `validate_config_path_test.cpp` were reworked to call the public C API (`OgaConfig::Create`) instead of the internal validation helper. This ensures tests remain valid even if the internal implementation changes. The tests now generate temporary config files and directories for each case, improving test isolation and realism.
* Additional helper functions for test setup and exception message capture were introduced, and test coverage for various path validation cases (absolute paths, traversal, etc.) was preserved and improved.