### PR TITLE
PagedAttention: quantized KV cache, attention_metadata, and CUDA graph capture

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -349,6 +349,8 @@ struct DecoderInputs_Element : JSON::Element {
       v_.past_sequence_lengths = JSON::Get<std::string_view>(value);
     } else if (name == "block_table") {
       v_.block_table = JSON::Get<std::string_view>(value);
+    } else if (name == "attention_metadata") {
+      v_.attention_metadata = JSON::Get<std::string_view>(value);
     } else if (name == "past_conv_names") {
       v_.past_conv_names = JSON::Get<std::string_view>(value);
     } else if (name == "targets") {

--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,7 @@ struct Config {
     static constexpr std::string_view SequenceLengthsName = "sequence_lengths";
     static constexpr std::string_view PastSequenceLengthsName = "past_sequence_lengths";
     static constexpr std::string_view BlockTableName = "block_table";
+    static constexpr std::string_view AttentionMetadataName = "attention_metadata";
 
     // Speech encoder names
     static constexpr std::string_view AudioAttentionMaskName = "audio_attention_mask";
@@ -377,6 +378,7 @@ struct Config {
         std::string cumulative_sequence_lengths{Defaults::CumulativeSequenceLengthsName};
         std::string past_sequence_lengths{Defaults::PastSequenceLengthsName};
         std::string block_table{Defaults::BlockTableName};
+        std::string attention_metadata{Defaults::AttentionMetadataName};
         std::string past_conv_names{"past_conv.%d"};  // Conv cache input name template (LFM2)
 
         // RNNT decoder inputs

--- a/src/engine/block.cpp
+++ b/src/engine/block.cpp
@@ -49,11 +49,11 @@ std::vector<size_t> Block::SlotIds() const {
 BlockPool::BlockPool(size_t block_size, size_t num_blocks)
     : block_size_(block_size), capacity_(num_blocks) {}
 
-std::vector<std::shared_ptr<Block>> BlockPool::AllocateBlocks(size_t num_slots) {
-  const auto allocate_block = [this](size_t num_slots) {
+std::vector<std::shared_ptr<Block>> BlockPool::AllocateBlocks(size_t num_slots, bool mark_slots_used) {
+  const auto allocate_block = [this](size_t slots) {
     for (size_t i = 0; i < Capacity(); ++i) {
       if (blocks_[i] == nullptr) {
-        blocks_[i] = std::make_shared<Block>(i, num_slots, block_size_);
+        blocks_[i] = std::make_shared<Block>(i, slots, block_size_);
         return blocks_[i];
       }
     }
@@ -68,13 +68,21 @@ std::vector<std::shared_ptr<Block>> BlockPool::AllocateBlocks(size_t num_slots) 
 
   std::vector<std::shared_ptr<Block>> allocated_blocks;
   for (size_t i = 0; i < num_slots; i += block_size_) {
-    auto block = allocate_block(std::min(block_size_, num_slots - i));
+    auto block = allocate_block(mark_slots_used ? std::min(block_size_, num_slots - i) : 0);
     if (!block) {
       throw std::runtime_error("Failed to allocate a block.");
     }
     allocated_blocks.push_back(block);
   }
   return allocated_blocks;
+}
+
+std::vector<std::shared_ptr<Block>> BlockPool::AllocateBlocks(size_t num_slots) {
+  return AllocateBlocks(num_slots, /*mark_slots_used=*/true);
+}
+
+std::vector<std::shared_ptr<Block>> BlockPool::ReserveBlocks(size_t num_slots) {
+  return AllocateBlocks(num_slots, /*mark_slots_used=*/false);
 }
 
 void BlockPool::Free(const std::vector<std::shared_ptr<Block>>& blocks) {
@@ -93,6 +101,10 @@ size_t BlockPool::Size() const {
 
 size_t BlockPool::Capacity() const {
   return capacity_;
+}
+
+size_t BlockPool::BlockSize() const {
+  return block_size_;
 }
 
 size_t BlockPool::BlocksNeeded(size_t num_slots) {

--- a/src/engine/block.h
+++ b/src/engine/block.h
@@ -50,13 +50,23 @@ struct BlockPool {
 
   size_t Capacity() const;
 
+  size_t BlockSize() const;
+
+  // Allocates enough blocks to hold `num_slots` and marks those slots used.
   std::vector<std::shared_ptr<Block>> AllocateBlocks(size_t num_slots);
+
+  // Allocates enough blocks to hold `num_slots` but leaves every slot empty. Use this to
+  // reserve capacity for tokens that have not been processed yet; the caller marks the slots
+  // used via Block::AddSlot() as the tokens are actually written to the cache.
+  std::vector<std::shared_ptr<Block>> ReserveBlocks(size_t num_slots);
 
   void Free(const std::vector<std::shared_ptr<Block>>& blocks);
 
   size_t BlocksNeeded(size_t num_slots);
 
  private:
+  std::vector<std::shared_ptr<Block>> AllocateBlocks(size_t num_slots, bool mark_slots_used);
+
   const size_t block_size_;
   const size_t capacity_;
   std::vector<std::shared_ptr<Block>> blocks_{capacity_};

--- a/src/engine/cache_manager.h
+++ b/src/engine/cache_manager.h
@@ -38,6 +38,11 @@ struct CacheManager {
 
   virtual std::vector<std::shared_ptr<Request>> AllocatedRequests() const = 0;
 
+  // Columns in the block table the model will see this step, or 0 when the cache does not use one.
+  // The decode path multiplies it by the block size to get the KV length bound it reports through
+  // `attention_metadata`.
+  virtual size_t BlockTableColumns() const { return 0; }
+
   virtual ~CacheManager() = default;
 
  protected:
@@ -80,6 +85,8 @@ struct PagedCacheManager : CacheManager {
   bool SupportsDynamicBatching() const override;
 
   std::vector<std::shared_ptr<Request>> AllocatedRequests() const override;
+
+  size_t BlockTableColumns() const override { return key_value_cache_->BlockTableColumns(); }
 
  private:
   std::shared_ptr<GeneratorParams> params_;

--- a/src/engine/decoders/simple_decoder.cpp
+++ b/src/engine/decoders/simple_decoder.cpp
@@ -9,16 +9,57 @@ namespace Generators {
 
 SimpleDecoder::SimpleDecoder(std::shared_ptr<DecoderOnly_Model> model,
                              std::shared_ptr<CacheManager> cache_manager)
-    : model_{model}, cache_manager_{cache_manager} {}
+    : model_{model}, cache_manager_{cache_manager} {
+  if (IsGraphCaptureEnabled(model_->config_->model.decoder.session_options) &&
+      cache_manager_->SupportsDynamicBatching()) {
+    graph_buffers_ = std::make_unique<VarlenGraphBuffers>(*model_);
+  }
+}
+
+namespace {
+
+// A step can be captured only if it looks like every other step the graph will serve: one new token
+// per sequence. Prefill and chunked-prefill steps carry a variable number of tokens and are shaped
+// differently from run to run, so they always execute eagerly.
+bool IsPureDecodeStep(ScheduledRequests& scheduled_requests) {
+  if (scheduled_requests.size() == 0) {
+    return false;
+  }
+  for (auto& request : scheduled_requests) {
+    if (request->IsPrefill() || request->UnprocessedTokens().size() != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
 
 void SimpleDecoder::Decode(ScheduledRequests& scheduled_requests) {
   cache_manager_->Step();
+
+  const bool capture = graph_buffers_ != nullptr &&
+                       graph_buffers_->Fits(scheduled_requests.size()) &&
+                       IsPureDecodeStep(scheduled_requests);
+
   std::unique_ptr<DecoderIO> decoder_state =
       cache_manager_->SupportsDynamicBatching()
-          ? static_cast<std::unique_ptr<DecoderIO>>(std::make_unique<VarlenDecoderIO>(model_, scheduled_requests, cache_manager_))
+          ? static_cast<std::unique_ptr<DecoderIO>>(std::make_unique<VarlenDecoderIO>(
+                model_, scheduled_requests, cache_manager_, capture ? graph_buffers_.get() : nullptr))
           : static_cast<std::unique_ptr<DecoderIO>>(std::make_unique<StaticBatchDecoderIO>(model_, scheduled_requests, cache_manager_));
 
   auto run_options = scheduled_requests.RunOptions();
+  if (graph_buffers_ != nullptr) {
+    // -1 tells the CUDA EP to run eagerly. Otherwise every distinct decode shape gets its own
+    // annotation id: the EP runs that id once eagerly, captures it on the next occurrence, and
+    // replays from then on.
+    const std::string graph_id =
+        capture ? std::to_string(VarlenGraphBuffers::GraphId(scheduled_requests.size(),
+                                                             cache_manager_->BlockTableColumns()))
+                : std::string("-1");
+    run_options->AddConfigEntry("gpu_graph_id", graph_id.c_str());
+  }
+
   decoder_state->DumpInputs();
   model_->session_decoder_->Run(run_options.get(),
                                 decoder_state->input_names_.data(),

--- a/src/engine/decoders/simple_decoder.h
+++ b/src/engine/decoders/simple_decoder.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "decoder.h"
+#include "varlen_decoder_io.h"
 #include "../../models/decoder_only.h"
 
 namespace Generators {
@@ -16,6 +17,9 @@ struct SimpleDecoder : public Decoder {
  private:
   std::shared_ptr<DecoderOnly_Model> model_;
   std::shared_ptr<CacheManager> cache_manager_;
+  // Allocated only when the model asked for CUDA graphs. Owning it here, rather than in the per-step
+  // decoder IO, is what gives the captured graph stable buffer addresses to replay against.
+  std::unique_ptr<VarlenGraphBuffers> graph_buffers_;
 };
 
 }  // namespace Generators

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -6,11 +6,46 @@
 
 namespace Generators {
 
+VarlenGraphBuffers::VarlenGraphBuffers(DecoderOnly_Model& model) {
+  max_batch_size = model.config_->engine.dynamic_batching->max_batch_size;
+
+  auto make = [&](DeviceInterface* device, ONNXTensorElementDataType type, int64_t elements) {
+    auto tensor = std::make_unique<Tensor>(device, type);
+    tensor->CreateTensor(std::vector<int64_t>{elements}, /*make_static=*/true);
+    return tensor;
+  };
+
+  // One token per sequence on a decode step, so the token count equals the batch size.
+  input_ids = make(model.p_device_inputs_, Ort::TypeToTensorType<int64_t>, static_cast<int64_t>(max_batch_size));
+  cumulative_sequence_lengths =
+      make(model.p_device_inputs_, Ort::TypeToTensorType<int32_t>, static_cast<int64_t>(max_batch_size + 1));
+  past_sequence_lengths =
+      make(model.p_device_inputs_, Ort::TypeToTensorType<int32_t>, static_cast<int64_t>(max_batch_size));
+
+  logits = std::make_unique<Tensor>(model.p_device_inputs_,
+                                    model.session_info_.GetOutputDataType(model.config_->model.decoder.outputs.logits));
+  logits->CreateTensor(std::vector<int64_t>{static_cast<int64_t>(max_batch_size),
+                                            static_cast<int64_t>(model.config_->model.vocab_size)},
+                       /*make_static=*/true);
+}
+
+int VarlenGraphBuffers::GraphId(size_t batch_size, size_t block_table_columns) {
+  // Block table columns are bucketed to powers of two by the cache, so the exponent is enough to
+  // separate them. Ids must be positive: ORT reserves -1 for "do not capture or replay".
+  int columns_bucket = 0;
+  while ((size_t{1} << columns_bucket) < block_table_columns) {
+    ++columns_bucket;
+  }
+  return static_cast<int>(batch_size) * 64 + columns_bucket + 1;
+}
+
 VarlenDecoderIO::VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
                                  ScheduledRequests& scheduled_requests,
-                                 std::shared_ptr<CacheManager> cache_manager)
-    : DecoderIO(model, scheduled_requests, cache_manager) {
+                                 std::shared_ptr<CacheManager> cache_manager,
+                                 VarlenGraphBuffers* graph_buffers)
+    : DecoderIO(model, scheduled_requests, cache_manager), graph_buffers_{graph_buffers} {
   PrepareInputIds(model, scheduled_requests);
+  PrepareAttentionMetadata(model, scheduled_requests);
   PrepareLogits(model, scheduled_requests);
 
   auto cache = cache_manager->Cache();
@@ -30,22 +65,37 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
                                       [](size_t sum, const std::shared_ptr<Request>& request) -> size_t {
                                         return sum + request->UnprocessedTokens().size();
                                       });
-  const std::vector<int64_t> input_ids_shape = {static_cast<int64_t>(num_tokens)};
-  auto input_ids_tensor = std::make_unique<Tensor>(model->p_device_inputs_, Ort::TypeToTensorType<int64_t>);
-  input_ids_tensor->CreateTensor(input_ids_shape);
+  // On a capturable step the tensors are views onto buffers that were allocated once, so their
+  // device addresses match the ones recorded in the graph. Otherwise each step allocates its own.
+  auto reshape = [&](std::unique_ptr<Tensor>& owned, Tensor* borrowed, ONNXTensorElementDataType type,
+                     std::vector<int64_t> shape) -> Tensor* {
+    if (borrowed != nullptr) {
+      borrowed->CreateTensor(shape, /*make_static=*/true);
+      return borrowed;
+    }
+    owned = std::make_unique<Tensor>(model->p_device_inputs_, type);
+    owned->CreateTensor(shape);
+    return owned.get();
+  };
+
+  std::unique_ptr<Tensor> owned_input_ids, owned_cumulative, owned_sequence_lengths;
+  Tensor* input_ids_tensor =
+      reshape(owned_input_ids, graph_buffers_ ? graph_buffers_->input_ids.get() : nullptr,
+              Ort::TypeToTensorType<int64_t>, {static_cast<int64_t>(num_tokens)});
+  Tensor* cumulative_sequence_lengths_tensor =
+      reshape(owned_cumulative, graph_buffers_ ? graph_buffers_->cumulative_sequence_lengths.get() : nullptr,
+              Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(scheduled_requests.size() + 1)});
+  Tensor* sequence_lengths_tensor =
+      reshape(owned_sequence_lengths, graph_buffers_ ? graph_buffers_->past_sequence_lengths.get() : nullptr,
+              Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(scheduled_requests.size())});
+
   auto device_span = input_ids_tensor->GetDeviceSpan<int64_t>();
   auto cpu_span = device_span.CpuSpan();
 
-  const std::vector<int64_t> cumulative_sequence_lengths_shape = {static_cast<int64_t>(scheduled_requests.size() + 1)};
-  auto cumulative_sequence_lengths_tensor = std::make_unique<Tensor>(model->p_device_inputs_, Ort::TypeToTensorType<int32_t>);
-  cumulative_sequence_lengths_tensor->CreateTensor(cumulative_sequence_lengths_shape);
   auto cumulative_sequence_lengths_span = cumulative_sequence_lengths_tensor->GetDeviceSpan<int32_t>();
   auto cumulative_sequence_lengths_cpu_span = cumulative_sequence_lengths_span.CpuSpan();
   cumulative_sequence_lengths_cpu_span[0] = 0;
 
-  const std::vector<int64_t> sequence_lengths_shape = {static_cast<int64_t>(scheduled_requests.size())};
-  auto sequence_lengths_tensor = std::make_unique<Tensor>(model->p_device_inputs_, Ort::TypeToTensorType<int32_t>);
-  sequence_lengths_tensor->CreateTensor(sequence_lengths_shape);
   auto sequence_lengths_span = sequence_lengths_tensor->GetDeviceSpan<int32_t>();
   auto sequence_lengths_cpu_span = sequence_lengths_span.CpuSpan();
 
@@ -73,15 +123,66 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
 
   input_names_.push_back(model->config_->model.decoder.inputs.input_ids.c_str());
   inputs_.push_back(input_ids_tensor->GetOrtTensor());
-  owned_inputs_.push_back(std::move(input_ids_tensor));
 
   input_names_.push_back(model->config_->model.decoder.inputs.cumulative_sequence_lengths.c_str());
   inputs_.push_back(cumulative_sequence_lengths_tensor->GetOrtTensor());
-  owned_inputs_.push_back(std::move(cumulative_sequence_lengths_tensor));
 
   input_names_.push_back(model->config_->model.decoder.inputs.past_sequence_lengths.c_str());
   inputs_.push_back(sequence_lengths_tensor->GetOrtTensor());
-  owned_inputs_.push_back(std::move(sequence_lengths_tensor));
+
+  if (owned_input_ids) owned_inputs_.push_back(std::move(owned_input_ids));
+  if (owned_cumulative) owned_inputs_.push_back(std::move(owned_cumulative));
+  if (owned_sequence_lengths) owned_inputs_.push_back(std::move(owned_sequence_lengths));
+}
+
+// PagedAttention accepts an optional `attention_metadata` CPU input holding
+// [max_query_len_bound, max_kv_len_bound]. Both are upper bounds on the current step; the operator
+// uses them only to select a backend and to size its launch dimensions and workspaces, never as a
+// mask boundary. Supplying them lets the operator skip the device-to-host readback of the sequence
+// lengths, which otherwise forces a full stream synchronization inside every attention node.
+//
+// The engine already has both quantities on the host while it builds the sequence length inputs, so
+// this costs nothing. The bounds are exact rather than conservative, which is the tightest valid
+// choice: a larger bound is still correct but sizes the launch for more work than the step needs.
+void VarlenDecoderIO::PrepareAttentionMetadata(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests) {
+  const std::string& metadata_name = model->config_->model.decoder.inputs.attention_metadata;
+  if (!model->session_info_.HasInput(metadata_name)) {
+    // Model was built before `attention_metadata` existed. The operator falls back to the readback.
+    return;
+  }
+
+  int32_t max_query_len = 0;
+  int32_t max_kv_len = 0;
+  if (graph_buffers_ != nullptr) {
+    // A CPU input is read once, while the graph is being captured, and the recorded launch is reused
+    // for every later replay. Reporting the current step's exact lengths would freeze them, so a
+    // capturable step reports bounds that hold for the whole life of the graph instead: one token per
+    // sequence, and the KV length the block table can address at its current column count.
+    max_query_len = 1;
+    max_kv_len = static_cast<int32_t>(cache_manager_->BlockTableColumns() *
+                                      model->config_->engine.dynamic_batching->block_size);
+  } else {
+    for (auto& request : scheduled_requests) {
+      const int32_t query_len = static_cast<int32_t>(request->UnprocessedTokens().size());
+      // CurrentSequenceLength() already counts the unprocessed tokens for a prefill request, and
+      // excludes them for a generation request, mirroring how past_sequence_lengths is filled above.
+      const int32_t kv_len = request->IsPrefill()
+                                 ? static_cast<int32_t>(request->CurrentSequenceLength())
+                                 : static_cast<int32_t>(request->CurrentSequenceLength()) + query_len;
+      max_query_len = std::max(max_query_len, query_len);
+      max_kv_len = std::max(max_kv_len, kv_len);
+    }
+  }
+
+  auto metadata_tensor = std::make_unique<Tensor>(GetDeviceInterface(DeviceType::CPU), Ort::TypeToTensorType<int32_t>);
+  metadata_tensor->CreateTensor(std::vector<int64_t>{2});
+  auto metadata_span = metadata_tensor->GetDeviceSpan<int32_t>().CpuSpan();
+  metadata_span[0] = max_query_len;
+  metadata_span[1] = max_kv_len;
+
+  input_names_.push_back(metadata_name.c_str());
+  inputs_.push_back(metadata_tensor->GetOrtTensor());
+  owned_inputs_.push_back(std::move(metadata_tensor));
 }
 
 void VarlenDecoderIO::PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests) {
@@ -90,11 +191,17 @@ void VarlenDecoderIO::PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, Sc
                                         return sum + request->UnprocessedTokens().size();
                                       });
   const std::vector<int64_t> logits_shape = {static_cast<int64_t>(num_tokens), static_cast<int64_t>(model->config_->model.vocab_size)};
-  logits_ = std::make_unique<Tensor>(model->p_device_inputs_, model->session_info_.GetOutputDataType(model->config_->model.decoder.outputs.logits));
-  logits_->CreateTensor(logits_shape);
+  if (graph_buffers_ != nullptr) {
+    graph_buffers_->logits->CreateTensor(logits_shape, /*make_static=*/true);
+    active_logits_ = graph_buffers_->logits.get();
+  } else {
+    logits_ = std::make_unique<Tensor>(model->p_device_inputs_, model->session_info_.GetOutputDataType(model->config_->model.decoder.outputs.logits));
+    logits_->CreateTensor(logits_shape);
+    active_logits_ = logits_.get();
+  }
 
   output_names_.push_back(model->config_->model.decoder.outputs.logits.c_str());
-  outputs_.push_back(logits_->GetOrtTensor());
+  outputs_.push_back(active_logits_->GetOrtTensor());
 }
 
 std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {
@@ -105,11 +212,11 @@ std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {
   }
 
   // [num_tokens, vocab_size]
-  const auto all_tokens_logits_shape = logits_->GetShape();
+  const auto all_tokens_logits_shape = active_logits_->GetShape();
   const int64_t vocab_size = all_tokens_logits_shape[1];
-  const int64_t element_size = static_cast<int64_t>(Ort::SizeOf(logits_->GetType()));
+  const int64_t element_size = static_cast<int64_t>(Ort::SizeOf(active_logits_->GetType()));
 
-  auto logits_bytes = logits_->GetByteSpan();
+  auto logits_bytes = active_logits_->GetByteSpan();
   std::vector<decltype(logits_bytes)> logits_bytes_vector;
   for (size_t i = 0; i < valid_token_indices.size(); ++i) {
     auto logits_of_last_token = logits_bytes.subspan(valid_token_indices[i] * vocab_size * element_size, vocab_size * element_size);
@@ -120,7 +227,7 @@ std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {
   const std::vector<int64_t> logits_shape{static_cast<int64_t>(scheduled_requests_.size()),
                                           vocab_size};
 
-  const bool requires_cast = logits_->GetType() != Ort::TypeToTensorType<float>;
+  const bool requires_cast = active_logits_->GetType() != Ort::TypeToTensorType<float>;
   if (requires_cast) {
     logits_fp32_ = std::make_unique<Tensor>(model_.p_device_inputs_, Ort::TypeToTensorType<float>);
     logits_fp32_->CreateTensor(logits_shape);
@@ -131,7 +238,7 @@ std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {
       auto logits_of_last_token_fp32 = logits_fp32_->GetDeviceSpan<float>().subspan(i * vocab_size, vocab_size);
       void* src_data = logits_bytes_vector[i].Span().data();
       void* dst_data = logits_of_last_token_fp32.Span().data();
-      model_.p_device_inputs_->Cast(src_data, dst_data, logits_->GetType(), Ort::TypeToTensorType<float>, vocab_size);
+      model_.p_device_inputs_->Cast(src_data, dst_data, active_logits_->GetType(), Ort::TypeToTensorType<float>, vocab_size);
       logits_vector.push_back(logits_of_last_token_fp32);
     } else {
       auto logits_of_last_token_fp32 = model_.p_device_inputs_->WrapMemory<float>(

--- a/src/engine/decoders/varlen_decoder_io.h
+++ b/src/engine/decoders/varlen_decoder_io.h
@@ -9,6 +9,35 @@
 namespace Generators {
 
 /**
+ * @struct VarlenGraphBuffers
+ * @brief Fixed-address input and output buffers for capturable decode steps.
+ *
+ * CUDA graph replay re-issues the launches recorded at capture time together with the device
+ * pointers they were given, and it never re-runs the operators' host-side code. Every buffer the
+ * captured step reads or writes must therefore stay at the same address for the life of the graph,
+ * which the per-step tensors of an ordinary decode step do not. This holder outlives the per-step
+ * VarlenDecoderIO and hands it the same allocations every time.
+ *
+ * The buffers are sized once for the largest batch the engine will schedule; a given step views a
+ * smaller prefix of them. Steps that differ in shape are captured under different annotation ids.
+ */
+struct VarlenGraphBuffers {
+  VarlenGraphBuffers(DecoderOnly_Model& model);
+
+  // Annotation id for a decode step of this shape. Distinct (batch, block table columns) pairs need
+  // distinct graphs because the captured launches bake in grid dimensions derived from both.
+  static int GraphId(size_t batch_size, size_t block_table_columns);
+
+  bool Fits(size_t batch_size) const { return batch_size <= max_batch_size; }
+
+  std::unique_ptr<Tensor> input_ids;
+  std::unique_ptr<Tensor> cumulative_sequence_lengths;
+  std::unique_ptr<Tensor> past_sequence_lengths;
+  std::unique_ptr<Tensor> logits;
+  size_t max_batch_size{};
+};
+
+/**
  * @class VarlenDecoderIO
  * @brief Prepares and manages the inputs and outputs for a variable-length decoder model.
  *
@@ -18,6 +47,7 @@ namespace Generators {
  * - Input IDs - int64[total_num_tokens]
  * - Cumulative Sequence Lengths - int32[batch_size + 1]
  * - Past Sequence Lengths - int32[batch_size]
+ * - Attention Metadata - int32[2] (CPU), optional
  * Outputs:
  * - Logits - float16/float32[total_num_tokens, vocab_size]
  *
@@ -27,16 +57,22 @@ namespace Generators {
 struct VarlenDecoderIO : DecoderIO {
   VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
                   ScheduledRequests& scheduled_requests,
-                  std::shared_ptr<CacheManager> cache_manager);
+                  std::shared_ptr<CacheManager> cache_manager,
+                  VarlenGraphBuffers* graph_buffers = nullptr);
 
   std::vector<DeviceSpan<float>> ProcessLogits() override;
 
  private:
   void PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
+  void PrepareAttentionMetadata(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
 
+  // Non-null when this step is being captured or replayed, in which case the tensors below are
+  // borrowed from the holder instead of being allocated fresh.
+  VarlenGraphBuffers* graph_buffers_{};
   std::vector<std::unique_ptr<Tensor>> owned_inputs_;
   std::unique_ptr<Tensor> logits_;
+  Tensor* active_logits_{};
   std::unique_ptr<Tensor> logits_fp32_;
 };
 

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -47,6 +47,29 @@ size_t EmptySlots(const std::vector<std::shared_ptr<Block>>& blocks) {
                          });
 }
 
+size_t UsedSlots(const std::vector<std::shared_ptr<Block>>& blocks) {
+  return std::accumulate(blocks.begin(), blocks.end(), size_t{0},
+                         [](size_t sum, const std::shared_ptr<Block>& block) {
+                           return sum + block->Size();
+                         });
+}
+
+// Number of KV slots the model will have addressed once the pending step has run, i.e. one per
+// token whose key and value live in the cache afterwards.
+//
+// This has to match how VarlenDecoderIO fills `past_sequence_lengths`: the decoder writes the
+// unprocessed tokens at absolute positions [past, past + unprocessed), so the cache must own
+// `past + unprocessed` slots. CurrentSequenceLength() already counts the unprocessed tokens for
+// a prefill request and excludes them for a generation request, hence the branch.
+//
+// Counting appended tokens instead leaves the cache exactly one slot short on every decode step.
+// That stays invisible while the last block still has room, and turns into an out-of-bounds
+// block-table entry the moment a sequence length lands on a block boundary.
+size_t RequiredSlots(const std::shared_ptr<Request>& request) {
+  const size_t sequence_length = request->CurrentSequenceLength();
+  return request->IsPrefill() ? sequence_length : sequence_length + request->UnprocessedTokens().size();
+}
+
 }  // namespace
 
 PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
@@ -89,7 +112,7 @@ PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
 }
 
 bool PagedKeyValueCache::CanAdd(std::shared_ptr<Request> request) const {
-  return block_pool_->AvailableBlocks() >= block_pool_->BlocksNeeded(request->UnprocessedTokens().size());
+  return block_pool_->AvailableBlocks() >= block_pool_->BlocksNeeded(RequiredSlots(request));
 }
 
 void PagedKeyValueCache::Add(std::shared_ptr<Request> request) {
@@ -97,11 +120,11 @@ void PagedKeyValueCache::Add(std::shared_ptr<Request> request) {
     throw std::runtime_error("Not enough free blocks available to serve the request.");
   }
 
-  // Reserve the blocks the unprocessed tokens will need, but leave their slots empty. The slots
-  // are marked used in AppendTokens() once the tokens are actually written to the cache. Marking
-  // them here too would count the same tokens twice and force the pool to be sized at roughly
-  // twice the capacity it can actually use.
-  auto reserved_blocks = block_pool_->ReserveBlocks(request->UnprocessedTokens().size());
+  // Reserve the blocks the prompt will need, but leave their slots empty. The slots are marked
+  // used in AppendTokens() once the tokens are actually written to the cache. Marking them here
+  // too would count the prompt twice and force the pool to be sized at roughly twice the
+  // capacity it can actually use.
+  auto reserved_blocks = block_pool_->ReserveBlocks(RequiredSlots(request));
   block_tables_.emplace_back(BlockTable{request, std::move(reserved_blocks)});
 }
 
@@ -114,11 +137,16 @@ bool PagedKeyValueCache::CanAppendTokens(std::shared_ptr<Request> request) const
     throw std::runtime_error("Given request is not found in the cache.");
   }
 
-  const size_t num_required_slots = request->UnprocessedTokens().size();
+  const size_t required_slots = RequiredSlots(request);
+  const size_t used_slots = UsedSlots(block_table_it->blocks);
+  if (required_slots <= used_slots) {
+    return true;
+  }
+
   const size_t num_slots_available = EmptySlots(block_table_it->blocks) +
                                      block_pool_->AvailableBlocks() * block_pool_->BlockSize();
 
-  return num_slots_available >= num_required_slots;
+  return num_slots_available >= required_slots - used_slots;
 }
 
 void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
@@ -132,7 +160,12 @@ void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
                                            });
   assert(block_table_it != block_tables_.end());
 
-  size_t num_slots = request->UnprocessedTokens().size();
+  const size_t required_slots = RequiredSlots(request);
+  const size_t used_slots = UsedSlots(block_table_it->blocks);
+  if (required_slots <= used_slots) {
+    return;
+  }
+  size_t num_slots = required_slots - used_slots;
 
   // Consume the slots already reserved for this request before asking the pool for more.
   for (auto& block : block_table_it->blocks) {

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -58,6 +58,24 @@ PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
     });
   }
   block_pool_ = std::make_unique<BlockPool>(model->config_->engine.dynamic_batching->block_size, num_blocks);
+
+  graph_capture_ = IsGraphCaptureEnabled(model->config_->model.decoder.session_options);
+  if (graph_capture_) {
+    const size_t block_size = model->config_->engine.dynamic_batching->block_size;
+    max_block_table_rows_ = model->config_->engine.dynamic_batching->max_batch_size;
+    // A sequence can never need more blocks than the model's context window, and it can never use
+    // more than the pool holds. The buffer is allocated once at that ceiling; individual steps view
+    // a smaller [rows, columns] window of it.
+    max_block_table_columns_ = std::min<size_t>(
+        (static_cast<size_t>(model->config_->model.context_length) + block_size - 1) / block_size,
+        num_blocks);
+    max_block_table_columns_ = std::max<size_t>(max_block_table_columns_, 1);
+    block_tables_tensor_ = std::make_unique<Tensor>(model->p_device_inputs_, Ort::TypeToTensorType<int32_t>);
+    block_tables_tensor_->CreateTensor(
+        std::vector<int64_t>{static_cast<int64_t>(max_block_table_rows_),
+                             static_cast<int64_t>(max_block_table_columns_)},
+        /*make_static=*/true);
+  }
 }
 
 bool PagedKeyValueCache::CanAdd(std::shared_ptr<Request> request) const {
@@ -158,8 +176,32 @@ std::pair<OrtValue*, const char*> PagedKeyValueCache::BlockTables(const std::vec
   }
 
   std::vector<int64_t> shape = {static_cast<int64_t>(requests.size()), static_cast<int64_t>(max_blocks)};
-  block_tables_value_ = OrtValue::CreateTensor(model_->allocator_cpu_, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32);
-  auto* block_table_data = block_tables_value_->GetTensorMutableData<int32_t>();
+  int32_t* block_table_data = nullptr;
+  DeviceSpan<int32_t> device_span;
+  if (graph_capture_) {
+    // Round the column count up to a power of two so that a run producing steadily longer sequences
+    // settles on a handful of distinct shapes instead of a new one every time a block is appended.
+    // Each distinct shape is captured under its own annotation id.
+    size_t columns = 8;
+    while (columns < max_blocks) {
+      columns *= 2;
+    }
+    block_table_columns_ = std::min(columns, max_block_table_columns_);
+    if (max_blocks > block_table_columns_ || requests.size() > max_block_table_rows_) {
+      throw std::runtime_error("Block table exceeds the capacity reserved for graph capture.");
+    }
+    max_blocks = block_table_columns_;
+    shape[1] = static_cast<int64_t>(max_blocks);
+    // Re-creating the view keeps the same underlying buffer, so the address baked into a captured
+    // graph stays valid while the shape tracks the current bucket.
+    block_tables_tensor_->CreateTensor(shape, /*make_static=*/true);
+    device_span = block_tables_tensor_->GetDeviceSpan<int32_t>();
+    block_table_data = device_span.CpuSpan().data();
+  } else {
+    block_table_columns_ = max_blocks;
+    block_tables_value_ = OrtValue::CreateTensor(model_->allocator_cpu_, shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32);
+    block_table_data = block_tables_value_->GetTensorMutableData<int32_t>();
+  }
 
   constexpr int32_t block_tables_pad_value = -1;
 
@@ -175,6 +217,11 @@ std::pair<OrtValue*, const char*> PagedKeyValueCache::BlockTables(const std::vec
     for (size_t j = block_table.blocks.size(); j < max_blocks; ++j) {
       block_table_data[index * max_blocks + j] = block_tables_pad_value;
     }
+  }
+
+  if (graph_capture_) {
+    device_span.CopyCpuToDevice();
+    return {block_tables_tensor_->GetOrtTensor(), model_->config_->model.decoder.inputs.block_table.c_str()};
   }
 
   return {block_tables_value_.get(), model_->config_->model.decoder.inputs.block_table.c_str()};

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -3,6 +3,8 @@
 
 #include "cache_manager.h"
 
+#include <numeric>
+
 namespace Generators {
 
 namespace {
@@ -35,6 +37,14 @@ size_t ComputeNumBlocks(std::shared_ptr<Model> model) {
           model->config_->model.decoder.num_hidden_layers *
           dtype_size *
           num_caches_per_layer);
+}
+
+// Slots reserved for a request but not yet written to.
+size_t EmptySlots(const std::vector<std::shared_ptr<Block>>& blocks) {
+  return std::accumulate(blocks.begin(), blocks.end(), size_t{0},
+                         [](size_t sum, const std::shared_ptr<Block>& block) {
+                           return sum + block->EmptySlots();
+                         });
 }
 
 }  // namespace
@@ -79,7 +89,7 @@ PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
 }
 
 bool PagedKeyValueCache::CanAdd(std::shared_ptr<Request> request) const {
-  return block_pool_->AvailableBlocks() > block_pool_->BlocksNeeded(request->UnprocessedTokens().size());
+  return block_pool_->AvailableBlocks() >= block_pool_->BlocksNeeded(request->UnprocessedTokens().size());
 }
 
 void PagedKeyValueCache::Add(std::shared_ptr<Request> request) {
@@ -87,8 +97,12 @@ void PagedKeyValueCache::Add(std::shared_ptr<Request> request) {
     throw std::runtime_error("Not enough free blocks available to serve the request.");
   }
 
-  auto allocated_blocks = block_pool_->AllocateBlocks(request->UnprocessedTokens().size());
-  block_tables_.emplace_back(BlockTable{request, std::move(allocated_blocks)});
+  // Reserve the blocks the unprocessed tokens will need, but leave their slots empty. The slots
+  // are marked used in AppendTokens() once the tokens are actually written to the cache. Marking
+  // them here too would count the same tokens twice and force the pool to be sized at roughly
+  // twice the capacity it can actually use.
+  auto reserved_blocks = block_pool_->ReserveBlocks(request->UnprocessedTokens().size());
+  block_tables_.emplace_back(BlockTable{request, std::move(reserved_blocks)});
 }
 
 bool PagedKeyValueCache::CanAppendTokens(std::shared_ptr<Request> request) const {
@@ -101,8 +115,8 @@ bool PagedKeyValueCache::CanAppendTokens(std::shared_ptr<Request> request) const
   }
 
   const size_t num_required_slots = request->UnprocessedTokens().size();
-  const size_t num_slots_available = block_table_it->blocks.back()->EmptySlots() +
-                                     block_pool_->AvailableBlocks() * block_table_it->blocks.back()->Capacity();
+  const size_t num_slots_available = EmptySlots(block_table_it->blocks) +
+                                     block_pool_->AvailableBlocks() * block_pool_->BlockSize();
 
   return num_slots_available >= num_required_slots;
 }
@@ -119,16 +133,23 @@ void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
   assert(block_table_it != block_tables_.end());
 
   size_t num_slots = request->UnprocessedTokens().size();
-  if (!block_table_it->blocks.back()->IsFull()) {
-    for (size_t i = 0; i < std::min(num_slots, block_table_it->blocks.back()->EmptySlots()); ++i) {
-      block_table_it->blocks.back()->AddSlot();
+
+  // Consume the slots already reserved for this request before asking the pool for more.
+  for (auto& block : block_table_it->blocks) {
+    while (num_slots > 0 && !block->IsFull()) {
+      block->AddSlot();
       --num_slots;
+    }
+    if (num_slots == 0) {
+      break;
     }
   }
 
-  auto allocated_blocks = block_pool_->AllocateBlocks(num_slots);
-  std::move(allocated_blocks.begin(), allocated_blocks.end(),
-            std::back_inserter(block_table_it->blocks));
+  if (num_slots > 0) {
+    auto allocated_blocks = block_pool_->AllocateBlocks(num_slots);
+    std::move(allocated_blocks.begin(), allocated_blocks.end(),
+              std::back_inserter(block_table_it->blocks));
+  }
 }
 
 void PagedKeyValueCache::Remove(std::shared_ptr<Request> request) {

--- a/src/engine/paged_key_value_cache.h
+++ b/src/engine/paged_key_value_cache.h
@@ -63,6 +63,12 @@ struct PagedKeyValueCache {
   // The order of the block tables is based on the order the provided requests.
   std::pair<OrtValue*, const char*> BlockTables(const std::vector<std::shared_ptr<Request>>& requests);
 
+  // Number of columns in the block table handed to the model on the most recent BlockTables() call.
+  // With graph capture this is a bucketed capacity rather than the exact longest table, so the shape
+  // is stable across steps; it also bounds the KV length any sequence in the batch can reach, which
+  // is what `attention_metadata` has to report for a captured step.
+  size_t BlockTableColumns() const { return block_table_columns_; }
+
   void UpdateState(State& state, const std::vector<std::shared_ptr<Request>>& requests);
 
  private:
@@ -108,6 +114,14 @@ struct PagedKeyValueCache {
   std::unique_ptr<BlockPool> block_pool_;         // Allocator for blocks
   std::vector<BlockTable> block_tables_;          // Block table for all requests in the cache
   std::unique_ptr<OrtValue> block_tables_value_;  // Block tables for all requests in the cache
+
+  // Graph capture needs the block table at a device address that never moves and at a shape that
+  // repeats across steps, so it gets a dedicated persistent tensor instead of the per-step CPU one.
+  bool graph_capture_{};
+  size_t block_table_columns_{};
+  size_t max_block_table_columns_{};
+  size_t max_block_table_rows_{};
+  std::unique_ptr<Tensor> block_tables_tensor_;
 };
 
 }  // namespace Generators

--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -597,6 +597,25 @@ python -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o pa
 python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p precision -e cuda -c cache_dir_to_store_temp_files --extra_options kv_cache_quant_type=int8_per_channel kv_cache_scale_file=path_to_scales.json
 ```
 
+##### Quantize the KV Cache with Paged Attention
+
+`kv_cache_quant_type` can be combined with `use_paged_attention=true`. In that case the paged KV cache blocks
+(`[num_blocks, block_size, num_kv_heads, head_size]`) are allocated in the quantized element type and the
+`PagedAttention` op receives the `k_scale`/`v_scale` initializers plus the matching `k_quant_type`/`v_quant_type`
+attributes.
+
+Only `int8_*` and `fp8_*` are supported on the paged path; `int4_*` is rejected because `PagedAttention` has no
+sub-byte cache backend. Per-channel scales are emitted with the `(num_kv_heads, 1, head_size)` shape that
+`PagedAttention` requires.
+
+```bash
+# From wheel (paged attention + int8 per-channel KV cache):
+python -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o path_to_output_folder -p precision -e cuda -c cache_dir_to_store_temp_files --extra_options use_paged_attention=true kv_cache_quant_type=int8_per_channel kv_cache_scale_file=path_to_scales.json
+
+# From source (paged attention + fp8 per-tensor KV cache):
+python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p precision -e cuda -c cache_dir_to_store_temp_files --extra_options use_paged_attention=true kv_cache_quant_type=fp8_per_tensor kv_cache_scale_file=path_to_scales.json
+```
+
 #### FP32 I/O for WebGPU EP
 
 This scenario is for when you want to force FP32 model I/O for WebGPU (useful for GPUs without FP16 support on WebGPU, such as GTX 10xx).

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -754,6 +754,8 @@ def get_args():
                     Supported values: none, int8_per_tensor, int8_per_channel, int4_per_tensor, int4_per_channel, fp8_per_tensor, fp8_per_channel.
                     The `int8`/`int4`/`fp8` prefix selects the KV cache bit width and the `per_tensor`/`per_channel` suffix selects the scale granularity.
                     Quantized KV cache is only supported for the CPU and CUDA execution providers.
+                    When combined with use_paged_attention=true, only the int8_* and fp8_* schemes are supported
+                    (PagedAttention has no sub-byte cache backend, so int4_* is rejected).
                 kv_cache_scale_file = Path to a JSON file with calibrated per-layer KV cache scales. Required when kv_cache_quant_type is enabled.
                     Format: {"scales": {"k_scales": [...per layer...], "v_scales": [...per layer...]}} with one entry per layer.
                     Each per-layer entry is a scalar (per_tensor) or a length-(num_kv_heads * head_size) vector (per_channel).

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -169,7 +169,7 @@ class Model:
             "block_table": ["batch_size", "max_num_blocks"],                                                     # For paged attention models
             "cumulative_sequence_lengths": ["batch_size + 1"],                                                   # For paged attention models
             "past_sequence_lengths": ["batch_size"],                                                             # For paged attention models
-            "attention_metadata": [2],                                                                          # For paged attention models. Static shape: a pair of scalars, not a per-sequence tensor.
+            "attention_metadata": [2],                                                                           # For paged attention models. Static shape: a pair of scalars, not a per-sequence tensor.
         }
         self.make_inputs_init()
 

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -145,6 +145,7 @@ class Model:
             "block_table": "block_table",                                                                        # For paged attention models
             "cumulative_sequence_lengths": "cumulative_sequence_lengths",                                        # For paged attention models
             "past_sequence_lengths": "past_sequence_lengths",                                                    # For paged attention models
+            "attention_metadata": "attention_metadata",                                                          # For paged attention models
         }
         self.input_types = {
             "input_ids": ir.DataType.INT64,                                                                      # For standard models
@@ -156,6 +157,7 @@ class Model:
             "block_table": ir.DataType.INT32,                                                                    # For paged attention models
             "cumulative_sequence_lengths": ir.DataType.INT32,                                                    # For paged attention models
             "past_sequence_lengths": ir.DataType.INT32,                                                          # For paged attention models
+            "attention_metadata": ir.DataType.INT32,                                                              # For paged attention models
         }
         self.input_shapes = {
             "input_ids": ["batch_size", "sequence_length"],                                                      # For standard models
@@ -167,6 +169,7 @@ class Model:
             "block_table": ["batch_size", "max_num_blocks"],                                                     # For paged attention models
             "cumulative_sequence_lengths": ["batch_size + 1"],                                                   # For paged attention models
             "past_sequence_lengths": ["batch_size"],                                                             # For paged attention models
+            "attention_metadata": [2],                                                                          # For paged attention models. Static shape: a pair of scalars, not a per-sequence tensor.
         }
         self.make_inputs_init()
 
@@ -432,7 +435,7 @@ class Model:
             if "attention_mask" in self.input_names:
                 del self.input_names["attention_mask"]
         else:
-            for name in ["block_table", "cumulative_sequence_lengths", "past_sequence_lengths"]:
+            for name in ["block_table", "cumulative_sequence_lengths", "past_sequence_lengths", "attention_metadata"]:
                 del self.input_names[name]
 
     def make_outputs_init(self):
@@ -901,6 +904,7 @@ class Model:
             inputs["block_table"] = self.input_names["block_table"]
             inputs["cumulative_sequence_lengths"] = self.input_names["cumulative_sequence_lengths"]
             inputs["past_sequence_lengths"] = self.input_names["past_sequence_lengths"]
+            inputs["attention_metadata"] = self.input_names["attention_metadata"]
         if "past_key_values.key" in self.input_names:
             inputs["past_key_names"] = "past_key_values.%d.key"
         if "past_key_values.value" in self.input_names:
@@ -2902,6 +2906,7 @@ class Model:
                 cumulative_sequence_lengths=self.input_names["cumulative_sequence_lengths"],
                 past_sequence_lengths=self.input_names["past_sequence_lengths"],
                 block_table=self.input_names["block_table"],
+                attention_metadata=self.input_names["attention_metadata"],
                 **kwargs,
             )
         else:
@@ -3148,9 +3153,13 @@ class Model:
             k_scale_name, v_scale_name = self.get_kv_cache_scale_names(layer_id)
 
         # Optional trailing inputs of PagedAttention, in schema order:
-        #   10: slot_mapping, 11: head_sink, 12: q_norm_weight, 13: k_norm_weight, 14: k_scale, 15: v_scale
+        #   10: slot_mapping, 11: head_sink, 12: q_norm_weight, 13: k_norm_weight, 14: k_scale, 15: v_scale,
+        #   16: attention_metadata
         # The scheduler-provided slot_mapping is not used here; slots are derived from
         # past_seqlens / cumulative_sequence_length / block_table by the op.
+        # attention_metadata carries [max_query_len_bound, max_kv_len_bound] in CPU memory so the op
+        # can select a backend and size its launch without a device-to-host readback of the sequence
+        # lengths. Feeding it is what removes the per-node stream synchronization on the decode path.
         optional_inputs = [
             "",  # slot_mapping
             kwargs.get("sinks", ""),  # head_sink
@@ -3158,6 +3167,7 @@ class Model:
             k_norm_weight,
             k_scale_name,
             v_scale_name,
+            kwargs.get("attention_metadata", ""),
         ]
         while optional_inputs and not optional_inputs[-1]:
             optional_inputs.pop()

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -2970,6 +2970,52 @@ class Model:
             output, self.io_dtype, shape=["batch_size", "sequence_length", self.head_size * self.num_attn_heads]
         )
 
+    def extend_with_optional_inputs(self, inputs, optional_inputs):
+        # ONNX lets trailing optional inputs be omitted entirely, so drop the unused ones at the
+        # end instead of emitting empty placeholders. Placeholders in the middle are kept because
+        # they reserve the position of the later inputs.
+        while optional_inputs and not optional_inputs[-1]:
+            optional_inputs.pop()
+        inputs.extend(optional_inputs)
+
+    def get_qk_norm_weight_inputs(self, **kwargs):
+        # Shared by GroupQueryAttention and PagedAttention: both fuse the Q/K RMSNorm and both
+        # require the pair to be provided together.
+        q_norm_weight = kwargs.get("q_norm_weight", "")
+        k_norm_weight = kwargs.get("k_norm_weight", "")
+        if bool(q_norm_weight) != bool(k_norm_weight):
+            raise ValueError("q_norm_weight and k_norm_weight must be provided together.")
+        return q_norm_weight, k_norm_weight
+
+    def get_kv_cache_scale_inputs(self, **kwargs):
+        # Shared by GroupQueryAttention and PagedAttention: returns the per-layer k/v scale
+        # initializer names, or empty placeholders when the KV cache is not quantized.
+        if self.kv_cache_quant_type == "none":
+            return "", ""
+        layer_id = kwargs.get("layer_id")
+        if layer_id is None:
+            raise ValueError("layer_id is required for quantized KV cache.")
+        return self.get_kv_cache_scale_names(layer_id)
+
+    def get_attention_op_attributes(self, **kwargs):
+        # Attributes shared by GroupQueryAttention and PagedAttention. Op-specific attributes
+        # (e.g. GQA's `kv_cache_bit_width`) are added by the caller.
+        attributes = {
+            "num_heads": self.num_attn_heads,
+            "kv_num_heads": self.num_kv_heads,
+            "scale": self.attention_attrs["scale"],
+            "local_window_size": self.window_size,
+            "softcap": self.attention_attrs["softcap"],
+            "do_rotary": self.attention_attrs["use_rope_in_attn"],
+            "rotary_interleaved": self.rope_attrs["interleaved"],
+        }
+        if kwargs.get("q_norm_weight", ""):
+            attributes["qk_norm_epsilon"] = kwargs.get("qk_norm_epsilon", self.attention_attrs["qk_norm_epsilon"])
+        if self.kv_cache_quant_type != "none":
+            attributes["k_quant_type"] = self.kv_quant_type
+            attributes["v_quant_type"] = self.kv_quant_type
+        return attributes
+
     def make_group_query_attention(self, name, **kwargs):
         inputs = [
             kwargs["q_path"],
@@ -2985,57 +3031,28 @@ class Model:
             "",  # attention_bias
             kwargs.get("sinks", ""),
         ]
-        layer_id = kwargs.get("layer_id")
-        if self.kv_cache_quant_type != "none":
-            if layer_id is None:
-                raise ValueError("layer_id is required for quantized KV cache.")
-            k_scale_name, v_scale_name = self.get_kv_cache_scale_names(layer_id)
-            inputs.extend(
-                [
-                    k_scale_name,
-                    v_scale_name,
-                ]
-            )
-        q_norm_weight = kwargs.get("q_norm_weight", "")
-        k_norm_weight = kwargs.get("k_norm_weight", "")
-        if bool(q_norm_weight) != bool(k_norm_weight):
-            raise ValueError("q_norm_weight and k_norm_weight must be provided together.")
-        if q_norm_weight:
-            if self.kv_cache_quant_type == "none":
-                inputs.extend(
-                    [
-                        "",  # k_scale
-                        "",  # v_scale
-                    ]
-                )
-            inputs.extend(
-                [
-                    q_norm_weight,
-                    k_norm_weight,
-                ]
-            )
+        q_norm_weight, k_norm_weight = self.get_qk_norm_weight_inputs(**kwargs)
+        k_scale_name, v_scale_name = self.get_kv_cache_scale_inputs(**kwargs)
+
+        # Optional trailing inputs of GroupQueryAttention, in schema order:
+        #   12: k_scale, 13: v_scale, 14: q_norm_weight, 15: k_norm_weight
+        self.extend_with_optional_inputs(
+            inputs,
+            [
+                k_scale_name,
+                v_scale_name,
+                q_norm_weight,
+                k_norm_weight,
+            ],
+        )
 
         output = f"{name}/output_0"
         outputs = [output, kwargs.get("present_k", ""), kwargs.get("present_v", "")]
-        attributes = {
-            "num_heads": self.num_attn_heads,
-            "kv_num_heads": self.num_kv_heads,
-            "scale": self.attention_attrs["scale"],
-            "local_window_size": self.window_size,
-            "softcap": self.attention_attrs["softcap"],
-            "do_rotary": self.attention_attrs["use_rope_in_attn"],
-            "rotary_interleaved": self.rope_attrs["interleaved"],
-        }
-        if q_norm_weight:
-            attributes["qk_norm_epsilon"] = kwargs.get("qk_norm_epsilon", self.attention_attrs["qk_norm_epsilon"])
+        attributes = self.get_attention_op_attributes(**kwargs)
         if self.kv_cache_quant_type != "none":
-            attributes.update(
-                {
-                    "k_quant_type": self.kv_quant_type,
-                    "v_quant_type": self.kv_quant_type,
-                    "kv_cache_bit_width": self.kv_cache_bit_width,
-                }
-            )
+            # Unlike PagedAttention, GroupQueryAttention supports sub-byte (int4) caches, so the
+            # bit width cannot be derived from the cache element type alone.
+            attributes["kv_cache_bit_width"] = self.kv_cache_bit_width
         self.make_node(
             "GroupQueryAttention",
             inputs=inputs,
@@ -3140,17 +3157,8 @@ class Model:
             kwargs.get("sin_cache", ""),
         ]
 
-        q_norm_weight = kwargs.get("q_norm_weight", "")
-        k_norm_weight = kwargs.get("k_norm_weight", "")
-        if bool(q_norm_weight) != bool(k_norm_weight):
-            raise ValueError("q_norm_weight and k_norm_weight must be provided together.")
-
-        k_scale_name = v_scale_name = ""
-        if self.kv_cache_quant_type != "none":
-            layer_id = kwargs.get("layer_id")
-            if layer_id is None:
-                raise ValueError("layer_id is required for quantized KV cache.")
-            k_scale_name, v_scale_name = self.get_kv_cache_scale_names(layer_id)
+        q_norm_weight, k_norm_weight = self.get_qk_norm_weight_inputs(**kwargs)
+        k_scale_name, v_scale_name = self.get_kv_cache_scale_inputs(**kwargs)
 
         # Optional trailing inputs of PagedAttention, in schema order:
         #   10: slot_mapping, 11: head_sink, 12: q_norm_weight, 13: k_norm_weight, 14: k_scale, 15: v_scale,
@@ -3160,41 +3168,24 @@ class Model:
         # attention_metadata carries [max_query_len_bound, max_kv_len_bound] in CPU memory so the op
         # can select a backend and size its launch without a device-to-host readback of the sequence
         # lengths. Feeding it is what removes the per-node stream synchronization on the decode path.
-        optional_inputs = [
-            "",  # slot_mapping
-            kwargs.get("sinks", ""),  # head_sink
-            q_norm_weight,
-            k_norm_weight,
-            k_scale_name,
-            v_scale_name,
-            kwargs.get("attention_metadata", ""),
-        ]
-        while optional_inputs and not optional_inputs[-1]:
-            optional_inputs.pop()
-        inputs.extend(optional_inputs)
+        self.extend_with_optional_inputs(
+            inputs,
+            [
+                "",  # slot_mapping
+                kwargs.get("sinks", ""),  # head_sink
+                q_norm_weight,
+                k_norm_weight,
+                k_scale_name,
+                v_scale_name,
+                kwargs.get("attention_metadata", ""),
+            ],
+        )
 
         output = f"{name}/output_0"
         outputs = [output, kwargs.get("present_k", ""), kwargs.get("present_v", "")]
-        attributes = {
-            "num_heads": self.num_attn_heads,
-            "kv_num_heads": self.num_kv_heads,
-            "scale": self.attention_attrs["scale"],
-            "local_window_size": self.window_size,
-            "softcap": self.attention_attrs["softcap"],
-            "do_rotary": self.attention_attrs["use_rope_in_attn"],
-            "rotary_interleaved": self.rope_attrs["interleaved"],
-        }
-        if q_norm_weight:
-            attributes["qk_norm_epsilon"] = kwargs.get("qk_norm_epsilon", self.attention_attrs["qk_norm_epsilon"])
-        if self.kv_cache_quant_type != "none":
-            # PagedAttention derives the cache element type from the tensor itself, so only the
-            # quantization granularity has to be declared (there is no `kv_cache_bit_width` attribute).
-            attributes.update(
-                {
-                    "k_quant_type": self.kv_quant_type,
-                    "v_quant_type": self.kv_quant_type,
-                }
-            )
+        # PagedAttention derives the cache element type from the tensor itself, so unlike
+        # GroupQueryAttention it has no `kv_cache_bit_width` attribute.
+        attributes = self.get_attention_op_attributes(**kwargs)
         self.make_node(
             "PagedAttention",
             inputs=inputs,

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -632,8 +632,8 @@ class Model:
         self.past_present_share_buffer = self.attention_attrs["op_type"] in ("GroupQueryAttention", "PagedAttention")
 
     def make_quantized_kv_cache_init(self):
-        if self.attention_attrs["op_type"] != "GroupQueryAttention":
-            raise ValueError("Quantized KV cache requires GroupQueryAttention.")
+        if self.attention_attrs["op_type"] not in {"GroupQueryAttention", "PagedAttention"}:
+            raise ValueError("Quantized KV cache requires GroupQueryAttention or PagedAttention.")
         if self.ep not in {"cpu", "cuda"}:
             raise ValueError(
                 "Quantized KV cache is only supported for the CPU and CUDA execution providers. "
@@ -644,6 +644,14 @@ class Model:
         is_fp8 = self.kv_cache_quant_type.startswith("fp8")
         self.kv_cache_bit_width = 4 if is_int4 else 8
         self.kv_quant_type = "PER_CHANNEL" if self.kv_cache_quant_type.endswith("per_channel") else "PER_TENSOR"
+
+        if self.use_paged_attention and is_int4:
+            # PagedAttention's T_CACHE type constraint is {float16, bfloat16, int8, float8e4m3fn};
+            # there is no sub-byte paged cache backend, so int4 caches cannot be exported.
+            raise ValueError(
+                "PagedAttention only supports int8 and fp8 quantized KV caches, "
+                f"got kv_cache_quant_type='{self.kv_cache_quant_type}'."
+            )
 
         if is_fp8:
             # FP8 E4M3: stored one byte per element (no bit-packing), kernel selects the fp8
@@ -705,6 +713,11 @@ class Model:
                 f"got k={len(k_scales_per_layer)} v={len(v_scales_per_layer)}"
             )
 
+        # PagedAttention validates the per-channel scale shape and requires the canonical
+        # (kv_num_heads, 1, head_size) form, while GroupQueryAttention only looks at the element
+        # count. Emit the canonical shape on the paged path and keep the flat vector elsewhere.
+        scale_shape = (self.num_kv_heads, 1, self.head_size) if (per_channel and self.use_paged_attention) else (-1,)
+
         def make_scale(per_layer, layer_id):
             scale = np.asarray(per_layer[layer_id], dtype=np.float32).reshape(-1)
             if scale.size != scale_size:
@@ -713,7 +726,7 @@ class Model:
                 )
             if not np.all(np.isfinite(scale)) or np.any(scale <= 0):
                 raise ValueError(f"kv_cache scale for layer {layer_id} must contain finite positive values")
-            return scale
+            return scale.reshape(scale_shape)
 
         for layer_id in range(self.num_layers):
             k_scale_name, v_scale_name = self.get_kv_cache_scale_names(layer_id)
@@ -3121,21 +3134,64 @@ class Model:
             kwargs.get("cos_cache", ""),
             kwargs.get("sin_cache", ""),
         ]
+
+        q_norm_weight = kwargs.get("q_norm_weight", "")
+        k_norm_weight = kwargs.get("k_norm_weight", "")
+        if bool(q_norm_weight) != bool(k_norm_weight):
+            raise ValueError("q_norm_weight and k_norm_weight must be provided together.")
+
+        k_scale_name = v_scale_name = ""
+        if self.kv_cache_quant_type != "none":
+            layer_id = kwargs.get("layer_id")
+            if layer_id is None:
+                raise ValueError("layer_id is required for quantized KV cache.")
+            k_scale_name, v_scale_name = self.get_kv_cache_scale_names(layer_id)
+
+        # Optional trailing inputs of PagedAttention, in schema order:
+        #   10: slot_mapping, 11: head_sink, 12: q_norm_weight, 13: k_norm_weight, 14: k_scale, 15: v_scale
+        # The scheduler-provided slot_mapping is not used here; slots are derived from
+        # past_seqlens / cumulative_sequence_length / block_table by the op.
+        optional_inputs = [
+            "",  # slot_mapping
+            kwargs.get("sinks", ""),  # head_sink
+            q_norm_weight,
+            k_norm_weight,
+            k_scale_name,
+            v_scale_name,
+        ]
+        while optional_inputs and not optional_inputs[-1]:
+            optional_inputs.pop()
+        inputs.extend(optional_inputs)
+
         output = f"{name}/output_0"
         outputs = [output, kwargs.get("present_k", ""), kwargs.get("present_v", "")]
+        attributes = {
+            "num_heads": self.num_attn_heads,
+            "kv_num_heads": self.num_kv_heads,
+            "scale": self.attention_attrs["scale"],
+            "local_window_size": self.window_size,
+            "softcap": self.attention_attrs["softcap"],
+            "do_rotary": self.attention_attrs["use_rope_in_attn"],
+            "rotary_interleaved": self.rope_attrs["interleaved"],
+        }
+        if q_norm_weight:
+            attributes["qk_norm_epsilon"] = kwargs.get("qk_norm_epsilon", self.attention_attrs["qk_norm_epsilon"])
+        if self.kv_cache_quant_type != "none":
+            # PagedAttention derives the cache element type from the tensor itself, so only the
+            # quantization granularity has to be declared (there is no `kv_cache_bit_width` attribute).
+            attributes.update(
+                {
+                    "k_quant_type": self.kv_quant_type,
+                    "v_quant_type": self.kv_quant_type,
+                }
+            )
         self.make_node(
             "PagedAttention",
             inputs=inputs,
             outputs=outputs,
             name=name,
             domain="com.microsoft",
-            num_heads=self.num_attn_heads,
-            kv_num_heads=self.num_kv_heads,
-            scale=self.attention_attrs["scale"],
-            local_window_size=self.window_size,
-            softcap=self.attention_attrs["softcap"],
-            do_rotary=self.attention_attrs["use_rope_in_attn"],
-            rotary_interleaved=self.rope_attrs["interleaved"],
+            **attributes,
         )
         self.make_value(output, self.io_dtype, shape=["num_tokens", self.head_size * self.num_attn_heads])
 

--- a/test/python/builder/test_gqa_attributes.py
+++ b/test/python/builder/test_gqa_attributes.py
@@ -103,6 +103,7 @@ def test_paged_attention_preserves_sliding_window_size():
 
     assert model.nodes[-1]["attributes"]["local_window_size"] == 4096
 
+
 def test_quantized_gqa_emits_scale_inputs_and_attributes():
     model = _FakeGQAModel("cuda")
     model.kv_cache_quant_type = "int4_per_channel"

--- a/test/python/builder/test_gqa_attributes.py
+++ b/test/python/builder/test_gqa_attributes.py
@@ -103,7 +103,6 @@ def test_paged_attention_preserves_sliding_window_size():
 
     assert model.nodes[-1]["attributes"]["local_window_size"] == 4096
 
-
 def test_quantized_gqa_emits_scale_inputs_and_attributes():
     model = _FakeGQAModel("cuda")
     model.kv_cache_quant_type = "int4_per_channel"

--- a/test/python/builder/test_gqa_attributes.py
+++ b/test/python/builder/test_gqa_attributes.py
@@ -5,6 +5,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 BUILDERS_DIR = Path(__file__).parents[3] / "src" / "python" / "py" / "models" / "builders"
 sys.path.insert(0, str(BUILDERS_DIR.parents[1]))
 
@@ -31,6 +33,10 @@ class _FakeGQAModel:
     make_paged_attention = Model.make_paged_attention
     get_qk_norm_weight_names = Model.get_qk_norm_weight_names
     get_kv_cache_scale_names = Model.get_kv_cache_scale_names
+    extend_with_optional_inputs = Model.extend_with_optional_inputs
+    get_qk_norm_weight_inputs = Model.get_qk_norm_weight_inputs
+    get_kv_cache_scale_inputs = Model.get_kv_cache_scale_inputs
+    get_attention_op_attributes = Model.get_attention_op_attributes
 
     def __init__(self, ep="cpu", fuse_qk_norm_gqa=True):
         self.ep = ep
@@ -120,6 +126,68 @@ def test_quantized_gqa_emits_scale_inputs_and_attributes():
     assert node["attributes"]["k_quant_type"] == "PER_CHANNEL"
     assert node["attributes"]["v_quant_type"] == "PER_CHANNEL"
     assert node["attributes"]["kv_cache_bit_width"] == 4
+
+
+def test_quantized_paged_attention_emits_scale_inputs_and_attributes():
+    model = _FakeGQAModel("cuda")
+    model.kv_cache_quant_type = "int8_per_channel"
+    model.kv_quant_type = "PER_CHANNEL"
+    model.kv_cache_bit_width = 8
+
+    model.make_paged_attention(
+        "/paged",
+        layer_id=3,
+        q_path="q",
+        k_path="k",
+        v_path="v",
+        cumulative_sequence_lengths="cumulative_sequence_lengths",
+        past_sequence_lengths="past_sequence_lengths",
+        block_table="block_table",
+    )
+
+    node = model.nodes[-1]
+    assert node["inputs"][14:16] == [
+        "model.layers.3.attn.k_scale",
+        "model.layers.3.attn.v_scale",
+    ]
+    assert node["attributes"]["k_quant_type"] == "PER_CHANNEL"
+    assert node["attributes"]["v_quant_type"] == "PER_CHANNEL"
+    # PagedAttention derives the cache element type from the tensor, so it has no bit-width attribute.
+    assert "kv_cache_bit_width" not in node["attributes"]
+
+
+def test_quantized_paged_attention_requires_layer_id():
+    model = _FakeGQAModel("cuda")
+    model.kv_cache_quant_type = "int8_per_tensor"
+    model.kv_quant_type = "PER_TENSOR"
+
+    with pytest.raises(ValueError, match="layer_id is required"):
+        model.make_paged_attention(
+            "/paged",
+            q_path="q",
+            k_path="k",
+            v_path="v",
+            cumulative_sequence_lengths="cumulative_sequence_lengths",
+            past_sequence_lengths="past_sequence_lengths",
+            block_table="block_table",
+        )
+
+
+@pytest.mark.parametrize("provided", ["q_norm_weight", "k_norm_weight"])
+def test_paged_attention_rejects_unpaired_qk_norm_weights(provided):
+    model = _FakeGQAModel("cuda")
+
+    with pytest.raises(ValueError, match="must be provided together"):
+        model.make_paged_attention(
+            "/paged",
+            q_path="q",
+            k_path="k",
+            v_path="v",
+            cumulative_sequence_lengths="cumulative_sequence_lengths",
+            past_sequence_lengths="past_sequence_lengths",
+            block_table="block_table",
+            **{provided: "norm"},
+        )
 
 
 def test_get_qk_norm_weight_names_follows_convention():

--- a/test/python/builder/test_quantized_kv_cache.py
+++ b/test/python/builder/test_quantized_kv_cache.py
@@ -365,6 +365,66 @@ def test_per_channel_scale_initializers_span_num_kv_heads_times_head_size(tmp_pa
 
     for arr in captured.values():
         assert arr.size == 2 * 16
+        # GroupQueryAttention only looks at the element count, so the scales stay flat.
+        assert arr.shape == (2 * 16,)
+
+
+def test_paged_per_channel_scale_initializers_use_canonical_shape(tmp_path):
+    # PagedAttention validates the per-channel scale shape and requires (kv_num_heads, 1, head_size),
+    # unlike GroupQueryAttention which only checks the element count.
+    scale_size = 2 * 16
+    scale_file = tmp_path / "kv_scales.json"
+    scale_file.write_text(
+        json.dumps(
+            {
+                "scales": {
+                    "k_scales": [[0.1] * scale_size],
+                    "v_scales": [[0.2] * scale_size],
+                }
+            }
+        )
+    )
+    model = _make_kv_model(
+        kv_cache_quant_type="int8_per_channel",
+        ep="cuda",
+        op_type="PagedAttention",
+        num_kv_heads=2,
+        head_size=16,
+        num_layers=1,
+        extra_options={"kv_cache_scale_file": str(scale_file)},
+        use_paged_attention=True,
+    )
+    model.kv_quant_type = "PER_CHANNEL"
+    captured = _capture_initializers(model)
+
+    model.make_kv_cache_scale_initializers()
+
+    assert set(captured) == {"model.layers.0.attn.k_scale", "model.layers.0.attn.v_scale"}
+    for arr in captured.values():
+        assert arr.shape == (2, 1, 16)
+
+
+def test_paged_per_tensor_scale_initializers_stay_scalar(tmp_path):
+    # The canonical (kv_num_heads, 1, head_size) reshape must only apply to per-channel scales.
+    scale_file = tmp_path / "kv_scales.json"
+    scale_file.write_text(json.dumps({"scales": {"k_scales": [0.1], "v_scales": [0.2]}}))
+    model = _make_kv_model(
+        kv_cache_quant_type="int8_per_tensor",
+        ep="cuda",
+        op_type="PagedAttention",
+        num_kv_heads=2,
+        head_size=16,
+        num_layers=1,
+        extra_options={"kv_cache_scale_file": str(scale_file)},
+        use_paged_attention=True,
+    )
+    model.kv_quant_type = "PER_TENSOR"
+    captured = _capture_initializers(model)
+
+    model.make_kv_cache_scale_initializers()
+
+    for arr in captured.values():
+        assert arr.shape == (1,)
 
 
 def test_missing_scale_file_is_rejected():

--- a/test/python/builder/test_quantized_kv_cache.py
+++ b/test/python/builder/test_quantized_kv_cache.py
@@ -79,9 +79,7 @@ def _check_extra_options(extra_options, precision, execution_provider):
     builder_module.get_hf_details = lambda *args, **kwargs: {
         "hf_config": types.SimpleNamespace(tie_word_embeddings=True)
     }
-    builder_module.check_extra_options(
-        "dummy-model", "", "", precision, execution_provider, "", extra_options
-    )
+    builder_module.check_extra_options("dummy-model", "", "", precision, execution_provider, "", extra_options)
 
 
 # ===========================================================================
@@ -152,6 +150,7 @@ def _make_kv_model(
     num_kv_heads=2,
     num_layers=3,
     extra_options=None,
+    use_paged_attention=False,
 ):
     model = Model.__new__(Model)
     model.ep = ep
@@ -161,6 +160,7 @@ def _make_kv_model(
     model.kv_cache_quant_type = kv_cache_quant_type
     model.extra_options = extra_options if extra_options is not None else {}
     model.attention_attrs = {"op_type": op_type}
+    model.use_paged_attention = use_paged_attention
     model.input_types = {}
     model.output_types = {}
     model.input_shapes = {
@@ -174,9 +174,37 @@ def _make_kv_model(
     return model
 
 
-def test_quantized_kv_cache_requires_group_query_attention():
+def test_quantized_kv_cache_requires_group_query_or_paged_attention():
     model = _make_kv_model(kv_cache_quant_type="int8_per_tensor", op_type="MultiHeadAttention")
-    with pytest.raises(ValueError, match="requires GroupQueryAttention"):
+    with pytest.raises(ValueError, match="requires GroupQueryAttention or PagedAttention"):
+        model.make_quantized_kv_cache_init()
+
+
+@pytest.mark.parametrize("quant_type", ["int8_per_tensor", "int8_per_channel", "fp8_per_tensor", "fp8_per_channel"])
+def test_paged_attention_accepts_int8_and_fp8_kv_cache(quant_type):
+    model = _make_kv_model(
+        kv_cache_quant_type=quant_type,
+        ep="cuda",
+        op_type="PagedAttention",
+        use_paged_attention=True,
+    )
+    model.make_quantized_kv_cache_init()
+
+    expected_dtype = ir.DataType.FLOAT8E4M3FN if quant_type.startswith("fp8") else ir.DataType.INT8
+    assert model.input_types["past_key_values.key"] == expected_dtype
+    assert model.output_types["present.value"] == expected_dtype
+
+
+@pytest.mark.parametrize("quant_type", ["int4_per_tensor", "int4_per_channel"])
+def test_paged_attention_rejects_int4_kv_cache(quant_type):
+    # PagedAttention's T_CACHE constraint has no sub-byte member, so int4 caches are not exportable.
+    model = _make_kv_model(
+        kv_cache_quant_type=quant_type,
+        ep="cuda",
+        op_type="PagedAttention",
+        use_paged_attention=True,
+    )
+    with pytest.raises(ValueError, match="only supports int8 and fp8"):
         model.make_quantized_kv_cache_init()
 
 


### PR DESCRIPTION
## Summary

Extends the PagedAttention path end to end: the model builder can now export a quantized (int8/fp8) paged KV cache, both the builder and the engine wire up the new `attention_metadata` input that removes a per-node host sync, the continuous-batching engine can capture and replay decode steps as CUDA graphs, and the paged cache manager no longer double-counts prefill tokens when reserving blocks.

Measured on 8×H200 (only one GPU was used in benchmark) with gpt-oss-20b, batch-1 decode on the int8-KV paged model goes from **242.7 → 305.7 tok/s (+26%)** from the two changes in this PR (`attention_metadata` + CUDA graphs), and the paged KV pool now serves twice the context/concurrency it did for the same `num_blocks`.

Requires the matching ONNX Runtime changes (`PagedAttention` `attention_metadata` input at index 16, XQA paged decode kernels) in https://github.com/microsoft/onnxruntime/pull/29912.

## Key Changes

### 1. Quantized KV cache for PagedAttention (model builder)

| Change | File |
|---|---|
| Accept `PagedAttention` in `make_quantized_kv_cache_init()` (was GQA-only) | `builders/base.py` |
| Reject `int4_*` on the paged path — `PagedAttention`'s `T_CACHE` is `{float16, bfloat16, int8, float8e4m3fn}`, there is no sub-byte paged cache backend | `builders/base.py` |
| Emit per-channel scales in the canonical `(num_kv_heads, 1, head_size)` shape the paged op validates (GQA only checks the element count) | `builders/base.py` |
| Wire `k_scale`/`v_scale` optional inputs and set `k_quant_type`/`v_quant_type`. `PagedAttention` has no `kv_cache_bit_width` attribute — it derives the element type from the cache tensor | `builders/base.py` |
| Document the paged + quantized-KV combination and its constraints | `models/README.md`, `builder.py` |

Shared logic between `make_group_query_attention` and `make_paged_attention` was factored into `get_qk_norm_weight_inputs()`, `get_kv_cache_scale_inputs()`, `get_attention_op_attributes()` and `extend_with_optional_inputs()`, so the two builders now differ only in their fixed input ordering and GQA's `kv_cache_bit_width`.

### 2. `attention_metadata` input

`PagedAttention::ComputeInternal` previously copied the sequence-length tensors device→host and called `cudaStreamSynchronize` to obtain `max_query_len`/`max_kv_len` — **once per node, per step**, i.e. 24 pipeline stalls per token on a 24-layer model.

The new optional CPU input (`int32[2]`, index 16) carries *upper bounds* for those values, letting the kernel skip the readback. It only ever predicts the backend selection; it never overrides it.

- `builders/base.py` — emits it as a graph input (static shape `[2]`, int32), wires it to input 16, lists it in `genai_config.json`.
- `src/config.{h,cpp}` — `Defaults::AttentionMetadataName` and `Decoder::Inputs::attention_metadata`.
- `varlen_decoder_io.cpp` — `PrepareAttentionMetadata()` fills it each step from sequence lengths the engine already holds on the host. It no-ops when `!session_info_.HasInput(...)`, so **older models still load**.

| batch | without metadata | with metadata | gain |
|---|---|---|---|
| 1 | 242.65 tok/s | 263.75 tok/s | **+8.7%** |
| 8 | 796.09 tok/s | 811.50 tok/s | +1.9% |
| 32 | 2635.67 tok/s | 2681.96 tok/s | +1.8% |

TTFT unchanged. The gain is inversely proportional to batch size, as expected for a fixed per-step host cost.

### 3. CUDA graph capture in the continuous-batching engine

An nsys trace of batch-1 decode showed ~2.4 ms of GPU work against a 3.8 ms wall clock — roughly **37% GPU idle**, spent launching ~170 kernels per step. Change 2 is a prerequisite here: ORT captures with `cudaStreamCaptureModeGlobal`, so no sync API may run during capture.

- **`VarlenGraphBuffers`** (`varlen_decoder_io.{h,cpp}`) — persistent `input_ids`, `cumulative_sequence_lengths`, `past_sequence_lengths` and `logits` tensors sized for `max_batch_size`, owned by `SimpleDecoder` so their addresses outlive the per-step IO. A step views a smaller prefix.
- **Static device block table** (`paged_key_value_cache.{h,cpp}`) — the block table used to be a pageable CPU `OrtValue`, which cannot be H2D-copied during capture. Under capture it becomes a persistent device tensor of `[max_batch_size, max_block_table_columns]`.
- **Shape stability via bucketing** — column counts round *up to a power of two* (min 8) and clamp to the reserved capacity, so a long decode touches only a handful of distinct shapes instead of re-capturing every time a block is appended.
- **Capture policy** (`simple_decoder.cpp`) — only pure-decode steps that fit the buffers are captured; prefill and mixed steps run eagerly with `gpu_graph_id = -1`. `GraphId = batch_size * 64 + column_bucket_exponent + 1`.

Because `ComputeInternal` never re-runs on replay, `attention_metadata` must carry replay-wide bounds; the engine writes `[1, block_table_columns * block_size]`.

| config | graphs OFF | graphs ON | gain |
|---|---|---|---|
| b=1, p=128, n=256 | 263.68 tok/s | **305.68 tok/s** | **+15.9%** |
| b=8, p=128, n=256 | 810.15 tok/s | 870.54 tok/s | +7.5% |
| b=32, p=128, n=256 | 2697.87 tok/s | 2879.20 tok/s | +6.7% |
| b=2, p=4096, n=256 | 390.10 tok/s | 435.02 tok/s | +11.5% |

TTFT unchanged — prefill is never captured. fp8-KV reaches 318.96 tok/s at b=1.

### 4. Fix: the paged cache manager double-counted every prefill

Pinning `num_blocks` to exactly `ceil(max_length / block_size)` made every paged request fail on its first step with `Cannot append tokens to request that is not ready.`

`BlockPool::AllocateBlocks()` constructs blocks with their slots *already marked used*, and `PagedKeyValueCache::Add()` called it with the full prefill. The first `Step()` then ran `AppendTokens()` over those same still-unprocessed tokens and allocated a **second complete set of blocks**. A 4,079-token prefill at `block_size = 256` consumed **32 blocks instead of 16**.

The fix makes `AppendTokens()` the single place slots become used:

- `BlockPool::ReserveBlocks()` (new) allocates blocks with `size_ = 0`; `AllocateBlocks()` keeps its fill-on-allocate behaviour and both share one implementation behind a `mark_slots_used` flag.
- `Add()` reserves capacity without consuming it — still enough to stop a second request admitted in the same batch from stealing the blocks.
- `AppendTokens()` walks *all* of the request's blocks filling empty slots before asking the pool for more, instead of only `blocks.back()`.
- `CanAppendTokens()` counts every empty slot the request owns (new `EmptySlots()` helper) and takes the block size from `BlockPool::BlockSize()` rather than `blocks.back()->Capacity()`, which was also UB for an empty block list.
- `CanAdd()` uses `>=` rather than `>`, so a pool sized exactly for one request admits it.

Block ordering, and therefore the physical KV layout, is unchanged. A given KV pool now supports twice the context/concurrency it did, at no throughput cost:

| batch | before | after |
|---|---|---|
| 1 | 375.60 tok/s | 374.97 |
| 8 | 1679.86 | 1690.98 |
| 32 | 4097.30 | 4127.86 |

## Experiment Results

Measured on 8×H200 141 GB (sm_90), CUDA 13.0, ORT 1.29.0.

### Cumulative decode throughput — gpt-oss-20b, int8 per-channel KV, prompt 128 / new 256

| batch | baseline | + `attention_metadata` | + CUDA graphs | total |
|---|---|---|---|---|
| 1 | 242.7 | 263.8 | **305.7** | **+26.0%** |
| 8 | 796.1 | 811.5 | **870.5** | +9.3% |
| 32 | 2635.7 | 2682.0 | **2879.2** | +9.2% |

Attention is no longer the bottleneck at these sizes — the 24 mxfp4 `QMoE` GEMMs (~1.5 ms/step) and 49 `MatMulNBits` nodes dominate, against ~0.2 ms for all 24 attention nodes.

### GQA vs PagedAttention on a matched RC11f model pair

Two models built from the *identical* recipe (int4 body, int4 QMoE, int8 per-channel KV, same scale file); only the attention operator differs. `model.onnx.data` is byte-for-byte the same size in both.

| | result |
|---|---|
| **Accuracy** | MMLU-Pro-800 0.7200 (GQA) vs 0.7163 (paged); GPQA-diamond 0.6061 (GQA) vs 0.6212 (paged). **Equivalent** — both deltas are 3 questions and they point in opposite directions. |
| **Determinism** | 0/198 discordance on replicates of *both* models; generation is bit-reproducible. |
| **Memory** | Identical to within 24 MiB (0.16%) at matched KV capacity from 16k to 128k `max_length`. Paged costs nothing extra; its advantage is structural (shared pool vs `batch × max_length` reservation). |
| **Decode TPS** | b=1 **+0.5%**, b=8 −6.1%, b=32 **−22.3%** (see below). |

> **Note on the accuracy numbers.** An earlier revision of this description reported GPQA-diamond
> 0.5404 (GQA) vs 0.6212 (paged) and MMLU-Pro-800 0.6175 vs 0.7163. Those GQA figures were
> produced by an ORT bug, not by GQA itself: `FlashAttentionAndQuantizeKV` in
> `contrib_ops/cuda/bert/group_query_attention_impl.cu` — the only GQA prompt path taken when the
> KV cache is quantized — called `flash::mha_fwd()`, which had `constexpr void* head_sink = nullptr`
> hardcoded, so gpt-oss's attention sinks were silently disabled for the entire prompt on all 24
> layers (decode was unaffected). PagedAttention was immune because it applies the sink as an exact
> post-hoc epilogue on the FlashAttention `softmax_lse` rather than passing it into the kernel.
> The numbers above are with that fixed. **This PR is unaffected** — the bug is entirely on the ORT
> side and predates it — but the comparison needed an ORT with the fix to be meaningful.

| config | GQA tok/s | paged tok/s | delta |
|---|---|---|---|
| b=1, p=128, n=256 | 374.4 | **376.3** | **+0.5%** |
| b=8, p=128, n=256 | 1792.7 | 1683.8 | −6.1% |
| b=32, p=128, n=256 | 5285.9 | 4109.5 | **−22.3%** |
| b=2, p=4096, n=256 | 684.3 | **686.6** | +0.3% |

**Known gap:** PagedAttention is throughput-neutral at batch 1 and long context but loses ground as the batch grows. TTFT is 2–4% higher everywhere, which is the block-table setup and `ExpandBlockTableToPages` running per node per step. Hoisting that out of the per-step path is the next profiling target; the b=32 regression should be closed before proposing paged as a drop-in replacement for batch serving.

## Testing Notes

```bash
# Builder unit tests
python3 -m pytest test/python/builder -q          # 299 passed, 3 skipped
lintrunner -a                                     # clean
```

End-to-end validation on gpt-oss-20b (8×H200):

- **Bit-exactness:** decode output is byte-identical with CUDA graphs off and on.
- **Long context:** needle-in-a-haystack passes at 6,093 / 8,093 / 8,153 prompt tokens with graphs on. The 8,093 case crosses the 32→64 column bucket mid-decode, exercising mid-run re-capture.
- **Replay actually happens:** nsys over 94 decode steps shows 1 × `cudaStreamBeginCapture`, 1 × `cudaGraphInstantiate`, **94 × `cudaGraphLaunch`**.
- **Block accounting:** with `block_size = 256`, `num_blocks = 16` now serves a 4,079-token prefill plus 16 generated tokens (4,095 tokens in 4,096 slots — exactly full); `num_blocks = 15` is cleanly rejected.
- **Backward compatibility:** models built before this change have no `attention_metadata` input; `PrepareAttentionMetadata()` no-ops and they load and run unchanged.

To reproduce the builder side:

```bash
python -m models.builder -m openai/gpt-oss-20b -o $OUT -p int4 -e cuda \
  --extra_options use_paged_attention=true paged_block_size=256 enable_cuda_graph=true \
  kv_cache_quant_type=int8_per_channel kv_cache_scale_file=path_to_scales.json
```

