### PR TITLE
Add aggregate engine request telemetry

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -9,15 +9,26 @@ Engine::Engine(std::shared_ptr<Model> model)
     : model_{model},
       cache_manager_{CacheManager::Create(model)},
       scheduler_{Scheduler::Create(model, cache_manager_)},
-      model_executor_{std::make_unique<ModelExecutor>(model, cache_manager_)} {}
+      model_executor_{std::make_unique<ModelExecutor>(model, cache_manager_)} {
+#if defined(ORTGENAI_ENABLE_TELEMETRY)
+  telemetry_id_ = AllocateEngineTelemetryId();
+  dynamic_batching_ = cache_manager_->SupportsDynamicBatching();
+#endif
+}
 
 void Engine::AddRequest(std::shared_ptr<Request> request) {
-  request->Assign(shared_from_this());
+#if defined(ORTGENAI_ENABLE_TELEMETRY)
+  request->Assign(shared_from_this(), model_->telemetry_session_id_, telemetry_id_,
+                  dynamic_batching_);
+#else
+  request->Assign(shared_from_this(), 0, 0, false);
+#endif
   scheduler_->AddRequest(request);
 }
 
 void Engine::RemoveRequest(std::shared_ptr<Request> request) {
   scheduler_->RemoveRequest(request);
+  request->CompleteRemoval();
 }
 
 std::shared_ptr<Request> Engine::Step() {

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -6,6 +6,7 @@
 #include "request.h"
 #include "model_executor.h"
 #include "scheduler.h"
+#include "../telemetry/engine_telemetry.h"
 
 /**
  * @file engine.h
@@ -71,6 +72,10 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::unique_ptr<Scheduler> scheduler_;                 // The scheduler responsible for managing execution order.
   std::unique_ptr<ModelExecutor> model_executor_;        // The executor responsible for running the model.
   std::queue<std::shared_ptr<Request>> ready_requests_;  // The list of requests that are ready for the application to process.
+#if defined(ORTGENAI_ENABLE_TELEMETRY)
+  uint32_t telemetry_id_{};
+  bool dynamic_batching_{};
+#endif
 };
 
 }  // namespace Generators

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -24,7 +24,8 @@ DeviceSpan<int32_t> AllocateOnDevice(GeneratorParams& params,
 Request::Request(std::shared_ptr<GeneratorParams> params)
     : params_{params}, search_{CreateSearch(*params.get())} {}
 
-void Request::Assign(std::shared_ptr<Engine> engine) {
+void Request::Assign(std::shared_ptr<Engine> engine, uint32_t session_id,
+                     uint32_t engine_id, bool dynamic_batching) {
   if (status_ != RequestStatus::Unassigned) {
     throw std::runtime_error("Cannot add the request to the engine since it is already assigned.");
   }
@@ -36,6 +37,7 @@ void Request::Assign(std::shared_ptr<Engine> engine) {
   search_->AppendTokens(device_tokens);
   seen_sequence_length_ = CurrentSequenceLength();
   prefill_input_ids_.clear();
+  telemetry_.Begin(session_id, engine_id, dynamic_batching, seen_sequence_length_);
 }
 
 void Request::Schedule() {
@@ -48,13 +50,22 @@ void Request::Schedule() {
   }
 
   status_ = RequestStatus::InProgress;
+  telemetry_.OnScheduled();
 }
 
 void Request::Remove() {
   auto engine = engine_.lock();
   if (engine) {
     engine->RemoveRequest(shared_from_this());
+  } else {
+    CompleteRemoval();
   }
+}
+
+void Request::CompleteRemoval() {
+  const bool completed = status_ == RequestStatus::Completed;
+  telemetry_.OnRemoved(completed);
+  engine_.reset();
   status_ = RequestStatus::Unassigned;
 }
 
@@ -108,7 +119,7 @@ bool Request::IsPrefill() const {
   return is_prefill_;
 }
 
-void Request::GenerateNextTokens(DeviceSpan<float> logits) {
+void Request::GenerateNextTokens(DeviceSpan<float> logits, size_t batch_size) {
   processed_sequence_length_ = search_->GetSequence(0).size();
   is_prefill_ = false;
 
@@ -144,6 +155,8 @@ void Request::GenerateNextTokens(DeviceSpan<float> logits) {
   if (search_->IsDone()) {
     status_ = RequestStatus::Completed;
   }
+  telemetry_.OnStep(CurrentSequenceLength(), batch_size,
+                    status_ == RequestStatus::Completed);
 }
 
 std::shared_ptr<GeneratorParams> Request::Params() {

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../generators.h"
+#include "../telemetry/engine_telemetry.h"
 
 /**
  * @file request.h
@@ -46,7 +47,8 @@ struct Request : std::enable_shared_from_this<Request>,
    *
    * Once assigned, the request will finalize the prefill tokens and prepare for scheduling.
    */
-  void Assign(std::shared_ptr<Engine> engine);
+  void Assign(std::shared_ptr<Engine> engine, uint32_t session_id, uint32_t engine_id,
+              bool dynamic_batching);
 
   /**
    * @brief Updates the status of the request to InProgress and prepares it for processing.
@@ -93,7 +95,7 @@ struct Request : std::enable_shared_from_this<Request>,
    * @brief Generates the next set of tokens based on the provided logits.
    * @param logits DeviceSpan containing logits for token generation.
    */
-  void GenerateNextTokens(DeviceSpan<float> logits);
+  void GenerateNextTokens(DeviceSpan<float> logits, size_t batch_size);
 
   /**
    * @brief Checks if the termination condition for the request has been met.
@@ -147,6 +149,10 @@ struct Request : std::enable_shared_from_this<Request>,
   void* GetOpaqueData();
 
  private:
+  friend struct Engine;
+
+  void CompleteRemoval();
+
   std::vector<int32_t> prefill_input_ids_;
   int64_t seen_sequence_length_{};
   int64_t processed_sequence_length_{};
@@ -156,6 +162,12 @@ struct Request : std::enable_shared_from_this<Request>,
   bool is_prefill_{true};
 
   void* opaque_data_{nullptr};  // Opaque data for user-defined purposes, can be set and retrieved by the application
+#if defined(_MSC_VER)
+  [[msvc::no_unique_address]]
+#else
+  [[no_unique_address]]
+#endif
+  EngineRequestTelemetry telemetry_;
 };
 
 }  // namespace Generators

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -38,9 +38,15 @@ void ScheduledRequests::GenerateNextTokens() {
     throw std::runtime_error("Logits size does not match the number of requests.");
   }
 
+  const size_t active_request_count =
+      std::count_if(requests_.begin(), requests_.end(),
+                    [](const std::shared_ptr<Request>& request) {
+                      return request->status_ != RequestStatus::Completed;
+                    });
   for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
     if (requests_[request_idx]->status_ != RequestStatus::Completed) {
-      requests_[request_idx]->GenerateNextTokens(logits[request_idx]);
+      requests_[request_idx]->GenerateNextTokens(logits[request_idx],
+                                                 active_request_count);
     }
   }
 }

--- a/src/telemetry/device_info.cpp
+++ b/src/telemetry/device_info.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "device_info.h"
+#include "sha256.h"
 
 // The platform device-info implementation is only needed when telemetry is
 // compiled in. Guarding the whole translation unit keeps default (OFF) builds
@@ -61,21 +62,6 @@
 namespace Generators {
 
 namespace {
-
-constexpr char kDeviceIdHashSalt[] = "onnxruntime-genai:";
-
-// FNV-1a 64-bit hash -> fixed-width hex. Stable across platforms and runs
-// (unlike std::hash), so the derived device id stays consistent over time.
-std::string Fnv1aHex(const std::string& input) {
-  uint64_t h = 14695981039346656037ULL;
-  for (unsigned char c : input) {
-    h ^= c;
-    h *= 1099511628211ULL;
-  }
-  char buf[17];
-  std::snprintf(buf, sizeof(buf), "%016llx", static_cast<unsigned long long>(h));
-  return std::string(buf);
-}
 
 // Generate a random v4 UUID string.
 std::string GenerateUuidV4() {
@@ -842,9 +828,9 @@ const DeviceInfo& GetDeviceInfo() {
     if (UsePlatformDeviceId()) {
       id_status = DeviceIdStatus::Platform;
     } else {
-      // "c:" prefix marks a custom device id; the value is a stable hash of a
-      // locally-generated UUID plus a product salt (no hardware identifier is ever sent).
-      di.device_id = "c:" + Fnv1aHex(std::string{kDeviceIdHashSalt} + GetOrCreatePersistentDeviceId(id_status));
+      // Every Microsoft AI developer tool reads the same UUID and derives the same upload identifier.
+      // The raw UUID is never transmitted.
+      di.device_id = "c:" + TelemetryInternal::Sha256::HashStringHex(GetOrCreatePersistentDeviceId(id_status));
     }
     di.device_id_status = DeviceIdStatusString(id_status);
     di.os_architecture = GetOsArchitecture();

--- a/src/telemetry/engine_telemetry.cpp
+++ b/src/telemetry/engine_telemetry.cpp
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "engine_telemetry.h"
+
+#if defined(ORTGENAI_ENABLE_TELEMETRY)
+
+#include <algorithm>
+#include <atomic>
+#include <string_view>
+
+#include "telemetry.h"
+
+namespace Generators {
+
+namespace {
+std::atomic<uint32_t> g_next_engine_id{1};
+std::atomic<uint32_t> g_next_engine_request_id{1};
+std::atomic<EngineRequestTelemetry::FinalizeCallback> g_finalize_callback{nullptr};
+}  // namespace
+
+uint32_t AllocateEngineTelemetryId() {
+  return g_next_engine_id.fetch_add(1);
+}
+
+void EngineRequestTelemetry::SetFinalizeCallbackForTest(FinalizeCallback callback) {
+  g_finalize_callback.store(callback);
+}
+
+EngineRequestTelemetry::~EngineRequestTelemetry() {
+  if (!active_) return;
+  Finish(completed_ ? Outcome::Completed : Outcome::Abandoned,
+         completed_ ? completed_time_ : std::chrono::steady_clock::now());
+}
+
+void EngineRequestTelemetry::Begin(uint32_t session_id, uint32_t engine_id,
+                                   bool dynamic_batching, int64_t prompt_tokens) {
+  if (active_) {
+    Finish(completed_ ? Outcome::Completed : Outcome::Abandoned,
+           completed_ ? completed_time_ : std::chrono::steady_clock::now());
+  }
+
+  if (!IsEnabled()) return;
+
+  session_id_ = session_id;
+  engine_id_ = engine_id;
+  request_id_ = g_next_engine_request_id.fetch_add(1);
+  prompt_tokens_ = prompt_tokens;
+  dynamic_batching_ = dynamic_batching;
+  assigned_time_ = std::chrono::steady_clock::now();
+  steady_clock_anchor_ = assigned_time_;
+  system_clock_anchor_ = std::chrono::system_clock::now();
+  active_ = true;
+}
+
+void EngineRequestTelemetry::OnScheduled() {
+  if (!active_ || scheduled_) return;
+  if (!IsEnabled()) {
+    Reset();
+    return;
+  }
+  scheduled_time_ = std::chrono::steady_clock::now();
+  scheduled_ = true;
+}
+
+void EngineRequestTelemetry::OnStep(int64_t sequence_length, size_t batch_size,
+                                    bool completed) {
+  if (!active_) return;
+  if (!IsEnabled()) {
+    Reset();
+    return;
+  }
+
+  const auto now = std::chrono::steady_clock::now();
+  if (!first_token_recorded_) {
+    first_token_time_ = now;
+    first_token_recorded_ = true;
+  }
+  generated_tokens_ = std::max<int64_t>(0, sequence_length - prompt_tokens_);
+  ++step_count_;
+  batch_size_total_ += static_cast<int64_t>(batch_size);
+  max_batch_size_ = std::max(max_batch_size_, static_cast<int64_t>(batch_size));
+  if (completed && !completed_) {
+    completed_time_ = now;
+    completed_ = true;
+  }
+}
+
+void EngineRequestTelemetry::OnRemoved(bool completed) {
+  if (!active_) return;
+  const auto now = std::chrono::steady_clock::now();
+  Finish(completed || completed_ ? Outcome::Completed : Outcome::Removed,
+         completed_ ? completed_time_ : now);
+}
+
+bool EngineRequestTelemetry::IsEnabled() const {
+  return g_finalize_callback.load() != nullptr ||
+         (!GenAiTelemetry::IsDestroyed() && GenAiTelemetry::Instance().IsEnabled());
+}
+
+void EngineRequestTelemetry::Finish(Outcome outcome,
+                                    std::chrono::steady_clock::time_point end_time) {
+  if (!active_) return;
+  const auto finalize_callback = g_finalize_callback.load();
+  if (!finalize_callback && GenAiTelemetry::IsDestroyed()) {
+    Reset();
+    return;
+  }
+
+  EngineRequestInfo info{};
+  info.dynamic_batching = dynamic_batching_;
+  info.prompt_tokens = prompt_tokens_;
+  info.generated_tokens = generated_tokens_;
+  info.step_count = step_count_;
+  info.max_batch_size = max_batch_size_;
+  info.average_batch_size =
+      step_count_ > 0 ? static_cast<double>(batch_size_total_) / step_count_ : 0.0;
+  info.queue_time_ms =
+      scheduled_
+          ? std::chrono::duration<double, std::milli>(scheduled_time_ - assigned_time_).count()
+          : 0.0;
+  info.time_to_first_token_ms =
+      first_token_recorded_
+          ? std::chrono::duration<double, std::milli>(first_token_time_ - assigned_time_).count()
+          : 0.0;
+  info.decode_time_ms =
+      first_token_recorded_
+          ? std::chrono::duration<double, std::milli>(end_time - first_token_time_).count()
+          : 0.0;
+  info.total_time_ms =
+      std::chrono::duration<double, std::milli>(end_time - assigned_time_).count();
+  switch (outcome) {
+    case Outcome::Completed:
+      info.outcome = "completed";
+      break;
+    case Outcome::Removed:
+      info.outcome = "removed";
+      break;
+    case Outcome::Abandoned:
+      info.outcome = "abandoned";
+      break;
+  }
+
+  const auto end_wall_time =
+      system_clock_anchor_ +
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(
+          end_time - steady_clock_anchor_);
+  const auto end_timestamp_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          end_wall_time.time_since_epoch())
+          .count();
+  if (finalize_callback) {
+    finalize_callback(session_id_, engine_id_, request_id_, info, end_timestamp_ms);
+  }
+  if (!GenAiTelemetry::IsDestroyed()) {
+    GenAiTelemetry::Instance().LogEngineRequest(
+        session_id_, engine_id_, request_id_, info, end_timestamp_ms);
+  }
+  Reset();
+}
+
+void EngineRequestTelemetry::Reset() {
+  session_id_ = 0;
+  engine_id_ = 0;
+  request_id_ = 0;
+  prompt_tokens_ = 0;
+  generated_tokens_ = 0;
+  step_count_ = 0;
+  batch_size_total_ = 0;
+  max_batch_size_ = 0;
+  dynamic_batching_ = false;
+  active_ = false;
+  scheduled_ = false;
+  first_token_recorded_ = false;
+  completed_ = false;
+  assigned_time_ = {};
+  scheduled_time_ = {};
+  first_token_time_ = {};
+  completed_time_ = {};
+  steady_clock_anchor_ = {};
+  system_clock_anchor_ = {};
+}
+
+}  // namespace Generators
+
+#else
+
+namespace Generators {
+
+uint32_t AllocateEngineTelemetryId() {
+  return 0;
+}
+
+}  // namespace Generators
+
+#endif

--- a/src/telemetry/engine_telemetry.h
+++ b/src/telemetry/engine_telemetry.h
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(ORTGENAI_ENABLE_TELEMETRY)
+#include <chrono>
+#endif
+
+namespace Generators {
+
+struct EngineRequestInfo;
+
+uint32_t AllocateEngineTelemetryId();
+
+class EngineRequestTelemetry {
+ public:
+#if defined(ORTGENAI_ENABLE_TELEMETRY)
+  using FinalizeCallback = void (*)(
+      uint32_t session_id, uint32_t engine_id, uint32_t request_id,
+      const EngineRequestInfo& info, int64_t end_timestamp_ms);
+
+  EngineRequestTelemetry() = default;
+  ~EngineRequestTelemetry();
+
+#if defined(__GNUC__) && !defined(_WIN32)
+  [[gnu::visibility("hidden")]]
+#endif
+  static void SetFinalizeCallbackForTest(FinalizeCallback callback);
+
+  void Begin(uint32_t session_id, uint32_t engine_id, bool dynamic_batching,
+             int64_t prompt_tokens);
+  void OnScheduled();
+  void OnStep(int64_t sequence_length, size_t batch_size, bool completed);
+  void OnRemoved(bool completed);
+
+ private:
+  enum class Outcome {
+    Completed,
+    Removed,
+    Abandoned,
+  };
+
+  bool IsEnabled() const;
+  void Finish(Outcome outcome, std::chrono::steady_clock::time_point end_time);
+  void Reset();
+
+  uint32_t session_id_{};
+  uint32_t engine_id_{};
+  uint32_t request_id_{};
+  int64_t prompt_tokens_{};
+  int64_t generated_tokens_{};
+  int64_t step_count_{};
+  int64_t batch_size_total_{};
+  int64_t max_batch_size_{};
+  bool dynamic_batching_{};
+  bool active_{};
+  bool scheduled_{};
+  bool first_token_recorded_{};
+  bool completed_{};
+  std::chrono::steady_clock::time_point assigned_time_;
+  std::chrono::steady_clock::time_point scheduled_time_;
+  std::chrono::steady_clock::time_point first_token_time_;
+  std::chrono::steady_clock::time_point completed_time_;
+  std::chrono::steady_clock::time_point steady_clock_anchor_;
+  std::chrono::system_clock::time_point system_clock_anchor_;
+#else
+  ~EngineRequestTelemetry() = default;
+
+  void Begin(uint32_t, uint32_t, bool, int64_t) {}
+  void OnScheduled() {}
+  void OnStep(int64_t, size_t, bool) {}
+  void OnRemoved(bool) {}
+#endif
+};
+
+}  // namespace Generators

--- a/src/telemetry/sha256.cpp
+++ b/src/telemetry/sha256.cpp
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "sha256.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace Generators::TelemetryInternal {
+
+namespace {
+
+constexpr uint32_t kInitialState[8] = {
+    0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+    0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u,
+};
+
+constexpr uint32_t kRoundConstants[64] = {
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu, 0x59f111f1u, 0x923f82a4u,
+    0xab1c5ed5u, 0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu,
+    0x9bdc06a7u, 0xc19bf174u, 0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu, 0x2de92c6fu,
+    0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau, 0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u,
+    0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u, 0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu,
+    0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u, 0xa2bfe8a1u, 0xa81a664bu,
+    0xc24b8b70u, 0xc76c51a3u, 0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u, 0x19a4c116u,
+    0x1e376c08u, 0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+    0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u, 0x90befffau, 0xa4506cebu, 0xbef9a3f7u,
+    0xc67178f2u,
+};
+
+uint32_t RotateRight(uint32_t value, int bits) {
+  return (value >> bits) | (value << (32 - bits));
+}
+
+uint32_t Choose(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) ^ (~x & z);
+}
+
+uint32_t Majority(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+uint32_t BigSigma0(uint32_t value) {
+  return RotateRight(value, 2) ^ RotateRight(value, 13) ^ RotateRight(value, 22);
+}
+
+uint32_t BigSigma1(uint32_t value) {
+  return RotateRight(value, 6) ^ RotateRight(value, 11) ^ RotateRight(value, 25);
+}
+
+uint32_t SmallSigma0(uint32_t value) {
+  return RotateRight(value, 7) ^ RotateRight(value, 18) ^ (value >> 3);
+}
+
+uint32_t SmallSigma1(uint32_t value) {
+  return RotateRight(value, 17) ^ RotateRight(value, 19) ^ (value >> 10);
+}
+
+}  // namespace
+
+Sha256::Sha256() {
+  std::memcpy(state_, kInitialState, sizeof(state_));
+}
+
+void Sha256::Transform(const uint8_t block[64]) {
+  uint32_t words[64];
+  for (int i = 0; i < 16; ++i) {
+    words[i] = (static_cast<uint32_t>(block[i * 4]) << 24) |
+               (static_cast<uint32_t>(block[i * 4 + 1]) << 16) |
+               (static_cast<uint32_t>(block[i * 4 + 2]) << 8) |
+               static_cast<uint32_t>(block[i * 4 + 3]);
+  }
+  for (int i = 16; i < 64; ++i) {
+    words[i] = SmallSigma1(words[i - 2]) + words[i - 7] + SmallSigma0(words[i - 15]) + words[i - 16];
+  }
+
+  uint32_t a = state_[0];
+  uint32_t b = state_[1];
+  uint32_t c = state_[2];
+  uint32_t d = state_[3];
+  uint32_t e = state_[4];
+  uint32_t f = state_[5];
+  uint32_t g = state_[6];
+  uint32_t h = state_[7];
+  for (int i = 0; i < 64; ++i) {
+    const uint32_t first = h + BigSigma1(e) + Choose(e, f, g) + kRoundConstants[i] + words[i];
+    const uint32_t second = BigSigma0(a) + Majority(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = d + first;
+    d = c;
+    c = b;
+    b = a;
+    a = first + second;
+  }
+
+  state_[0] += a;
+  state_[1] += b;
+  state_[2] += c;
+  state_[3] += d;
+  state_[4] += e;
+  state_[5] += f;
+  state_[6] += g;
+  state_[7] += h;
+}
+
+void Sha256::Update(const void* data, size_t length) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  bit_count_ += static_cast<uint64_t>(length) * 8;
+  while (length > 0) {
+    const size_t count = std::min<size_t>(64 - buffer_length_, length);
+    std::memcpy(buffer_ + buffer_length_, bytes, count);
+    buffer_length_ += count;
+    bytes += count;
+    length -= count;
+    if (buffer_length_ == 64) {
+      Transform(buffer_);
+      buffer_length_ = 0;
+    }
+  }
+}
+
+void Sha256::Final(uint8_t output[kDigestSize]) {
+  buffer_[buffer_length_++] = 0x80;
+  if (buffer_length_ > 56) {
+    std::memset(buffer_ + buffer_length_, 0, 64 - buffer_length_);
+    Transform(buffer_);
+    buffer_length_ = 0;
+  }
+  std::memset(buffer_ + buffer_length_, 0, 56 - buffer_length_);
+  uint64_t bit_count = bit_count_;
+  for (int i = 7; i >= 0; --i) {
+    buffer_[56 + i] = static_cast<uint8_t>(bit_count & 0xff);
+    bit_count >>= 8;
+  }
+  Transform(buffer_);
+
+  for (int i = 0; i < 8; ++i) {
+    output[i * 4] = static_cast<uint8_t>((state_[i] >> 24) & 0xff);
+    output[i * 4 + 1] = static_cast<uint8_t>((state_[i] >> 16) & 0xff);
+    output[i * 4 + 2] = static_cast<uint8_t>((state_[i] >> 8) & 0xff);
+    output[i * 4 + 3] = static_cast<uint8_t>(state_[i] & 0xff);
+  }
+}
+
+std::string Sha256::FinalHex() {
+  static constexpr char kHex[] = "0123456789ABCDEF";
+  uint8_t output[kDigestSize];
+  Final(output);
+
+  std::string result(kDigestSize * 2, '0');
+  for (size_t i = 0; i < kDigestSize; ++i) {
+    result[i * 2] = kHex[(output[i] >> 4) & 0x0f];
+    result[i * 2 + 1] = kHex[output[i] & 0x0f];
+  }
+  return result;
+}
+
+std::string Sha256::HashStringHex(std::string_view value) {
+  Sha256 hash;
+  hash.Update(value.data(), value.size());
+  return hash.FinalHex();
+}
+
+}  // namespace Generators::TelemetryInternal

--- a/src/telemetry/sha256.h
+++ b/src/telemetry/sha256.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace Generators::TelemetryInternal {
+
+class Sha256 {
+ public:
+  static constexpr size_t kDigestSize = 32;
+
+  Sha256();
+  void Update(const void* data, size_t length);
+  void Final(uint8_t output[kDigestSize]);
+  std::string FinalHex();
+
+  static std::string HashStringHex(std::string_view value);
+
+ private:
+  void Transform(const uint8_t block[64]);
+
+  uint32_t state_[8];
+  uint64_t bit_count_{};
+  uint8_t buffer_[64]{};
+  size_t buffer_length_{};
+};
+
+}  // namespace Generators::TelemetryInternal

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -366,9 +366,6 @@ void GenAiTelemetry::LogProcessInfo() {
 
     MAT::EventProperties event("OnnxRuntimeGenAI.ProcessInfo");
     event.SetPopsample(100.0);
-    // sessionId 0 = process scope (model sessions are numbered from 1); ProcessInfo
-    // correlates with model/generate events via the AppSessionGuid logger context.
-    event.SetProperty("sessionId", static_cast<int64_t>(0));
     event.SetProperty("libraryVersion", ORTGENAI_VERSION);
     // Device id is sent as ext.device.localId by the SDK (desktop override in Initialize, platform id
     // on Android/iOS), so it is not duplicated as a custom property here.
@@ -510,6 +507,33 @@ void GenAiTelemetry::LogGeneration(uint32_t session_id, uint32_t generator_id,
     end_event.SetProperty("totalTimeMs", info.total_time_ms);
     end_event.SetProperty("tokensPerSecond", info.tokens_per_second);
     impl_->logger->LogEvent(end_event);
+  });
+#endif
+}
+
+void GenAiTelemetry::LogEngineRequest(uint32_t session_id, uint32_t engine_id,
+                                      uint32_t request_id, const EngineRequestInfo& info,
+                                      int64_t end_timestamp_ms) {
+#if defined(ORTGENAI_ENABLE_TELEMETRY)
+  RunLocked([&] {
+    MAT::EventProperties event("OnnxRuntimeGenAI.EngineRequest");
+    if (!PrepareSampledEvent(event, app_session_guid_, session_id)) return;
+    event.SetTimestamp(end_timestamp_ms);
+    event.SetProperty("sessionId", static_cast<int64_t>(session_id));
+    event.SetProperty("engineId", static_cast<int64_t>(engine_id));
+    event.SetProperty("requestId", static_cast<int64_t>(request_id));
+    event.SetProperty("dynamicBatching", info.dynamic_batching);
+    event.SetProperty("promptTokens", info.prompt_tokens);
+    event.SetProperty("generatedTokens", info.generated_tokens);
+    event.SetProperty("stepCount", info.step_count);
+    event.SetProperty("averageBatchSize", info.average_batch_size);
+    event.SetProperty("maxBatchSize", info.max_batch_size);
+    event.SetProperty("queueTimeMs", info.queue_time_ms);
+    event.SetProperty("timeToFirstTokenMs", info.time_to_first_token_ms);
+    event.SetProperty("decodeTimeMs", info.decode_time_ms);
+    event.SetProperty("totalTimeMs", info.total_time_ms);
+    event.SetProperty("outcome", std::string{info.outcome});
+    impl_->logger->LogEvent(event);
   });
 #endif
 }

--- a/src/telemetry/telemetry.h
+++ b/src/telemetry/telemetry.h
@@ -57,6 +57,20 @@ struct GenerateEndInfo {
   double tokens_per_second{};
 };
 
+struct EngineRequestInfo {
+  int64_t prompt_tokens{};
+  int64_t generated_tokens{};
+  int64_t step_count{};
+  int64_t max_batch_size{};
+  double average_batch_size{};
+  double queue_time_ms{};
+  double time_to_first_token_ms{};
+  double decode_time_ms{};
+  double total_time_ms{};
+  bool dynamic_batching{};
+  std::string_view outcome;
+};
+
 class GenAiTelemetry {
  public:
   static GenAiTelemetry& Instance();
@@ -102,6 +116,10 @@ class GenAiTelemetry {
   void LogGeneration(uint32_t session_id, uint32_t generator_id, int64_t prompt_tokens,
                      const std::string& input_modality, const GenerateEndInfo& info,
                      int64_t start_timestamp_ms, int64_t end_timestamp_ms);
+
+  // EngineRequest: one aggregate event emitted after an engine request leaves the decode path.
+  void LogEngineRequest(uint32_t session_id, uint32_t engine_id, uint32_t request_id,
+                        const EngineRequestInfo& info, int64_t end_timestamp_ms);
 
   // AdapterActivated: Emitted when a LoRA adapter is activated for a generator.
   // The adapter name is NOT sent (it may be sensitive); only correlation ids, so

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ file(GLOB test_srcs CONFIGURE_DEPENDS
 # reinit_tests.cpp is a standalone executable (it calls OgaShutdown() to exercise re-initialization
 # and has its own main()), so keep it out of the unit_tests sources.
 list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/reinit_tests.cpp")
+list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/engine_telemetry_tests.cpp")
 
 if(USE_CUDA AND CMAKE_CUDA_COMPILER AND ENABLE_CUDA_KERNEL_TESTS)
   message(STATUS "Including CUDA kernel tests in the build.")
@@ -103,6 +104,29 @@ if (NOT MSVC)
 endif()
 
 add_test(NAME ReInitTests COMMAND reinit_tests)
+
+if(ENABLE_TELEMETRY)
+  add_executable(engine_telemetry_tests
+    "${CMAKE_CURRENT_SOURCE_DIR}/engine_telemetry_tests.cpp")
+  target_include_directories(engine_telemetry_tests PRIVATE
+    ${ORT_HEADER_DIR}
+    ${onnxruntime_extensions_SOURCE_DIR}/shared/api
+    ${CMAKE_SOURCE_DIR}/src
+  )
+  target_link_libraries(engine_telemetry_tests PRIVATE
+    onnxruntime-genai-obj
+    GTest::gtest_main
+  )
+  add_dependencies(engine_telemetry_tests onnxruntime-genai)
+  set_target_properties(engine_telemetry_tests PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "$<TARGET_FILE_DIR:onnxruntime-genai>"
+    FOLDER "Tests"
+  )
+  if(NOT MSVC)
+    target_compile_options(engine_telemetry_tests PRIVATE "-fvisibility=hidden")
+  endif()
+  add_test(NAME EngineTelemetryTests COMMAND engine_telemetry_tests)
+endif()
 
 if (ENABLE_TELEMETRY AND NOT WIN32 AND NOT ANDROID AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
   add_executable(telemetry_device_info_tests

--- a/test/engine_telemetry_tests.cpp
+++ b/test/engine_telemetry_tests.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include "../src/telemetry/engine_telemetry.h"
+#include "../src/telemetry/telemetry.h"
+
+#if defined(ORTGENAI_ENABLE_TELEMETRY)
+
+#include <optional>
+#include <string>
+
+namespace Generators::test {
+
+namespace {
+
+struct CapturedEngineRequest {
+  uint32_t session_id{};
+  uint32_t engine_id{};
+  uint32_t request_id{};
+  EngineRequestInfo info;
+  std::string outcome;
+  int64_t end_timestamp_ms{};
+};
+
+std::optional<CapturedEngineRequest> g_capture;
+size_t g_capture_count{};
+
+void CaptureEngineRequest(uint32_t session_id, uint32_t engine_id, uint32_t request_id,
+                          const EngineRequestInfo& info, int64_t end_timestamp_ms) {
+  g_capture = CapturedEngineRequest{
+      session_id,
+      engine_id,
+      request_id,
+      info,
+      std::string{info.outcome},
+      end_timestamp_ms,
+  };
+  g_capture->info.outcome = g_capture->outcome;
+  ++g_capture_count;
+}
+
+class EngineTelemetryTests : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    g_capture.reset();
+    g_capture_count = 0;
+    EngineRequestTelemetry::SetFinalizeCallbackForTest(CaptureEngineRequest);
+  }
+
+  void TearDown() override {
+    EngineRequestTelemetry::SetFinalizeCallbackForTest(nullptr);
+  }
+};
+
+TEST_F(EngineTelemetryTests, CompletedRequestAggregatesMetricsOnce) {
+  EngineRequestTelemetry telemetry;
+  telemetry.Begin(7, 11, true, 10);
+  telemetry.OnScheduled();
+  telemetry.OnStep(11, 3, false);
+  telemetry.OnStep(14, 2, true);
+  telemetry.OnRemoved(true);
+
+  ASSERT_TRUE(g_capture.has_value());
+  EXPECT_EQ(g_capture_count, 1U);
+  EXPECT_EQ(g_capture->session_id, 7U);
+  EXPECT_EQ(g_capture->engine_id, 11U);
+  EXPECT_NE(g_capture->request_id, 0U);
+  EXPECT_TRUE(g_capture->info.dynamic_batching);
+  EXPECT_EQ(g_capture->info.prompt_tokens, 10);
+  EXPECT_EQ(g_capture->info.generated_tokens, 4);
+  EXPECT_EQ(g_capture->info.step_count, 2);
+  EXPECT_DOUBLE_EQ(g_capture->info.average_batch_size, 2.5);
+  EXPECT_EQ(g_capture->info.max_batch_size, 3);
+  EXPECT_EQ(g_capture->outcome, "completed");
+  EXPECT_GE(g_capture->info.queue_time_ms, 0.0);
+  EXPECT_GE(g_capture->info.time_to_first_token_ms, g_capture->info.queue_time_ms);
+  EXPECT_GE(g_capture->info.total_time_ms, g_capture->info.time_to_first_token_ms);
+  EXPECT_GT(g_capture->end_timestamp_ms, 0);
+}
+
+TEST_F(EngineTelemetryTests, ExplicitRemovalIsNotAbandonment) {
+  EngineRequestTelemetry telemetry;
+  telemetry.Begin(1, 2, false, 5);
+  telemetry.OnScheduled();
+  telemetry.OnStep(6, 1, false);
+  telemetry.OnRemoved(false);
+
+  ASSERT_TRUE(g_capture.has_value());
+  EXPECT_EQ(g_capture_count, 1U);
+  EXPECT_EQ(g_capture->outcome, "removed");
+  EXPECT_FALSE(g_capture->info.dynamic_batching);
+  EXPECT_EQ(g_capture->info.generated_tokens, 1);
+}
+
+TEST_F(EngineTelemetryTests, DestructionWithoutRemovalIsAbandoned) {
+  {
+    EngineRequestTelemetry telemetry;
+    telemetry.Begin(1, 2, false, 5);
+    telemetry.OnScheduled();
+    telemetry.OnStep(6, 1, false);
+  }
+
+  ASSERT_TRUE(g_capture.has_value());
+  EXPECT_EQ(g_capture_count, 1U);
+  EXPECT_EQ(g_capture->outcome, "abandoned");
+}
+
+}  // namespace
+
+}  // namespace Generators::test
+
+#endif

--- a/test/telemetry/device_info_tests.cpp
+++ b/test/telemetry/device_info_tests.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include "telemetry/device_info.h"
+#include "telemetry/sha256.h"
 #include "telemetry_test_environment.h"
 
 namespace {
@@ -86,6 +87,16 @@ TEST(TelemetryDeviceInfoTest, IgnoresRelativeXdgCacheHome) {
 }
 
 #endif
+
+TEST(TelemetryDeviceInfoTest, SharedDeviceIdUsesUnsaltedSha256) {
+  EXPECT_EQ(Generators::TelemetryInternal::Sha256::HashStringHex(""),
+            "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855");
+  EXPECT_EQ(Generators::TelemetryInternal::Sha256::HashStringHex("abc"),
+            "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD");
+  EXPECT_EQ(Generators::TelemetryInternal::Sha256::HashStringHex(
+                "01234567-89ab-4def-8123-456789abcdef"),
+            "6225BD190D6CCF87766A49C9986D174DEF3391FE175A61525E49A1D2334D6A43");
+}
 
 TEST(TelemetryDeviceInfoDeathTest, RejectsSymlinkedOwnedDirectoryBeforeReading) {
   ScopedTestDirectory test_dir{"symlink_leaf"};


### PR DESCRIPTION
## Summary

- add one deferred `OnnxRuntimeGenAI.EngineRequest` event with request outcome, token counts, batch-size aggregates, and latency measurements
- keep 1DS logging out of the decode path; per-step work is limited to a clock read and local counters
- cover completed, explicitly removed, and abandoned request lifecycles
- remove the unused numeric `sessionId = 0` field from `ProcessInfo`; `AppSessionGuid` remains the process-wide correlation key

The event does not include prompts, generated text, model paths, or adapter names. The privacy inventory workbook has been updated with the final schema.

## Testing

- Linux telemetry enabled: `UnitTests`, `ReInitTests`, `EngineTelemetryTests`, and `TelemetryDeviceInfoTests`
- Linux telemetry disabled build
- Windows telemetry enabled: `UnitTests`, `ReInitTests`, and `EngineTelemetryTests`