### PR TITLE
Support windowed KV cache for sliding-window layers on CUDA

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1245,12 +1245,16 @@ struct Model_Element : JSON::Element {
   VAD_Element vad_{v_.vad};
 };
 
+// Throws std::runtime_error (rather than std::overflow_error/std::invalid_argument) on failure.
+// JSON::Parse_Value only re-throws with the offending field's path prepended when it sees a
+// std::runtime_error, and the public C API boundary reports std::runtime_error, so every config
+// parsing error must use that single type to keep messages (and behavior) consistent.
 int SafeDoubleToInt(double x, std::string_view name) {
   // 1. Check for non-finite values (NaN, infinity)
   if (!std::isfinite(x)) {
     std::stringstream ss;
     ss << "Field '" << name << "' cannot be converted to int32 (NaN or Inf)";
-    throw std::overflow_error(ss.str());
+    throw std::runtime_error(ss.str());
   }
 
   // 2. Check if the value is outside the representable range of an integer.
@@ -1261,14 +1265,14 @@ int SafeDoubleToInt(double x, std::string_view name) {
     std::stringstream ss;
     ss << "Field '" << name << "' value " << x << " is out of int32 range ["
        << std::numeric_limits<int>::min() << ", " << std::numeric_limits<int>::max() << "]";
-    throw std::overflow_error(ss.str());
+    throw std::runtime_error(ss.str());
   }
 
   // 3. Reject fractional values — these fields must be integral.
   if (x != std::trunc(x)) {
     std::stringstream ss;
     ss << "Field '" << name << "' value " << x << " is not an integer";
-    throw std::invalid_argument(ss.str());
+    throw std::runtime_error(ss.str());
   }
 
   // 4. Perform the cast.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -535,6 +535,8 @@ struct SlidingWindow_Element : JSON::Element {
       v_->slide_key_value_cache = JSON::Get<bool>(value);
     } else if (name == "slide_inputs") {
       v_->slide_inputs = JSON::Get<bool>(value);
+    } else if (name == "cache_slack") {
+      v_->cache_slack = SafeDoubleToInt(JSON::Get<double>(value), name);
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.h
+++ b/src/config.h
@@ -355,6 +355,12 @@ struct Config {
         bool slide_key_value_cache{true};  // Whether to slide the key-value cache along with the input prompt
         bool slide_inputs{true};           // Whether to slide the input prompt along with the key-value cache
         std::vector<int> layers;           // Layer indices that use sliding window attention (for models with alternating patterns)
+        // Extra key-value cache positions allocated beyond window_size on execution providers that
+        // own eviction themselves (CUDA and CPU GroupQueryAttention with sliding_window_cache=1).
+        // 0 means "use the EP default": 0 for CUDA (optimal — launch overhead dominates, attention
+        // is O(W) regardless of C), 16 for CPU (optimal — amortises O(C) shift traffic at W+16).
+        // Set explicitly to cover a whole prefill chunk or to tune the amortisation tradeoff.
+        int cache_slack{0};
       };
       std::optional<SlidingWindow> sliding_window;
 

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -425,11 +425,20 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
     throw std::runtime_error("Graph capture is not supported with past_present_share_buffer set to false.");
   }
 
-  // Set the size after empty_past_ has been created with 0 for this field
-  if (state_.model_.p_device_->GetType() == DeviceType::NvTensorRtRtx && model_.config_->model.decoder.sliding_window.has_value() &&
-      model_.config_->model.decoder.sliding_window->window_size > 0) {
-    const int sliding_window_size = model_.config_->model.decoder.sliding_window->window_size;
-    const int max_length = state_.params_->search.max_length;
+  // Compute the capacity for sliding-window layers and apply it to the cache shapes.
+  // ComputeWindowedKvCacheSize() returns 0 when the config does not call for a windowed cache.
+  const DeviceType device_type = state_.model_.p_device_->GetType();
+  const int max_length = state_.params_->search.max_length;
+  const int windowed_cache_size = ComputeWindowedKvCacheSize(
+      device_type, model_.config_->model.decoder, state_.params_->search, max_length);
+
+  if (windowed_cache_size > 0 &&
+      // Beam reordering across a compacted cache is correct in principle but untested.
+      state_.params_->search.num_beams == 1) {
+    // Only a cache smaller than max_length ever evicts, and only then is RewindTo restricted.
+    if (windowed_cache_size < max_length) {
+      windowed_cache_size_ = windowed_cache_size;
+    }
 
     // Check if we need per-layer allocation for models with alternating attention patterns
     if (!model_.config_->model.decoder.sliding_window->layers.empty()) {
@@ -459,14 +468,14 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
       for (int model_layer_idx : model_.config_->model.decoder.sliding_window->layers) {
         auto it = model_layer_to_cache_slot.find(model_layer_idx);
         if (it != model_layer_to_cache_slot.end()) {
-          layer_shapes_[it->second][2] = std::min(max_length, sliding_window_size);
+          layer_shapes_[it->second][2] = windowed_cache_size;
         }
       }
       // Set shape_[2] to max of all layer shapes for RewindTo bounds checking
       shape_[2] = max_length;
     } else {
       // Uniform sliding window allocation (backward compatibility)
-      shape_[2] = std::min(max_length, sliding_window_size);
+      shape_[2] = windowed_cache_size;
     }
   } else if (past_present_share_buffer_) {
     // For fixed kv-cache models the cache size comes from the model graph,
@@ -548,6 +557,8 @@ void DefaultKeyValueCache::Add() {
 }
 
 void DefaultKeyValueCache::Update(DeviceSpan<int32_t> beam_indices, int total_length) {
+  current_length_ = total_length;
+
   // If we're sharing past & present buffers there is nothing to do here, so early exit
   if (past_present_share_buffer_)
     return;
@@ -593,6 +604,10 @@ void DefaultKeyValueCache::Update(DeviceSpan<int32_t> beam_indices, int total_le
 
 void DefaultKeyValueCache::RewindTo(size_t index) {
   if (past_present_share_buffer_) {
+    // Sliding-window layers hold only the most recent windowed_cache_size_ positions, anchored at
+    // cache index 0. Once anything has been evicted, position i no longer lives at cache offset i,
+    // so a rewind would silently read misaligned keys. Refuse instead of returning wrong logits.
+    CheckWindowedKvCacheRewind(windowed_cache_size_, current_length_, index);
     return;
   } else if (shape_[2] <= static_cast<int>(index)) {
     throw std::runtime_error("Requested length of rewind is greater than the current length.");

--- a/src/models/kv_cache.h
+++ b/src/models/kv_cache.h
@@ -104,6 +104,12 @@ struct DefaultKeyValueCache : KeyValueCache {
   // Support for per-layer KV cache shapes (for models with alternating attention patterns)
   std::vector<std::array<int64_t, 4>> layer_shapes_;
 
+  // Sequence capacity allocated for sliding-window layers, or 0 when no layer is windowed.
+  // Only the most recent windowed_cache_size_ positions of those layers are retained, which bounds
+  // how far RewindTo can go back.
+  int windowed_cache_size_{0};
+  int current_length_{0};  // Total sequence length seen by the most recent Update()
+
   std::unique_ptr<OrtValue> empty_past_;
   std::vector<std::unique_ptr<OrtValue>> empty_pasts_;  // Per-layer empty past tensors (for varying head_dim)
   std::vector<std::unique_ptr<OrtValue>> pasts_, presents_;

--- a/src/models/windowed_kv_cache.cpp
+++ b/src/models/windowed_kv_cache.cpp
@@ -13,6 +13,81 @@
 
 namespace Generators {
 
+// ---------------------------------------------------------------------------
+// GQA-based windowed KV cache helpers
+// ---------------------------------------------------------------------------
+
+int ComputeWindowedKvCacheSize(DeviceType device_type,
+                               const Config::Model::Decoder& decoder,
+                               const Config::Search& search,
+                               int max_length) {
+  // Three EPs keep a KV cache smaller than max_length for sliding-window layers:
+  //   NvTensorRtRtx -- evicts inside the EP; cache is exactly window_size, no slack.
+  //   CUDA          -- evicts by compaction inside GQA (sliding_window_cache=1);
+  //                    attention is O(W) regardless of C, launch overhead dominates and
+  //                    is flat in C => optimal C == W. Default slack is 0.
+  //   CPU           -- evicts by compaction inside GQA (sliding_window_cache=1);
+  //                    attention scans O(C) entries, so C = W+16 is the measured
+  //                    minimum (drifting layout amortises shift traffic). Default slack 16.
+  const bool ep_supports_windowed_kv_cache =
+      device_type == DeviceType::NvTensorRtRtx ||
+      device_type == DeviceType::CUDA ||
+      device_type == DeviceType::CPU;
+
+  if (!ep_supports_windowed_kv_cache ||
+      !decoder.sliding_window.has_value() ||
+      decoder.sliding_window->window_size <= 0) {
+    return 0;
+  }
+
+  const int window_size = decoder.sliding_window->window_size;
+
+  // NvTensorRtRtx evicts internally — allocate exactly the window.
+  if (device_type == DeviceType::NvTensorRtRtx) {
+    return std::min(max_length, window_size);
+  }
+
+  // CUDA/CPU: apply slack.
+  // Per-EP default when cache_slack is 0 (the sentinel meaning "use EP default").
+  const int default_ep_slack = (device_type == DeviceType::CPU) ? 16 : 0;
+
+  // chunk_size is an unsigned config value and cache_slack is user-supplied, so the
+  // slack is computed in size_t and clamped to max_length before narrowing to int.
+  // A huge or negative configured value therefore can never wrap into a bogus size.
+  const auto& chunk_size_opt = search.chunk_size;
+  const size_t chunk_slack =
+      (chunk_size_opt.has_value() && *chunk_size_opt > 0) ? *chunk_size_opt - 1 : 0;
+  const int raw_config_slack = decoder.sliding_window->cache_slack;
+  const size_t config_slack = static_cast<size_t>(
+      std::max(0, raw_config_slack > 0 ? raw_config_slack : default_ep_slack));
+  const size_t desired = static_cast<size_t>(window_size) + std::max(chunk_slack, config_slack);
+  return desired >= static_cast<size_t>(max_length) ? max_length : static_cast<int>(desired);
+}
+
+void CheckWindowedKvCacheRewind(int windowed_cache_size, int current_length, size_t index) {
+  // Sliding-window layers hold only the most recent windowed_cache_size positions, anchored
+  // at cache index 0.  Once anything has been evicted, position i no longer lives at cache
+  // offset i, so a rewind would silently read misaligned keys.  Refuse instead of returning
+  // wrong logits.
+  //
+  // Note: this rejects rewinds to an index that is still resident as well.  With a shared
+  // past/present buffer the rewind is purely logical; the kernel re-derives the resident range
+  // from seqlens_k as [T - min(T, C), T).  Rewinding to i would make it read
+  // [i - min(i, C), i) while the buffer still physically holds [T - min(T, C), T).  Those
+  // ranges only coincide when nothing has been evicted; supporting the resident case would
+  // require left-shifting every sliding layer's cache, which is not implemented.
+  if (windowed_cache_size > 0 && current_length > windowed_cache_size &&
+      index < static_cast<size_t>(current_length)) {
+    throw std::runtime_error(
+        "Cannot rewind to " + std::to_string(index) +
+        ": the sliding-window KV cache holds only the last " +
+        std::to_string(windowed_cache_size) + " of " + std::to_string(current_length) +
+        " positions, so the tokens needed at that point have already been evicted. Increase "
+        "model.decoder.sliding_window.cache_slack in genai_config.json to keep more positions "
+        "resident, or rewind before the cache fills.");
+  }
+}
+
 namespace {
 
 std::vector<size_t> MakeAllLayerIndices(size_t layer_count) {

--- a/src/models/windowed_kv_cache.h
+++ b/src/models/windowed_kv_cache.h
@@ -3,9 +3,33 @@
 
 #pragma once
 
+#include "../config.h"
+#include "../smartptrs.h"
 #include "kv_cache.h"
 
 namespace Generators {
+
+// ---------------------------------------------------------------------------
+// GQA-based windowed KV cache helpers (used by DefaultKeyValueCache).
+//
+// These EPs hold a KV cache smaller than max_length for sliding-window layers;
+// the GQA kernel itself evicts old entries by compaction (sliding_window_cache=1).
+// ---------------------------------------------------------------------------
+
+// Returns the windowed cache capacity C for the given execution provider, or 0
+// if the configuration does not call for a windowed cache on this EP.
+// C = W + slack, where slack is the larger of:
+//   - chunk_size - 1 (to fit a whole prefill chunk without staging), and
+//   - the per-EP default (0 for CUDA, 16 for CPU) or the user's cache_slack override.
+// The result is clamped to [0, max_length].
+int ComputeWindowedKvCacheSize(DeviceType device_type,
+                               const Config::Model::Decoder& decoder,
+                               const Config::Search& search,
+                               int max_length);
+
+// Throws if rewinding to `index` is not safe because the windowed KV cache has
+// already evicted the positions needed at that point.
+void CheckWindowedKvCacheRewind(int windowed_cache_size, int current_length, size_t index);
 
 struct WindowedKeyValueCache : KeyValueCache {
   WindowedKeyValueCache(State& state);

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -53,6 +53,14 @@ class Model:
             else self.context_length
         )
         self.window_size = config.sliding_window if hasattr(config, "sliding_window") else -1  # default is -1 in GroupQueryAttention kernel
+        # EPs that can hold a KV cache smaller than max_length for sliding-window layers: trt-rtx
+        # evicts inside the EP, cuda and cpu evict inside GroupQueryAttention (sliding_window_cache=1).
+        self.eps_with_windowed_kv_cache = {"trt-rtx", "cuda", "cpu"}
+        # Positions kept beyond the window to cover a prefill chunk and amortize cache compaction.
+        # 0 means "use the EP default at runtime"; set explicitly to override.
+        # CUDA optimal: 0 (launch overhead dominates; attention is O(W) regardless of C).
+        # CPU  optimal: 16 (amortises O(C) shift traffic; measured minimum at W+16 on EPYC).
+        self.window_kv_cache_slack = 0  # runtime will apply the EP default when this is 0
         self.intermediate_size = config.ffn_hidden_size if hasattr(config, "ffn_hidden_size") else config.intermediate_size
         self.hidden_size = config.hidden_size
         self.num_kv_heads = (
@@ -969,7 +977,7 @@ class Model:
             },
         }
 
-        if self.ep == "trt-rtx" and self.window_size is not None and self.window_size > 0:
+        if self.ep in self.eps_with_windowed_kv_cache and self.window_size is not None and self.window_size > 0:
             # Compute layer indices that use sliding window attention
             layer_idxs = [
                 layer_id for layer_id in range(self.num_layers) if hasattr(self, "is_local") and self.is_local(layer_id)
@@ -980,6 +988,9 @@ class Model:
                 "slide_key_value_cache": False,
                 "slide_inputs": False,
                 "layers": layer_idxs,
+                # Positions kept beyond the window so the runtime can size the cache reproducibly.
+                # Unused by trt-rtx, whose EP evicts internally.
+                "cache_slack": self.window_kv_cache_slack,
             }
 
         if self.ep != "cpu":
@@ -1021,9 +1032,14 @@ class Model:
     def make_key_value_cache_shape(self, layer_id, shape):
         """
         Modifies KV cache shape dimension names for models with alternating attention patterns.
-        For TensorRT EP with sliding window layers, replaces 'sequence' with 'sliding' in dimension name.
+        Sliding window layers get a distinct symbolic sequence dim so ONNX shape inference does not
+        unify them with the full-attention layers, whose cache is allocated at max_length.
         """
-        if self.ep == "trt-rtx" and hasattr(self, "is_local") and self.is_local(layer_id):
+        if (
+            self.ep in self.eps_with_windowed_kv_cache
+            and hasattr(self, "is_local")
+            and self.is_local(layer_id)
+        ):
             return [shape[0], shape[1], shape[2].replace("sequence", "sliding"), shape[3]]
         return shape
 
@@ -3011,9 +3027,17 @@ class Model:
         }
         if kwargs.get("q_norm_weight", ""):
             attributes["qk_norm_epsilon"] = kwargs.get("qk_norm_epsilon", self.attention_attrs["qk_norm_epsilon"])
+
         if self.kv_cache_quant_type != "none":
             attributes["k_quant_type"] = self.kv_quant_type
             attributes["v_quant_type"] = self.kv_quant_type
+            attributes["kv_cache_bit_width"] = self.kv_cache_bit_width
+
+        if self.window_size is not None and self.window_size > 0 and self.ep in {"cuda", "cpu"}:
+            # The past/present buffers of this layer are window-sized rather than max_length-sized,
+            # so the kernel indexes them in cache-relative coordinates and evicts as the window moves.
+            attributes["sliding_window_cache"] = 1
+
         return attributes
 
     def make_group_query_attention(self, name, **kwargs):
@@ -3049,10 +3073,6 @@ class Model:
         output = f"{name}/output_0"
         outputs = [output, kwargs.get("present_k", ""), kwargs.get("present_v", "")]
         attributes = self.get_attention_op_attributes(**kwargs)
-        if self.kv_cache_quant_type != "none":
-            # Unlike PagedAttention, GroupQueryAttention supports sub-byte (int4) caches, so the
-            # bit width cannot be derived from the cache element type alone.
-            attributes["kv_cache_bit_width"] = self.kv_cache_bit_width
         self.make_node(
             "GroupQueryAttention",
             inputs=inputs,

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -3031,7 +3031,6 @@ class Model:
         if self.kv_cache_quant_type != "none":
             attributes["k_quant_type"] = self.kv_quant_type
             attributes["v_quant_type"] = self.kv_quant_type
-            attributes["kv_cache_bit_width"] = self.kv_cache_bit_width
 
         if self.window_size is not None and self.window_size > 0 and self.ep in {"cuda", "cpu"}:
             # The past/present buffers of this layer are window-sized rather than max_length-sized,
@@ -3073,6 +3072,8 @@ class Model:
         output = f"{name}/output_0"
         outputs = [output, kwargs.get("present_k", ""), kwargs.get("present_v", "")]
         attributes = self.get_attention_op_attributes(**kwargs)
+        if self.kv_cache_quant_type != "none":
+            attributes["kv_cache_bit_width"] = self.kv_cache_bit_width
         self.make_node(
             "GroupQueryAttention",
             inputs=inputs,

--- a/test/python/builder/test_windowed_kv_cache.py
+++ b/test/python/builder/test_windowed_kv_cache.py
@@ -1,0 +1,265 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License
+
+"""Unit tests for the windowed KV cache plumbing in the model builder.
+
+Sliding-window layers can keep a KV cache that is smaller than ``max_length`` on
+execution providers that evict entries themselves:
+
+* ``trt-rtx`` evicts inside the EP.
+* ``cuda`` evicts inside ``GroupQueryAttention`` via the ``sliding_window_cache``
+  attribute.
+
+These tests cover the three builder-side pieces that make that work, standalone
+(no model download):
+
+* the ``sliding_window_cache`` attribute on the GQA node,
+* the distinct symbolic ``sliding`` sequence dim on the windowed layers' cache,
+* the ``model.decoder.sliding_window`` block (including ``cache_slack``) written
+  to ``genai_config.json``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+BUILDERS_DIR = Path(__file__).parents[3] / "src" / "python" / "py" / "models" / "builders"
+sys.path.insert(0, str(BUILDERS_DIR.parents[1]))
+
+
+def _load_builder_module(module_name):
+    spec = importlib.util.spec_from_file_location(f"models.builders.{module_name}", BUILDERS_DIR / f"{module_name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f"models.builders.{module_name}"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("models", types.ModuleType("models"))
+builders_package = sys.modules.setdefault("models.builders", types.ModuleType("models.builders"))
+builders_package.__path__ = [str(BUILDERS_DIR)]
+
+base_module = _load_builder_module("base")
+Model = base_module.Model
+
+
+# ===========================================================================
+# make_group_query_attention: the sliding_window_cache attribute
+# ===========================================================================
+
+
+def _make_gqa_model(ep, window_size):
+    model = Model.__new__(Model)
+    model.ep = ep
+    model.extra_options = {}
+    model.kv_cache_quant_type = "none"
+    model.num_attn_heads = 8
+    model.num_kv_heads = 2
+    model.head_size = 16
+    # Builders for alternating-attention models (gemma, gpt-oss, smollm) temporarily set
+    # window_size to -1 around the global layers, so window_size > 0 here means "this
+    # layer is a sliding-window layer".
+    model.window_size = window_size
+    model.attention_attrs = {
+        "op_type": "GroupQueryAttention",
+        "scale": 0.125,
+        "softcap": 0.0,
+        "use_rope_in_attn": True,
+        "qk_norm_epsilon": 1e-6,
+    }
+    model.rope_attrs = {"interleaved": 0}
+    model.io_dtype = None
+    model.nodes = []
+
+    def make_node(op_type, inputs, outputs, name, domain="", **attributes):
+        model.nodes.append({"op_type": op_type, "inputs": inputs, "attributes": attributes})
+
+    model.make_node = make_node
+    model.make_value = lambda *args, **kwargs: None
+    return model
+
+
+def test_cuda_sliding_window_layer_enables_sliding_window_cache():
+    model = _make_gqa_model("cuda", window_size=128)
+
+    model.make_group_query_attention("/gqa", layer_id=0, q_path="q", k_path="k", v_path="v")
+
+    attributes = model.nodes[-1]["attributes"]
+    assert attributes["sliding_window_cache"] == 1
+    assert attributes["local_window_size"] == 128
+
+
+@pytest.mark.parametrize("window_size", [-1, 0, None])
+def test_cuda_global_layer_omits_sliding_window_cache(window_size):
+    # Global (full-attention) layers keep a max_length-sized cache, so the kernel must
+    # index it in absolute coordinates.
+    model = _make_gqa_model("cuda", window_size=window_size)
+
+    model.make_group_query_attention("/gqa", layer_id=1, q_path="q", k_path="k", v_path="v")
+
+    assert "sliding_window_cache" not in model.nodes[-1]["attributes"]
+
+
+def test_cpu_sliding_window_layer_enables_sliding_window_cache():
+    model = _make_gqa_model("cpu", window_size=128)
+
+    model.make_group_query_attention("/gqa", layer_id=0, q_path="q", k_path="k", v_path="v")
+
+    attributes = model.nodes[-1]["attributes"]
+    assert attributes["sliding_window_cache"] == 1
+    assert attributes["local_window_size"] == 128
+
+
+@pytest.mark.parametrize("ep", ["trt-rtx", "dml", "webgpu"])
+def test_non_cuda_ep_omits_sliding_window_cache(ep):
+    # trt-rtx gets a windowed cache but the EP evicts internally (no attribute).
+    # dml and webgpu have no windowed cache at all.
+    model = _make_gqa_model(ep, window_size=128)
+
+    model.make_group_query_attention("/gqa", layer_id=0, q_path="q", k_path="k", v_path="v")
+
+    assert "sliding_window_cache" not in model.nodes[-1]["attributes"]
+
+
+# ===========================================================================
+# make_key_value_cache_shape: the distinct symbolic dim for windowed layers
+# ===========================================================================
+
+
+_CACHE_SHAPE = ["batch_size", 2, "past_sequence_length", 16]
+
+
+def _make_shape_model(ep, local_layers=()):
+    model = Model.__new__(Model)
+    model.ep = ep
+    model.eps_with_windowed_kv_cache = {"trt-rtx", "cuda", "cpu"}
+    if local_layers is not None:
+        model.is_local = lambda layer_id: layer_id in local_layers
+    return model
+
+
+@pytest.mark.parametrize("ep", ["cuda", "trt-rtx", "cpu"])
+def test_windowed_ep_renames_sequence_dim_on_sliding_layers(ep):
+    model = _make_shape_model(ep, local_layers=(0,))
+
+    assert model.make_key_value_cache_shape(0, list(_CACHE_SHAPE)) == [
+        "batch_size",
+        2,
+        "past_sliding_length",
+        16,
+    ]
+
+
+@pytest.mark.parametrize("ep", ["cuda", "trt-rtx", "cpu"])
+def test_windowed_ep_keeps_sequence_dim_on_global_layers(ep):
+    # Global layers keep the shared 'sequence' dim so they stay unified at max_length.
+    model = _make_shape_model(ep, local_layers=(0,))
+
+    assert model.make_key_value_cache_shape(1, list(_CACHE_SHAPE)) == _CACHE_SHAPE
+
+
+@pytest.mark.parametrize("ep", ["dml", "webgpu"])
+def test_non_windowed_ep_keeps_sequence_dim(ep):
+    model = _make_shape_model(ep, local_layers=(0,))
+
+    assert model.make_key_value_cache_shape(0, list(_CACHE_SHAPE)) == _CACHE_SHAPE
+
+
+def test_model_without_alternating_attention_keeps_sequence_dim():
+    # Models that never define is_local have a uniform attention pattern.
+    model = _make_shape_model("cuda", local_layers=None)
+
+    assert model.make_key_value_cache_shape(0, list(_CACHE_SHAPE)) == _CACHE_SHAPE
+
+
+# ===========================================================================
+# make_genai_config: the model.decoder.sliding_window block
+# ===========================================================================
+
+
+class _NoGenerationConfig:
+    @staticmethod
+    def from_pretrained(*args, **kwargs):
+        raise FileNotFoundError("no generation_config.json")
+
+
+def _write_genai_config(monkeypatch, out_dir, ep, window_size, num_layers=4):
+    hf_config = SimpleNamespace(eos_token_id=[2])
+    monkeypatch.setattr(base_module, "AutoConfig", SimpleNamespace(from_pretrained=lambda *a, **k: hf_config))
+    monkeypatch.setattr(base_module, "GenerationConfig", _NoGenerationConfig)
+
+    model = Model.__new__(Model)
+    model.hf_token = None
+    model.hf_remote = False
+    model.ep = ep
+    model.ep_attrs = {ep: {}}
+    model.extra_options = {}
+    model.use_paged_attention = False
+    model.past_present_share_buffer = True
+    model.context_length = 1024
+    model.filename = "model.onnx"
+    model.head_size = 16
+    model.hidden_size = 128
+    model.num_attn_heads = 8
+    model.num_kv_heads = 2
+    model.num_layers = num_layers
+    model.model_type = "TestForCausalLM"
+    model.vocab_size = 32
+    model.window_size = window_size
+    model.eps_with_windowed_kv_cache = {"trt-rtx", "cuda", "cpu"}
+    model.window_kv_cache_slack = 0  # let runtime apply EP defaults
+    # Alternating attention: even layers are sliding-window layers.
+    model.is_local = lambda layer_id: layer_id % 2 == 0
+    model.input_names = {"input_ids": "input_ids", "past_key_values.key": [], "past_key_values.value": []}
+    model.output_names = {"logits": "logits", "present.key": [], "present.value": []}
+
+    model.make_genai_config("model_name_or_path", {}, str(out_dir))
+    return json.loads((Path(out_dir) / "genai_config.json").read_text())
+
+
+@pytest.mark.parametrize("ep", ["cuda", "trt-rtx"])
+def test_genai_config_emits_sliding_window_with_cache_slack(monkeypatch, tmp_path, ep):
+    config = _write_genai_config(monkeypatch, tmp_path, ep, window_size=128)
+
+    sliding_window = config["model"]["decoder"]["sliding_window"]
+    assert sliding_window == {
+        "window_size": 128,
+        "slide_key_value_cache": False,
+        "slide_inputs": False,
+        "layers": [0, 2],
+        "cache_slack": 0,  # 0 = use EP default at runtime (0 for CUDA, 16 for CPU)
+    }
+
+
+def test_genai_config_emits_sliding_window_for_cpu(monkeypatch, tmp_path):
+    config = _write_genai_config(monkeypatch, tmp_path, "cpu", window_size=128)
+
+    sliding_window = config["model"]["decoder"]["sliding_window"]
+    assert sliding_window == {
+        "window_size": 128,
+        "slide_key_value_cache": False,
+        "slide_inputs": False,
+        "layers": [0, 2],
+        "cache_slack": 0,  # runtime applies CPU default of 16
+    }
+
+
+@pytest.mark.parametrize("ep", ["dml", "webgpu"])
+def test_genai_config_omits_sliding_window_for_other_eps(monkeypatch, tmp_path, ep):
+    config = _write_genai_config(monkeypatch, tmp_path, ep, window_size=128)
+
+    assert "sliding_window" not in config["model"]["decoder"]
+
+
+@pytest.mark.parametrize("window_size", [-1, 0, None])
+def test_genai_config_omits_sliding_window_without_a_window(monkeypatch, tmp_path, window_size):
+    config = _write_genai_config(monkeypatch, tmp_path, "cuda", window_size=window_size)
+
+    assert "sliding_window" not in config["model"]["decoder"]

--- a/test/sliding_window_config_test.cpp
+++ b/test/sliding_window_config_test.cpp
@@ -54,6 +54,10 @@ std::string CaptureThrowMessage(Fn&& fn) {
     fn();
   } catch (const std::exception& e) {
     return e.what();
+  } catch (...) {
+    // The C API is only allowed to surface std::exception; report anything else instead of
+    // letting gtest print an opaque "Unknown C++ exception thrown in the test body".
+    return "<non-std::exception escaped the C API boundary>";
   }
   return {};
 }
@@ -89,7 +93,9 @@ TEST(SlidingWindowConfigTest, RejectsNonNumericCacheSlack) {
 
 TEST(SlidingWindowConfigTest, RejectsOutOfRangeCacheSlack) {
   // cache_slack is stored as an int; SafeDoubleToInt must reject values that do not fit.
-  const auto root = WriteConfigWithSlidingWindow("overflow", "{ \"window_size\": 128, \"cache_slack\": 1e20 }");
+  // Spelled as a plain integer rather than in exponent form so the test exercises the range
+  // check and not the platform-specific number scanner (std::from_chars vs std::strtod).
+  const auto root = WriteConfigWithSlidingWindow("overflow", "{ \"window_size\": 128, \"cache_slack\": 4000000000 }");
   const std::string message = CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
   EXPECT_NE(message.find("cache_slack"), std::string::npos) << message;
 }

--- a/test/sliding_window_config_test.cpp
+++ b/test/sliding_window_config_test.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for the `model.decoder.sliding_window` config block, in particular the
+// `cache_slack` field used to size a windowed KV cache on execution providers that evict
+// entries themselves. Like validate_config_path_test.cpp these drive the parser through the
+// public C API boundary (OgaConfig::Create) instead of reaching into the internal Config
+// struct, which is not exported from the shared library.
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "ort_genai.h"
+
+namespace Generators::test {
+namespace {
+
+namespace fs_std = std::filesystem;
+
+fs_std::path MakeTempDir(const std::string& suffix) {
+  static int counter = 0;
+  ++counter;
+  const auto dir = fs_std::temp_directory_path() /
+                   ("ortgenai_sw_test_" + suffix + "_" + std::to_string(counter));
+  std::error_code ec;
+  fs_std::remove_all(dir, ec);
+  fs_std::create_directories(dir);
+  return dir;
+}
+
+// Builds a minimal genai_config.json whose decoder carries `sliding_window_json` as its
+// `sliding_window` block, and returns the containing directory.
+fs_std::path WriteConfigWithSlidingWindow(const std::string& suffix, const std::string& sliding_window_json) {
+  const auto root = MakeTempDir(suffix);
+  const std::string config =
+      "{ \"model\": { \"type\": \"tiny-test-model\","
+      " \"vocab_size\": 16, \"context_length\": 32,"
+      " \"decoder\": { \"filename\": \"model.onnx\","
+      " \"sliding_window\": " +
+      sliding_window_json +
+      " } },"
+      " \"search\": {} }";
+  std::ofstream out(root / "genai_config.json", std::ios::binary);
+  out << config;
+  return root;
+}
+
+template <typename Fn>
+std::string CaptureThrowMessage(Fn&& fn) {
+  try {
+    fn();
+  } catch (const std::exception& e) {
+    return e.what();
+  }
+  return {};
+}
+
+}  // namespace
+
+TEST(SlidingWindowConfigTest, AcceptsCacheSlack) {
+  const auto root = WriteConfigWithSlidingWindow(
+      "slack",
+      "{ \"window_size\": 128, \"slide_key_value_cache\": false, \"slide_inputs\": false,"
+      " \"layers\": [0, 2], \"cache_slack\": 256 }");
+  EXPECT_NO_THROW(OgaConfig::Create(root.string().c_str()));
+}
+
+TEST(SlidingWindowConfigTest, AcceptsSlidingWindowWithoutCacheSlack) {
+  // cache_slack is optional; older configs that predate it must keep loading.
+  const auto root = WriteConfigWithSlidingWindow("no_slack", "{ \"window_size\": 128 }");
+  EXPECT_NO_THROW(OgaConfig::Create(root.string().c_str()));
+}
+
+TEST(SlidingWindowConfigTest, RejectsMisspelledCacheSlack) {
+  // Guards against a typo silently falling back to the default slack.
+  const auto root = WriteConfigWithSlidingWindow("typo", "{ \"window_size\": 128, \"cache_slak\": 256 }");
+  const std::string message = CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
+  EXPECT_NE(message.find("cache_slak"), std::string::npos) << message;
+}
+
+TEST(SlidingWindowConfigTest, RejectsNonNumericCacheSlack) {
+  const auto root = WriteConfigWithSlidingWindow("string", "{ \"window_size\": 128, \"cache_slack\": \"256\" }");
+  const std::string message = CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
+  EXPECT_NE(message.find("cache_slack"), std::string::npos) << message;
+}
+
+TEST(SlidingWindowConfigTest, RejectsOutOfRangeCacheSlack) {
+  // cache_slack is stored as an int; SafeDoubleToInt must reject values that do not fit.
+  const auto root = WriteConfigWithSlidingWindow("overflow", "{ \"window_size\": 128, \"cache_slack\": 1e20 }");
+  const std::string message = CaptureThrowMessage([&] { OgaConfig::Create(root.string().c_str()); });
+  EXPECT_NE(message.find("cache_slack"), std::string::npos) << message;
+}
+
+}  // namespace Generators::test


### PR DESCRIPTION
## Description

Models with alternating attention (for example gpt-oss-20b: 24 layers, sliding-window `W=128` interleaved with full attention) currently get a KV cache of `search.max_length` for **every** layer on CUDA, even though the sliding-window layers can never attend beyond their window. This PR lets the CUDA EP hold a window-sized KV cache for those layers, which cuts KV memory roughly in half on gpt-oss-20b at long context.

The reduced allocation was previously gated to `NvTensorRtRtx`, which evicts inside the EP. CUDA now gets the same treatment by relying on the new `sliding_window_cache` attribute on `com.microsoft::GroupQueryAttention`, which makes the kernel index the past/present buffers in cache-relative coordinates and evict by compaction.

**Depends on** microsoft/onnxruntime#29904 (`[CUDA] GQA support sliding_window_cache`). Without that ORT change the emitted `sliding_window_cache` attribute is unknown to the kernel, so this PR should not be merged before it.

## Summary of Changes

### Runtime: window-sized KV cache on CUDA

| File | Change |
|------|--------|
| `src/models/kv_cache.cpp` | `DefaultKeyValueCache` now sizes sliding-window layers below `max_length` on CUDA as well as `NvTensorRtRtx`. CUDA gets `window_size + slack` (slack is at least `chunk_size - 1` so a whole prefill chunk fits); `NvTensorRtRtx` keeps exactly the window because its EP evicts internally. Restricted to `num_beams == 1` — beam reordering across a compacted cache is correct in principle but untested. |
| `src/models/kv_cache.cpp` | `RewindTo` throws a descriptive error when the requested position has already been evicted from a windowed cache, instead of silently returning misaligned keys. With `past_present_share_buffer_` the rewind is purely logical, while the kernel derives the resident range from `seqlens_k`, so the two only agree while nothing has been evicted. |
| `src/models/kv_cache.h` | Adds `windowed_cache_size_` (0 when no layer is windowed, so the guard is inert for full-size caches) and `current_length_`, tracked from `Update()`. |

### Config: `model.decoder.sliding_window.cache_slack`

| File | Change |
|------|--------|
| `src/config.h` | New `cache_slack` field (default 256) — the KV positions kept beyond `window_size` on EPs that evict by compaction. It amortizes compaction and doubles as the `RewindTo` budget. |
| `src/config.cpp` | Parses `cache_slack` in `SlidingWindow_Element`. |

### Model builder

| File | Change |
|------|--------|
| `src/python/py/models/builders/base.py` | Introduces `eps_with_windowed_kv_cache = {"trt-rtx", "cuda"}` and uses it for the `sliding_window` block in `genai_config.json` (now including `cache_slack`) and for `make_key_value_cache_shape`, so windowed layers get a distinct symbolic `sliding` sequence dim and ONNX shape inference does not unify them with the `max_length` full-attention layers. |
| `src/python/py/models/builders/base.py` | Emits `sliding_window_cache=1` on the GQA node for CUDA sliding-window layers. Subclasses (gemma, gpt-oss, smollm) already set `window_size = -1` around global layers, so the attribute lands only on windowed layers. |

### Tests

| File | Change |
|------|--------|
| `test/python/builder/test_windowed_kv_cache.py` | New, 24 offline tests: the `sliding_window_cache` GQA attribute (EP and per-layer gating), `make_key_value_cache_shape` dim renaming, and the `genai_config.json` `sliding_window` block including `cache_slack`. |
| `test/sliding_window_config_test.cpp` | New, 5 gtest cases for `cache_slack` parsing through `OgaConfig::Create`: accepted, optional, and rejected when misspelled, non-numeric, or out of int range. |

## Testing

- Python builder tests: `python -m pytest test/python/builder -q` → 311 passed, 3 skipped.
- C++ unit tests: `cmake --build <build-dir> --target unit_tests && ./unit_tests --gtest_filter='SlidingWindowConfigTest.*:*Rewind*:*Config*'` → all pass.
- The new builder tests were validated against the pre-change `base.py`, where 4 of them fail, confirming they are regression-catching.
- Backward compatibility: `cache_slack` is optional, so existing `genai_config.json` files keep loading. Non-CUDA/non-trt-rtx EPs, models without alternating attention, and beam search (`num_beams > 1`) all keep the previous full-length allocation.
- End-to-end (gpt-oss-20b, A100-80GB, int8 KV, `max_length=131072`): KV memory 5138 → 3090 MiB (−39.9%), process peak 18636 → 16556 MiB. GPQA-diamond accuracy 0.6010 → 0.5960 over 198 questions (McNemar p = 1.0, accuracy-neutral). Decode throughput regresses ~1–2% from the compaction launches.

## Motivation and Context

`local_window_size` in ORT's CUDA `GroupQueryAttention` narrows the attention *mask* only, never the cache: `CheckInputs` computes `present_sequence_length = max(total_sequence_length, past_sequence_length)`, and K/V are appended at the absolute index `past_seq_lens[b] + s`. Binding a shorter present buffer therefore fails shape validation outright. microsoft/onnxruntime#29904 adds the opt-in `sliding_window_cache` attribute that switches the kernel to cache-relative coordinates with shift compaction; this PR is the genai-side half that allocates the smaller cache and writes the attribute.

Note that windowed caching is not expected to be faster — the baseline already passes `local_window_size` to flash attention, so the sliding layers are already `O(W)` in compute. The feature buys memory, not speed.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes (opt-in via config; existing configs and EPs unaffected)
- [ ] Documentation updated (if applicable)
