### PR TITLE
Fix Phi3 out-of-place KV cache test expected output

### DIFF
--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -384,7 +384,7 @@ void Test_OutOfPlaceKvCache_Phi3_NvTensorRtRtx(const char* model_path, const cha
   // Expected output sequence (input + generated tokens) for validation with greedy search
   const std::vector<int32_t> expected_output{
       32006, 887, 526, 263, 8444, 29871, 23869, 20255, 29889, 32007, 32010, 6324, 29892, 1128, 526, 366, 29973, 32007, 32001,  // Input tokens (19)
-      15043, 1554, 13, 16271, 29892, 8733};
+      15043, 29991, 306, 29915, 29885, 2599};
 
   auto config = OgaConfig::Create(resolved_path.c_str());
   config->ClearProviders();


### PR DESCRIPTION
Changed the expected output of out-of-place kv cache test for phi3 model, since it was wrong

```
PROMPT (19 tokens)
  ids : [32006, 887, 526, 263, 8444, 29871, 23869, 20255, 29889, 32007, 32010, 6324, 29892, 1128, 526, 366, 29973, 32007, 32001]
  text: '<|system|> You are a helpful AI assistant.<|end|><|user|> Hi, How are you?<|end|><|assistant|>'

GREEDY  generated (expected == actual, test PASSES)
  ids : [15043, 29991, 306, 29915, 29885, 2599]
  text: "Hello! I'm doing"

OUTOFPLACE expected by test (golden in test)
  ids : [15043, 1554, 13, 16271, 29892, 8733]
  text: 'Hello something\nphia,terior'

OUTOFPLACE actual   (what EP produced now)
  ids : [15043, 29991, 306, 29915, 29885, 2599]
  text: "Hello! I'm doing"

```
