### PR TITLE
Model builder: structured per-node quant_config overrides

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -657,6 +657,11 @@ def get_args():
                 nodes_to_exclude = Specify nodes to exclude from int4/int8 weight-only quantization.
                     Use this option when you want to exclude certain nodes from being quantized.
                     Separate the node names with a ',' when passing them here (e.g. nodes_to_exclude=/lm_head/MatMul,/model/embed_tokens/Gather)
+                quant_config = Structured per-node quantization overrides, as inline JSON or a path to a JSON file.
+                    The JSON is either a list of override objects or an object with an "overrides" key, e.g.
+                    quant_config=[{"match": {"name": "/lm_head/MatMul"}, "type": "int8"}]
+                    Each override sets the bit width of the matched node; the MoE, block size and algorithm
+                    knobs still come from the flat extra_options above.
                 algo_config = Base method for int4/int8 weight-only quantization. Default is 'default'.
                     Currently supported base methods are: 'default', 'rtn', 'k_quant'.
                     - default = algo_config passed to MatMulNBitsQuantizer is None. Quantizer uses default RTN algorithm. All MatMuls are quantized to the requested bit width. Uses different node naming conventions to `rtn`.

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1095,6 +1095,20 @@ class Model:
                     for proj in ("gate_proj", "up_proj", "down_proj"):
                         customized_weight_config[f"/model/layers.{i}/mlp/{proj}/MatMul"] = {"bits": bits}
 
+        # Honor explicit per-node type overrides (match={"name": ...}, type=...) from the
+        # structured/JSON quant_config, in addition to the named presets above. This lets a
+        # caller set arbitrary per-node bit-widths (e.g. all dense MatMuls -> int8) while MoE
+        # stays on its own scheme. Exclusions are handled via quant_attrs["nodes_to_exclude"];
+        # name_regex / preset matches are resolved elsewhere.
+        weights_cfg = getattr(getattr(self, "quant_config", None), "weights", None)
+        if weights_cfg is not None:
+            for override in weights_cfg.overrides:
+                if override.exclude or override.type is None:
+                    continue
+                node_name = override.match.get("name")
+                if node_name:
+                    customized_weight_config[node_name] = {"bits": resolve_dtype(override.type).bits}
+
         self.int4_customized_weight_config = customized_weight_config
 
     def make_algo_config(self, quant_method: str, customized_weight_config=None):
@@ -1303,7 +1317,7 @@ class Model:
             )
 
         # Delete temporary cache dir if empty
-        if not os.listdir(self.cache_dir):
+        if os.path.isdir(self.cache_dir) and not os.listdir(self.cache_dir):
             os.rmdir(self.cache_dir)
 
     def to_str_dtype(self, dtype: ir.DataType) -> str:

--- a/src/python/py/models/builders/quant_config.py
+++ b/src/python/py/models/builders/quant_config.py
@@ -384,6 +384,27 @@ class QuantConfig:
         for node in extra_options.get("nodes_to_exclude", []) or []:
             overrides.append(Override(match={"name": node}, exclude=True))
 
+        # Optional structured per-node overrides supplied as JSON via `quant_config`.
+        # Accepts an inline JSON string or a file path. The JSON may be either a bare list
+        # of override dicts (``[{"match": {...}, "type": "int8"}, ...]``) or an object with
+        # an ``"overrides"`` key. These augment the flat placement/exclusion overrides above,
+        # letting callers set arbitrary per-node bit-widths (e.g. all dense MatMuls -> int8)
+        # while the MoE / block-size / method knobs still come from the flat extra_options.
+        quant_config_json = extra_options.get("quant_config")
+        if quant_config_json:
+            if isinstance(quant_config_json, str):
+                stripped = quant_config_json.strip()
+                if stripped.startswith("[") or stripped.startswith("{"):
+                    loaded = json.loads(stripped)
+                else:
+                    with open(stripped, encoding="utf-8") as handle:
+                        loaded = json.load(handle)
+            else:
+                loaded = quant_config_json
+            override_dicts = loaded.get("overrides", []) if isinstance(loaded, dict) else loaded
+            for override_dict in override_dicts:
+                overrides.append(Override.from_dict(override_dict))
+
         is_symmetric = extra_options.get("is_symmetric", True)
         weights = WeightsConfig(
             type=weights_type,

--- a/test/python/builder/test_quant_config.py
+++ b/test/python/builder/test_quant_config.py
@@ -311,3 +311,42 @@ def test_extra_options_runtime_and_prepack_knobs():
     assert cfg.runtime.matmulnbits_weights_prepacked == 2
     assert cfg.moe.weights_prepacked == 1
     assert cfg.moe.block_size == 64
+
+
+def test_extra_options_quant_config_json_string_overrides():
+    cfg = QuantConfig.from_extra_options(
+        {"quant_config": '[{"match": {"name": "/lm_head/MatMul"}, "type": "int8"}]'},
+        precision="int4",
+    )
+    assert cfg.weights.overrides == [Override(match={"name": "/lm_head/MatMul"}, type="int8")]
+
+
+def test_extra_options_quant_config_object_form_and_flat_merge():
+    cfg = QuantConfig.from_extra_options(
+        {
+            "algo_config": "rtn_last",
+            "nodes_to_exclude": ["/model/embed_tokens/Gather"],
+            "quant_config": {"overrides": [{"match": {"name": "/model/layers.0/attn/o_proj/MatMul"}, "type": "int8"}]},
+        },
+        precision="int4",
+    )
+    assert cfg.weights.overrides == [
+        Override(match={"preset": "last_matmul"}, type="int8"),
+        Override(match={"name": "/model/embed_tokens/Gather"}, exclude=True),
+        Override(match={"name": "/model/layers.0/attn/o_proj/MatMul"}, type="int8"),
+    ]
+
+
+def test_extra_options_quant_config_from_file(tmp_path):
+    path = tmp_path / "quant_config.json"
+    path.write_text(json.dumps({"overrides": [{"match": {"name": "/lm_head/MatMul"}, "exclude": True}]}))
+    cfg = QuantConfig.from_extra_options({"quant_config": str(path)}, precision="int4")
+    assert cfg.weights.overrides == [Override(match={"name": "/lm_head/MatMul"}, exclude=True)]
+
+
+def test_extra_options_quant_config_rejects_unknown_field():
+    with pytest.raises(ValueError, match="unknown override field"):
+        QuantConfig.from_extra_options(
+            {"quant_config": '[{"match": {"name": "/lm_head/MatMul"}, "bits": 8}]'},
+            precision="int4",
+        )


### PR DESCRIPTION
### Description

Adds a structured `quant_config` extra option so callers can set per-node weight bit widths without inventing a new flat flag for every case.

* `QuantConfig.from_extra_options` now parses `extra_options["quant_config"]`, accepting an inline JSON string, a path to a JSON file, or an already-parsed `dict` / `list`. Entries are appended as `Override` objects on top of whatever the flat options produced.
* `make_int4_customized_weight_config` honors overrides that match by node name (`{"match": {"name": ...}, "type": ...}`), mapping them into the quantizer's customized weight config at the resolved bit width. Exclusions keep going through `nodes_to_exclude`; `name_regex` / preset matching is unchanged.
* `save_model` only tries to `rmdir` the temp cache dir when it actually exists.
* Documents the option in `builder.py`'s `--extra_options` help.

Example:

```
--extra_options quant_config='[{"match": {"name": "/lm_head/MatMul"}, "type": "int8"}]'
```

### Motivation and Context

The flat `extra_options` surface has grown one boolean per quantization tweak. This gives a single structured entry point for per-node overrides (e.g. keeping specific MatMuls at int8 while the rest of the model is int4) and is a step toward the config layout discussed in #2299.

Adds 5 unit tests covering the JSON-string, object, file, and invalid-field forms.
