### PR TITLE
Support hybrid (linear-attention) models in KV cache calibration

### DIFF
--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -576,7 +576,7 @@ The `int8`/`int4`/`fp8` prefix selects the KV cache bit width and the `per_tenso
 
 The scales applied to the KV cache are supplied through a required calibration file:
 
-- `kv_cache_scale_file`: path to a JSON file with calibrated per-layer scales in the form `{"scales": {"k_scales": [...per layer...], "v_scales": [...per layer...]}}`. Each per-layer entry is a scalar (`per_tensor`) or a length-`(num_kv_heads * head_size)` vector (`per_channel`). This option is required when `kv_cache_quant_type` is enabled.
+- `kv_cache_scale_file`: path to a JSON file with calibrated per-layer scales in the form `{"scales": {"k_scales": [...per layer...], "v_scales": [...per layer...]}, "layer_ids": [...model layer IDs...]}`. Each per-layer entry is a scalar (`per_tensor`) or a length-`(num_kv_heads * head_size)` vector (`per_channel`). `layer_ids` maps each scale entry to its model layer; it is contiguous for dense models and sparse for hybrid models where only full-attention layers own a KV cache. This option is required when `kv_cache_quant_type` is enabled.
 
 The scale file is produced by the `kv_cache_calibration` module, which runs a baseline (non-quantized) build of the same model over a calibration corpus and captures the `present.*.key`/`present.*.value` tensors:
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -766,7 +766,7 @@ def get_args():
                     When combined with use_paged_attention=true, only the int8_* and fp8_* schemes are supported
                     (PagedAttention has no sub-byte cache backend, so int4_* is rejected).
                 kv_cache_scale_file = Path to a JSON file with calibrated per-layer KV cache scales. Required when kv_cache_quant_type is enabled.
-                    Format: {"scales": {"k_scales": [...per layer...], "v_scales": [...per layer...]}} with one entry per layer.
+                    Format: {"scales": {"k_scales": [...per layer...], "v_scales": [...per layer...]}, "layer_ids": [...optional model layer IDs...]}.
                     Each per-layer entry is a scalar (per_tensor) or a length-(num_kv_heads * head_size) vector (per_channel).
                 disable_qkv_fusion = Disable QKV fusion in the model. Default is false.
                     If true, the model will not fuse the Q, K, and V projections. Automatically assumed for certain EPs.

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -707,10 +707,9 @@ class Model:
         per_channel = self.kv_quant_type == "PER_CHANNEL"
         scale_size = self.num_kv_heads * self.head_size if per_channel else 1
 
-        # Calibrated per-layer scales are required and supplied via a JSON file:
-        #   {"scales": {"k_scales": [...per layer...], "v_scales": [...per layer...]}}
-        # where each per-layer entry is a scalar (PER_TENSOR) or a length-scale_size
-        # vector (PER_CHANNEL).
+        # Calibrated per-layer scales are required and supplied via a JSON file. Optional
+        # `layer_ids` maps sparse scale entries to their original model layers; without it,
+        # the scale arrays use the legacy dense 0..num_layers-1 order.
         scale_file = self.extra_options.get("kv_cache_scale_file", None)
         if scale_file is None:
             raise ValueError(
@@ -726,9 +725,36 @@ class Model:
             raise ValueError(
                 "kv_cache_scale_file must contain scales.k_scales and scales.v_scales."
             ) from error
-        if len(k_scales_per_layer) != self.num_layers or len(v_scales_per_layer) != self.num_layers:
+        layer_ids = scale_data.get("layer_ids")
+        if layer_ids is None:
+            layer_ids = list(range(self.num_layers))
+            expected_scale_count = self.num_layers
+        else:
+            if not isinstance(layer_ids, list) or any(type(layer_id) is not int for layer_id in layer_ids):
+                raise ValueError("kv_cache_scale_file layer_ids must be a list of integer model layer IDs.")
+            if not layer_ids:
+                raise ValueError("kv_cache_scale_file layer_ids must not be empty.")
+            if len(set(layer_ids)) != len(layer_ids):
+                raise ValueError("kv_cache_scale_file layer_ids must not contain duplicates.")
+            if any(layer_id < 0 or layer_id >= self.num_layers for layer_id in layer_ids):
+                raise ValueError(
+                    f"kv_cache_scale_file layer_ids must be in [0, {self.num_layers}), got {layer_ids}."
+                )
+            kv_input_names = self.input_names.get("past_key_values.key", [])
+            kv_layer_ids = {
+                int(parts[1])
+                for input_name in kv_input_names
+                if len(parts := input_name.split(".")) == 3 and parts[1].isdigit()
+            }
+            if set(layer_ids) != kv_layer_ids:
+                raise ValueError(
+                    f"kv_cache_scale_file layer_ids must match the model's KV-cache layers; "
+                    f"got {sorted(layer_ids)}, expected {sorted(kv_layer_ids)}."
+                )
+            expected_scale_count = len(layer_ids)
+        if len(k_scales_per_layer) != expected_scale_count or len(v_scales_per_layer) != expected_scale_count:
             raise ValueError(
-                f"kv_cache_scale_file must provide {self.num_layers} per-layer scales, "
+                f"kv_cache_scale_file must provide {expected_scale_count} per-layer scales, "
                 f"got k={len(k_scales_per_layer)} v={len(v_scales_per_layer)}"
             )
 
@@ -737,8 +763,8 @@ class Model:
         # count. Emit the canonical shape on the paged path and keep the flat vector elsewhere.
         scale_shape = (self.num_kv_heads, 1, self.head_size) if (per_channel and self.use_paged_attention) else (-1,)
 
-        def make_scale(per_layer, layer_id):
-            scale = np.asarray(per_layer[layer_id], dtype=np.float32).reshape(-1)
+        def make_scale(per_layer, scale_index, layer_id):
+            scale = np.asarray(per_layer[scale_index], dtype=np.float32).reshape(-1)
             if scale.size != scale_size:
                 raise ValueError(
                     f"kv_cache scale for layer {layer_id} has size {scale.size}, expected {scale_size}"
@@ -747,10 +773,10 @@ class Model:
                 raise ValueError(f"kv_cache scale for layer {layer_id} must contain finite positive values")
             return scale.reshape(scale_shape)
 
-        for layer_id in range(self.num_layers):
+        for scale_index, layer_id in enumerate(layer_ids):
             k_scale_name, v_scale_name = self.get_kv_cache_scale_names(layer_id)
-            self.make_initializer(make_scale(k_scales_per_layer, layer_id), k_scale_name)
-            self.make_initializer(make_scale(v_scales_per_layer, layer_id), v_scale_name)
+            self.make_initializer(make_scale(k_scales_per_layer, scale_index, layer_id), k_scale_name)
+            self.make_initializer(make_scale(v_scales_per_layer, scale_index, layer_id), v_scale_name)
 
     def make_lm_head_init(self, config):
         pass

--- a/src/python/py/models/kv_cache_calibration.py
+++ b/src/python/py/models/kv_cache_calibration.py
@@ -299,7 +299,12 @@ def _detect_kv_shape(sess, model_path: str) -> tuple[int, int]:
     """
     num_kv_heads = head_size = None
     for meta in sess.get_inputs():
-        if not meta.name.startswith("past_key_values."):
+        # Only the attention cache carries the [batch, num_kv_heads, past_seq_len, head_size]
+        # layout. Hybrid models (e.g. Qwen3.5) also expose `past_key_values.<layer>.conv_state`
+        # and `.recurrent_state` inputs, which are 4-D/5-D linear-attention state buffers with a
+        # completely different meaning, so match on the `.key`/`.value` suffix rather than on the
+        # `past_key_values.` prefix alone.
+        if not (meta.name.startswith("past_key_values.") and meta.name.endswith((".key", ".value"))):
             continue
         shape = meta.shape
         if len(shape) == 4:
@@ -498,26 +503,30 @@ def calibrate_kv_scales(
         num_layers = len(present_keys)
     if num_layers <= 0:
         raise ValueError("Model has no present.*.key outputs; cannot calibrate KV scales.")
-    expected_layers = set(range(num_layers))
-    missing_keys = sorted(expected_layers - present_keys.keys())
-    missing_values = sorted(expected_layers - present_values.keys())
-    if missing_keys or missing_values:
+    # Hybrid attention models interleave full-attention and linear-attention layers, so only a
+    # subset of layers owns a KV cache and the `present.<layer>.key` indices are sparse (e.g.
+    # Qwen3.5 emits layers 3, 7, 11, ... 39). Calibrate whichever layers are present, in
+    # ascending layer order, instead of demanding a contiguous 0..N-1 range.
+    layer_ids = sorted(present_keys.keys() & present_values.keys())
+    unpaired = sorted(present_keys.keys() ^ present_values.keys())
+    if unpaired:
         raise ValueError(
-            "Calibration requires contiguous present.<layer>.key/value outputs starting at layer 0; "
-            f"missing keys={missing_keys}, values={missing_values}."
+            f"Every present.<layer>.key needs a matching present.<layer>.value; unpaired layers={unpaired}."
         )
-    read_names = [present_keys[i] for i in range(num_layers)] + [present_values[i] for i in range(num_layers)]
+    if len(layer_ids) < num_layers:
+        raise ValueError(
+            f"Requested num_layers={num_layers} but the model only exposes {len(layer_ids)} "
+            f"KV-cache layers (present.<layer>.key/value ids={layer_ids})."
+        )
+    layer_ids = layer_ids[:num_layers]
+    read_names = [present_keys[i] for i in layer_ids] + [present_values[i] for i in layer_ids]
     channels = num_kv_heads * head_size
 
     input_metas = {meta.name: meta for meta in sess.get_inputs()}
     for required_name in ("input_ids", "attention_mask"):
         if required_name not in input_metas:
             raise ValueError(f"Calibration model is missing required input '{required_name}'.")
-    past_metas = [
-        meta
-        for meta in input_metas.values()
-        if meta.name.startswith("past_key_values.") and meta.name.endswith((".key", ".value"))
-    ]
+    past_metas = [meta for meta in input_metas.values() if meta.name.startswith("past_key_values.")]
     supported_inputs = {"input_ids", "attention_mask", "position_ids", *(meta.name for meta in past_metas)}
     unsupported_inputs = sorted(input_metas.keys() - supported_inputs)
     if unsupported_inputs:
@@ -560,9 +569,20 @@ def calibrate_kv_scales(
                 raise ValueError(f"Unsupported position_ids shape {position_meta.shape}.")
             feeds["position_ids"] = position_ids
         for meta in past_metas:
-            feeds[meta.name] = np.zeros(
-                (1, num_kv_heads, 0, head_size), dtype=_numpy_dtype(meta.type)
-            )
+            if meta.name.endswith((".key", ".value")):
+                # Empty attention cache: prefill starts from zero past tokens.
+                feeds[meta.name] = np.zeros(
+                    (1, num_kv_heads, 0, head_size), dtype=_numpy_dtype(meta.type)
+                )
+            else:
+                # Linear-attention conv/recurrent state buffers on hybrid models. These are
+                # fixed-size (not sequence-growing), so allocate the declared shape with the
+                # symbolic batch dimension resolved to 1 and zero-initialize them, which is the
+                # correct "no history" state for the start of a sequence.
+                feeds[meta.name] = np.zeros(
+                    tuple(1 if not isinstance(dim, int) else dim for dim in meta.shape),
+                    dtype=_numpy_dtype(meta.type),
+                )
         outputs = sess.run(read_names, feeds)
 
         for i in range(num_layers):
@@ -615,7 +635,12 @@ def calibrate_kv_scales(
     os.makedirs(os.path.dirname(out_json), exist_ok=True)
     with open(out_json, "w", encoding="utf-8") as file:
         json.dump(
-            {"scales": {"k_scales": k_scales.tolist(), "v_scales": v_scales.tolist()}},
+            {
+                "scales": {"k_scales": k_scales.tolist(), "v_scales": v_scales.tolist()},
+                # Which model layers the scales belong to, in the same order as the arrays above.
+                # Contiguous for dense models; sparse for hybrid attention models.
+                "layer_ids": layer_ids,
+            },
             file,
             allow_nan=False,
         )

--- a/src/python/py/models/kv_cache_calibration.py
+++ b/src/python/py/models/kv_cache_calibration.py
@@ -20,7 +20,13 @@ where ``threshold`` per channel is the abs-max (``method="minmax"``), a high per
 ``|x|`` (``method="percentile"``, tames outliers), or the clip point that minimizes the
 quantization mean squared error (``method="mse"``). The output JSON is::
 
-    {"scales": {"k_scales": [<per-layer>...], "v_scales": [<per-layer>...]}}
+    {
+        "scales": {"k_scales": [<per-layer>...], "v_scales": [<per-layer>...]},
+        "layer_ids": [<model-layer-id>...]
+    }
+
+``layer_ids`` maps each scale entry to its model layer. It is contiguous for dense models and
+sparse for hybrid models where only full-attention layers own a KV cache.
 
 Typical two-step flow::
 
@@ -300,7 +306,7 @@ def _detect_kv_shape(sess, model_path: str) -> tuple[int, int]:
     num_kv_heads = head_size = None
     for meta in sess.get_inputs():
         # Only the attention cache carries the [batch, num_kv_heads, past_seq_len, head_size]
-        # layout. Hybrid models (e.g. Qwen3.5) also expose `past_key_values.<layer>.conv_state`
+        # layout. Hybrid models also expose `past_key_values.<layer>.conv_state`
         # and `.recurrent_state` inputs, which are 4-D/5-D linear-attention state buffers with a
         # completely different meaning, so match on the `.key`/`.value` suffix rather than on the
         # `past_key_values.` prefix alone.
@@ -505,7 +511,7 @@ def calibrate_kv_scales(
         raise ValueError("Model has no present.*.key outputs; cannot calibrate KV scales.")
     # Hybrid attention models interleave full-attention and linear-attention layers, so only a
     # subset of layers owns a KV cache and the `present.<layer>.key` indices are sparse (e.g.
-    # Qwen3.5 emits layers 3, 7, 11, ... 39). Calibrate whichever layers are present, in
+    # some models emit layers 3, 7, 11, ... 39). Calibrate whichever layers are present, in
     # ascending layer order, instead of demanding a contiguous 0..N-1 range.
     layer_ids = sorted(present_keys.keys() & present_values.keys())
     unpaired = sorted(present_keys.keys() ^ present_values.keys())

--- a/test/python/builder/test_kv_cache_calibration.py
+++ b/test/python/builder/test_kv_cache_calibration.py
@@ -426,19 +426,27 @@ def test_calibrate_kv_scales_feeds_model_metadata_and_writes_scales(tmp_path, mo
         _FakeInput("input_ids", ["batch", "sequence"], "tensor(int64)"),
         _FakeInput("attention_mask", ["batch", "total_sequence"], "tensor(int64)"),
         _FakeInput("position_ids", ["batch", "sequence"], "tensor(int64)"),
-        _FakeInput("past_key_values.0.key", ["batch", 1, "past_sequence", 4], "tensor(float)"),
-        _FakeInput("past_key_values.0.value", ["batch", 1, "past_sequence", 4], "tensor(float)"),
+        _FakeInput("past_key_values.3.key", ["batch", 1, "past_sequence", 4], "tensor(float)"),
+        _FakeInput("past_key_values.3.value", ["batch", 1, "past_sequence", 4], "tensor(float)"),
+        _FakeInput("past_key_values.1.conv_state", ["batch", 8, 3], "tensor(float16)"),
+        _FakeInput("past_key_values.1.recurrent_state", ["batch", 2, 4, 4], "tensor(float)"),
     ]
     outputs = [
-        types.SimpleNamespace(name="present.0.key"),
-        types.SimpleNamespace(name="present.0.value"),
+        types.SimpleNamespace(name="present.3.key"),
+        types.SimpleNamespace(name="present.3.value"),
     ]
 
     def run(output_names, feeds):
-        assert output_names == ["present.0.key", "present.0.value"]
+        assert output_names == ["present.3.key", "present.3.value"]
         np.testing.assert_array_equal(feeds["position_ids"], np.arange(target_seq).reshape(1, target_seq))
-        assert feeds["past_key_values.0.key"].dtype == np.float32
-        assert feeds["past_key_values.0.value"].dtype == np.float32
+        assert feeds["past_key_values.3.key"].dtype == np.float32
+        assert feeds["past_key_values.3.value"].dtype == np.float32
+        assert feeds["past_key_values.3.key"].shape == (1, 1, 0, 4)
+        assert feeds["past_key_values.3.value"].shape == (1, 1, 0, 4)
+        np.testing.assert_array_equal(feeds["past_key_values.1.conv_state"], np.zeros((1, 8, 3), dtype=np.float16))
+        np.testing.assert_array_equal(
+            feeds["past_key_values.1.recurrent_state"], np.zeros((1, 2, 4, 4), dtype=np.float32)
+        )
         shape = (1, 1, target_seq, 4)
         return [np.full(shape, 2.0, dtype=np.float32), np.full(shape, 4.0, dtype=np.float32)]
 
@@ -478,6 +486,8 @@ def test_calibrate_kv_scales_feeds_model_metadata_and_writes_scales(tmp_path, mo
     assert result == str(output_path.resolve())
     # Unavailable providers must be filtered out so CPU-only onnxruntime installs work.
     assert requested_providers == ["CPUExecutionProvider"]
-    scales = json.loads(output_path.read_text())["scales"]
+    scale_data = json.loads(output_path.read_text())
+    assert scale_data["layer_ids"] == [3]
+    scales = scale_data["scales"]
     np.testing.assert_allclose(scales["k_scales"], [[2.0 / 128.0] * 4])
     np.testing.assert_allclose(scales["v_scales"], [[4.0 / 128.0] * 4])

--- a/test/python/builder/test_quantized_kv_cache.py
+++ b/test/python/builder/test_quantized_kv_cache.py
@@ -161,6 +161,10 @@ def _make_kv_model(
     model.extra_options = extra_options if extra_options is not None else {}
     model.attention_attrs = {"op_type": op_type}
     model.use_paged_attention = use_paged_attention
+    model.input_names = {
+        "past_key_values.key": [f"past_key_values.{layer_id}.key" for layer_id in range(num_layers)],
+        "past_key_values.value": [f"past_key_values.{layer_id}.value" for layer_id in range(num_layers)],
+    }
     model.input_types = {}
     model.output_types = {}
     model.input_shapes = {
@@ -465,6 +469,104 @@ def test_calibrated_per_layer_scales_are_loaded_from_file(tmp_path):
     np.testing.assert_allclose(captured["model.layers.1.attn.k_scale"], 0.2)
     np.testing.assert_allclose(captured["model.layers.0.attn.v_scale"], 0.3)
     np.testing.assert_allclose(captured["model.layers.1.attn.v_scale"], 0.4)
+
+
+def test_sparse_layer_ids_map_scales_to_model_layers(tmp_path):
+    scale_file = tmp_path / "kv_scales.json"
+    scale_file.write_text(
+        json.dumps(
+            {
+                "scales": {
+                    "k_scales": [0.1, 0.2],
+                    "v_scales": [0.3, 0.4],
+                },
+                "layer_ids": [1, 3],
+            }
+        )
+    )
+    model = _make_kv_model(
+        kv_cache_quant_type="int8_per_tensor",
+        num_layers=4,
+        extra_options={"kv_cache_scale_file": str(scale_file)},
+    )
+    model.kv_quant_type = "PER_TENSOR"
+    model.input_names["past_key_values.key"] = ["past_key_values.1.key", "past_key_values.3.key"]
+    model.input_names["past_key_values.value"] = ["past_key_values.1.value", "past_key_values.3.value"]
+    captured = _capture_initializers(model)
+
+    model.make_kv_cache_scale_initializers()
+
+    assert set(captured) == {
+        "model.layers.1.attn.k_scale",
+        "model.layers.1.attn.v_scale",
+        "model.layers.3.attn.k_scale",
+        "model.layers.3.attn.v_scale",
+    }
+    np.testing.assert_allclose(captured["model.layers.1.attn.k_scale"], 0.1)
+    np.testing.assert_allclose(captured["model.layers.3.attn.k_scale"], 0.2)
+    np.testing.assert_allclose(captured["model.layers.1.attn.v_scale"], 0.3)
+    np.testing.assert_allclose(captured["model.layers.3.attn.v_scale"], 0.4)
+
+
+def test_sparse_layer_ids_must_match_model_kv_layers(tmp_path):
+    scale_file = tmp_path / "kv_scales.json"
+    scale_file.write_text(
+        json.dumps(
+            {
+                "scales": {
+                    "k_scales": [0.1, 0.2],
+                    "v_scales": [0.3, 0.4],
+                },
+                "layer_ids": [0, 2],
+            }
+        )
+    )
+    model = _make_kv_model(
+        kv_cache_quant_type="int8_per_tensor",
+        num_layers=4,
+        extra_options={"kv_cache_scale_file": str(scale_file)},
+    )
+    model.kv_quant_type = "PER_TENSOR"
+    model.input_names["past_key_values.key"] = ["past_key_values.1.key", "past_key_values.3.key"]
+    model.input_names["past_key_values.value"] = ["past_key_values.1.value", "past_key_values.3.value"]
+    _capture_initializers(model)
+
+    with pytest.raises(ValueError, match="must match the model's KV-cache layers"):
+        model.make_kv_cache_scale_initializers()
+
+
+@pytest.mark.parametrize(
+    "layer_ids,error",
+    [
+        ([], "must not be empty"),
+        ([1, 1], "must not contain duplicates"),
+        ([True], "must be a list of integer"),
+        ([4], r"must be in \[0, 4\)"),
+    ],
+)
+def test_invalid_sparse_layer_ids_are_rejected(tmp_path, layer_ids, error):
+    scale_file = tmp_path / "kv_scales.json"
+    scale_file.write_text(
+        json.dumps(
+            {
+                "scales": {
+                    "k_scales": [0.1] * len(layer_ids),
+                    "v_scales": [0.2] * len(layer_ids),
+                },
+                "layer_ids": layer_ids,
+            }
+        )
+    )
+    model = _make_kv_model(
+        kv_cache_quant_type="int8_per_tensor",
+        num_layers=4,
+        extra_options={"kv_cache_scale_file": str(scale_file)},
+    )
+    model.kv_quant_type = "PER_TENSOR"
+    _capture_initializers(model)
+
+    with pytest.raises(ValueError, match=error):
+        model.make_kv_cache_scale_initializers()
 
 
 def test_calibrated_per_channel_scales_are_loaded_from_file(tmp_path):


### PR DESCRIPTION
### Description

Makes `kv_cache_calibration.py` work on hybrid (linear-attention + full-attention) models such as Qwen3.6, where only a subset of layers have a KV cache.

* `_detect_kv_shape` now requires both the `past_key_values.` prefix **and** a `.key` / `.value` suffix, so the linear-attention `conv_state` / `recurrent_state` inputs are no longer mistaken for KV cache entries.
* `calibrate_kv_scales` accepts a sparse, non-contiguous set of layer ids (`sorted(present_keys & present_values)`) instead of assuming layers `0..N-1`.
* Non-KV state inputs (`conv_state`, `recurrent_state`) are fed zero-initialized buffers matching their declared shapes so the session can run.
* The emitted JSON now records `layer_ids` alongside the scales, so a consumer can tell which layers the scales belong to.

### Motivation and Context

Without this, running KV-cache calibration on a hybrid model either fails to build the input feeds or produces scales indexed against the wrong layers.
