### PR TITLE
Testing foundation for the continuous-batching engine

### DIFF
--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -164,3 +164,4 @@ jobs:
           export ORTGENAI_LOG_ORT_LIB=1
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/ort/lib
           ./build/cpu/unit_tests
+          ./build/cpu/engine_unit_tests

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -204,4 +204,4 @@ jobs:
             --rm \
             --volume /data/ortgenai/:/data/ortgenai/ \
             --volume $GITHUB_WORKSPACE:/ort_genai_src \
-            -w /ort_genai_src onnxruntimecudabuildx64 bash -c "ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/build/cuda/ /ort_genai_src/build/cuda/unit_tests"
+            -w /ort_genai_src onnxruntimecudabuildx64 bash -c "ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/build/cuda/ /ort_genai_src/build/cuda/unit_tests && ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/build/cuda/ /ort_genai_src/build/cuda/engine_unit_tests"

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -156,6 +156,9 @@ jobs:
         run: |
           copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
           & .\$env:binaryDir\Release\unit_tests.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & .\$env:binaryDir\Release\engine_unit_tests.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -191,3 +191,6 @@ jobs:
           echo "Current PATH variable is: $env:PATH"
           copy $env:GITHUB_WORKSPACE\ort\lib\* .\$env:binaryDir\Release
           & .\$env:binaryDir\Release\unit_tests.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & .\$env:binaryDir\Release\engine_unit_tests.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/src/engine/block.cpp
+++ b/src/engine/block.cpp
@@ -88,8 +88,10 @@ std::vector<std::shared_ptr<Block>> BlockPool::ReserveBlocks(size_t num_slots) {
 void BlockPool::Free(const std::vector<std::shared_ptr<Block>>& blocks) {
   // Validate every block before mutating any pool state so that an invalid request (a null block,
   // an out-of-range id, a block this pool does not currently own, or the same block listed twice)
-  // is rejected without partially freeing the batch.
-  std::vector<bool> seen(Capacity(), false);
+  // is rejected without partially freeing the batch. Work stays proportional to the batch size
+  // rather than the pool capacity.
+  std::vector<size_t> ids;
+  ids.reserve(blocks.size());
   for (const auto& block : blocks) {
     if (!block) {
       throw std::runtime_error("Cannot free a null block.");
@@ -106,11 +108,14 @@ void BlockPool::Free(const std::vector<std::shared_ptr<Block>>& blocks) {
                                " that is not currently allocated by this pool.");
     }
 
-    if (seen[id]) {
-      throw std::runtime_error("Cannot free block with id " + std::to_string(id) +
-                               " more than once in the same call.");
-    }
-    seen[id] = true;
+    ids.push_back(id);
+  }
+
+  std::sort(ids.begin(), ids.end());
+  const auto duplicate = std::adjacent_find(ids.begin(), ids.end());
+  if (duplicate != ids.end()) {
+    throw std::runtime_error("Cannot free block with id " + std::to_string(*duplicate) +
+                             " more than once in the same call.");
   }
 
   for (const auto& block : blocks) {

--- a/src/engine/block.cpp
+++ b/src/engine/block.cpp
@@ -86,6 +86,33 @@ std::vector<std::shared_ptr<Block>> BlockPool::ReserveBlocks(size_t num_slots) {
 }
 
 void BlockPool::Free(const std::vector<std::shared_ptr<Block>>& blocks) {
+  // Validate every block before mutating any pool state so that an invalid request (a null block,
+  // an out-of-range id, a block this pool does not currently own, or the same block listed twice)
+  // is rejected without partially freeing the batch.
+  std::vector<bool> seen(Capacity(), false);
+  for (const auto& block : blocks) {
+    if (!block) {
+      throw std::runtime_error("Cannot free a null block.");
+    }
+
+    const size_t id = block->Id();
+    if (id >= Capacity()) {
+      throw std::runtime_error("Cannot free block with out-of-range id " + std::to_string(id) +
+                               " for a pool with capacity " + std::to_string(Capacity()) + ".");
+    }
+
+    if (blocks_[id] != block) {
+      throw std::runtime_error("Cannot free block with id " + std::to_string(id) +
+                               " that is not currently allocated by this pool.");
+    }
+
+    if (seen[id]) {
+      throw std::runtime_error("Cannot free block with id " + std::to_string(id) +
+                               " more than once in the same call.");
+    }
+    seen[id] = true;
+  }
+
   for (const auto& block : blocks) {
     blocks_[block->Id()].reset();
   }

--- a/src/engine/cache_manager.h
+++ b/src/engine/cache_manager.h
@@ -43,6 +43,10 @@ struct CacheManager {
   // `attention_metadata`.
   virtual size_t BlockTableColumns() const { return 0; }
 
+  // Immutable snapshot of the cache's block accounting for invariant validation and state
+  // inspection. Caches that do not use paged blocks return an empty snapshot.
+  virtual PagedCacheSnapshot Snapshot() const { return {}; }
+
   virtual ~CacheManager() = default;
 
  protected:
@@ -87,6 +91,8 @@ struct PagedCacheManager : CacheManager {
   std::vector<std::shared_ptr<Request>> AllocatedRequests() const override;
 
   size_t BlockTableColumns() const override { return key_value_cache_->BlockTableColumns(); }
+
+  PagedCacheSnapshot Snapshot() const override { return key_value_cache_->Snapshot(); }
 
  private:
   std::shared_ptr<GeneratorParams> params_;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -12,7 +12,18 @@ Engine::Engine(std::shared_ptr<Model> model, EngineDependencies dependencies)
     : model_{std::move(model)},
       cache_manager_{std::move(dependencies.cache_manager)},
       scheduler_{std::move(dependencies.scheduler)},
-      model_executor_{std::move(dependencies.model_executor)} {}
+      model_executor_{std::move(dependencies.model_executor)} {
+  // Fail fast on a missing collaborator rather than crashing later on first use.
+  if (!cache_manager_) {
+    throw std::runtime_error("Engine requires a non-null cache manager.");
+  }
+  if (!scheduler_) {
+    throw std::runtime_error("Engine requires a non-null scheduler.");
+  }
+  if (!model_executor_) {
+    throw std::runtime_error("Engine requires a non-null model executor.");
+  }
+}
 
 EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
   std::shared_ptr<CacheManager> cache_manager = CacheManager::Create(model);

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -6,10 +6,20 @@
 namespace Generators {
 
 Engine::Engine(std::shared_ptr<Model> model)
-    : model_{model},
-      cache_manager_{CacheManager::Create(model)},
-      scheduler_{Scheduler::Create(model, cache_manager_)},
-      model_executor_{std::make_unique<ModelExecutor>(model, cache_manager_)} {}
+    : Engine(model, CreateDependencies(model)) {}
+
+Engine::Engine(std::shared_ptr<Model> model, EngineDependencies dependencies)
+    : model_{std::move(model)},
+      cache_manager_{std::move(dependencies.cache_manager)},
+      scheduler_{std::move(dependencies.scheduler)},
+      model_executor_{std::move(dependencies.model_executor)} {}
+
+EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
+  std::shared_ptr<CacheManager> cache_manager = CacheManager::Create(model);
+  auto scheduler = Scheduler::Create(model, cache_manager);
+  auto model_executor = std::make_unique<ModelExecutor>(model, cache_manager);
+  return EngineDependencies{std::move(cache_manager), std::move(scheduler), std::move(model_executor)};
+}
 
 void Engine::AddRequest(std::shared_ptr<Request> request) {
   request->Assign(shared_from_this());

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -17,6 +17,25 @@
 namespace Generators {
 
 /**
+ * @struct EngineDependencies
+ * @brief Bundle of the collaborators the Engine drives.
+ *
+ * The Engine constructor assembles these from the model via CreateDependencies and forwards them
+ * to the dependency-injecting constructor, so there is a single construction flow. The injecting
+ * constructor accepts a pre-assembled bundle, which also lets a caller supply alternative
+ * collaborators. The scheduler and cache manager are abstract interfaces and are substitutable
+ * today; the model executor is a concrete type until its interface is introduced, so only the real
+ * executor can be supplied for now.
+ * This is a composition seam, not a setter: the dependencies are supplied once at construction and
+ * never replaced mid-run.
+ */
+struct EngineDependencies {
+  std::shared_ptr<CacheManager> cache_manager;
+  std::unique_ptr<Scheduler> scheduler;
+  std::unique_ptr<ModelExecutor> model_executor;
+};
+
+/**
  * @class Engine
  * @brief The Engine class is responsible for managing requests, executing models,
  *        and coordinating scheduling and caching mechanisms.
@@ -32,8 +51,28 @@ struct Engine : std::enable_shared_from_this<Engine>,
    * @brief Constructs an Engine instance with the specified model.
    * @param model A shared pointer to the Model object to be used by the Engine
    *              and its components.
+   *
+   * Assembles the Engine's scheduler, cache manager, and model executor for the model via
+   * CreateDependencies and delegates to the dependency-injecting constructor. Behavior is identical
+   * to constructing those collaborators inline.
    */
   Engine(std::shared_ptr<Model> model);
+
+  /**
+   * @brief Dependency-injecting constructor.
+   * @param model A shared pointer to the Model object to be used by the Engine.
+   * @param dependencies A pre-assembled bundle of the Engine's collaborators.
+   *
+   * Takes ownership of the supplied collaborators as-is. The model-only constructor delegates here
+   * with the default bundle; callers may also supply an alternative bundle.
+   */
+  Engine(std::shared_ptr<Model> model, EngineDependencies dependencies);
+
+  /**
+   * @brief Assembles the Engine's collaborators (cache manager, scheduler, model executor) for a
+   *        model, in the order they depend on one another.
+   */
+  static EngineDependencies CreateDependencies(std::shared_ptr<Model> model);
 
   /**
    * @brief Adds a request to the Engine for processing.

--- a/src/engine/engine_invariants.cpp
+++ b/src/engine/engine_invariants.cpp
@@ -114,7 +114,7 @@ std::vector<InvariantViolation> ValidateRequestInvariants(const RequestStateSnap
   const std::string id = PtrId(request.request_id);
 
   if (request.current_sequence_length < 0 || request.processed_sequence_length < 0 ||
-      request.seen_sequence_length < 0 || request.unprocessed_token_count < 0) {
+      request.seen_sequence_length < 0) {
     add("Request " + id + " has a negative sequence-length counter.");
   }
 
@@ -126,13 +126,6 @@ std::vector<InvariantViolation> ValidateRequestInvariants(const RequestStateSnap
   if (request.seen_sequence_length > request.current_sequence_length) {
     add("Request " + id + " seen length (" + std::to_string(request.seen_sequence_length) +
         ") exceeds current length (" + std::to_string(request.current_sequence_length) + ").");
-  }
-
-  if (request.unprocessed_token_count !=
-      request.current_sequence_length - request.processed_sequence_length) {
-    add("Request " + id + " unprocessed count (" + std::to_string(request.unprocessed_token_count) +
-        ") != current (" + std::to_string(request.current_sequence_length) + ") - processed (" +
-        std::to_string(request.processed_sequence_length) + ").");
   }
 
   return violations;

--- a/src/engine/engine_invariants.cpp
+++ b/src/engine/engine_invariants.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "engine_invariants.h"
+
+#include <algorithm>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace Generators {
+
+namespace {
+
+std::string PtrId(const void* p) {
+  std::ostringstream oss;
+  oss << p;
+  return oss.str();
+}
+
+}  // namespace
+
+size_t PagedCacheSnapshot::AllocatedBlocks() const {
+  size_t allocated = 0;
+  for (const auto& request : requests) {
+    allocated += request.block_ids.size();
+  }
+  return allocated;
+}
+
+std::vector<InvariantViolation> ValidateCacheInvariants(const PagedCacheSnapshot& cache) {
+  std::vector<InvariantViolation> violations;
+  const auto add = [&violations](std::string message) {
+    violations.push_back(InvariantViolation{std::move(message)});
+  };
+
+  // Total accounting: every block is either free or owned by exactly one Request.
+  const size_t allocated = cache.AllocatedBlocks();
+  if (cache.free_blocks > cache.total_blocks) {
+    add("free_blocks (" + std::to_string(cache.free_blocks) + ") exceeds total_blocks (" +
+        std::to_string(cache.total_blocks) + ").");
+  }
+  if (cache.free_blocks + allocated != cache.total_blocks) {
+    add("free (" + std::to_string(cache.free_blocks) + ") + allocated (" + std::to_string(allocated) +
+        ") != total_blocks (" + std::to_string(cache.total_blocks) + ").");
+  }
+
+  // Single ownership: a physical block id appears in at most one Request's table.
+  std::unordered_map<size_t, const void*> owner_of_block;
+  std::unordered_set<const void*> seen_requests;
+  size_t max_blocks_per_request = 0;
+
+  for (const auto& request : cache.requests) {
+    max_blocks_per_request = std::max(max_blocks_per_request, request.block_ids.size());
+
+    // Each Request appears in the block-table listing at most once. A repeated row would let the
+    // same Request re-list a physical block without tripping the single-ownership check below.
+    if (!seen_requests.insert(request.request_id).second) {
+      add("Request " + PtrId(request.request_id) + " appears in more than one block table.");
+    }
+
+    std::unordered_set<size_t> seen_within_request;
+    for (const size_t block_id : request.block_ids) {
+      if (block_id >= cache.total_blocks) {
+        add("Request " + PtrId(request.request_id) + " owns out-of-range block id " +
+            std::to_string(block_id) + " (total_blocks " + std::to_string(cache.total_blocks) + ").");
+      }
+
+      if (!seen_within_request.insert(block_id).second) {
+        add("Request " + PtrId(request.request_id) + " lists block id " + std::to_string(block_id) +
+            " more than once.");
+      }
+
+      const auto [it, inserted] = owner_of_block.emplace(block_id, request.request_id);
+      if (!inserted && it->second != request.request_id) {
+        add("Block id " + std::to_string(block_id) + " is owned by more than one Request (" +
+            PtrId(it->second) + " and " + PtrId(request.request_id) + ").");
+      }
+    }
+
+    // Slot accounting: used + empty must fill exactly the owned blocks' capacity.
+    if (cache.block_size != 0) {
+      const size_t capacity = request.block_ids.size() * cache.block_size;
+      if (request.used_slots + request.empty_slots != capacity) {
+        add("Request " + PtrId(request.request_id) + " used (" + std::to_string(request.used_slots) +
+            ") + empty (" + std::to_string(request.empty_slots) + ") slots != owned capacity (" +
+            std::to_string(capacity) + ").");
+      }
+      if (request.used_slots > capacity) {
+        add("Request " + PtrId(request.request_id) + " used slots (" +
+            std::to_string(request.used_slots) + ") exceed owned capacity (" +
+            std::to_string(capacity) + ").");
+      }
+    }
+  }
+
+  // The padded block-table width must be able to hold the widest Request's table.
+  if (cache.block_table_columns != 0 && cache.block_table_columns < max_blocks_per_request) {
+    add("block_table_columns (" + std::to_string(cache.block_table_columns) +
+        ") is narrower than the widest Request table (" + std::to_string(max_blocks_per_request) + ").");
+  }
+
+  return violations;
+}
+
+std::vector<InvariantViolation> ValidateRequestInvariants(const RequestStateSnapshot& request) {
+  std::vector<InvariantViolation> violations;
+  const auto add = [&violations](std::string message) {
+    violations.push_back(InvariantViolation{std::move(message)});
+  };
+
+  const std::string id = PtrId(request.request_id);
+
+  if (request.current_sequence_length < 0 || request.processed_sequence_length < 0 ||
+      request.seen_sequence_length < 0 || request.unprocessed_token_count < 0) {
+    add("Request " + id + " has a negative sequence-length counter.");
+  }
+
+  if (request.processed_sequence_length > request.current_sequence_length) {
+    add("Request " + id + " processed length (" + std::to_string(request.processed_sequence_length) +
+        ") exceeds current length (" + std::to_string(request.current_sequence_length) + ").");
+  }
+
+  if (request.seen_sequence_length > request.current_sequence_length) {
+    add("Request " + id + " seen length (" + std::to_string(request.seen_sequence_length) +
+        ") exceeds current length (" + std::to_string(request.current_sequence_length) + ").");
+  }
+
+  if (request.unprocessed_token_count !=
+      request.current_sequence_length - request.processed_sequence_length) {
+    add("Request " + id + " unprocessed count (" + std::to_string(request.unprocessed_token_count) +
+        ") != current (" + std::to_string(request.current_sequence_length) + ") - processed (" +
+        std::to_string(request.processed_sequence_length) + ").");
+  }
+
+  return violations;
+}
+
+std::vector<InvariantViolation> ValidateInvariants(const PagedCacheSnapshot& cache,
+                                                   const std::vector<RequestStateSnapshot>& requests) {
+  std::vector<InvariantViolation> violations = ValidateCacheInvariants(cache);
+
+  for (const auto& request : requests) {
+    auto request_violations = ValidateRequestInvariants(request);
+    violations.insert(violations.end(), request_violations.begin(), request_violations.end());
+  }
+
+  // Block tables exist only for known Requests: every block-owning id must be a Request we were
+  // handed. (The reverse does not hold: an Assigned-but-unallocated Request owns no blocks yet.)
+  std::set<const void*> known_requests;
+  for (const auto& request : requests) {
+    known_requests.insert(request.request_id);
+  }
+  for (const auto& owner : cache.requests) {
+    if (known_requests.find(owner.request_id) == known_requests.end()) {
+      violations.push_back(InvariantViolation{
+          "Cache holds a block table for unknown Request " + PtrId(owner.request_id) + "."});
+    }
+  }
+
+  return violations;
+}
+
+void ThrowIfInvariantsViolated(const PagedCacheSnapshot& cache,
+                               const std::vector<RequestStateSnapshot>& requests) {
+  const auto violations = ValidateInvariants(cache, requests);
+  if (violations.empty()) {
+    return;
+  }
+
+  std::ostringstream oss;
+  oss << "Engine invariant validation failed with " << violations.size() << " violation(s):";
+  for (const auto& violation : violations) {
+    oss << "\n  - " << violation.message;
+  }
+  throw std::runtime_error(oss.str());
+}
+
+}  // namespace Generators

--- a/src/engine/engine_invariants.h
+++ b/src/engine/engine_invariants.h
@@ -36,7 +36,6 @@ struct RequestStateSnapshot {
   int64_t current_sequence_length{};    // Total tokens the Request's search currently holds.
   int64_t processed_sequence_length{};  // Tokens the model has already processed into the cache.
   int64_t seen_sequence_length{};       // Tokens already streamed to (seen by) the application.
-  int64_t unprocessed_token_count{};    // Tokens produced/appended but not yet processed.
   bool is_prefill{};
 };
 

--- a/src/engine/engine_invariants.h
+++ b/src/engine/engine_invariants.h
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "request_status.h"
+
+/**
+ * @file engine_invariants.h
+ * @brief Immutable snapshots of the continuous-batching Engine's Request and paged-cache state,
+ *        plus a central invariant validator that operates purely on those snapshots.
+ *
+ * These value types are read-only records: they copy out the state needed to reason about
+ * correctness and never expose mutable pointers into the live Request or cache. Defining the
+ * invariant formulas here once keeps them in a single place instead of being restated wherever the
+ * state is inspected; the same snapshots and checks back runtime and telemetry consumers as the
+ * Engine grows, and the Engine's correctness tests.
+ *
+ * This header deliberately depends only on lightweight standard types and RequestStatus so the
+ * validator remains model- and device-independent and can be exercised without a real model.
+ */
+
+namespace Generators {
+
+// Immutable view of a single Request's progress counters. Produced by Request::Snapshot().
+struct RequestStateSnapshot {
+  // Stable opaque identity of the Request (its address), used only to cross-reference this snapshot
+  // with the paged-cache snapshot. Never dereferenced by the validator.
+  const void* request_id{nullptr};
+  RequestStatus status{RequestStatus::Unassigned};
+  int64_t current_sequence_length{};     // Total tokens the Request's search currently holds.
+  int64_t processed_sequence_length{};   // Tokens the model has already processed into the cache.
+  int64_t seen_sequence_length{};        // Tokens already streamed to (seen by) the application.
+  int64_t unprocessed_token_count{};     // Tokens produced/appended but not yet processed.
+  bool is_prefill{};
+};
+
+// Immutable view of one Request's block ownership within the paged cache.
+struct RequestBlockSnapshot {
+  const void* request_id{nullptr};
+  std::vector<size_t> block_ids;  // Physical block ids owned by this Request, in block-table order.
+  size_t used_slots{};            // Slots already written (committed) across the Request's blocks.
+  size_t empty_slots{};           // Slots reserved for the Request but not yet written.
+};
+
+// Immutable view of the paged cache's block accounting. Produced by PagedKeyValueCache::Snapshot().
+struct PagedCacheSnapshot {
+  size_t block_size{};
+  size_t total_blocks{};
+  size_t free_blocks{};           // Blocks currently owned by no Request.
+  size_t block_table_columns{};   // Padded block-table width the model sees, or 0 when unused.
+  std::vector<RequestBlockSnapshot> requests;
+
+  // Blocks currently owned by some Request (sum of per-Request block counts).
+  size_t AllocatedBlocks() const;
+};
+
+// A single invariant violation, carrying a human-readable description of what was inconsistent.
+struct InvariantViolation {
+  std::string message;
+};
+
+// Pure invariant checks over the paged-cache snapshot. Returns every violation found; an empty
+// result means the snapshot satisfies all cache invariants.
+std::vector<InvariantViolation> ValidateCacheInvariants(const PagedCacheSnapshot& cache);
+
+// Pure invariant checks over a single Request snapshot.
+std::vector<InvariantViolation> ValidateRequestInvariants(const RequestStateSnapshot& request);
+
+// Cross-cutting checks that need both a Request's progress and its cache ownership, in addition to
+// the per-snapshot checks above.
+std::vector<InvariantViolation> ValidateInvariants(const PagedCacheSnapshot& cache,
+                                                   const std::vector<RequestStateSnapshot>& requests);
+
+// Throwing convenience wrapper. Runs ValidateInvariants and throws std::runtime_error listing every
+// violation if the snapshots are inconsistent, so callers can fail fast with the full list.
+void ThrowIfInvariantsViolated(const PagedCacheSnapshot& cache,
+                               const std::vector<RequestStateSnapshot>& requests);
+
+}  // namespace Generators

--- a/src/engine/engine_invariants.h
+++ b/src/engine/engine_invariants.h
@@ -33,10 +33,10 @@ struct RequestStateSnapshot {
   // with the paged-cache snapshot. Never dereferenced by the validator.
   const void* request_id{nullptr};
   RequestStatus status{RequestStatus::Unassigned};
-  int64_t current_sequence_length{};     // Total tokens the Request's search currently holds.
-  int64_t processed_sequence_length{};   // Tokens the model has already processed into the cache.
-  int64_t seen_sequence_length{};        // Tokens already streamed to (seen by) the application.
-  int64_t unprocessed_token_count{};     // Tokens produced/appended but not yet processed.
+  int64_t current_sequence_length{};    // Total tokens the Request's search currently holds.
+  int64_t processed_sequence_length{};  // Tokens the model has already processed into the cache.
+  int64_t seen_sequence_length{};       // Tokens already streamed to (seen by) the application.
+  int64_t unprocessed_token_count{};    // Tokens produced/appended but not yet processed.
   bool is_prefill{};
 };
 
@@ -52,8 +52,8 @@ struct RequestBlockSnapshot {
 struct PagedCacheSnapshot {
   size_t block_size{};
   size_t total_blocks{};
-  size_t free_blocks{};           // Blocks currently owned by no Request.
-  size_t block_table_columns{};   // Padded block-table width the model sees, or 0 when unused.
+  size_t free_blocks{};          // Blocks currently owned by no Request.
+  size_t block_table_columns{};  // Padded block-table width the model sees, or 0 when unused.
   std::vector<RequestBlockSnapshot> requests;
 
   // Blocks currently owned by some Request (sum of per-Request block counts).

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -195,6 +195,27 @@ void PagedKeyValueCache::Remove(std::shared_ptr<Request> request) {
   }
 }
 
+PagedCacheSnapshot PagedKeyValueCache::Snapshot() const {
+  PagedCacheSnapshot snapshot;
+  snapshot.block_size = block_pool_->BlockSize();
+  snapshot.total_blocks = block_pool_->Capacity();
+  snapshot.free_blocks = block_pool_->AvailableBlocks();
+  snapshot.block_table_columns = block_table_columns_;
+  snapshot.requests.reserve(block_tables_.size());
+  for (const auto& block_table : block_tables_) {
+    RequestBlockSnapshot request_snapshot;
+    request_snapshot.request_id = block_table.request.get();
+    request_snapshot.block_ids.reserve(block_table.blocks.size());
+    for (const auto& block : block_table.blocks) {
+      request_snapshot.block_ids.push_back(block->Id());
+      request_snapshot.used_slots += block->Size();
+      request_snapshot.empty_slots += block->EmptySlots();
+    }
+    snapshot.requests.push_back(std::move(request_snapshot));
+  }
+  return snapshot;
+}
+
 std::vector<std::pair<OrtValue*, OrtValue*>> PagedKeyValueCache::Cache() {
   std::vector<std::pair<OrtValue*, OrtValue*>> cache;
   for (auto& layer_cache : cache_) {

--- a/src/engine/paged_key_value_cache.h
+++ b/src/engine/paged_key_value_cache.h
@@ -9,6 +9,7 @@
 
 #include "block.h"
 #include "request.h"
+#include "engine_invariants.h"
 
 namespace Generators {
 
@@ -70,6 +71,11 @@ struct PagedKeyValueCache {
   size_t BlockTableColumns() const { return block_table_columns_; }
 
   void UpdateState(State& state, const std::vector<std::shared_ptr<Request>>& requests);
+
+  // Captures an immutable snapshot of the cache's block accounting (free/allocated blocks, and per
+  // request block ids and used/empty slots) for invariant validation and state inspection. The
+  // snapshot copies out the state and holds no reference into the cache.
+  PagedCacheSnapshot Snapshot() const;
 
  private:
   struct LayerCache {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -82,6 +82,19 @@ int64_t Request::CurrentSequenceLength() const {
   return search_->GetSequenceLength();
 }
 
+RequestStateSnapshot Request::Snapshot() const {
+  const int64_t current = CurrentSequenceLength();
+  RequestStateSnapshot snapshot;
+  snapshot.request_id = this;
+  snapshot.status = status_;
+  snapshot.current_sequence_length = current;
+  snapshot.processed_sequence_length = processed_sequence_length_;
+  snapshot.seen_sequence_length = seen_sequence_length_;
+  snapshot.unprocessed_token_count = current - processed_sequence_length_;
+  snapshot.is_prefill = is_prefill_;
+  return snapshot;
+}
+
 int32_t Request::UnseenToken() {
   auto sequence = search_->GetSequence(0).CopyDeviceToCpu();
   if (static_cast<size_t>(seen_sequence_length_) >= sequence.size())

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -90,7 +90,6 @@ RequestStateSnapshot Request::Snapshot() const {
   snapshot.current_sequence_length = current;
   snapshot.processed_sequence_length = processed_sequence_length_;
   snapshot.seen_sequence_length = seen_sequence_length_;
-  snapshot.unprocessed_token_count = current - processed_sequence_length_;
   snapshot.is_prefill = is_prefill_;
   return snapshot;
 }

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "../generators.h"
+#include "request_status.h"
+#include "engine_invariants.h"
 
 /**
  * @file request.h
@@ -12,14 +14,6 @@
  */
 
 namespace Generators {
-
-enum class RequestStatus {
-  Unassigned,  // A request has been created but has not been added to the engine yet.
-               // This is the state of a request when it is first created.
-  Assigned,    // The request has been added to the engine and is waiting to be scheduled.
-  InProgress,  // The request has been scheduled and is currently being processed.
-  Completed,   // The request has been completed successfully.
-};
 
 /**
  * @class Request
@@ -117,6 +111,15 @@ struct Request : std::enable_shared_from_this<Request>,
    * @return The current sequence length.
    */
   int64_t CurrentSequenceLength() const;
+
+  /**
+   * @brief Captures an immutable snapshot of this request's progress counters.
+   * @return A RequestStateSnapshot for invariant validation and state inspection.
+   *
+   * The snapshot copies out the request's status and sequence-length counters; it holds no
+   * reference into the request and does not mutate any state.
+   */
+  RequestStateSnapshot Snapshot() const;
 
   RequestStatus status_{RequestStatus::Unassigned};
 

--- a/src/engine/request_status.h
+++ b/src/engine/request_status.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+/**
+ * @file request_status.h
+ * @brief Defines the lifecycle status of an engine Request.
+ *
+ * Kept in its own lightweight header (free of heavy engine/model includes) so that
+ * invariant-checking and state-observing code can depend on the status enum without pulling in the
+ * full Request or the rest of the generators runtime.
+ */
+
+namespace Generators {
+
+enum class RequestStatus {
+  Unassigned,  // A request has been created but has not been added to the engine yet.
+               // This is the state of a request when it is first created.
+  Assigned,    // The request has been added to the engine and is waiting to be scheduled.
+  InProgress,  // The request has been scheduled and is currently being processed.
+  Completed,   // The request has been completed successfully.
+};
+
+}  // namespace Generators

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -127,3 +127,40 @@ if (ENABLE_TELEMETRY AND NOT WIN32 AND NOT ANDROID AND NOT CMAKE_SYSTEM_NAME STR
   endif()
   add_test(NAME TelemetryDeviceInfoTests COMMAND telemetry_device_info_tests)
 endif()
+
+# Dedicated white-box unit tests for the continuous-batching Engine. Like reinit_tests, this binary
+# links the genai OBJECT library (not the public shared DLL) so it can exercise internal Engine
+# types (Block/BlockPool today; scheduler, cache manager, and Request invariants as the framework
+# grows) directly. It is kept separate from unit_tests so that internal test-only fakes/helpers do
+# not leak into the public-API suite and Engine failures are attributable to Engine correctness.
+# These are Tier 0 pure unit tests: no model, no ONNX session, no GPU.
+file(GLOB engine_unit_test_srcs CONFIGURE_DEPENDS
+  "${CMAKE_CURRENT_SOURCE_DIR}/engine/*.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/engine/*.cpp"
+)
+add_executable(engine_unit_tests ${engine_unit_test_srcs})
+target_include_directories(engine_unit_tests PRIVATE
+  ${ORT_HEADER_DIR}
+  ${onnxruntime_extensions_SOURCE_DIR}/shared/api
+  ${CMAKE_SOURCE_DIR}/src
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+# onnxruntime-genai-obj propagates its PUBLIC usage requirements (ORT + extensions include dirs and
+# link libs), so those are inherited here.
+target_link_libraries(engine_unit_tests PRIVATE
+  onnxruntime-genai-obj
+  GTest::gtest
+)
+# The shared library stages the ORT runtime (and CUDA add-on) next to itself; depend on it so those
+# are present in engine_unit_tests' output directory at run time.
+add_dependencies(engine_unit_tests onnxruntime-genai)
+set_target_properties(engine_unit_tests PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "$<TARGET_FILE_DIR:onnxruntime-genai>"
+    FOLDER "Tests"
+)
+if (NOT MSVC)
+  target_compile_options(engine_unit_tests PRIVATE "-fvisibility=hidden")
+endif()
+
+add_test(NAME EngineUnitTests COMMAND engine_unit_tests)
+set_tests_properties(EngineUnitTests PROPERTIES LABELS "engine;unit")

--- a/test/engine/block_pool_tests.cpp
+++ b/test/engine/block_pool_tests.cpp
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tier 0 pure unit tests for the paged-cache block arithmetic and ownership primitives
+// (Generators::Block and Generators::BlockPool). These require no model, no ONNX session, and no
+// GPU; they validate slot arithmetic, allocation/reservation semantics, capacity accounting, and
+// free-time ownership guards deterministically.
+
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine/block.h"
+
+namespace Generators {
+namespace {
+
+constexpr size_t kBlockSize = 4;
+
+// ---------------------------------------------------------------------------------------------
+// Block
+// ---------------------------------------------------------------------------------------------
+
+TEST(BlockTest, ConstructEmpty) {
+  Block block(/*id=*/0, /*slots=*/0, kBlockSize);
+  EXPECT_EQ(block.Id(), 0u);
+  EXPECT_EQ(block.Size(), 0u);
+  EXPECT_EQ(block.Capacity(), kBlockSize);
+  EXPECT_EQ(block.EmptySlots(), kBlockSize);
+  EXPECT_FALSE(block.IsFull());
+  EXPECT_TRUE(block.SlotIds().empty());
+}
+
+TEST(BlockTest, ConstructPartial) {
+  Block block(/*id=*/2, /*slots=*/1, kBlockSize);
+  EXPECT_EQ(block.Size(), 1u);
+  EXPECT_EQ(block.EmptySlots(), kBlockSize - 1);
+  EXPECT_FALSE(block.IsFull());
+  // Slot ids are contiguous and offset by id * capacity.
+  EXPECT_EQ(block.SlotIds(), (std::vector<size_t>{2 * kBlockSize}));
+}
+
+TEST(BlockTest, ConstructFull) {
+  Block block(/*id=*/1, /*slots=*/kBlockSize, kBlockSize);
+  EXPECT_EQ(block.Size(), kBlockSize);
+  EXPECT_EQ(block.EmptySlots(), 0u);
+  EXPECT_TRUE(block.IsFull());
+  EXPECT_EQ(block.SlotIds(),
+            (std::vector<size_t>{kBlockSize, kBlockSize + 1, kBlockSize + 2, kBlockSize + 3}));
+}
+
+TEST(BlockTest, AddSlotProgression) {
+  Block block(/*id=*/0, /*slots=*/0, kBlockSize);
+  for (size_t expected = 1; expected <= kBlockSize; ++expected) {
+    block.AddSlot();
+    EXPECT_EQ(block.Size(), expected);
+    EXPECT_EQ(block.EmptySlots(), kBlockSize - expected);
+    EXPECT_EQ(block.SlotIds().size(), expected);
+  }
+  EXPECT_TRUE(block.IsFull());
+}
+
+TEST(BlockTest, AddSlotOverflowRejected) {
+  Block block(/*id=*/0, /*slots=*/kBlockSize, kBlockSize);
+  ASSERT_TRUE(block.IsFull());
+  EXPECT_THROW(block.AddSlot(), std::runtime_error);
+  // The rejected AddSlot must not have mutated the block.
+  EXPECT_EQ(block.Size(), kBlockSize);
+}
+
+TEST(BlockTest, IdentityAndSlotIdsAreStable) {
+  Block block(/*id=*/3, /*slots=*/0, kBlockSize);
+  block.AddSlot();
+  block.AddSlot();
+  EXPECT_EQ(block.Id(), 3u);
+  EXPECT_EQ(block.SlotIds(), (std::vector<size_t>{3 * kBlockSize, 3 * kBlockSize + 1}));
+}
+
+// ---------------------------------------------------------------------------------------------
+// BlockPool: BlocksNeeded
+// ---------------------------------------------------------------------------------------------
+
+TEST(BlockPoolTest, BlocksNeededBoundaries) {
+  constexpr size_t kNumBlocks = 8;
+  BlockPool pool(kBlockSize, kNumBlocks);
+  EXPECT_EQ(pool.BlocksNeeded(0), 0u);
+  EXPECT_EQ(pool.BlocksNeeded(1), 1u);
+  EXPECT_EQ(pool.BlocksNeeded(kBlockSize - 1), 1u);
+  EXPECT_EQ(pool.BlocksNeeded(kBlockSize), 1u);
+  EXPECT_EQ(pool.BlocksNeeded(kBlockSize + 1), 2u);
+  EXPECT_EQ(pool.BlocksNeeded(kNumBlocks * kBlockSize), kNumBlocks);
+}
+
+// ---------------------------------------------------------------------------------------------
+// BlockPool: allocation vs reservation
+// ---------------------------------------------------------------------------------------------
+
+TEST(BlockPoolTest, AllocateMarksSlotsUsed) {
+  BlockPool pool(kBlockSize, /*num_blocks=*/4);
+  auto blocks = pool.AllocateBlocks(kBlockSize + 1);  // 2 blocks: one full, one with a single slot.
+  ASSERT_EQ(blocks.size(), 2u);
+  EXPECT_TRUE(blocks[0]->IsFull());
+  EXPECT_EQ(blocks[0]->Size(), kBlockSize);
+  EXPECT_EQ(blocks[1]->Size(), 1u);
+  EXPECT_EQ(pool.AvailableBlocks(), 2u);
+  EXPECT_EQ(pool.Size(), 2u);
+}
+
+TEST(BlockPoolTest, ReserveLeavesSlotsEmpty) {
+  BlockPool pool(kBlockSize, /*num_blocks=*/4);
+  auto blocks = pool.ReserveBlocks(kBlockSize + 1);  // 2 blocks reserved, no slots used yet.
+  ASSERT_EQ(blocks.size(), 2u);
+  EXPECT_EQ(blocks[0]->Size(), 0u);
+  EXPECT_EQ(blocks[1]->Size(), 0u);
+  // Reservation still consumes pool capacity even though the slots are empty.
+  EXPECT_EQ(pool.AvailableBlocks(), 2u);
+}
+
+TEST(BlockPoolTest, ExactFitConsumesFinalBlock) {
+  constexpr size_t kNumBlocks = 3;
+  BlockPool pool(kBlockSize, kNumBlocks);
+  auto blocks = pool.AllocateBlocks(kNumBlocks * kBlockSize);
+  EXPECT_EQ(blocks.size(), kNumBlocks);
+  EXPECT_EQ(pool.AvailableBlocks(), 0u);
+  EXPECT_EQ(pool.Size(), kNumBlocks);
+}
+
+TEST(BlockPoolTest, OneOverCapacityFailsWithoutPartialAllocation) {
+  constexpr size_t kNumBlocks = 3;
+  BlockPool pool(kBlockSize, kNumBlocks);
+  EXPECT_THROW(pool.AllocateBlocks(kNumBlocks * kBlockSize + 1), std::runtime_error);
+  // A rejected allocation must not consume any capacity.
+  EXPECT_EQ(pool.AvailableBlocks(), kNumBlocks);
+  EXPECT_EQ(pool.Size(), 0u);
+}
+
+TEST(BlockPoolTest, FailedMultiBlockAllocationLeavesPoolUnchanged) {
+  constexpr size_t kNumBlocks = 4;
+  BlockPool pool(kBlockSize, kNumBlocks);
+  auto held = pool.AllocateBlocks(2 * kBlockSize);  // Occupy 2 of 4 blocks.
+  ASSERT_EQ(pool.AvailableBlocks(), 2u);
+
+  // Asking for 3 blocks when only 2 remain must fail atomically, leaving the earlier allocation and
+  // the free count untouched.
+  EXPECT_THROW(pool.AllocateBlocks(3 * kBlockSize), std::runtime_error);
+  EXPECT_EQ(pool.AvailableBlocks(), 2u);
+  EXPECT_EQ(pool.Size(), 2u);
+}
+
+// ---------------------------------------------------------------------------------------------
+// BlockPool: free
+// ---------------------------------------------------------------------------------------------
+
+TEST(BlockPoolTest, FreeRestoresCapacity) {
+  BlockPool pool(kBlockSize, /*num_blocks=*/4);
+  auto blocks = pool.AllocateBlocks(2 * kBlockSize);
+  ASSERT_EQ(pool.AvailableBlocks(), 2u);
+  pool.Free(blocks);
+  EXPECT_EQ(pool.AvailableBlocks(), 4u);
+  EXPECT_EQ(pool.Size(), 0u);
+}
+
+TEST(BlockPoolTest, FreeNullBlockRejected) {
+  BlockPool pool(kBlockSize, /*num_blocks=*/4);
+  std::vector<std::shared_ptr<Block>> blocks{nullptr};
+  EXPECT_THROW(pool.Free(blocks), std::runtime_error);
+}
+
+TEST(BlockPoolTest, FreeOutOfRangeIdRejected) {
+  BlockPool pool(kBlockSize, /*num_blocks=*/2);
+  std::vector<std::shared_ptr<Block>> blocks{std::make_shared<Block>(/*id=*/5, 0, kBlockSize)};
+  EXPECT_THROW(pool.Free(blocks), std::runtime_error);
+  EXPECT_EQ(pool.AvailableBlocks(), 2u);
+}
+
+TEST(BlockPoolTest, FreeForeignBlockRejected) {
+  BlockPool pool(kBlockSize, /*num_blocks=*/4);
+  // A block with a valid id that this pool never handed out (the slot is currently free).
+  std::vector<std::shared_ptr<Block>> foreign{std::make_shared<Block>(/*id=*/0, 0, kBlockSize)};
+  EXPECT_THROW(pool.Free(foreign), std::runtime_error);
+  EXPECT_EQ(pool.AvailableBlocks(), 4u);
+}
+
+TEST(BlockPoolTest, DuplicateFreeInSameCallRejected) {
+  BlockPool pool(kBlockSize, /*num_blocks=*/4);
+  auto blocks = pool.AllocateBlocks(kBlockSize);
+  ASSERT_EQ(blocks.size(), 1u);
+  std::vector<std::shared_ptr<Block>> duplicated{blocks[0], blocks[0]};
+  EXPECT_THROW(pool.Free(duplicated), std::runtime_error);
+  // Rejected before any mutation: the block is still owned by the pool.
+  EXPECT_EQ(pool.AvailableBlocks(), 3u);
+}
+
+TEST(BlockPoolTest, DoubleFreeAcrossCallsRejected) {
+  BlockPool pool(kBlockSize, /*num_blocks=*/4);
+  auto blocks = pool.AllocateBlocks(kBlockSize);
+  pool.Free(blocks);
+  ASSERT_EQ(pool.AvailableBlocks(), 4u);
+  // Freeing the same (now stale) block again must be rejected, not silently double-freed.
+  EXPECT_THROW(pool.Free(blocks), std::runtime_error);
+  EXPECT_EQ(pool.AvailableBlocks(), 4u);
+}
+
+TEST(BlockPoolTest, RepeatedAllocateFreeCyclesPreserveTotals) {
+  constexpr size_t kNumBlocks = 4;
+  BlockPool pool(kBlockSize, kNumBlocks);
+  for (int cycle = 0; cycle < 5; ++cycle) {
+    auto blocks = pool.AllocateBlocks(kNumBlocks * kBlockSize);
+    EXPECT_EQ(pool.AvailableBlocks(), 0u);
+    pool.Free(blocks);
+    EXPECT_EQ(pool.AvailableBlocks(), kNumBlocks);
+    EXPECT_EQ(pool.Capacity(), kNumBlocks);
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// BlockPool: production reservation pattern
+// ---------------------------------------------------------------------------------------------
+
+// Mirrors how the cache reserves capacity ahead of time and then fills slots one token at a time:
+// reserve block_size + 1 slots, advance the returned blocks slot-by-slot, and verify the state
+// transitions converge on what an allocation of block_size + 1 slots would have produced.
+TEST(BlockPoolTest, ReserveThenAdvanceMatchesAllocation) {
+  BlockPool pool(kBlockSize, /*num_blocks=*/4);
+  auto reserved = pool.ReserveBlocks(kBlockSize + 1);
+  ASSERT_EQ(reserved.size(), 2u);
+
+  // Fill the first block one slot at a time.
+  for (size_t i = 0; i < kBlockSize; ++i) {
+    EXPECT_EQ(reserved[0]->Size(), i);
+    EXPECT_FALSE(reserved[0]->IsFull());
+    reserved[0]->AddSlot();
+  }
+  EXPECT_TRUE(reserved[0]->IsFull());
+
+  // Fill the single trailing slot of the second block.
+  EXPECT_EQ(reserved[1]->Size(), 0u);
+  reserved[1]->AddSlot();
+
+  // Compare against a direct allocation of the same slot count.
+  BlockPool allocated_pool(kBlockSize, /*num_blocks=*/4);
+  auto allocated = allocated_pool.AllocateBlocks(kBlockSize + 1);
+  ASSERT_EQ(allocated.size(), reserved.size());
+  for (size_t i = 0; i < reserved.size(); ++i) {
+    EXPECT_EQ(reserved[i]->Size(), allocated[i]->Size());
+    EXPECT_EQ(reserved[i]->IsFull(), allocated[i]->IsFull());
+    EXPECT_EQ(reserved[i]->EmptySlots(), allocated[i]->EmptySlots());
+  }
+}
+
+}  // namespace
+}  // namespace Generators

--- a/test/engine/block_pool_tests.cpp
+++ b/test/engine/block_pool_tests.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Tier 0 pure unit tests for the paged-cache block arithmetic and ownership primitives
+// Pure unit tests for the paged-cache block arithmetic and ownership primitives
 // (Generators::Block and Generators::BlockPool). These require no model, no ONNX session, and no
 // GPU; they validate slot arithmetic, allocation/reservation semantics, capacity accounting, and
 // free-time ownership guards deterministically.

--- a/test/engine/engine_invariants_tests.cpp
+++ b/test/engine/engine_invariants_tests.cpp
@@ -16,9 +16,13 @@
 namespace Generators {
 namespace {
 
-// Distinct fake request identities. The validator only compares/prints these, never dereferences.
-const void* const kRequestA = reinterpret_cast<const void*>(0x1);
-const void* const kRequestB = reinterpret_cast<const void*>(0x2);
+// Distinct fake request identities. The validator only compares/prints these, never dereferences,
+// so any two distinct, stable addresses work. Using addresses of static storage avoids
+// implementation-defined integer-to-pointer casts (which can trip UB tooling).
+const char kRequestStorageA{};
+const char kRequestStorageB{};
+const void* const kRequestA = &kRequestStorageA;
+const void* const kRequestB = &kRequestStorageB;
 
 constexpr size_t kBlockSize = 4;
 

--- a/test/engine/engine_invariants_tests.cpp
+++ b/test/engine/engine_invariants_tests.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Tier 0 pure unit tests for the Engine invariant validator (Generators::ValidateInvariants and
+// Pure unit tests for the Engine invariant validator (Generators::ValidateInvariants and
 // friends). The validator operates only on immutable snapshot value types, so these tests need no
 // model, cache, scheduler, or GPU: they construct snapshots directly and assert which invariant
 // violations are (and are not) reported.

--- a/test/engine/engine_invariants_tests.cpp
+++ b/test/engine/engine_invariants_tests.cpp
@@ -49,7 +49,6 @@ RequestStateSnapshot MakeValidRequest(const void* id, RequestStatus status, int6
   request.current_sequence_length = current;
   request.processed_sequence_length = processed;
   request.seen_sequence_length = seen;
-  request.unprocessed_token_count = current - processed;
   request.is_prefill = false;
   return request;
 }
@@ -150,18 +149,11 @@ TEST(InvariantValidatorTest, ValidRequestHasNoViolations) {
 
 TEST(InvariantValidatorTest, ProcessedBeyondCurrentReported) {
   auto request = MakeValidRequest(kRequestA, RequestStatus::InProgress, 10, 12, 6);
-  request.unprocessed_token_count = 10 - 12;  // -2 keeps the arithmetic identity but is negative
   EXPECT_FALSE(ValidateRequestInvariants(request).empty());
 }
 
 TEST(InvariantValidatorTest, SeenBeyondCurrentReported) {
   auto request = MakeValidRequest(kRequestA, RequestStatus::InProgress, 10, 4, 11);
-  EXPECT_FALSE(ValidateRequestInvariants(request).empty());
-}
-
-TEST(InvariantValidatorTest, UnprocessedArithmeticMismatchReported) {
-  auto request = MakeValidRequest(kRequestA, RequestStatus::InProgress, 10, 4, 6);
-  request.unprocessed_token_count = 5;  // should be 10 - 4 = 6
   EXPECT_FALSE(ValidateRequestInvariants(request).empty());
 }
 

--- a/test/engine/engine_invariants_tests.cpp
+++ b/test/engine/engine_invariants_tests.cpp
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tier 0 pure unit tests for the Engine invariant validator (Generators::ValidateInvariants and
+// friends). The validator operates only on immutable snapshot value types, so these tests need no
+// model, cache, scheduler, or GPU: they construct snapshots directly and assert which invariant
+// violations are (and are not) reported.
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine/engine_invariants.h"
+
+namespace Generators {
+namespace {
+
+// Distinct fake request identities. The validator only compares/prints these, never dereferences.
+const void* const kRequestA = reinterpret_cast<const void*>(0x1);
+const void* const kRequestB = reinterpret_cast<const void*>(0x2);
+
+constexpr size_t kBlockSize = 4;
+
+// A consistent two-request cache: A owns blocks {0,1} (full + one used slot), B owns block {2}
+// (fully used); one block free. Helpers below mutate copies to violate a single invariant at a time.
+PagedCacheSnapshot MakeValidCache() {
+  PagedCacheSnapshot cache;
+  cache.block_size = kBlockSize;
+  cache.total_blocks = 4;
+  cache.free_blocks = 1;
+  cache.block_table_columns = 2;
+  cache.requests = {
+      RequestBlockSnapshot{kRequestA, {0, 1}, /*used=*/kBlockSize + 1, /*empty=*/kBlockSize - 1},
+      RequestBlockSnapshot{kRequestB, {2}, /*used=*/kBlockSize, /*empty=*/0},
+  };
+  return cache;
+}
+
+RequestStateSnapshot MakeValidRequest(const void* id, RequestStatus status, int64_t current,
+                                      int64_t processed, int64_t seen) {
+  RequestStateSnapshot request;
+  request.request_id = id;
+  request.status = status;
+  request.current_sequence_length = current;
+  request.processed_sequence_length = processed;
+  request.seen_sequence_length = seen;
+  request.unprocessed_token_count = current - processed;
+  request.is_prefill = false;
+  return request;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Cache invariants
+// ---------------------------------------------------------------------------------------------
+
+TEST(InvariantValidatorTest, ValidCacheHasNoViolations) {
+  EXPECT_TRUE(ValidateCacheInvariants(MakeValidCache()).empty());
+}
+
+TEST(InvariantValidatorTest, AllocatedBlocksCountsOwnedBlocks) {
+  const auto cache = MakeValidCache();
+  EXPECT_EQ(cache.AllocatedBlocks(), 3u);
+  EXPECT_EQ(cache.free_blocks + cache.AllocatedBlocks(), cache.total_blocks);
+}
+
+TEST(InvariantValidatorTest, BlockAccountingMismatchReported) {
+  auto cache = MakeValidCache();
+  cache.free_blocks = 2;  // free(2) + allocated(3) != total(4)
+  EXPECT_FALSE(ValidateCacheInvariants(cache).empty());
+}
+
+TEST(InvariantValidatorTest, FreeExceedingTotalReported) {
+  auto cache = MakeValidCache();
+  cache.total_blocks = 2;  // free(1)+allocated(3) mismatch and allocated ids now out of range too
+  EXPECT_FALSE(ValidateCacheInvariants(cache).empty());
+}
+
+TEST(InvariantValidatorTest, OutOfRangeBlockIdReported) {
+  auto cache = MakeValidCache();
+  cache.requests[1].block_ids = {9};  // id 9 >= total_blocks (4)
+  // Keep accounting otherwise sound so the out-of-range id is the reported problem.
+  cache.free_blocks = 1;
+  const auto violations = ValidateCacheInvariants(cache);
+  ASSERT_FALSE(violations.empty());
+}
+
+TEST(InvariantValidatorTest, DuplicateBlockWithinRequestReported) {
+  auto cache = MakeValidCache();
+  cache.requests[0].block_ids = {0, 0};  // same block listed twice within request A
+  EXPECT_FALSE(ValidateCacheInvariants(cache).empty());
+}
+
+TEST(InvariantValidatorTest, BlockOwnedByTwoRequestsReported) {
+  auto cache = MakeValidCache();
+  cache.requests[1].block_ids = {1};  // block 1 already owned by request A
+  cache.free_blocks = 2;              // keep total accounting consistent (A:2 + B:1 - shared)
+  const auto violations = ValidateCacheInvariants(cache);
+  bool found_shared = false;
+  for (const auto& v : violations) {
+    if (v.message.find("more than one Request") != std::string::npos) found_shared = true;
+  }
+  EXPECT_TRUE(found_shared);
+}
+
+TEST(InvariantValidatorTest, DuplicateRequestBlockTableReported) {
+  auto cache = MakeValidCache();
+  // Request A appears twice in the block-table listing (a malformed/duplicated row).
+  cache.requests.push_back(cache.requests[0]);
+  const auto violations = ValidateCacheInvariants(cache);
+  bool found_duplicate_row = false;
+  for (const auto& v : violations) {
+    if (v.message.find("more than one block table") != std::string::npos) found_duplicate_row = true;
+  }
+  EXPECT_TRUE(found_duplicate_row);
+}
+
+TEST(InvariantValidatorTest, SlotCapacityMismatchReported) {
+  auto cache = MakeValidCache();
+  cache.requests[1].used_slots = kBlockSize + 1;  // one block can hold at most block_size slots
+  cache.requests[1].empty_slots = 0;
+  EXPECT_FALSE(ValidateCacheInvariants(cache).empty());
+}
+
+TEST(InvariantValidatorTest, NarrowBlockTableColumnsReported) {
+  auto cache = MakeValidCache();
+  cache.block_table_columns = 1;  // request A owns 2 blocks, so 1 column cannot hold it
+  EXPECT_FALSE(ValidateCacheInvariants(cache).empty());
+}
+
+TEST(InvariantValidatorTest, ZeroBlockTableColumnsIsAllowed) {
+  auto cache = MakeValidCache();
+  cache.block_table_columns = 0;  // 0 means "cache does not use a block table"
+  EXPECT_TRUE(ValidateCacheInvariants(cache).empty());
+}
+
+// ---------------------------------------------------------------------------------------------
+// Request invariants
+// ---------------------------------------------------------------------------------------------
+
+TEST(InvariantValidatorTest, ValidRequestHasNoViolations) {
+  EXPECT_TRUE(ValidateRequestInvariants(
+                  MakeValidRequest(kRequestA, RequestStatus::InProgress, 10, 4, 6))
+                  .empty());
+}
+
+TEST(InvariantValidatorTest, ProcessedBeyondCurrentReported) {
+  auto request = MakeValidRequest(kRequestA, RequestStatus::InProgress, 10, 12, 6);
+  request.unprocessed_token_count = 10 - 12;  // -2 keeps the arithmetic identity but is negative
+  EXPECT_FALSE(ValidateRequestInvariants(request).empty());
+}
+
+TEST(InvariantValidatorTest, SeenBeyondCurrentReported) {
+  auto request = MakeValidRequest(kRequestA, RequestStatus::InProgress, 10, 4, 11);
+  EXPECT_FALSE(ValidateRequestInvariants(request).empty());
+}
+
+TEST(InvariantValidatorTest, UnprocessedArithmeticMismatchReported) {
+  auto request = MakeValidRequest(kRequestA, RequestStatus::InProgress, 10, 4, 6);
+  request.unprocessed_token_count = 5;  // should be 10 - 4 = 6
+  EXPECT_FALSE(ValidateRequestInvariants(request).empty());
+}
+
+TEST(InvariantValidatorTest, CompletedRequestWithFinalUnprocessedTokenIsValid) {
+  // At completion the just-generated final token is appended but never fed back to the model, so a
+  // Completed Request legitimately reports one (or more) unprocessed token(s). This must not fire.
+  auto request = MakeValidRequest(kRequestA, RequestStatus::Completed, 10, 9, 10);
+  EXPECT_TRUE(ValidateRequestInvariants(request).empty());
+}
+
+TEST(InvariantValidatorTest, CompletedRequestFullyProcessedIsValid) {
+  EXPECT_TRUE(ValidateRequestInvariants(
+                  MakeValidRequest(kRequestA, RequestStatus::Completed, 10, 10, 10))
+                  .empty());
+}
+
+// ---------------------------------------------------------------------------------------------
+// Combined / cross-cutting invariants
+// ---------------------------------------------------------------------------------------------
+
+TEST(InvariantValidatorTest, ConsistentSnapshotsValidateClean) {
+  const auto cache = MakeValidCache();
+  const std::vector<RequestStateSnapshot> requests{
+      MakeValidRequest(kRequestA, RequestStatus::InProgress, 9, 9, 9),
+      MakeValidRequest(kRequestB, RequestStatus::InProgress, 4, 4, 4),
+  };
+  EXPECT_TRUE(ValidateInvariants(cache, requests).empty());
+  EXPECT_NO_THROW(ThrowIfInvariantsViolated(cache, requests));
+}
+
+TEST(InvariantValidatorTest, BlockTableForUnknownRequestReported) {
+  const auto cache = MakeValidCache();  // owns tables for A and B
+  const std::vector<RequestStateSnapshot> requests{
+      MakeValidRequest(kRequestA, RequestStatus::InProgress, 9, 9, 9),
+      // B is missing from the request set, yet the cache holds a block table for it.
+  };
+  EXPECT_FALSE(ValidateInvariants(cache, requests).empty());
+}
+
+TEST(InvariantValidatorTest, ThrowWrapperListsViolations) {
+  auto cache = MakeValidCache();
+  cache.free_blocks = 0;  // break block accounting
+  const std::vector<RequestStateSnapshot> requests{
+      MakeValidRequest(kRequestA, RequestStatus::InProgress, 9, 9, 9),
+      MakeValidRequest(kRequestB, RequestStatus::InProgress, 4, 4, 4),
+  };
+  EXPECT_THROW(ThrowIfInvariantsViolated(cache, requests), std::runtime_error);
+}
+
+}  // namespace
+}  // namespace Generators

--- a/test/engine/engine_test_main.cpp
+++ b/test/engine/engine_test_main.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Entry point for the dedicated Engine unit-test binary (`engine_unit_tests`).
+//
+// This binary links the genai OBJECT library (onnxruntime-genai-obj) rather than the public shared
+// library so it can exercise internal continuous-batching Engine types (Block, BlockPool, and, as
+// the framework grows, the scheduler, cache manager, and Request invariants) directly as white-box
+// unit tests. It deliberately stays separate from `unit_tests` (which validates only the public C
+// API through the shared library) so that internal test-only fakes and helpers never leak into the
+// public-boundary suite and so Engine failures point straight at Engine correctness.
+//
+// These are Tier 0 pure unit tests: they require no model download, no ONNX session, and no GPU.
+// They must run in seconds on every CPU and CUDA native PR build.
+
+#include <gtest/gtest.h>
+
+#include "telemetry_test_environment.h"
+
+int main(int argc, char** argv) {
+  // Suppress telemetry before any genai symbol runs, matching the other native test binaries.
+  Generators::test::SuppressTelemetryForTests();
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This lays the groundwork for testing the correctness of the continuous-batching Engine. The Engine juggles request scheduling, a paged KV-cache, and model execution, but there's no direct way to check that its internal bookkeeping stays consistent. This PR adds the scaffolding and the correctness contracts to start doing that.

### Changes

- A small production fix: `BlockPool::Free` now validates every block in a batch (non-null, in-range id, actually owned by this pool, not listed twice) before touching any pool state, so a bad request throws up front instead of half-freeing the batch and corrupting the free list.
- A new `engine_unit_tests` binary: a white-box suite that links the genai object library so it can reach internal Engine types, kept separate from the public-API `unit_tests` so test-only helpers don't leak into it.
- State snapshots and a validator: immutable, read-only snapshots of Request and paged-cache state, plus one validator that defines the Engine's invariants in a single place (block accounting, single block ownership, slot capacity, and the sequence-length relationships per request).
- A dependency-injection seam for the engine.