### PR TITLE
Validate Marian decoder input_ids size before copy

### DIFF
--- a/src/models/marian.cpp
+++ b/src/models/marian.cpp
@@ -88,16 +88,17 @@ void MarianInputIDs::Add() {
 }
 
 void MarianInputIDs::Update(DeviceSpan<int32_t> new_tokens) {
-  // The tensor holds one token per batch entry, but the copy below is unchecked
-  // in release builds (DeviceSpan::CopyFrom only asserts). A source shorter than
-  // the tensor leaves the tail uninitialized, and that garbage is consumed as
-  // token ids by the decoder's embedding gather, which reads out of bounds.
+  // The tensor holds one token per batch*beam entry. The copy below is
+  // unchecked in release builds (DeviceSpan::CopyFrom only asserts) and always
+  // copies the destination's length, so a shorter source is read past its end
+  // and the tail fills with unrelated memory. That is then consumed as token
+  // ids by the decoder's embedding gather, which reads out of bounds.
   // Validate explicitly so the caller gets a diagnosable error instead.
   if (new_tokens.size() != static_cast<size_t>(shape_[0])) {
     throw std::runtime_error(
         "MarianInputIDs::Update: got " + std::to_string(new_tokens.size()) +
         " token(s) but the input tensor holds " + std::to_string(shape_[0]) +
-        " (one per batch entry). Marian does not support batch_size > 1.");
+        " (batch_size * num_beams). Marian does not support batch_size > 1.");
   }
 
   value_->CreateTensor(shape_, state_.params_->use_graph_capture);

--- a/src/models/marian.cpp
+++ b/src/models/marian.cpp
@@ -88,6 +88,18 @@ void MarianInputIDs::Add() {
 }
 
 void MarianInputIDs::Update(DeviceSpan<int32_t> new_tokens) {
+  // The tensor holds one token per batch entry, but the copy below is unchecked
+  // in release builds (DeviceSpan::CopyFrom only asserts). A source shorter than
+  // the tensor leaves the tail uninitialized, and that garbage is consumed as
+  // token ids by the decoder's embedding gather, which reads out of bounds.
+  // Validate explicitly so the caller gets a diagnosable error instead.
+  if (new_tokens.size() != static_cast<size_t>(shape_[0])) {
+    throw std::runtime_error(
+        "MarianInputIDs::Update: got " + std::to_string(new_tokens.size()) +
+        " token(s) but the input tensor holds " + std::to_string(shape_[0]) +
+        " (one per batch entry). Marian does not support batch_size > 1.");
+  }
+
   value_->CreateTensor(shape_, state_.params_->use_graph_capture);
   state_.inputs_[input_index_] = value_->GetOrtTensor();
 


### PR DESCRIPTION
## Summary

`MarianInputIDs::Update` copies a caller-supplied span into a tensor sized for the whole batch, but `DeviceSpan::CopyFrom` only `assert`s on a size mismatch. In release builds that assert compiles away, so a source shorter than the tensor silently leaves the tail **uninitialized**. That memory is then consumed as token ids by the decoder's embedding gather, which reads out of bounds and aborts the process.

This PR validates the size explicitly and throws, so the caller gets a diagnosable error instead of memory corruption.

## Repro

Reachable through the public C API on any `marian-ssru` model:

```c
params.SetSearchOption("batch_size", 2);
generator = OgaGenerator(model, params);
// two sequences of EQUAL length - padding is not required to trigger this
generator.AppendTokenSequences(sequences);
generator.GenerateNextToken();
```

Aborts inside ONNX Runtime:

```
gather_block_quantized.cc:205 ... indices element out of data bounds,
idx=-1414812757 must be within the inclusive range [-320,319]
```

`-1414812757` is `0xABABABAB`, the MSVC debug heap "no man's land" fill, i.e. memory that was allocated and never written.

## Root cause

`MarianState::Run` primes the decoder with a single token regardless of batch size:

```cpp
next_tokens.CpuSpan()[next_tokens.size() - 1] = model_.config_->model.bos_token_id;
decoder_input_ids_.Update(next_tokens.subspan(next_tokens.size() - 1, 1));
```

`MarianInputIDs::Update` then creates a tensor of `BatchBeamSize()` elements and copies only 1, leaving `N-1` entries unwritten.

Equal-length sequences reproduce it, so this is not a padding bug. Without setting `batch_size`, `OgaGenerator_AppendTokenSequences` rejects `N > 1` cleanly; it is specifically the configuration the API invites you to use that corrupts memory.

## Validation

Built against `v0.14.0` with the fix cherry-picked and exercised through a downstream harness with real `marian-ssru` translation models (three language packs):

- Before: process abort in `GatherBlockQuantized` (above)
- After: `MarianInputIDs::Update: got 1 token(s) but the input tensor holds 2 (one per batch entry). Marian does not support batch_size > 1.`
- Existing single-sequence translation: **30/30 tests passing**, no regression

I did not add a regression test because `test/models` has no `marian-ssru` fixture. Happy to add one if you can point me at a suitable small model.
