### PR TITLE
feat: Allow multimodal models without speech components

### DIFF
--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -899,11 +899,6 @@ std::shared_ptr<Model> CreateModel(OrtEnv& ort_env, std::unique_ptr<Config> conf
           "speech.filename is set but speech.config_filename is missing. "
           "Both are required for audio support.");
     }
-    if (!has_speech_model && has_speech_config) {
-      throw std::runtime_error(
-          "speech.config_filename is set but speech.filename is missing. "
-          "Both are required for audio support.");
-    }
     return std::make_shared<MultiModalLanguageModel>(std::move(config), ort_env, true, has_speech_model);
   }
   if (config->model.type == "marian-ssru")


### PR DESCRIPTION
## Problem

According to the gemma-4-26B-A4B-it model card, It is a text-and-image model rather than a speech-enabled multimodal model.

https://huggingface.co/google/gemma-4-26B-A4B-it/blob/main/README.md

However, `model.cpp` currently categorizes Gemma 4 as an MMM model and assumes speech support is available. As a result, model initialization expects a valid `speech.config_filename`, causing Gemma 4 to fail to load even though it has no speech component.

## Solution

This PR relaxes the speech requirements for multimodal models that do not include speech support.

Changes:

- allowing models without speech to construct `MultiModalLanguageModel` with `has_speech_model == false`.
- In the MMM initialization path in `model.cpp`, do not throw an exception when `!has_speech_model && has_speech_config`.

This keeps speech-enabled models unchanged while allowing vision-language models such as Gemma 4 to initialize successfully.

## Motivation

Gemma 4 is fundamentally a vision-language model (text + image) rather than a speech multimodal model. Requiring speech configuration for all MMM models unnecessarily prevents such models from loading.