### PR TITLE
Model builder: NVFP4 QMoE scheme and Model Optimizer checkpoint loader

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -240,7 +240,7 @@ def check_extra_options(
 
     # `moe_quant_type` is the single option that selects the MoE quantization scheme. It replaces the
     # older per-type flags (`use_8bits_moe``) so new schemes can be added without a new flag.
-    supported_moe_quant_types = {"int4", "int8", "mxfp4"}
+    supported_moe_quant_types = {"int4", "int8", "mxfp4", "nvfp4"}
 
     # Backward compatibility: `use_8bits_moe` is deprecated in favor of `moe_quant_type`.
     if "use_8bits_moe" in extra_options:
@@ -254,16 +254,19 @@ def check_extra_options(
             raise ValueError(
                 f"moe_quant_type must be one of {sorted(supported_moe_quant_types)}, got '{moe_quant_type}'."
             )
-        if moe_quant_type == "mxfp4":
+        if moe_quant_type in ("mxfp4", "nvfp4"):
+            # MXFP4 and NVFP4 share the CUDA QMoE FP4 op path and both require the int4 build
+            # precision (that is what exports the quantized QMoE op); the FP4 scheme only sets the
+            # MoE expert weights to the FP4 encoding.
             if execution_provider != "cuda":
                 raise ValueError(
-                    f"moe_quant_type=mxfp4 is only supported on the CUDA EP, got ep='{execution_provider}'."
+                    f"moe_quant_type={moe_quant_type} is only supported on the CUDA EP, got ep='{execution_provider}'."
                 )
             if not (precision == "int4" and extra_options.get("is_symmetric", True)):
                 raise ValueError(
-                    "moe_quant_type=mxfp4 requires building with precision=int4 (symmetric int4): the int4 build "
-                    "precision is what exports the quantized QMoE op, and mxfp4 only sets the MoE expert weights to "
-                    "the FP4 encoding."
+                    f"moe_quant_type={moe_quant_type} requires building with precision=int4 (symmetric int4): the "
+                    "int4 build precision is what exports the quantized QMoE op, and the FP4 scheme only sets the "
+                    "MoE expert weights to the FP4 encoding."
                 )
 
     if extra_options.get("exclude_lm_head", False) and extra_options.get("include_hidden_states", False):
@@ -740,13 +743,16 @@ def get_args():
                     This affects attention mask reformatting and position IDs handling.
                 use_qdq = Use the QDQ decomposition for ops.
                     Use this option when you want to use quantize-dequantize ops. For example, you will have a quantized MatMul op instead of the MatMulNBits op.
-                moe_quant_type = int4/int8/mxfp4: Quantization scheme for MoE (QMoE) layers. Default is int4.
+                moe_quant_type = int4/int8/mxfp4/nvfp4: Quantization scheme for MoE (QMoE) layers. Default is int4.
                     int4 = 4-bit integer QMoE weights (expert_weight_bits=4, quant_type="int").
                     int8 = 8-bit integer QMoE weights (expert_weight_bits=8, quant_type="int").
                     mxfp4 = MXFP4 QMoE weights on the CUDA EP (quant_type="fp4", expert_weight_bits=4, block_size=32):
                         4-bit e2m1 weights with ue8m0 (float8e8m0) block scales and a per-expert float32 global scale.
                         Requires an ONNX Runtime build with onnxruntime_USE_FP4_QMOE=ON, precision=int4 with symmetric
                         INT4 quantization, and is only supported on the CUDA EP.
+                    nvfp4 = NVFP4 QMoE weights on the CUDA EP (quant_type="nvfp4", expert_weight_bits=4, block_size=16):
+                        4-bit e2m1 weights with FP8-E4M3 block scales and a per-expert float32 global scale.
+                        Same build/precision/EP requirements as mxfp4.
                     This single option replaces the older per-type flags so new schemes can be added without a new flag.
                 use_8bits_moe = [DEPRECATED] Use 'moe_quant_type=int8' instead. Use 8-bit quantization for MoE layers. Default is false.
                     If true, the QMoE op will use 8-bit quantization. If false, the QMoE op will use 4-bit quantization.

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -329,14 +329,20 @@ class Model:
         moe_op_type = "QMoE" if (self.onnx_dtype == ir.DataType.INT4 or quantize_to_8bits) else "MoE"
         num_experts = config.num_local_experts if hasattr(config, "num_local_experts") else 0
         top_k_experts = config.num_experts_per_tok if hasattr(config, "num_experts_per_tok") else 0
-        # MoE quantization scheme comes from `quant_config.moe.type` ("int4"/"int8"/"mxfp4"), which maps to
+        # MoE quantization scheme comes from `quant_config.moe.type` ("int4"/"int8"/"mxfp4"/"nvfp4"), which maps to
         # (expert_weight_bits, QMoE quant_type):
-        #   "int4"  -> (4, "int")  INT4 QMoE (default)
-        #   "int8"  -> (8, "int")  INT8 QMoE
-        #   "mxfp4" -> (4, "fp4")  MXFP4 QMoE (CUDA-only)
+        #   "int4"  -> (4, "int")    INT4 QMoE (default)
+        #   "int8"  -> (8, "int")    INT8 QMoE
+        #   "mxfp4" -> (4, "fp4")    MXFP4 QMoE (CUDA-only)
+        #   "nvfp4" -> (4, "nvfp4")  NVFP4 QMoE (CUDA-only)
         moe_descriptor = resolve_dtype(self.quant_config.moe.type)
         expert_weight_bits = moe_descriptor.bits
-        qmoe_quant_type = "fp4" if moe_descriptor.kind == "mx" else "int"
+        # MXFP4 and NVFP4 both resolve to the "mx" kind; the QMoE op tells them apart by dtype name
+        # ("mxfp4" -> op "fp4", "nvfp4" -> op "nvfp4"). Integer dtypes use the plain "int" QMoE path.
+        if moe_descriptor.kind == "mx":
+            qmoe_quant_type = "nvfp4" if moe_descriptor.name == "nvfp4" else "fp4"
+        else:
+            qmoe_quant_type = "int"
         swiglu_limit = config.swiglu_limit if hasattr(config, "swiglu_limit") else None
         # weights_prepacked is a CUDA-only QMoE layout contract. Non-CUDA EPs omit the attribute and use
         # their normal blockwise QMoE encoding, so CUDA-prepacked exports are not intended to be shared
@@ -356,7 +362,7 @@ class Model:
             "swiglu_limit": swiglu_limit,                    # Value used to clamp results into a certain range in SwiGLU activation function
             "use_sparse_mixer": False,                       # Use SparseMixer in MoE layer (used in Phi-3.5 MoE)
             "weights_prepacked": weights_prepacked,          # CUDA QMoE layout: -1=auto/omit, 0=raw, 1=CUTLASS-prepacked
-            "quant_type": qmoe_quant_type,                   # QMoE quantization type: "int" (INT4/INT8) or "fp4" (MXFP4).
+            "quant_type": qmoe_quant_type,                   # QMoE quantization type: "int" (INT4/INT8), "fp4" (MXFP4), or "nvfp4" (NVFP4).
         }
 
         # LM head-specific variables
@@ -377,7 +383,7 @@ class Model:
         # 2 = SM90/Hopper fpA_intB layout (weight_prepacked=2). Only meaningful on the CUDA EP; other EPs
         # keep the raw blockwise layout. Override via extra_options["matmulnbits_weights_prepacked"].
         self.matmulnbits_weights_prepacked = self.quant_config.runtime.matmulnbits_weights_prepacked
-        # QMoE block size (MXFP4 is pinned to a block size of 32 inside MoEConfig).
+        # QMoE block size (MXFP4 is pinned to 32 and NVFP4 to 16 inside MoEConfig).
         self.qmoe_block_size = self.quant_config.moe.block_size
         self.quant_attrs = {
             "accuracy_level": weights_cfg.accuracy_level,
@@ -3890,6 +3896,52 @@ class Model:
         value.const_value = ir_tensor
         self.model.graph.register_initializer(value)
 
+    def make_fp8e4m3_initializer(self, scales_uint8, name):
+        """Register a FLOAT8E4M3FN initializer from raw e4m3 code bytes (uint8).
+
+        NVFP4 block scales are stored as FP8 e4m3 bytes. Build the IR tensor directly
+        from the raw uint8 bytes and tag it FLOAT8E4M3FN (the encoding the CUDA QMoE
+        NVFP4 kernel expects).
+        """
+        arr = scales_uint8.detach().cpu().numpy().astype(np.uint8) if isinstance(scales_uint8, torch.Tensor) else np.asarray(scales_uint8, dtype=np.uint8)
+        ir_tensor = ir.Tensor(np.ascontiguousarray(arr), dtype=ir.DataType.FLOAT8E4M3FN, name=name)
+        value = self.make_value(name, ir_tensor.dtype, ir_tensor.shape)
+        value.const_value = ir_tensor
+        self.model.graph.register_initializer(value)
+
+    @staticmethod
+    def repack_modelopt_nvfp4_weight_codes(packed_nk2):
+        """Unpack a Model Optimizer NVFP4 weight tensor to per-element e2m1 codes.
+
+        ``packed_nk2`` is uint8 ``[N, K/2]`` where each byte holds two adjacent K-axis
+        e2m1 codes for the same output row N (low nibble = even K, high nibble = odd K)
+        -- the layout Model Optimizer writes. Returns uint8 codes ``[N, K]`` (0-15).
+        """
+        if packed_nk2.dtype != torch.uint8:
+            packed_nk2 = packed_nk2.to(torch.uint8)
+        low = packed_nk2 & 0x0F
+        high = packed_nk2 >> 4
+        n = packed_nk2.shape[0]
+        codes = torch.stack((low, high), dim=-1).reshape(n, -1)  # [N, K]
+        return codes.contiguous()
+
+    @staticmethod
+    def pack_nvfp4_codes_for_qmoe(codes_nk):
+        """Pack per-element e2m1 codes ``[N, K]`` into the CUDA QMoE ``[K, N/2]`` layout.
+
+        The QMoE FP4 kernel reads weights as ``[E, K, N/2]`` with each byte holding two
+        adjacent N-axis codes for the same K (even N = low nibble, odd N = high nibble).
+        """
+        if codes_nk.dtype != torch.uint8:
+            codes_nk = codes_nk.to(torch.uint8)
+        n = codes_nk.shape[0]
+        if n % 2 != 0:
+            raise ValueError(f"NVFP4 QMoE packing requires an even N={n} for nibble packing.")
+        codes_kn = codes_nk.T.contiguous()  # [K, N]
+        low = codes_kn[:, 0::2] & 0x0F
+        high = codes_kn[:, 1::2] & 0x0F
+        return ((high << 4) | low).contiguous()  # [K, N/2]
+
     def make_mxfp4_weights(self, weight, block_size=32):
         """Quantize one expert weight matrix [N, K] to MXFP4 (FP4 e2m1 + ue8m0 scales).
 
@@ -3965,9 +4017,10 @@ class Model:
                 kwargs.get("zero_points3", ""),
             ])
 
-        is_fp4 = self.moe_attrs.get("quant_type") == "fp4"
+        quant_type = self.moe_attrs.get("quant_type")
+        is_fp4 = quant_type in ("fp4", "nvfp4")
         if is_fp4:
-            # The FP4 (MXFP4) QMoE op consumes per-expert float32 global scales at
+            # The FP4 (MXFP4/NVFP4) QMoE op consumes per-expert float32 global scales at
             # fixed input positions 15 (fc1) and 16 (fc2). Positions 11-14 are the
             # optional zero_points (11-13) and router_weights (14). The zero_points
             # block above already appended inputs up to index 13 for non-TRT-RTX EPs
@@ -3988,8 +4041,8 @@ class Model:
             extra_kwargs["block_size"] = self.moe_attrs["block_size"]
 
         if is_fp4:
-            # Select the MXFP4 kernel path; integer QMoE leaves quant_type at its default.
-            extra_kwargs["quant_type"] = "fp4"
+            # Select the MXFP4/NVFP4 kernel path; integer QMoE leaves quant_type at its default.
+            extra_kwargs["quant_type"] = quant_type
 
         # weights_prepacked is a tri-state CUDA QMoE attribute describing the expert-weight layout
         # (see make_qmoe_weights, which produces the matching bytes):

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -3909,39 +3909,6 @@ class Model:
         value.const_value = ir_tensor
         self.model.graph.register_initializer(value)
 
-    @staticmethod
-    def repack_modelopt_nvfp4_weight_codes(packed_nk2):
-        """Unpack a Model Optimizer NVFP4 weight tensor to per-element e2m1 codes.
-
-        ``packed_nk2`` is uint8 ``[N, K/2]`` where each byte holds two adjacent K-axis
-        e2m1 codes for the same output row N (low nibble = even K, high nibble = odd K)
-        -- the layout Model Optimizer writes. Returns uint8 codes ``[N, K]`` (0-15).
-        """
-        if packed_nk2.dtype != torch.uint8:
-            packed_nk2 = packed_nk2.to(torch.uint8)
-        low = packed_nk2 & 0x0F
-        high = packed_nk2 >> 4
-        n = packed_nk2.shape[0]
-        codes = torch.stack((low, high), dim=-1).reshape(n, -1)  # [N, K]
-        return codes.contiguous()
-
-    @staticmethod
-    def pack_nvfp4_codes_for_qmoe(codes_nk):
-        """Pack per-element e2m1 codes ``[N, K]`` into the CUDA QMoE ``[K, N/2]`` layout.
-
-        The QMoE FP4 kernel reads weights as ``[E, K, N/2]`` with each byte holding two
-        adjacent N-axis codes for the same K (even N = low nibble, odd N = high nibble).
-        """
-        if codes_nk.dtype != torch.uint8:
-            codes_nk = codes_nk.to(torch.uint8)
-        n = codes_nk.shape[0]
-        if n % 2 != 0:
-            raise ValueError(f"NVFP4 QMoE packing requires an even N={n} for nibble packing.")
-        codes_kn = codes_nk.T.contiguous()  # [K, N]
-        low = codes_kn[:, 0::2] & 0x0F
-        high = codes_kn[:, 1::2] & 0x0F
-        return ((high << 4) | low).contiguous()  # [K, N/2]
-
     def make_mxfp4_weights(self, weight, block_size=32):
         """Quantize one expert weight matrix [N, K] to MXFP4 (FP4 e2m1 + ue8m0 scales).
 

--- a/src/python/py/models/builders/gptoss.py
+++ b/src/python/py/models/builders/gptoss.py
@@ -671,7 +671,13 @@ class GPTOSSModel(Model):
         moe_weight_type = f"{'q' if op_type == 'QMoE' else ''}weight"
 
         has_quark_experts = self.has_quark_experts(mlp.experts)
-        is_fp4_moe = self.moe_attrs.get("quant_type") == "fp4"
+        moe_quant_type = self.moe_attrs.get("quant_type")
+        if moe_quant_type == "nvfp4":
+            # GPT-OSS checkpoints ship MXFP4 experts; there is no NVFP4 source to preserve and
+            # re-quantizing MXFP4 to NVFP4 is not implemented. Fail loudly instead of silently
+            # falling through to the integer QMoE path.
+            raise ValueError("moe_quant_type=nvfp4 is not supported for GPT-OSS. Use moe_quant_type=mxfp4.")
+        is_fp4_moe = moe_quant_type == "fp4"
         if is_fp4_moe and has_quark_experts:
             raise ValueError("moe_quant_type=mxfp4 is not supported with pre-quantized Quark GPT-OSS experts.")
 

--- a/src/python/py/models/builders/quant_config.py
+++ b/src/python/py/models/builders/quant_config.py
@@ -47,7 +47,9 @@ class DtypeDescriptor:
 
 
 # Only the dtypes the builder supports today. Float dtypes are I/O pass-through
-# (no weight quantization). ``mxfp4`` fixes block size 32 and is MoE-only.
+# (no weight quantization). The microscaling FP4 dtypes are MoE-only and fix their
+# block size: ``mxfp4`` -> 32 (ue8m0 block scales), ``nvfp4`` -> 16 (FP8-E4M3 block
+# scales + per-expert FP32 global scale).
 _DTYPES: dict[str, DtypeDescriptor] = {
     "fp32": DtypeDescriptor("fp32", "float", 32),
     "fp16": DtypeDescriptor("fp16", "float", 16),
@@ -57,6 +59,7 @@ _DTYPES: dict[str, DtypeDescriptor] = {
     "int4": DtypeDescriptor("int4", "int", 4, signed=True),
     "uint4": DtypeDescriptor("uint4", "int", 4, signed=False),
     "mxfp4": DtypeDescriptor("mxfp4", "mx", 4, block_size=32),
+    "nvfp4": DtypeDescriptor("nvfp4", "mx", 4, block_size=16),
     "none": DtypeDescriptor("none", "float", 0),  # explicit "do not quantize this target"
 }
 
@@ -220,7 +223,7 @@ class MoEConfig:
         descriptor = resolve_dtype(self.type)
         self.block_size = _normalize_block_size(self.block_size)
         if descriptor.kind == "mx":
-            # mxfp4 mandates block size 32.
+            # Microscaling FP4 mandates a fixed block size (mxfp4 -> 32, nvfp4 -> 16).
             self.block_size = descriptor.block_size
         if self.weights_prepacked not in (-1, 0, 1):
             raise ValueError(f"moe.weights_prepacked must be -1, 0, or 1, got {self.weights_prepacked}")

--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -1636,6 +1636,201 @@ class OliveModel(GPTQModel):
             module.qzeros = module.qzeros.reshape(-1).contiguous()
 
 
+# ---------------------------------------------------------------------------
+# NVIDIA Model Optimizer (modelopt) NVFP4 + FP8 checkpoints
+# ---------------------------------------------------------------------------
+# Model Optimizer exports a mixed-precision HF checkpoint:
+#   * MoE experts + shared expert + lm_head : W4A16_NVFP4 (block-16 E2M1 weights,
+#     FP8-E4M3 block scales, per-tensor FP32 global scale `weight_scale_2`).
+#   * attention (self_attn / linear_attn projections) : FP8 (per-tensor weight_scale).
+#   * everything else (norms, conv1d, router, embeddings) : BF16.
+#
+# The ONNX Runtime GenAI QMoE op consumes the NVFP4 *routed* experts natively
+# (quant_type="nvfp4"), and the Qwen builder reads those per-expert tensors
+# straight from the source safetensors (see make_nvfp4_moe_initializers). So this
+# loader only has to materialize the NON-routed weights the builder walks as plain
+# modules: it dequantizes the FP8 attention and NVFP4 shared-expert / lm_head to
+# BF16 and passes BF16 tensors through unchanged. Attention is exported through the
+# builder's normal (int4 RTN) path since ONNX Runtime has no native FP8 attention
+# GEMM; dequantizing the FP8 weights to BF16 reconstructs them exactly.
+
+_MODELOPT_FP4_E2M1_LUT = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
+
+
+def _modelopt_dequant_nvfp4(weight_u8, block_scale_e4m3, global_scale):
+    """Reconstruct a BF16 weight from Model Optimizer NVFP4 tensors.
+
+    ``weight_u8``        uint8 ``[N, K/2]`` (E2M1, low nibble = even K, high = odd K)
+    ``block_scale_e4m3`` float8_e4m3fn ``[N, K/16]`` (one block scale per 16 K-elements)
+    ``global_scale``     f32 scalar (per-tensor)
+    Value: ``w = e2m1(code) * e4m3(block_scale[n, k//16]) * global_scale``.
+    """
+    if weight_u8.dtype != torch.uint8:
+        weight_u8 = weight_u8.to(torch.uint8)
+    n = weight_u8.shape[0]
+    low = weight_u8 & 0x0F
+    high = weight_u8 >> 4
+    codes = torch.stack([low, high], dim=-1).reshape(n, -1).long()  # [N, K]
+    mag = _MODELOPT_FP4_E2M1_LUT[codes & 0x7]
+    val = torch.where((codes & 0x8) > 0, -mag, mag)  # [N, K]
+    bs = block_scale_e4m3.to(torch.float32)  # [N, K/16]
+    k = codes.shape[1]
+    bs = bs.repeat_interleave(k // bs.shape[1], dim=1)  # [N, K]
+    return (val * bs * float(global_scale)).to(torch.bfloat16)
+
+
+def _modelopt_dequant_fp8(weight_f8, weight_scale):
+    """Reconstruct a BF16 weight from an FP8 (E4M3) weight + per-tensor scale."""
+    return (weight_f8.to(torch.float32) * float(weight_scale)).to(torch.bfloat16)
+
+
+class ModeloptDecoderLayer:
+    """Lightweight decoder-layer container (name ends in 'DecoderLayer' so the
+    builder's is_layer() recognizes it). Only the attention variant present in the
+    checkpoint (linear_attn or self_attn) is populated; the other stays None."""
+
+    def __init__(self, layer_id):
+        self.layer_id = layer_id
+        self.input_layernorm = TensorModule()
+        self.post_attention_layernorm = TensorModule()
+        self.self_attn = None
+        self.linear_attn = None
+        self.mlp = None
+
+    def is_empty(self):
+        return self.input_layernorm.weight is None
+
+
+class ModeloptModel(QuantizedModel):
+    """Loader for NVIDIA Model Optimizer NVFP4 + FP8 mixed-precision checkpoints."""
+
+    def __init__(self, quant_type, input_path, quant_attrs, q_size, kv_size, intermediate_size, num_layers):
+        import json
+        from types import SimpleNamespace
+        from safetensors import safe_open
+
+        self.quant_type = quant_type
+        self.embedding = TensorModule()
+        self.final_norm = TensorModule()
+        self.lm_head = TensorModule()
+        self._input_path = input_path
+        self._safe_open = safe_open
+        self._simple_namespace = SimpleNamespace
+        self._open_handles = {}
+        self._handle_keys = {}
+
+        with open(os.path.join(input_path, "config.json")) as f:
+            cfg = json.load(f)
+        tc = cfg.get("text_config", cfg)
+        n_layers = num_layers or tc.get("num_hidden_layers")
+        self.num_layers = n_layers
+
+        index_path = os.path.join(input_path, "model.safetensors.index.json")
+        if os.path.exists(index_path):
+            with open(index_path) as f:
+                self._weight_map = json.load(f)["weight_map"]
+            self._single_file = None
+        else:
+            self._weight_map = None
+            self._single_file = next(f for f in os.listdir(input_path) if f.endswith(".safetensors"))
+
+        self.layers = [self._build_layer(layer_id) for layer_id in range(n_layers)]
+
+        # Globals: embeddings + final norm are BF16; lm_head is NVFP4.
+        self.embedding.weight = self._get("model.language_model.embed_tokens.weight")
+        self.final_norm.weight = self._get("model.language_model.norm.weight")
+        self.lm_head.weight = self._dequant_linear("lm_head")
+
+    # -- raw tensor access ------------------------------------------------------
+    def _get(self, name):
+        if self._weight_map is not None:
+            fname = self._weight_map.get(name)
+            files = [fname] if fname is not None else []
+        else:
+            files = [self._single_file]
+        for fname in files:
+            handle = self._open_handles.get(fname)
+            if handle is None:
+                handle = self._safe_open(os.path.join(self._input_path, fname), framework="pt", device="cpu")
+                self._open_handles[fname] = handle
+                self._handle_keys[fname] = set(handle.keys())
+            if name in self._handle_keys[fname]:
+                return handle.get_tensor(name)
+        return None
+
+    # -- dequantized linear weight ---------------------------------------------
+    def _dequant_linear(self, base):
+        weight = self._get(f"{base}.weight")
+        if weight is None:
+            return None
+        weight_scale_2 = self._get(f"{base}.weight_scale_2")
+        weight_scale = self._get(f"{base}.weight_scale")
+        if weight_scale_2 is not None:  # NVFP4 (block-16 E2M1 + E4M3 block scale + global)
+            return _modelopt_dequant_nvfp4(weight, weight_scale, weight_scale_2)
+        if weight_scale is not None and weight.dtype == torch.float8_e4m3fn:  # FP8 (per-tensor scale)
+            return _modelopt_dequant_fp8(weight, weight_scale)
+        return weight.to(torch.bfloat16)
+
+    def _linear_module(self, base):
+        weight = self._dequant_linear(base)
+        if weight is None:
+            return None
+        module = TensorModule()
+        module.weight = weight
+        bias = self._get(f"{base}.bias")
+        if bias is not None:
+            module.bias = bias
+        return module
+
+    def _tensor_module(self, name):
+        module = TensorModule()
+        module.weight = self._get(name)
+        return module
+
+    def _build_layer(self, layer_id):
+        ns = self._simple_namespace
+        p = f"model.language_model.layers.{layer_id}"
+        layer = ModeloptDecoderLayer(layer_id)
+        layer.input_layernorm.weight = self._get(f"{p}.input_layernorm.weight")
+        layer.post_attention_layernorm.weight = self._get(f"{p}.post_attention_layernorm.weight")
+
+        if self._get(f"{p}.linear_attn.in_proj_qkv.weight") is not None:
+            la = ns()
+            la.in_proj_qkv = self._linear_module(f"{p}.linear_attn.in_proj_qkv")
+            la.in_proj_z = self._linear_module(f"{p}.linear_attn.in_proj_z")
+            la.in_proj_a = self._linear_module(f"{p}.linear_attn.in_proj_a")
+            la.in_proj_b = self._linear_module(f"{p}.linear_attn.in_proj_b")
+            la.out_proj = self._linear_module(f"{p}.linear_attn.out_proj")
+            la.conv1d = self._tensor_module(f"{p}.linear_attn.conv1d.weight")
+            la.A_log = self._get(f"{p}.linear_attn.A_log")
+            la.dt_bias = self._get(f"{p}.linear_attn.dt_bias")
+            la.norm = self._tensor_module(f"{p}.linear_attn.norm.weight")
+            layer.linear_attn = la
+        else:
+            sa = ns()
+            sa.q_proj = self._linear_module(f"{p}.self_attn.q_proj")
+            sa.k_proj = self._linear_module(f"{p}.self_attn.k_proj")
+            sa.v_proj = self._linear_module(f"{p}.self_attn.v_proj")
+            sa.o_proj = self._linear_module(f"{p}.self_attn.o_proj")
+            sa.q_norm = self._tensor_module(f"{p}.self_attn.q_norm.weight")
+            sa.k_norm = self._tensor_module(f"{p}.self_attn.k_norm.weight")
+            layer.self_attn = sa
+
+        mlp = ns()
+        mlp.gate = self._tensor_module(f"{p}.mlp.gate.weight")
+        shared = ns()
+        shared.gate_proj = self._linear_module(f"{p}.mlp.shared_expert.gate_proj")
+        shared.up_proj = self._linear_module(f"{p}.mlp.shared_expert.up_proj")
+        shared.down_proj = self._linear_module(f"{p}.mlp.shared_expert.down_proj")
+        mlp.shared_expert = shared
+        mlp.shared_expert_gate = self._tensor_module(f"{p}.mlp.shared_expert_gate.weight")
+        # Routed experts are streamed from raw safetensors by the builder's
+        # make_nvfp4_moe_initializers(); nothing to materialize here.
+        mlp.experts = None
+        layer.mlp = mlp
+        return layer
+
+
 class QuantModel:
     @staticmethod
     def from_pretrained(quant_type, **kwargs):
@@ -1652,6 +1847,8 @@ class QuantModel:
             model = OliveModel(quant_type, **kwargs)
         elif quant_type == "quark":
             model = QuarkModel(quant_type, **kwargs)
+        elif quant_type == "modelopt":
+            model = ModeloptModel(quant_type, **kwargs)
         else:
             raise NotImplementedError(f"The {quant_type} quantized model is not currently supported.")
 

--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -1857,7 +1857,7 @@ class ModeloptModel:
             la.dt_bias = self._get(f"{p}.linear_attn.dt_bias")
             la.norm = self._tensor_module(f"{p}.linear_attn.norm.weight")
             layer.linear_attn = la
-        else:
+        elif self._get(f"{p}.self_attn.q_proj.weight") is not None:
             sa = ns()
             sa.q_proj = self._linear_module(f"{p}.self_attn.q_proj")
             sa.k_proj = self._linear_module(f"{p}.self_attn.k_proj")
@@ -1866,6 +1866,12 @@ class ModeloptModel:
             sa.q_norm = self._tensor_module(f"{p}.self_attn.q_norm.weight")
             sa.k_norm = self._tensor_module(f"{p}.self_attn.k_norm.weight")
             layer.self_attn = sa
+        else:
+            raise ValueError(
+                f"Layer {layer_id} has neither '{p}.linear_attn.in_proj_qkv.weight' nor "
+                f"'{p}.self_attn.q_proj.weight', so its attention variant cannot be determined. "
+                "The Model Optimizer checkpoint is incomplete or uses unsupported weight names."
+            )
 
         mlp = ns()
         mlp.gate = self._tensor_module(f"{p}.mlp.gate.weight")

--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -1657,7 +1657,7 @@ class OliveModel(GPTQModel):
 _MODELOPT_FP4_E2M1_LUT = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
 
 
-def _modelopt_dequant_nvfp4(weight_u8, block_scale_e4m3, global_scale):
+def _modelopt_dequant_nvfp4(weight_u8, block_scale_e4m3, global_scale, name=""):
     """Reconstruct a BF16 weight from Model Optimizer NVFP4 tensors.
 
     ``weight_u8``        uint8 ``[N, K/2]`` (E2M1, low nibble = even K, high = odd K)
@@ -1665,6 +1665,19 @@ def _modelopt_dequant_nvfp4(weight_u8, block_scale_e4m3, global_scale):
     ``global_scale``     f32 scalar (per-tensor)
     Value: ``w = e2m1(code) * e4m3(block_scale[n, k//16]) * global_scale``.
     """
+    if block_scale_e4m3 is None:
+        raise ValueError(
+            f"NVFP4 tensor '{name}' has 'weight_scale_2' but no 'weight_scale' (FP8-E4M3 block scales). "
+            "The Model Optimizer checkpoint is incomplete."
+        )
+    if block_scale_e4m3.dtype == torch.uint8:
+        # Some exporters store the E4M3 block scales as raw bytes; reinterpret, do not convert.
+        block_scale_e4m3 = block_scale_e4m3.view(torch.float8_e4m3fn)
+    elif block_scale_e4m3.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            f"NVFP4 tensor '{name}' block scales must be float8_e4m3fn (or raw uint8 bytes), "
+            f"got {block_scale_e4m3.dtype}."
+        )
     if weight_u8.dtype != torch.uint8:
         weight_u8 = weight_u8.to(torch.uint8)
     n = weight_u8.shape[0]
@@ -1675,6 +1688,11 @@ def _modelopt_dequant_nvfp4(weight_u8, block_scale_e4m3, global_scale):
     val = torch.where((codes & 0x8) > 0, -mag, mag)  # [N, K]
     bs = block_scale_e4m3.to(torch.float32)  # [N, K/16]
     k = codes.shape[1]
+    if bs.shape[0] != n or bs.shape[1] == 0 or k % bs.shape[1] != 0:
+        raise ValueError(
+            f"NVFP4 tensor '{name}' block scales {tuple(bs.shape)} are not a block-wise split of the "
+            f"[{n}, {k}] weight."
+        )
     bs = bs.repeat_interleave(k // bs.shape[1], dim=1)  # [N, K]
     return (val * bs * float(global_scale)).to(torch.bfloat16)
 
@@ -1701,8 +1719,15 @@ class ModeloptDecoderLayer:
         return self.input_layernorm.weight is None
 
 
-class ModeloptModel(QuantizedModel):
-    """Loader for NVIDIA Model Optimizer NVFP4 + FP8 mixed-precision checkpoints."""
+class ModeloptModel:
+    """Loader for NVIDIA Model Optimizer NVFP4 + FP8 mixed-precision checkpoints.
+
+    Deliberately not a ``QuantizedModel`` subclass: that base eagerly loads every
+    safetensors file into memory and unpacks/repacks integer quantized tensors,
+    while this loader streams tensors on demand and dequantizes to BF16. It shares
+    no implementation with the base, only the duck-typed surface the model builder
+    walks (``modules()`` plus the module tree).
+    """
 
     def __init__(self, quant_type, input_path, quant_attrs, q_size, kv_size, intermediate_size, num_layers):
         import json
@@ -1732,14 +1757,40 @@ class ModeloptModel(QuantizedModel):
             self._single_file = None
         else:
             self._weight_map = None
-            self._single_file = next(f for f in os.listdir(input_path) if f.endswith(".safetensors"))
+            candidates = sorted(f for f in os.listdir(input_path) if f.endswith(".safetensors"))
+            if len(candidates) != 1:
+                raise ValueError(
+                    f"'{input_path}' has no 'model.safetensors.index.json', so it must contain exactly one "
+                    f".safetensors file, but found {len(candidates)}: {candidates}."
+                )
+            self._single_file = candidates[0]
 
-        self.layers = [self._build_layer(layer_id) for layer_id in range(n_layers)]
+        try:
+            self.layers = [self._build_layer(layer_id) for layer_id in range(n_layers)]
 
-        # Globals: embeddings + final norm are BF16; lm_head is NVFP4.
-        self.embedding.weight = self._get("model.language_model.embed_tokens.weight")
-        self.final_norm.weight = self._get("model.language_model.norm.weight")
-        self.lm_head.weight = self._dequant_linear("lm_head")
+            # Globals: embeddings + final norm are BF16; lm_head is NVFP4.
+            self.embedding.weight = self._get("model.language_model.embed_tokens.weight")
+            self.final_norm.weight = self._get("model.language_model.norm.weight")
+            self.lm_head.weight = self._dequant_linear("lm_head")
+        finally:
+            # Every tensor is materialized above; do not hold file descriptors open for
+            # the rest of the (long) export. `_get` re-opens lazily if it is called again.
+            self.close()
+
+    def close(self):
+        """Release the cached safetensors file handles."""
+        for handle in self._open_handles.values():
+            handle.__exit__(None, None, None)
+        self._open_handles.clear()
+        self._handle_keys.clear()
+
+    def __del__(self):
+        if getattr(self, "_open_handles", None):
+            self.close()
+
+    def modules(self):
+        """Modules in order of appearance in the model (the builder's walk order)."""
+        return [self.embedding] + self.layers + [self.final_norm, self.lm_head]
 
     # -- raw tensor access ------------------------------------------------------
     def _get(self, name):
@@ -1766,7 +1817,7 @@ class ModeloptModel(QuantizedModel):
         weight_scale_2 = self._get(f"{base}.weight_scale_2")
         weight_scale = self._get(f"{base}.weight_scale")
         if weight_scale_2 is not None:  # NVFP4 (block-16 E2M1 + E4M3 block scale + global)
-            return _modelopt_dequant_nvfp4(weight, weight_scale, weight_scale_2)
+            return _modelopt_dequant_nvfp4(weight, weight_scale, weight_scale_2, name=base)
         if weight_scale is not None and weight.dtype == torch.float8_e4m3fn:  # FP8 (per-tensor scale)
             return _modelopt_dequant_fp8(weight, weight_scale)
         return weight.to(torch.bfloat16)

--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -227,7 +227,7 @@ class QuantizedModel:
         self.embedding = TensorModule()
         self.final_norm = TensorModule()
         self.lm_head = TensorModule()
-        self.layers = {}
+        self.layers = {} if load_weights else []
         self.num_layers = num_layers
         if not load_weights:
             return
@@ -1692,6 +1692,10 @@ class ModeloptModel(QuantizedModel):
         from types import SimpleNamespace
         from safetensors import safe_open
 
+        with open(os.path.join(input_path, "config.json")) as f:
+            cfg = json.load(f)
+        text_config = cfg.get("text_config", cfg)
+        num_layers = num_layers or text_config.get("num_hidden_layers")
         super().__init__(
             quant_type, input_path, quant_attrs, q_size, kv_size, intermediate_size, num_layers, load_weights=False
         )
@@ -1700,12 +1704,6 @@ class ModeloptModel(QuantizedModel):
         self._simple_namespace = SimpleNamespace
         self._open_handles = {}
         self._handle_keys = {}
-
-        with open(os.path.join(input_path, "config.json")) as f:
-            cfg = json.load(f)
-        tc = cfg.get("text_config", cfg)
-        n_layers = num_layers or tc.get("num_hidden_layers")
-        self.num_layers = n_layers
 
         index_path = os.path.join(input_path, "model.safetensors.index.json")
         if os.path.exists(index_path):
@@ -1723,7 +1721,7 @@ class ModeloptModel(QuantizedModel):
             self._single_file = candidates[0]
 
         try:
-            self.layers = [self._build_layer(layer_id) for layer_id in range(n_layers)]
+            self.layers.extend(self._build_layer(layer_id) for layer_id in range(num_layers))
 
             # Globals: embeddings + final norm are BF16; lm_head is NVFP4.
             self.embedding.weight = self._get("model.language_model.embed_tokens.weight")

--- a/src/python/py/models/quantized_model.py
+++ b/src/python/py/models/quantized_model.py
@@ -220,13 +220,18 @@ class QuantizedDecoderLayer:
 
 
 class QuantizedModel:
-    def __init__(self, quant_type, input_path, quant_attrs, q_size, kv_size, intermediate_size, num_layers):
+    def __init__(
+        self, quant_type, input_path, quant_attrs, q_size, kv_size, intermediate_size, num_layers, load_weights=True
+    ):
         self.quant_type = quant_type
         self.embedding = TensorModule()
         self.final_norm = TensorModule()
         self.lm_head = TensorModule()
         self.layers = {}
         self.num_layers = num_layers
+        if not load_weights:
+            return
+
         self._quant_attrs = quant_attrs
         self._load_quant_config(quant_attrs)
 
@@ -1654,53 +1659,6 @@ class OliveModel(GPTQModel):
 # builder's normal (int4 RTN) path since ONNX Runtime has no native FP8 attention
 # GEMM; dequantizing the FP8 weights to BF16 reconstructs them exactly.
 
-_MODELOPT_FP4_E2M1_LUT = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
-
-
-def _modelopt_dequant_nvfp4(weight_u8, block_scale_e4m3, global_scale, name=""):
-    """Reconstruct a BF16 weight from Model Optimizer NVFP4 tensors.
-
-    ``weight_u8``        uint8 ``[N, K/2]`` (E2M1, low nibble = even K, high = odd K)
-    ``block_scale_e4m3`` float8_e4m3fn ``[N, K/16]`` (one block scale per 16 K-elements)
-    ``global_scale``     f32 scalar (per-tensor)
-    Value: ``w = e2m1(code) * e4m3(block_scale[n, k//16]) * global_scale``.
-    """
-    if block_scale_e4m3 is None:
-        raise ValueError(
-            f"NVFP4 tensor '{name}' has 'weight_scale_2' but no 'weight_scale' (FP8-E4M3 block scales). "
-            "The Model Optimizer checkpoint is incomplete."
-        )
-    if block_scale_e4m3.dtype == torch.uint8:
-        # Some exporters store the E4M3 block scales as raw bytes; reinterpret, do not convert.
-        block_scale_e4m3 = block_scale_e4m3.view(torch.float8_e4m3fn)
-    elif block_scale_e4m3.dtype != torch.float8_e4m3fn:
-        raise ValueError(
-            f"NVFP4 tensor '{name}' block scales must be float8_e4m3fn (or raw uint8 bytes), "
-            f"got {block_scale_e4m3.dtype}."
-        )
-    if weight_u8.dtype != torch.uint8:
-        weight_u8 = weight_u8.to(torch.uint8)
-    n = weight_u8.shape[0]
-    low = weight_u8 & 0x0F
-    high = weight_u8 >> 4
-    codes = torch.stack([low, high], dim=-1).reshape(n, -1).long()  # [N, K]
-    mag = _MODELOPT_FP4_E2M1_LUT[codes & 0x7]
-    val = torch.where((codes & 0x8) > 0, -mag, mag)  # [N, K]
-    bs = block_scale_e4m3.to(torch.float32)  # [N, K/16]
-    k = codes.shape[1]
-    if bs.shape[0] != n or bs.shape[1] == 0 or k % bs.shape[1] != 0:
-        raise ValueError(
-            f"NVFP4 tensor '{name}' block scales {tuple(bs.shape)} are not a block-wise split of the "
-            f"[{n}, {k}] weight."
-        )
-    bs = bs.repeat_interleave(k // bs.shape[1], dim=1)  # [N, K]
-    return (val * bs * float(global_scale)).to(torch.bfloat16)
-
-
-def _modelopt_dequant_fp8(weight_f8, weight_scale):
-    """Reconstruct a BF16 weight from an FP8 (E4M3) weight + per-tensor scale."""
-    return (weight_f8.to(torch.float32) * float(weight_scale)).to(torch.bfloat16)
-
 
 class ModeloptDecoderLayer:
     """Lightweight decoder-layer container (name ends in 'DecoderLayer' so the
@@ -1719,25 +1677,24 @@ class ModeloptDecoderLayer:
         return self.input_layernorm.weight is None
 
 
-class ModeloptModel:
+class ModeloptModel(QuantizedModel):
     """Loader for NVIDIA Model Optimizer NVFP4 + FP8 mixed-precision checkpoints.
 
-    Deliberately not a ``QuantizedModel`` subclass: that base eagerly loads every
-    safetensors file into memory and unpacks/repacks integer quantized tensors,
-    while this loader streams tensors on demand and dequantizes to BF16. It shares
-    no implementation with the base, only the duck-typed surface the model builder
-    walks (``modules()`` plus the module tree).
+    The base initializes the module surface the builder walks without running its
+    eager integer-checkpoint loading path. This loader instead streams tensors on
+    demand and dequantizes only the non-routed weights to BF16.
     """
+
+    _FP4_E2M1_LUT = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
 
     def __init__(self, quant_type, input_path, quant_attrs, q_size, kv_size, intermediate_size, num_layers):
         import json
         from types import SimpleNamespace
         from safetensors import safe_open
 
-        self.quant_type = quant_type
-        self.embedding = TensorModule()
-        self.final_norm = TensorModule()
-        self.lm_head = TensorModule()
+        super().__init__(
+            quant_type, input_path, quant_attrs, q_size, kv_size, intermediate_size, num_layers, load_weights=False
+        )
         self._input_path = input_path
         self._safe_open = safe_open
         self._simple_namespace = SimpleNamespace
@@ -1788,9 +1745,57 @@ class ModeloptModel:
         if getattr(self, "_open_handles", None):
             self.close()
 
-    def modules(self):
-        """Modules in order of appearance in the model (the builder's walk order)."""
-        return [self.embedding] + self.layers + [self.final_norm, self.lm_head]
+    def repack_nvfp4_weight_codes(self, packed_nk2):
+        """Unpack a Model Optimizer NVFP4 weight tensor to per-element e2m1 codes."""
+        if packed_nk2.dtype != torch.uint8:
+            packed_nk2 = packed_nk2.to(torch.uint8)
+        low = packed_nk2 & 0x0F
+        high = packed_nk2 >> 4
+        n = packed_nk2.shape[0]
+        return torch.stack((low, high), dim=-1).reshape(n, -1).contiguous()
+
+    def pack_nvfp4_codes_for_qmoe(self, codes_nk):
+        """Pack e2m1 codes ``[N, K]`` into the CUDA QMoE ``[K, N/2]`` layout."""
+        if codes_nk.dtype != torch.uint8:
+            codes_nk = codes_nk.to(torch.uint8)
+        n = codes_nk.shape[0]
+        if n % 2 != 0:
+            raise ValueError(f"NVFP4 QMoE packing requires an even N={n} for nibble packing.")
+        codes_kn = codes_nk.T.contiguous()
+        low = codes_kn[:, 0::2] & 0x0F
+        high = codes_kn[:, 1::2] & 0x0F
+        return ((high << 4) | low).contiguous()
+
+    def _dequant_nvfp4(self, weight_u8, block_scale_e4m3, global_scale, name=""):
+        """Reconstruct a BF16 weight from Model Optimizer NVFP4 tensors."""
+        if block_scale_e4m3 is None:
+            raise ValueError(
+                f"NVFP4 tensor '{name}' has 'weight_scale_2' but no 'weight_scale' (FP8-E4M3 block scales). "
+                "The Model Optimizer checkpoint is incomplete."
+            )
+        if block_scale_e4m3.dtype == torch.uint8:
+            block_scale_e4m3 = block_scale_e4m3.view(torch.float8_e4m3fn)
+        elif block_scale_e4m3.dtype != torch.float8_e4m3fn:
+            raise ValueError(
+                f"NVFP4 tensor '{name}' block scales must be float8_e4m3fn (or raw uint8 bytes), "
+                f"got {block_scale_e4m3.dtype}."
+            )
+        codes = self.repack_nvfp4_weight_codes(weight_u8).long()
+        mag = self._FP4_E2M1_LUT[codes & 0x7]
+        values = torch.where((codes & 0x8) > 0, -mag, mag)
+        block_scales = block_scale_e4m3.to(torch.float32)
+        n, k = codes.shape
+        if block_scales.shape[0] != n or block_scales.shape[1] == 0 or k % block_scales.shape[1] != 0:
+            raise ValueError(
+                f"NVFP4 tensor '{name}' block scales {tuple(block_scales.shape)} are not a block-wise split of the "
+                f"[{n}, {k}] weight."
+            )
+        block_scales = block_scales.repeat_interleave(k // block_scales.shape[1], dim=1)
+        return (values * block_scales * float(global_scale)).to(torch.bfloat16)
+
+    def _dequant_fp8(self, weight_f8, weight_scale):
+        """Reconstruct a BF16 weight from an FP8 (E4M3) weight and per-tensor scale."""
+        return (weight_f8.to(torch.float32) * float(weight_scale)).to(torch.bfloat16)
 
     # -- raw tensor access ------------------------------------------------------
     def _get(self, name):
@@ -1817,9 +1822,9 @@ class ModeloptModel:
         weight_scale_2 = self._get(f"{base}.weight_scale_2")
         weight_scale = self._get(f"{base}.weight_scale")
         if weight_scale_2 is not None:  # NVFP4 (block-16 E2M1 + E4M3 block scale + global)
-            return _modelopt_dequant_nvfp4(weight, weight_scale, weight_scale_2, name=base)
+            return self._dequant_nvfp4(weight, weight_scale, weight_scale_2, name=base)
         if weight_scale is not None and weight.dtype == torch.float8_e4m3fn:  # FP8 (per-tensor scale)
-            return _modelopt_dequant_fp8(weight, weight_scale)
+            return self._dequant_fp8(weight, weight_scale)
         return weight.to(torch.bfloat16)
 
     def _linear_module(self, base):

--- a/test/python/models/test_modelopt_loader.py
+++ b/test/python/models/test_modelopt_loader.py
@@ -135,6 +135,7 @@ def test_modelopt_loader_tree_and_dequant():
             "modelopt", input_path=d, quant_attrs={}, q_size=32, kv_size=32, intermediate_size=16, num_layers=2
         )
 
+        assert isinstance(model, QM.QuantizedModel)
         mods = model.modules()
         assert mods[0] is model.embedding and mods[-1] is model.lm_head
         assert len(model.layers) == 2

--- a/test/python/models/test_modelopt_loader.py
+++ b/test/python/models/test_modelopt_loader.py
@@ -195,6 +195,17 @@ def test_modelopt_loader_rejects_bad_checkpoints():
             json.dump({"weight_map": dict.fromkeys(tensors, "model.safetensors")}, f)
         with pytest.raises(ValueError, match="no 'weight_scale'"):
             _load(d)
+
+    # A layer with neither linear_attn nor self_attn -> named error, not a later AttributeError.
+    with tempfile.TemporaryDirectory() as d:
+        _build_synthetic_checkpoint(d)
+        tensors = load_file(os.path.join(d, "model.safetensors"))
+        del tensors["model.language_model.layers.1.self_attn.q_proj.weight"]
+        save_file(tensors, os.path.join(d, "model.safetensors"))
+        with open(os.path.join(d, "model.safetensors.index.json"), "w") as f:
+            json.dump({"weight_map": dict.fromkeys(tensors, "model.safetensors")}, f)
+        with pytest.raises(ValueError, match="attention variant cannot be determined"):
+            _load(d)
     print("OK: ModeloptModel rejects ambiguous and incomplete checkpoints.")
 
 

--- a/test/python/models/test_modelopt_loader.py
+++ b/test/python/models/test_modelopt_loader.py
@@ -17,11 +17,13 @@ one full-attention layer, plus globals) and verifies that ModeloptModel:
 import importlib.util
 import json
 import os
+import shutil
 import tempfile
 
 import numpy as np
+import pytest
 import torch
-from safetensors.torch import save_file
+from safetensors.torch import load_file, save_file
 
 
 def _load_quantized_model_module():
@@ -163,8 +165,53 @@ def test_modelopt_loader_tree_and_dequant():
         assert l0.mlp.experts is None
         # Router / shared-expert-gate are present as plain tensors.
         assert l0.mlp.gate.weight is not None and l0.mlp.shared_expert_gate.weight is not None
+        # All safetensors handles are released once loading finishes.
+        assert not model._open_handles
     print("OK: ModeloptModel builds the tree and dequantizes FP8/NVFP4 correctly.")
+
+
+def _load(d):
+    return QM.QuantModel.from_pretrained(
+        "modelopt", input_path=d, quant_attrs={}, q_size=32, kv_size=32, intermediate_size=16, num_layers=2
+    )
+
+
+def test_modelopt_loader_rejects_bad_checkpoints():
+    # No index file and an ambiguous number of shards -> deterministic error, not StopIteration.
+    with tempfile.TemporaryDirectory() as d:
+        _build_synthetic_checkpoint(d)
+        os.remove(os.path.join(d, "model.safetensors.index.json"))
+        shutil.copyfile(os.path.join(d, "model.safetensors"), os.path.join(d, "model-2.safetensors"))
+        with pytest.raises(ValueError, match="exactly one .safetensors file"):
+            _load(d)
+
+    # NVFP4 tensor with a global scale but no FP8 block scales -> explicit error.
+    with tempfile.TemporaryDirectory() as d:
+        _build_synthetic_checkpoint(d)
+        tensors = load_file(os.path.join(d, "model.safetensors"))
+        del tensors["lm_head.weight_scale"]
+        save_file(tensors, os.path.join(d, "model.safetensors"))
+        with open(os.path.join(d, "model.safetensors.index.json"), "w") as f:
+            json.dump({"weight_map": dict.fromkeys(tensors, "model.safetensors")}, f)
+        with pytest.raises(ValueError, match="no 'weight_scale'"):
+            _load(d)
+    print("OK: ModeloptModel rejects ambiguous and incomplete checkpoints.")
+
+
+def test_modelopt_loader_accepts_raw_uint8_block_scales():
+    """Some exporters store the E4M3 block scales as raw uint8 bytes."""
+    with tempfile.TemporaryDirectory() as d:
+        refs = _build_synthetic_checkpoint(d)
+        tensors = load_file(os.path.join(d, "model.safetensors"))
+        tensors["lm_head.weight_scale"] = tensors["lm_head.weight_scale"].view(torch.uint8)
+        save_file(tensors, os.path.join(d, "model.safetensors"))
+        with open(os.path.join(d, "model.safetensors.index.json"), "w") as f:
+            json.dump({"weight_map": dict.fromkeys(tensors, "model.safetensors")}, f)
+        torch.testing.assert_close(_load(d).lm_head.weight, refs["lm_head"])
+    print("OK: ModeloptModel decodes uint8-stored E4M3 block scales.")
 
 
 if __name__ == "__main__":
     test_modelopt_loader_tree_and_dequant()
+    test_modelopt_loader_rejects_bad_checkpoints()
+    test_modelopt_loader_accepts_raw_uint8_block_scales()

--- a/test/python/models/test_modelopt_loader.py
+++ b/test/python/models/test_modelopt_loader.py
@@ -1,0 +1,170 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""Structural + numerical test for the Model Optimizer (NVFP4/FP8) loader.
+
+Builds a tiny synthetic modelopt-style checkpoint (one linear-attention layer,
+one full-attention layer, plus globals) and verifies that ModeloptModel:
+  * builds the module tree the ONNX Runtime GenAI builder walks,
+  * exposes dequantized weights as plain TensorModule.weight (no `qweight`, so
+    make_matmul takes the float path),
+  * dequantizes FP8 attention and NVFP4 shared-expert/lm_head correctly, and
+  * skips (streams) the routed experts.
+"""
+
+import importlib.util
+import json
+import os
+import tempfile
+
+import numpy as np
+import torch
+from safetensors.torch import save_file
+
+
+def _load_quantized_model_module():
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "src", "python", "py", "models", "quantized_model.py"
+    )
+    spec = importlib.util.spec_from_file_location("_genai_quantized_model_under_test", os.path.abspath(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+QM = _load_quantized_model_module()
+
+_FP4_LUT = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float32)
+
+
+def _make_nvfp4(n, k, rng):
+    """Return (weight_u8[N,K/2], weight_scale_e4m3[N,K/16], weight_scale_2 scalar, ref_bf16[N,K])."""
+    codes = rng.integers(0, 16, size=(n, k), dtype=np.uint8)  # e2m1 codes [N,K]
+    low, high = codes[:, 0::2], codes[:, 1::2]
+    weight_u8 = ((high << 4) | low).astype(np.uint8)  # [N,K/2]
+    block = rng.integers(0, 0x40, size=(n, k // 16), dtype=np.uint8)
+    ws = torch.from_numpy(block).view(torch.float8_e4m3fn)  # [N,K/16]
+    g = np.float32(rng.uniform(0.02, 0.2))
+    mag = _FP4_LUT[codes & 0x7]
+    val = np.where((codes & 0x8) > 0, -mag, mag)
+    bs = ws.to(torch.float32).numpy().repeat(16, axis=1)
+    ref = torch.from_numpy((val * bs * float(g)).astype(np.float32)).to(torch.bfloat16)
+    return torch.from_numpy(weight_u8), ws, torch.tensor(g, dtype=torch.float32), ref
+
+
+def _make_fp8(out_f, in_f, rng):
+    """Return (weight_f8[out,in], weight_scale scalar, ref_bf16)."""
+    raw = rng.integers(0, 0x40, size=(out_f, in_f), dtype=np.uint8)
+    w = torch.from_numpy(raw).view(torch.float8_e4m3fn)
+    s = torch.tensor(np.float32(rng.uniform(0.02, 0.2)))
+    ref = (w.to(torch.float32) * float(s)).to(torch.bfloat16)
+    return w, s, ref
+
+
+def _build_synthetic_checkpoint(d):
+    rng = np.random.default_rng(0)
+    hidden, inter, vocab = 32, 16, 40
+    tensors = {}
+    refs = {}
+
+    tensors["model.language_model.embed_tokens.weight"] = torch.zeros(vocab, hidden, dtype=torch.bfloat16)
+    tensors["model.language_model.norm.weight"] = torch.ones(hidden, dtype=torch.bfloat16)
+    w, ws, g, ref = _make_nvfp4(vocab, hidden, rng)  # lm_head NVFP4
+    tensors["lm_head.weight"], tensors["lm_head.weight_scale"], tensors["lm_head.weight_scale_2"] = w, ws, g
+    refs["lm_head"] = ref
+
+    def add_nvfp4(prefix, n, k):
+        w, ws, g, ref = _make_nvfp4(n, k, rng)
+        tensors[f"{prefix}.weight"] = w
+        tensors[f"{prefix}.weight_scale"] = ws
+        tensors[f"{prefix}.weight_scale_2"] = g
+        refs[prefix] = ref
+
+    def add_fp8(prefix, out_f, in_f):
+        w, s, ref = _make_fp8(out_f, in_f, rng)
+        tensors[f"{prefix}.weight"] = w
+        tensors[f"{prefix}.weight_scale"] = s
+        refs[prefix] = ref
+
+    for layer in (0, 1):
+        p = f"model.language_model.layers.{layer}"
+        tensors[f"{p}.input_layernorm.weight"] = torch.ones(hidden, dtype=torch.bfloat16)
+        tensors[f"{p}.post_attention_layernorm.weight"] = torch.ones(hidden, dtype=torch.bfloat16)
+        if layer == 0:  # linear attention
+            add_fp8(f"{p}.linear_attn.in_proj_qkv", 24, hidden)
+            add_fp8(f"{p}.linear_attn.in_proj_z", 12, hidden)
+            add_fp8(f"{p}.linear_attn.out_proj", hidden, 12)
+            tensors[f"{p}.linear_attn.in_proj_a.weight"] = torch.zeros(8, hidden, dtype=torch.bfloat16)
+            tensors[f"{p}.linear_attn.in_proj_b.weight"] = torch.zeros(8, hidden, dtype=torch.bfloat16)
+            tensors[f"{p}.linear_attn.conv1d.weight"] = torch.zeros(24, 1, 4, dtype=torch.bfloat16)
+            tensors[f"{p}.linear_attn.A_log"] = torch.zeros(8, dtype=torch.bfloat16)
+            tensors[f"{p}.linear_attn.dt_bias"] = torch.zeros(8, dtype=torch.bfloat16)
+            tensors[f"{p}.linear_attn.norm.weight"] = torch.ones(12, dtype=torch.bfloat16)
+        else:  # full attention
+            add_fp8(f"{p}.self_attn.q_proj", hidden, hidden)
+            add_fp8(f"{p}.self_attn.k_proj", hidden, hidden)
+            add_fp8(f"{p}.self_attn.v_proj", hidden, hidden)
+            add_fp8(f"{p}.self_attn.o_proj", hidden, hidden)
+            tensors[f"{p}.self_attn.q_norm.weight"] = torch.ones(8, dtype=torch.bfloat16)
+            tensors[f"{p}.self_attn.k_norm.weight"] = torch.ones(8, dtype=torch.bfloat16)
+        tensors[f"{p}.mlp.gate.weight"] = torch.zeros(4, hidden, dtype=torch.bfloat16)
+        add_nvfp4(f"{p}.mlp.shared_expert.gate_proj", inter, hidden)
+        add_nvfp4(f"{p}.mlp.shared_expert.up_proj", inter, hidden)
+        add_nvfp4(f"{p}.mlp.shared_expert.down_proj", hidden, inter)
+        tensors[f"{p}.mlp.shared_expert_gate.weight"] = torch.zeros(1, hidden, dtype=torch.bfloat16)
+        # A routed expert that the loader must ignore (streamed by the builder).
+        add_nvfp4(f"{p}.mlp.experts.0.gate_proj", inter, hidden)
+
+    save_file(tensors, os.path.join(d, "model.safetensors"))
+    with open(os.path.join(d, "model.safetensors.index.json"), "w") as f:
+        json.dump({"weight_map": dict.fromkeys(tensors, "model.safetensors")}, f)
+    cfg = {"text_config": {"num_hidden_layers": 2, "hidden_size": hidden}}
+    with open(os.path.join(d, "config.json"), "w") as f:
+        json.dump(cfg, f)
+    return refs
+
+
+def test_modelopt_loader_tree_and_dequant():
+    with tempfile.TemporaryDirectory() as d:
+        refs = _build_synthetic_checkpoint(d)
+        model = QM.QuantModel.from_pretrained(
+            "modelopt", input_path=d, quant_attrs={}, q_size=32, kv_size=32, intermediate_size=16, num_layers=2
+        )
+
+        mods = model.modules()
+        assert mods[0] is model.embedding and mods[-1] is model.lm_head
+        assert len(model.layers) == 2
+        assert all(m.__class__.__name__.endswith("DecoderLayer") for m in model.layers)
+
+        l0, l1 = model.layers
+        # Layer 0 is linear-attention, layer 1 is full-attention.
+        assert l0.linear_attn is not None and l0.self_attn is None
+        assert l1.self_attn is not None and l1.linear_attn is None
+
+        # Dequantized linear layers are plain TensorModules (no qweight -> float path).
+        assert not hasattr(l0.linear_attn.in_proj_qkv, "qweight")
+        assert l0.linear_attn.in_proj_qkv.weight.dtype == torch.bfloat16
+        assert l0.linear_attn.A_log is not None and l0.linear_attn.conv1d.weight is not None
+
+        # FP8 attention dequant is exact.
+        torch.testing.assert_close(
+            l0.linear_attn.in_proj_qkv.weight, refs["model.language_model.layers.0.linear_attn.in_proj_qkv"]
+        )
+        torch.testing.assert_close(l1.self_attn.q_proj.weight, refs["model.language_model.layers.1.self_attn.q_proj"])
+        # NVFP4 shared-expert + lm_head dequant is exact.
+        torch.testing.assert_close(
+            l0.mlp.shared_expert.gate_proj.weight, refs["model.language_model.layers.0.mlp.shared_expert.gate_proj"]
+        )
+        torch.testing.assert_close(model.lm_head.weight, refs["lm_head"])
+
+        # Routed experts are NOT materialized by the loader (streamed later).
+        assert l0.mlp.experts is None
+        # Router / shared-expert-gate are present as plain tensors.
+        assert l0.mlp.gate.weight is not None and l0.mlp.shared_expert_gate.weight is not None
+    print("OK: ModeloptModel builds the tree and dequantizes FP8/NVFP4 correctly.")
+
+
+if __name__ == "__main__":
+    test_modelopt_loader_tree_and_dequant()

--- a/test/python/models/test_nvfp4_repack.py
+++ b/test/python/models/test_nvfp4_repack.py
@@ -36,7 +36,9 @@ def _load_builder_model_class():
     """Load ``Model`` from the source base.py, stubbing heavy optional imports.
 
     The two repack helpers under test are pure-torch static methods, so we do not
-    need transformers/onnxruntime installed just to exercise them.
+    need transformers/onnxruntime installed just to exercise them. Every entry this
+    function adds to ``sys.modules`` is removed again before returning, so a later
+    test in the same session still imports the real packages.
     """
     base_path = os.path.join(
         os.path.dirname(__file__), "..", "..", "..", "src", "python", "py", "models", "builders", "base.py"
@@ -44,6 +46,13 @@ def _load_builder_model_class():
     base_path = os.path.abspath(base_path)
     builders_dir = os.path.dirname(base_path)
     models_dir = os.path.dirname(builders_dir)
+    injected = []
+
+    def inject(name, module):
+        if name not in sys.modules:
+            sys.modules[name] = module
+            injected.append(name)
+
     for name in (
         "transformers",
         "tqdm",
@@ -52,21 +61,25 @@ def _load_builder_model_class():
         "onnxruntime.quantization",
         "onnxruntime.quantization.matmul_nbits_quantizer",
     ):
-        sys.modules.setdefault(name, mock.MagicMock())
+        inject(name, mock.MagicMock())
     # Synthetic parent packages so base.py's `from .cuda_quantizer import ...` resolves
     # without executing the real builders __init__ (which imports every builder).
     pkg_models = types.ModuleType("_genai_models_pkg")
     pkg_models.__path__ = [models_dir]
     pkg_builders = types.ModuleType("_genai_models_pkg.builders")
     pkg_builders.__path__ = [builders_dir]
-    sys.modules["_genai_models_pkg"] = pkg_models
-    sys.modules["_genai_models_pkg.builders"] = pkg_builders
-    sys.modules["_genai_models_pkg.builders.cuda_quantizer"] = mock.MagicMock()
+    inject("_genai_models_pkg", pkg_models)
+    inject("_genai_models_pkg.builders", pkg_builders)
+    inject("_genai_models_pkg.builders.cuda_quantizer", mock.MagicMock())
     spec = importlib.util.spec_from_file_location("_genai_models_pkg.builders.base", base_path)
     module = importlib.util.module_from_spec(spec)
-    sys.modules["_genai_models_pkg.builders.base"] = module
-    spec.loader.exec_module(module)
-    return module.Model
+    inject("_genai_models_pkg.builders.base", module)
+    try:
+        spec.loader.exec_module(module)
+        return module.Model
+    finally:
+        for name in injected:
+            sys.modules.pop(name, None)
 
 
 Model = _load_builder_model_class()

--- a/test/python/models/test_nvfp4_repack.py
+++ b/test/python/models/test_nvfp4_repack.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-"""Numerical guard for the NVFP4 model-builder repack helpers.
+"""Numerical guard for the Model Optimizer NVFP4 repack helpers.
 
 Model Optimizer stores each NVFP4 expert projection as:
   weight        uint8   [N, K/2]  (E2M1, 2 codes/byte, packed along K; low nibble = even K)
@@ -24,65 +24,22 @@ bit-for-bit (no re-quantization).
 
 import importlib.util
 import os
-import sys
-import types
-from unittest import mock
 
 import numpy as np
 import torch
 
 
-def _load_builder_model_class():
-    """Load ``Model`` from the source base.py, stubbing heavy optional imports.
-
-    The two repack helpers under test are pure-torch static methods, so we do not
-    need transformers/onnxruntime installed just to exercise them. Every entry this
-    function adds to ``sys.modules`` is removed again before returning, so a later
-    test in the same session still imports the real packages.
-    """
-    base_path = os.path.join(
-        os.path.dirname(__file__), "..", "..", "..", "src", "python", "py", "models", "builders", "base.py"
+def _load_modelopt_class():
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "src", "python", "py", "models", "quantized_model.py"
     )
-    base_path = os.path.abspath(base_path)
-    builders_dir = os.path.dirname(base_path)
-    models_dir = os.path.dirname(builders_dir)
-    injected = []
-
-    def inject(name, module):
-        if name not in sys.modules:
-            sys.modules[name] = module
-            injected.append(name)
-
-    for name in (
-        "transformers",
-        "tqdm",
-        "peft",
-        "onnxruntime",
-        "onnxruntime.quantization",
-        "onnxruntime.quantization.matmul_nbits_quantizer",
-    ):
-        inject(name, mock.MagicMock())
-    # Synthetic parent packages so base.py's `from .cuda_quantizer import ...` resolves
-    # without executing the real builders __init__ (which imports every builder).
-    pkg_models = types.ModuleType("_genai_models_pkg")
-    pkg_models.__path__ = [models_dir]
-    pkg_builders = types.ModuleType("_genai_models_pkg.builders")
-    pkg_builders.__path__ = [builders_dir]
-    inject("_genai_models_pkg", pkg_models)
-    inject("_genai_models_pkg.builders", pkg_builders)
-    inject("_genai_models_pkg.builders.cuda_quantizer", mock.MagicMock())
-    spec = importlib.util.spec_from_file_location("_genai_models_pkg.builders.base", base_path)
+    spec = importlib.util.spec_from_file_location("_genai_quantized_model_under_test", os.path.abspath(path))
     module = importlib.util.module_from_spec(spec)
-    inject("_genai_models_pkg.builders.base", module)
-    try:
-        spec.loader.exec_module(module)
-        return module.Model
-    finally:
-        for name in injected:
-            sys.modules.pop(name, None)
+    spec.loader.exec_module(module)
+    return module.ModeloptModel
 
 
-Model = _load_builder_model_class()
+ModeloptModel = _load_modelopt_class()
 
 _FP4_E2M1 = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float32)
 
@@ -130,13 +87,14 @@ def _kernel_dequant_from_qmoe_layout(packed_kn2, scale_nk16, global_scale, n, k)
 
 
 def test_nvfp4_repack_roundtrip_matches_modelopt():
+    model = ModeloptModel.__new__(ModeloptModel)
     for seed, (n, k) in enumerate([(8, 64), (16, 128), (32, 512), (2048, 512)]):
         packed_nk2, scale_bytes, global_scale, ref = _make_modelopt_nvfp4_projection(n, k, seed)
 
-        # Builder repack: K-unpack -> per-element codes [N, K] -> N-pack [K, N/2].
-        codes_nk = Model.repack_modelopt_nvfp4_weight_codes(torch.from_numpy(packed_nk2))
+        # Model Optimizer repack: K-unpack -> per-element codes [N, K] -> N-pack [K, N/2].
+        codes_nk = model.repack_nvfp4_weight_codes(torch.from_numpy(packed_nk2))
         assert tuple(codes_nk.shape) == (n, k)
-        qweight_kn2 = Model.pack_nvfp4_codes_for_qmoe(codes_nk)
+        qweight_kn2 = model.pack_nvfp4_codes_for_qmoe(codes_nk)
         assert tuple(qweight_kn2.shape) == (k, n // 2)
 
         # Block scales are unchanged ([N, K/16]); global scale passed through.

--- a/test/python/models/test_nvfp4_repack.py
+++ b/test/python/models/test_nvfp4_repack.py
@@ -74,14 +74,16 @@ Model = _load_builder_model_class()
 _FP4_E2M1 = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float32)
 
 
-def _decode_e2m1(code):
-    code = int(code) & 0xF
-    v = _FP4_E2M1[code & 0x7]
-    return -v if (code & 0x8) else v
+def _decode_e2m1(codes):
+    """Decode an array of e2m1 nibbles (0-15) to float32."""
+    codes = np.asarray(codes) & 0xF
+    mag = _FP4_E2M1[codes & 0x7]
+    return np.where((codes & 0x8) > 0, -mag, mag)
 
 
-def _e4m3_byte_to_float(byte):
-    return torch.tensor([byte], dtype=torch.uint8).view(torch.float8_e4m3fn).float().item()
+def _e4m3_bytes_to_float(byte_array):
+    """Reinterpret raw e4m3 bytes as float32 (torch has the only FP8 decoder here)."""
+    return torch.from_numpy(np.ascontiguousarray(byte_array)).view(torch.float8_e4m3fn).float().numpy()
 
 
 def _make_modelopt_nvfp4_projection(n, k, seed):
@@ -99,28 +101,19 @@ def _make_modelopt_nvfp4_projection(n, k, seed):
     packed_nk2 = ((high << 4) | low).astype(np.uint8)  # [N, K/2]
 
     # Reference reconstruction from the modelopt-form tensors.
-    ref = np.empty((n, k), dtype=np.float32)
-    for i in range(n):
-        for j in range(k):
-            ref[i, j] = (
-                _decode_e2m1(codes_nk[i, j]) * _e4m3_byte_to_float(scale_bytes[i, j // block]) * float(global_scale)
-            )
+    scales = _e4m3_bytes_to_float(scale_bytes).repeat(block, axis=1)  # [N, K]
+    ref = (_decode_e2m1(codes_nk) * scales * float(global_scale)).astype(np.float32)
     return packed_nk2, scale_bytes, global_scale, ref
 
 
 def _kernel_dequant_from_qmoe_layout(packed_kn2, scale_nk16, global_scale, n, k):
     """Mirror the ORT QMoE nvfp4 dequant kernel over a [K, N/2]-packed weight."""
     block = 16
-    out = np.empty((n, k), dtype=np.float32)
     packed_kn2 = packed_kn2.numpy() if isinstance(packed_kn2, torch.Tensor) else packed_kn2
-    for row_n in range(n):
-        for col_k in range(k):
-            byte = packed_kn2[col_k, row_n // 2]
-            code = (byte & 0x0F) if (row_n % 2 == 0) else (byte >> 4)
-            out[row_n, col_k] = (
-                _decode_e2m1(code) * _e4m3_byte_to_float(scale_nk16[row_n, col_k // block]) * float(global_scale)
-            )
-    return out
+    # Even N is the low nibble, odd N is the high nibble, of byte [K, N/2].
+    codes_kn = np.stack([packed_kn2 & 0x0F, packed_kn2 >> 4], axis=-1).reshape(k, n)
+    scales = _e4m3_bytes_to_float(scale_nk16).repeat(block, axis=1)  # [N, K]
+    return (_decode_e2m1(codes_kn.T) * scales * float(global_scale)).astype(np.float32)
 
 
 def test_nvfp4_repack_roundtrip_matches_modelopt():

--- a/test/python/models/test_nvfp4_repack.py
+++ b/test/python/models/test_nvfp4_repack.py
@@ -1,0 +1,145 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""Numerical guard for the NVFP4 model-builder repack helpers.
+
+Model Optimizer stores each NVFP4 expert projection as:
+  weight        uint8   [N, K/2]  (E2M1, 2 codes/byte, packed along K; low nibble = even K)
+  weight_scale  e4m3    [N, K/16] (one FP8 block scale per 16 K-elements)
+  weight_scale_2 f32    scalar    (per-tensor global scale)
+and the value is reconstructed as
+  w[n, k] = e2m1(code) * e4m3(weight_scale[n, k // 16]) * weight_scale_2.
+
+The ORT CUDA QMoE ``nvfp4`` kernel reads weights as ``[E, K, N/2]`` (N-packed,
+even N = low nibble), block scales as ``[E, N, K/16]`` e4m3, and per-expert
+float32 global scales, dequantizing as
+  w[n, k] = e2m1(code) * e4m3(block_scale[n, k // 16]) * global[e].
+
+This test proves the builder's repack (K-unpack -> N-pack) preserves the exact
+code<->(N, K) mapping, so the kernel reconstructs Model Optimizer's weights
+bit-for-bit (no re-quantization).
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from unittest import mock
+
+import numpy as np
+import torch
+
+
+def _load_builder_model_class():
+    """Load ``Model`` from the source base.py, stubbing heavy optional imports.
+
+    The two repack helpers under test are pure-torch static methods, so we do not
+    need transformers/onnxruntime installed just to exercise them.
+    """
+    base_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "src", "python", "py", "models", "builders", "base.py"
+    )
+    base_path = os.path.abspath(base_path)
+    builders_dir = os.path.dirname(base_path)
+    models_dir = os.path.dirname(builders_dir)
+    for name in (
+        "transformers",
+        "tqdm",
+        "peft",
+        "onnxruntime",
+        "onnxruntime.quantization",
+        "onnxruntime.quantization.matmul_nbits_quantizer",
+    ):
+        sys.modules.setdefault(name, mock.MagicMock())
+    # Synthetic parent packages so base.py's `from .cuda_quantizer import ...` resolves
+    # without executing the real builders __init__ (which imports every builder).
+    pkg_models = types.ModuleType("_genai_models_pkg")
+    pkg_models.__path__ = [models_dir]
+    pkg_builders = types.ModuleType("_genai_models_pkg.builders")
+    pkg_builders.__path__ = [builders_dir]
+    sys.modules["_genai_models_pkg"] = pkg_models
+    sys.modules["_genai_models_pkg.builders"] = pkg_builders
+    sys.modules["_genai_models_pkg.builders.cuda_quantizer"] = mock.MagicMock()
+    spec = importlib.util.spec_from_file_location("_genai_models_pkg.builders.base", base_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_genai_models_pkg.builders.base"] = module
+    spec.loader.exec_module(module)
+    return module.Model
+
+
+Model = _load_builder_model_class()
+
+_FP4_E2M1 = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float32)
+
+
+def _decode_e2m1(code):
+    code = int(code) & 0xF
+    v = _FP4_E2M1[code & 0x7]
+    return -v if (code & 0x8) else v
+
+
+def _e4m3_byte_to_float(byte):
+    return torch.tensor([byte], dtype=torch.uint8).view(torch.float8_e4m3fn).float().item()
+
+
+def _make_modelopt_nvfp4_projection(n, k, seed):
+    """Build a random Model-Optimizer-form NVFP4 projection and its reconstruction."""
+    rng = np.random.default_rng(seed)
+    block = 16
+    codes_nk = rng.integers(0, 16, size=(n, k), dtype=np.uint8)  # e2m1 codes [N, K]
+    # Random e4m3 block scales (avoid NaN encodings 0x7F / 0xFF).
+    scale_bytes = rng.integers(0, 0x7F, size=(n, k // block), dtype=np.uint8)  # [N, K/16]
+    global_scale = np.float32(rng.uniform(0.05, 0.5))
+
+    # Model Optimizer weight layout: [N, K/2], low nibble = even K, high = odd K.
+    low = codes_nk[:, 0::2]
+    high = codes_nk[:, 1::2]
+    packed_nk2 = ((high << 4) | low).astype(np.uint8)  # [N, K/2]
+
+    # Reference reconstruction from the modelopt-form tensors.
+    ref = np.empty((n, k), dtype=np.float32)
+    for i in range(n):
+        for j in range(k):
+            ref[i, j] = (
+                _decode_e2m1(codes_nk[i, j]) * _e4m3_byte_to_float(scale_bytes[i, j // block]) * float(global_scale)
+            )
+    return packed_nk2, scale_bytes, global_scale, ref
+
+
+def _kernel_dequant_from_qmoe_layout(packed_kn2, scale_nk16, global_scale, n, k):
+    """Mirror the ORT QMoE nvfp4 dequant kernel over a [K, N/2]-packed weight."""
+    block = 16
+    out = np.empty((n, k), dtype=np.float32)
+    packed_kn2 = packed_kn2.numpy() if isinstance(packed_kn2, torch.Tensor) else packed_kn2
+    for row_n in range(n):
+        for col_k in range(k):
+            byte = packed_kn2[col_k, row_n // 2]
+            code = (byte & 0x0F) if (row_n % 2 == 0) else (byte >> 4)
+            out[row_n, col_k] = (
+                _decode_e2m1(code) * _e4m3_byte_to_float(scale_nk16[row_n, col_k // block]) * float(global_scale)
+            )
+    return out
+
+
+def test_nvfp4_repack_roundtrip_matches_modelopt():
+    for seed, (n, k) in enumerate([(8, 64), (16, 128), (32, 512), (2048, 512)]):
+        packed_nk2, scale_bytes, global_scale, ref = _make_modelopt_nvfp4_projection(n, k, seed)
+
+        # Builder repack: K-unpack -> per-element codes [N, K] -> N-pack [K, N/2].
+        codes_nk = Model.repack_modelopt_nvfp4_weight_codes(torch.from_numpy(packed_nk2))
+        assert tuple(codes_nk.shape) == (n, k)
+        qweight_kn2 = Model.pack_nvfp4_codes_for_qmoe(codes_nk)
+        assert tuple(qweight_kn2.shape) == (k, n // 2)
+
+        # Block scales are unchanged ([N, K/16]); global scale passed through.
+        got = _kernel_dequant_from_qmoe_layout(qweight_kn2, scale_bytes, global_scale, n, k)
+
+        max_abs = float(np.max(np.abs(got - ref)))
+        assert max_abs == 0.0, f"shape ({n},{k}): repacked dequant differs from modelopt ref (max_abs={max_abs})"
+
+
+if __name__ == "__main__":
+    test_nvfp4_repack_roundtrip_matches_modelopt()
+    print("OK: NVFP4 repack round-trip is bit-exact against the Model Optimizer reconstruction.")


### PR DESCRIPTION
### Description

Adds NVFP4 as a first-class model-builder quantization scheme and a loader for NVIDIA TensorRT Model Optimizer checkpoints.

* `quant_config.py` registers `nvfp4` as an `mx`-kind 4-bit dtype pinned to block size 16.
* `base.py` maps the MoE descriptor to the `QMoE` op's `quant_type`: `mxfp4` -> `"fp4"`, `nvfp4` -> `"nvfp4"`, integer dtypes -> `"int"`. Adds `make_fp8e4m3_initializer` for E4M3 block scales, plus `repack_modelopt_nvfp4_weight_codes` / `pack_nvfp4_codes_for_qmoe` to convert ModelOpt's `[N, K/2]` packed E2M1 layout into the layout `QMoE` expects.
* `builder.py` accepts `moe_quant_type=nvfp4` and validates it the same way as `mxfp4` (CUDA EP, symmetric INT4 precision, FP4 QMoE build).
* `quantized_model.py` gains `ModeloptModel` / `ModeloptDecoderLayer` (`quant_type="modelopt"`), which dequantizes ModelOpt NVFP4 (E2M1 codes + E4M3 block scale + fp32 global scale) and FP8 tensors so a ModelOpt checkpoint can be loaded like any other quantized checkpoint.

### Motivation and Context

Prerequisite for exporting NVFP4-quantized Qwen3.6 MoE checkpoints. On its own this only adds the scheme and the loader; the Qwen-specific export wiring is a follow-up.

Adds unit tests for the ModelOpt loader and for the NVFP4 repack round-trip (`test_modelopt_loader.py`, `test_nvfp4_repack.py`).
