### PR TITLE
Add chunked prefill to the engine

### DIFF
--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -23,6 +23,7 @@ class PagedCacheStepReservation final : public CacheStepReservation {
           entry.request_id,
           entry.target_cache_slots,
           entry.newly_admitted,
+          entry.whole_sequence_cache_slots,
       });
       if (entry.newly_admitted) {
         newly_admitted_.push_back(entry.request);

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -127,9 +127,9 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
     // The operator writes token j at past_sequence_lengths[i] + j. The processed cursor is the
     // number of tokens already in the cache and therefore the base position for this step.
     const int64_t processed_sequence_length = request->ProcessedSequenceLength();
-  if (entry && (request->CurrentSequenceLength() != entry->sequence_length_before ||
-          SlotsAfterStep(processed_sequence_length, entry->unprocessed_token_count) !=
-            entry->target_cache_slots)) {
+    if (entry && (request->CurrentSequenceLength() != entry->sequence_length_before ||
+                  SlotsAfterStep(processed_sequence_length, entry->unprocessed_token_count) !=
+                      entry->target_cache_slots)) {
       throw std::runtime_error("Step plan processed sequence length does not match the request.");
     }
     sequence_lengths_cpu_span[i] = static_cast<int32_t>(processed_sequence_length);

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -127,9 +127,9 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
     // The operator writes token j at past_sequence_lengths[i] + j. The processed cursor is the
     // number of tokens already in the cache and therefore the base position for this step.
     const int64_t processed_sequence_length = request->ProcessedSequenceLength();
-    if (entry &&
-        processed_sequence_length !=
-            entry->sequence_length_before - static_cast<int64_t>(entry->unprocessed_token_count)) {
+  if (entry && (request->CurrentSequenceLength() != entry->sequence_length_before ||
+          SlotsAfterStep(processed_sequence_length, entry->unprocessed_token_count) !=
+            entry->target_cache_slots)) {
       throw std::runtime_error("Step plan processed sequence length does not match the request.");
     }
     sequence_lengths_cpu_span[i] = static_cast<int32_t>(processed_sequence_length);

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -107,8 +107,9 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
 
     // The operator writes this step's token j of sequence i at absolute position
     // past_sequence_lengths[i] + j, so this has to be the number of tokens already in the cache.
-    // Deriving it from the sequence length instead is off by one on a decode step, where the
-    // search has already appended the token that is about to be processed.
+    // Deriving it from the sequence length instead would be off by one on a decode step, where the
+    // search has already appended the token that is about to be processed, and would be wrong by a
+    // whole chunk during a chunked prefill.
     sequence_lengths_cpu_span[i] = static_cast<int32_t>(request->ProcessedSequenceLength());
 
     running_length += input_ids.size();

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -3,6 +3,7 @@
 
 #include "varlen_decoder_io.h"
 #include "../../models/decoder_only.h"
+#include "../sequence_positions.h"
 
 namespace Generators {
 

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -54,8 +54,11 @@ PagedCacheReservation::PagedCacheReservation(
     }
 
     const size_t committed_capacity = committed_blocks * block_pool.BlockSize();
+    // Blocks are taken for the whole sequence so that a chunked prefill cannot lose the rest of its
+    // capacity to another request between steps, but only target_slots is committed below.
+    const size_t reserved_slots = std::max(request.reserved_slots, request.target_slots);
     const size_t additional_slots =
-        request.target_slots > committed_capacity ? request.target_slots - committed_capacity : 0;
+        reserved_slots > committed_capacity ? reserved_slots - committed_capacity : 0;
     const size_t new_blocks = block_pool.BlocksNeeded(additional_slots);
     const size_t tail_capacity = committed_capacity - committed_slots;
     const size_t growth = request.target_slots - committed_slots;

--- a/src/engine/paged_cache_reservation.h
+++ b/src/engine/paged_cache_reservation.h
@@ -23,6 +23,9 @@ struct PagedCacheReservationRequest {
   const void* request_id{};
   size_t target_slots{};
   bool newly_admitted{};
+  // Slots the reservation has to own blocks for, which is the whole sequence rather than this
+  // step's target when a prefill is chunked. Clamped up to target_slots when left unset.
+  size_t reserved_slots{};
 };
 
 struct PagedCacheReservationDelta {

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -96,7 +96,7 @@ PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
 }
 
 bool PagedKeyValueCache::CanAdd(std::shared_ptr<Request> request) const {
-  return block_pool_->AvailableBlocks() >= block_pool_->BlocksNeeded(TotalSlots(request));
+  return block_pool_->AvailableBlocks() >= block_pool_->BlocksNeeded(RequiredSlots(request));
 }
 
 void PagedKeyValueCache::Add(std::shared_ptr<Request> request) {

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -5,6 +5,8 @@
 
 #include <numeric>
 
+#include "sequence_positions.h"
+
 namespace Generators {
 
 namespace {
@@ -94,7 +96,7 @@ PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
 }
 
 bool PagedKeyValueCache::CanAdd(std::shared_ptr<Request> request) const {
-  return block_pool_->AvailableBlocks() >= block_pool_->BlocksNeeded(RequiredSlots(request));
+  return block_pool_->AvailableBlocks() >= block_pool_->BlocksNeeded(TotalSlots(request));
 }
 
 void PagedKeyValueCache::Add(std::shared_ptr<Request> request) {

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -206,21 +206,31 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan,
     size_t proposed_blocks{};
     size_t new_blocks{};
   };
+  const auto growth_for_slots = [&](size_t target_slots,
+                                    const PagedCacheBlockTable* table) {
+    const size_t committed_blocks = table ? table->blocks.size() : 0;
+    const size_t committed_capacity = committed_blocks * block_pool_->BlockSize();
+    const size_t additional_slots =
+        target_slots > committed_capacity ? target_slots - committed_capacity : 0;
+    const size_t new_blocks = block_pool_->BlocksNeeded(additional_slots);
+    return CacheGrowth{committed_blocks + new_blocks, new_blocks};
+  };
   const auto calculate_growth = [&](const RequestStepPlan& entry,
                                     const PagedCacheBlockTable* table) {
     const size_t committed_slots = table ? table->committed_slots : 0;
-    const size_t committed_blocks = table ? table->blocks.size() : 0;
     if (entry.target_cache_slots < committed_slots) {
       throw std::runtime_error("Step plan target precedes the committed cache boundary.");
     }
 
-    const size_t committed_capacity = committed_blocks * block_pool_->BlockSize();
-    const size_t additional_slots =
-        entry.target_cache_slots > committed_capacity
-            ? entry.target_cache_slots - committed_capacity
-            : 0;
-    const size_t new_blocks = block_pool_->BlocksNeeded(additional_slots);
-    return CacheGrowth{committed_blocks + new_blocks, new_blocks};
+    return growth_for_slots(entry.target_cache_slots, table);
+  };
+  // A chunked prefill only asks for one chunk at a time, so serviceability has to be judged on the
+  // whole sequence. Otherwise a prompt that can never fit would be admitted on its first chunk and
+  // then stall part way through, holding the blocks it already took.
+  const auto whole_sequence_growth = [&](const RequestStepPlan& entry,
+                                         const PagedCacheBlockTable* table) {
+    return growth_for_slots(
+        std::max(entry.whole_sequence_cache_slots, entry.target_cache_slots), table);
   };
   const auto permanently_unserviceable = [&](const CacheGrowth& growth) {
     return growth.proposed_blocks > block_pool_->Capacity() ||
@@ -257,7 +267,7 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan,
     }
 
     const auto growth = calculate_growth(entry, &table);
-    if (permanently_unserviceable(growth)) {
+    if (permanently_unserviceable(whole_sequence_growth(entry, &table))) {
       if (!unserviceable_request_id) {
         unserviceable_request_id = entry.request_id;
       }
@@ -278,21 +288,23 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan,
       throw std::runtime_error("New step plan request already belongs to the paged cache.");
     }
 
-    const auto growth = calculate_growth(candidate, nullptr);
-    if (permanently_unserviceable(growth)) {
+    const auto admission_growth = whole_sequence_growth(candidate, nullptr);
+    if (permanently_unserviceable(admission_growth)) {
       if (!unserviceable_request_id) {
         unserviceable_request_id = candidate.request_id;
       }
       continue;
     }
 
+    // Admit only once the whole prompt fits: Add() reserves the blocks for the entire sequence, and
+    // a request that starts its prefill has to be able to finish it.
     if (committed_request_count + selected_new_requests >= max_batch_size_ ||
-        planned_blocks + growth.new_blocks > available_blocks) {
+        planned_blocks + admission_growth.new_blocks > available_blocks) {
       capacity_deferred = true;
       continue;
     }
 
-    select(i, growth);
+    select(i, admission_growth);
     ++selected_new_requests;
   }
   plan.requests.resize(selected_requests);

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -206,15 +206,10 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan,
     size_t proposed_blocks{};
     size_t new_blocks{};
   };
-  const auto growth_for_slots = [&](size_t target_slots,
-                                    const PagedCacheBlockTable* table) {
-    const size_t committed_blocks = table ? table->blocks.size() : 0;
-    const size_t committed_capacity = committed_blocks * block_pool_->BlockSize();
-    const size_t additional_slots =
-        target_slots > committed_capacity ? target_slots - committed_capacity : 0;
-    const size_t new_blocks = block_pool_->BlocksNeeded(additional_slots);
-    return CacheGrowth{committed_blocks + new_blocks, new_blocks};
-  };
+  // Blocks the request has to own for this step. A chunked prefill is planned one chunk at a time,
+  // but the blocks are taken for the whole sequence: admitting a prompt on the strength of its
+  // first chunk and then losing the rest of the pool to another request would stall it part way
+  // through, holding the blocks it already took. PagedCacheReservation reserves the same blocks.
   const auto calculate_growth = [&](const RequestStepPlan& entry,
                                     const PagedCacheBlockTable* table) {
     const size_t committed_slots = table ? table->committed_slots : 0;
@@ -222,15 +217,14 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan,
       throw std::runtime_error("Step plan target precedes the committed cache boundary.");
     }
 
-    return growth_for_slots(entry.target_cache_slots, table);
-  };
-  // A chunked prefill only asks for one chunk at a time, so serviceability has to be judged on the
-  // whole sequence. Otherwise a prompt that can never fit would be admitted on its first chunk and
-  // then stall part way through, holding the blocks it already took.
-  const auto whole_sequence_growth = [&](const RequestStepPlan& entry,
-                                         const PagedCacheBlockTable* table) {
-    return growth_for_slots(
-        std::max(entry.whole_sequence_cache_slots, entry.target_cache_slots), table);
+    const size_t reserved_slots =
+        std::max(entry.whole_sequence_cache_slots, entry.target_cache_slots);
+    const size_t committed_blocks = table ? table->blocks.size() : 0;
+    const size_t committed_capacity = committed_blocks * block_pool_->BlockSize();
+    const size_t additional_slots =
+        reserved_slots > committed_capacity ? reserved_slots - committed_capacity : 0;
+    const size_t new_blocks = block_pool_->BlocksNeeded(additional_slots);
+    return CacheGrowth{committed_blocks + new_blocks, new_blocks};
   };
   const auto permanently_unserviceable = [&](const CacheGrowth& growth) {
     return growth.proposed_blocks > block_pool_->Capacity() ||
@@ -267,7 +261,7 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan,
     }
 
     const auto growth = calculate_growth(entry, &table);
-    if (permanently_unserviceable(whole_sequence_growth(entry, &table))) {
+    if (permanently_unserviceable(growth)) {
       if (!unserviceable_request_id) {
         unserviceable_request_id = entry.request_id;
       }
@@ -288,23 +282,21 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan,
       throw std::runtime_error("New step plan request already belongs to the paged cache.");
     }
 
-    const auto admission_growth = whole_sequence_growth(candidate, nullptr);
-    if (permanently_unserviceable(admission_growth)) {
+    const auto growth = calculate_growth(candidate, nullptr);
+    if (permanently_unserviceable(growth)) {
       if (!unserviceable_request_id) {
         unserviceable_request_id = candidate.request_id;
       }
       continue;
     }
 
-    // Admit only once the whole prompt fits: Add() reserves the blocks for the entire sequence, and
-    // a request that starts its prefill has to be able to finish it.
     if (committed_request_count + selected_new_requests >= max_batch_size_ ||
-        planned_blocks + admission_growth.new_blocks > available_blocks) {
+        planned_blocks + growth.new_blocks > available_blocks) {
       capacity_deferred = true;
       continue;
     }
 
-    select(i, admission_growth);
+    select(i, growth);
     ++selected_new_requests;
   }
   plan.requests.resize(selected_requests);

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -67,8 +67,9 @@ size_t TotalSlots(const std::shared_ptr<Request>& request) {
 // token whose key and value live in the cache afterwards.
 //
 // This has to match how VarlenDecoderIO fills `past_sequence_lengths`: the decoder writes this
-// step's tokens at absolute positions [processed, processed + pending), so the cache must own
-// `processed + pending` slots.
+// step's tokens at absolute positions [processed, processed + scheduled), so the cache must own
+// `processed + scheduled` slots. With a chunked prefill only part of the prompt is covered, and
+// the remaining chunks extend it on later steps.
 size_t PendingSlots(const std::shared_ptr<Request>& request) {
   return SlotsAfterStep(request->ProcessedSequenceLength(), request->UnprocessedTokens().size());
 }

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -4,6 +4,7 @@
 #include "request.h"
 
 #include "engine.h"
+#include "sequence_positions.h"
 #include "../search.h"
 
 namespace Generators {
@@ -120,6 +121,24 @@ int64_t Request::ProcessedSequenceLength() const {
   return processed_sequence_length_;
 }
 
+size_t Request::ScheduledTokenCount() const {
+  const size_t unprocessed = static_cast<size_t>(CurrentSequenceLength() - processed_sequence_length_);
+  return std::min(scheduled_token_count_, unprocessed);
+}
+
+void Request::ScheduleTokens(bool allow_chunking) {
+  const size_t unprocessed = static_cast<size_t>(CurrentSequenceLength() - processed_sequence_length_);
+  scheduled_token_count_ = Generators::ScheduledTokenCount(unprocessed, params_->search.chunk_size, allow_chunking);
+}
+
+bool Request::IsChunkComplete() const {
+  return processed_sequence_length_ + static_cast<int64_t>(ScheduledTokenCount()) >= CurrentSequenceLength();
+}
+
+void Request::AdvanceChunk() {
+  processed_sequence_length_ += static_cast<int64_t>(ScheduledTokenCount());
+}
+
 int32_t Request::UnseenToken() {
   if (static_cast<size_t>(seen_sequence_length_) >= tokens_host_.size())
     throw std::runtime_error("All tokens have been seen.");
@@ -133,13 +152,12 @@ bool Request::HasUnseenTokens() const {
 
 DeviceSpan<int32_t> Request::UnprocessedTokens() {
   auto sequence = search_->GetSequence(0);
-  auto unprocessed_tokens = sequence.subspan(processed_sequence_length_, CurrentSequenceLength() - processed_sequence_length_);
-  return unprocessed_tokens;
+  return sequence.subspan(processed_sequence_length_, ScheduledTokenCount());
 }
 
 std::span<const int32_t> Request::UnprocessedTokensCpu() const {
   const size_t begin = static_cast<size_t>(processed_sequence_length_);
-  const size_t end = static_cast<size_t>(CurrentSequenceLength());
+  const size_t end = begin + ScheduledTokenCount();
   if (end > tokens_host_.size())
     throw std::runtime_error("The host token mirror is out of sync with the search sequence.");
 
@@ -240,7 +258,7 @@ void Request::CommitStep(const RequestStepPlan& plan,
   if (result.token_appended) {
     tokens_host_.push_back(result.token);
   }
-  processed_sequence_length_ = plan.sequence_length_before;
+  processed_sequence_length_ = static_cast<int64_t>(plan.target_cache_slots);
   status_ = result.done ? RequestStatus::Completed : RequestStatus::InProgress;
 }
 

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -4,6 +4,7 @@
 #include "request.h"
 
 #include "engine.h"
+#include "sequence_positions.h"
 #include "../search.h"
 
 namespace Generators {
@@ -86,6 +87,24 @@ int64_t Request::ProcessedSequenceLength() const {
   return processed_sequence_length_;
 }
 
+size_t Request::ScheduledTokenCount() const {
+  const size_t unprocessed = static_cast<size_t>(CurrentSequenceLength() - processed_sequence_length_);
+  return std::min(scheduled_token_count_, unprocessed);
+}
+
+void Request::ScheduleTokens(bool allow_chunking) {
+  const size_t unprocessed = static_cast<size_t>(CurrentSequenceLength() - processed_sequence_length_);
+  scheduled_token_count_ = Generators::ScheduledTokenCount(unprocessed, params_->search.chunk_size, allow_chunking);
+}
+
+bool Request::IsChunkComplete() const {
+  return processed_sequence_length_ + static_cast<int64_t>(ScheduledTokenCount()) >= CurrentSequenceLength();
+}
+
+void Request::AdvanceChunk() {
+  processed_sequence_length_ += static_cast<int64_t>(ScheduledTokenCount());
+}
+
 int32_t Request::UnseenToken() {
   auto sequence = search_->GetSequence(0).CopyDeviceToCpu();
   if (static_cast<size_t>(seen_sequence_length_) >= sequence.size())
@@ -100,8 +119,7 @@ bool Request::HasUnseenTokens() const {
 
 DeviceSpan<int32_t> Request::UnprocessedTokens() {
   auto sequence = search_->GetSequence(0);
-  auto unprocessed_tokens = sequence.subspan(processed_sequence_length_, CurrentSequenceLength() - processed_sequence_length_);
-  return unprocessed_tokens;
+  return sequence.subspan(processed_sequence_length_, ScheduledTokenCount());
 }
 
 bool Request::IsDone() const {
@@ -113,7 +131,7 @@ bool Request::IsPrefill() const {
 }
 
 void Request::GenerateNextTokens(DeviceSpan<float> logits) {
-  processed_sequence_length_ = search_->GetSequence(0).size();
+  AdvanceChunk();
   is_prefill_ = false;
 
   search_->SetLogits(logits);

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -54,6 +54,7 @@ void Request::Assign(std::shared_ptr<Engine> engine) {
   auto device_tokens = AllocateOnDevice(*params_, prefill_input_ids_);
   processed_sequence_length_ = 0;
   search_->AppendTokens(device_tokens);
+  prompt_sequence_length_ = CurrentSequenceLength();
   seen_sequence_length_ = CurrentSequenceLength();
   tokens_host_.reserve(params_->search.max_length);
   tokens_host_.insert(tokens_host_.end(), prefill_input_ids_.begin(), prefill_input_ids_.end());
@@ -97,6 +98,7 @@ void Request::AddTokens(std::span<const int32_t> tokens) {
   } else if (status_ == RequestStatus::Completed) {
     auto device_tokens = AllocateOnDevice(*params_, tokens);
     search_->AppendTokens(device_tokens);
+    prompt_sequence_length_ = CurrentSequenceLength();
     tokens_host_.insert(tokens_host_.end(), tokens.begin(), tokens.end());
   }
 }
@@ -126,9 +128,9 @@ size_t Request::ScheduledTokenCount() const {
   return std::min(scheduled_token_count_, unprocessed);
 }
 
-void Request::ScheduleTokens(bool allow_chunking) {
+void Request::ScheduleTokens() {
   const size_t unprocessed = static_cast<size_t>(CurrentSequenceLength() - processed_sequence_length_);
-  scheduled_token_count_ = Generators::ScheduledTokenCount(unprocessed, params_->search.chunk_size, allow_chunking);
+  scheduled_token_count_ = Generators::ScheduledTokenCount(unprocessed, params_->search.chunk_size);
 }
 
 bool Request::IsChunkComplete() const {
@@ -169,7 +171,7 @@ bool Request::IsDone() const {
 }
 
 bool Request::IsPrefill() const {
-  return processed_sequence_length_ == 0;
+  return processed_sequence_length_ < prompt_sequence_length_;
 }
 
 void Request::GenerateNextTokens(DeviceSpan<float> logits) {

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -145,7 +145,11 @@ struct Request : std::enable_shared_from_this<Request>,
 
   /**
    * @brief Checks if the request is in prefill mode.
-   * @return True if no tokens have been processed yet, false otherwise.
+   * @return True while the tokens the application supplied have not all been through the model.
+   *
+   * Stays true across every chunk of a chunked prefill, so callers that treat prefill steps
+   * differently from decode steps (graph capture, for one) never mistake a trailing one token
+   * prefill chunk for a decode step.
    */
   bool IsPrefill() const;
 
@@ -174,13 +178,12 @@ struct Request : std::enable_shared_from_this<Request>,
 
   /**
    * @brief Chooses the tokens this request contributes to the step that is about to run.
-   * @param allow_chunking Whether the caller can serve a prompt across several steps.
    *
-   * Called once per step, before anything reads UnprocessedTokens(). With chunking enabled and a
-   * `search.chunk_size` configured, a prompt longer than the chunk size is processed over several
-   * steps, which bounds the number of tokens a single model run carries.
+   * Called once per step, before anything reads UnprocessedTokens(). With a `search.chunk_size`
+   * configured, a prompt longer than the chunk size is processed over several steps, which bounds
+   * the number of tokens a single model run carries.
    */
-  void ScheduleTokens(bool allow_chunking);
+  void ScheduleTokens();
 
   /**
    * @brief True when this step's tokens run to the end of the sequence.
@@ -268,6 +271,9 @@ struct Request : std::enable_shared_from_this<Request>,
   std::vector<int32_t> tokens_host_;
   int64_t seen_sequence_length_{};
   int64_t processed_sequence_length_{};
+  // Sequence length the application's tokens reach up to. Everything below it is prompt, so the
+  // request is still prefilling while processed_sequence_length_ has not caught up with it.
+  int64_t prompt_sequence_length_{};
   size_t scheduled_token_count_{};
   std::shared_ptr<GeneratorParams> params_;
   std::unique_ptr<Search> search_;

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -172,6 +172,29 @@ struct Request : std::enable_shared_from_this<Request>,
    */
   int64_t ProcessedSequenceLength() const;
 
+  /**
+   * @brief Chooses the tokens this request contributes to the step that is about to run.
+   * @param allow_chunking Whether the caller can serve a prompt across several steps.
+   *
+   * Called once per step, before anything reads UnprocessedTokens(). With chunking enabled and a
+   * `search.chunk_size` configured, a prompt longer than the chunk size is processed over several
+   * steps, which bounds the number of tokens a single model run carries.
+   */
+  void ScheduleTokens(bool allow_chunking);
+
+  /**
+   * @brief True when this step's tokens run to the end of the sequence.
+   *
+   * Only then does the last logits row of this request predict a new token. A partial prefill chunk
+   * ends in the middle of the prompt, so its logits are discarded.
+   */
+  bool IsChunkComplete() const;
+
+  /**
+   * @brief Moves the cursor past the tokens this step processed.
+   */
+  void AdvanceChunk();
+
   RequestStatus status_{RequestStatus::Unassigned};
 
   /**
@@ -233,15 +256,19 @@ struct Request : std::enable_shared_from_this<Request>,
   void* GetOpaqueData();
 
  private:
+  // Tokens of the current step, clamped to what is actually left to process.
+  size_t ScheduledTokenCount() const;
+
   // The search sequence is partitioned at processed_sequence_length_: tokens before it already
-  // have KV entries, and UnprocessedTokens() returns [processed, current). seen_sequence_length_
-  // independently tracks tokens consumed by the application; both cursors are at most current.
+  // have KV entries, and UnprocessedTokens() returns the scheduled prefix of [processed, current).
+  // seen_sequence_length_ independently tracks tokens consumed by the application.
   std::vector<int32_t> prefill_input_ids_;
   // Host-side mirror of the full sequence (prompt + generated tokens). Kept in step with the
   // search's device sequence so that streaming and input-id preparation never read it back.
   std::vector<int32_t> tokens_host_;
   int64_t seen_sequence_length_{};
   int64_t processed_sequence_length_{};
+  size_t scheduled_token_count_{};
   std::shared_ptr<GeneratorParams> params_;
   std::unique_ptr<Search> search_;
   std::unique_ptr<BatchedSamplerState> batched_sampler_state_;

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -126,6 +126,29 @@ struct Request : std::enable_shared_from_this<Request>,
    */
   int64_t ProcessedSequenceLength() const;
 
+  /**
+   * @brief Chooses the tokens this request contributes to the step that is about to run.
+   * @param allow_chunking Whether the caller can serve a prompt across several steps.
+   *
+   * Called once per step, before anything reads UnprocessedTokens(). With chunking enabled and a
+   * `search.chunk_size` configured, a prompt longer than the chunk size is processed over several
+   * steps, which bounds the number of tokens a single model run carries.
+   */
+  void ScheduleTokens(bool allow_chunking);
+
+  /**
+   * @brief True when this step's tokens run to the end of the sequence.
+   *
+   * Only then does the last logits row of this request predict a new token. A partial prefill chunk
+   * ends in the middle of the prompt, so its logits are discarded.
+   */
+  bool IsChunkComplete() const;
+
+  /**
+   * @brief Moves the cursor past the tokens this step processed.
+   */
+  void AdvanceChunk();
+
   RequestStatus status_{RequestStatus::Unassigned};
 
   /**
@@ -155,9 +178,13 @@ struct Request : std::enable_shared_from_this<Request>,
   void* GetOpaqueData();
 
  private:
+  // Tokens of the current step, clamped to what is actually left to process.
+  size_t ScheduledTokenCount() const;
+
   std::vector<int32_t> prefill_input_ids_;
   int64_t seen_sequence_length_{};
   int64_t processed_sequence_length_{};
+  size_t scheduled_token_count_{};
   std::shared_ptr<GeneratorParams> params_;
   std::unique_ptr<Search> search_;
   std::weak_ptr<Engine> engine_;

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -9,8 +9,14 @@
 namespace Generators {
 
 ScheduledRequests::ScheduledRequests(std::vector<std::shared_ptr<Request>> requests,
-                                     std::shared_ptr<Model> model)
+                                     std::shared_ptr<Model> model,
+                                     bool allow_chunked_prefill)
     : requests_{requests}, model_{model} {
+  // Fixes what each request contributes to this step before anything reads UnprocessedTokens():
+  // the cache sizing, the decoder inputs and the logits row selection all have to agree on it.
+  for (auto& request : requests_) {
+    request->ScheduleTokens(allow_chunked_prefill);
+  }
 }
 
 std::unique_ptr<OrtRunOptions> ScheduledRequests::RunOptions() {
@@ -39,8 +45,18 @@ void ScheduledRequests::GenerateNextTokens() {
   }
 
   for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
-    if (requests_[request_idx]->status_ != RequestStatus::Completed) {
-      requests_[request_idx]->GenerateNextTokens(logits[request_idx]);
+    auto& request = requests_[request_idx];
+    if (request->status_ == RequestStatus::Completed) {
+      continue;
+    }
+
+    // A request whose prompt is still being chunked ends this step in the middle of its own prompt,
+    // so its last logits row predicts a token the prompt already supplies. It selects nothing and
+    // only moves its cursor, which is what makes the next step resume where this one stopped.
+    if (request->IsChunkComplete()) {
+      request->GenerateNextTokens(logits[request_idx]);
+    } else {
+      request->AdvanceChunk();
     }
   }
 }

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -34,12 +34,11 @@ std::optional<BatchedSamplingParams> ResolveSampleArgs(const Config::Search& sea
 ScheduledRequests::ScheduledRequests(std::vector<std::shared_ptr<Request>> requests,
                                      std::shared_ptr<Model> model,
                                      BatchedSampler* batched_sampler,
-                                     BatchedSamplingPlan* sampling_plan,
-                                     bool allow_chunked_prefill)
+                                     BatchedSamplingPlan* sampling_plan)
     : requests_{requests}, model_{model}, batched_sampler_{batched_sampler}, sampling_plan_{sampling_plan} {
   // Fixes what each request contributes to this step before anything reads UnprocessedTokens().
   for (auto& request : requests_) {
-    request->ScheduleTokens(allow_chunked_prefill);
+    request->ScheduleTokens();
   }
 }
 

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -34,8 +34,13 @@ std::optional<BatchedSamplingParams> ResolveSampleArgs(const Config::Search& sea
 ScheduledRequests::ScheduledRequests(std::vector<std::shared_ptr<Request>> requests,
                                      std::shared_ptr<Model> model,
                                      BatchedSampler* batched_sampler,
-                                     BatchedSamplingPlan* sampling_plan)
+                                     BatchedSamplingPlan* sampling_plan,
+                                     bool allow_chunked_prefill)
     : requests_{requests}, model_{model}, batched_sampler_{batched_sampler}, sampling_plan_{sampling_plan} {
+  // Fixes what each request contributes to this step before anything reads UnprocessedTokens().
+  for (auto& request : requests_) {
+    request->ScheduleTokens(allow_chunked_prefill);
+  }
 }
 
 ExecutionContext& ScheduledRequests::CreateExecutionContext() {
@@ -70,15 +75,22 @@ void ScheduledRequests::GenerateNextTokens() {
     // serialize the whole batch; launching all of them first means only the first completion below
     // actually waits for the device.
     for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
-      if (requests_[request_idx]->status_ != RequestStatus::Completed) {
+      if (requests_[request_idx]->status_ != RequestStatus::Completed &&
+          requests_[request_idx]->IsChunkComplete()) {
         requests_[request_idx]->GenerateNextTokens(logits[request_idx]);
       }
     }
 
     for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
-      if (requests_[request_idx]->status_ != RequestStatus::Completed) {
+      if (requests_[request_idx]->status_ != RequestStatus::Completed &&
+          requests_[request_idx]->IsChunkComplete()) {
         requests_[request_idx]->CompleteGeneration();
       }
+    }
+
+    for (const auto& request : requests_) {
+      if (request->status_ != RequestStatus::Completed && !request->IsChunkComplete())
+        request->AdvanceChunk();
     }
   } catch (...) {
     const auto error = std::current_exception();
@@ -110,7 +122,8 @@ bool ScheduledRequests::TryGenerateNextTokensBatched(std::vector<DeviceSpan<floa
     return false;
 
   for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
-    if (requests_[request_idx]->status_ != RequestStatus::Completed)
+    if (requests_[request_idx]->status_ != RequestStatus::Completed &&
+        requests_[request_idx]->IsChunkComplete())
       sampling_plan_->logits.push_back(logits[request_idx]);
   }
 
@@ -136,6 +149,10 @@ bool ScheduledRequests::TryGenerateNextTokensBatched(std::vector<DeviceSpan<floa
   for (auto* request : sampling_plan_->requests) {
     request->CompleteGeneration();
   }
+  for (const auto& request : requests_) {
+    if (request->status_ != RequestStatus::Completed && !request->IsChunkComplete())
+      request->AdvanceChunk();
+  }
 
   return true;
 }
@@ -149,7 +166,7 @@ bool ScheduledRequests::PrepareBatchedSamplingPlan(
 
   sampling_plan_->Clear();
   for (const auto& request : requests_) {
-    if (request->status_ == RequestStatus::Completed)
+    if (request->status_ == RequestStatus::Completed || !request->IsChunkComplete())
       continue;
 
     const auto args = ResolveSampleArgs(request->SearchOptions());
@@ -161,7 +178,7 @@ bool ScheduledRequests::PrepareBatchedSamplingPlan(
     sampling_plan_->params.push_back(*args);
     sampling_plan_->states.push_back(&request->SamplingState(*batched_sampler_));
   }
-  return true;
+  return !sampling_plan_->requests.empty();
 }
 
 void ScheduledRequests::BeginTransaction() {
@@ -200,35 +217,46 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
   }
 
   auto logits = ProcessLogits();
-  results.clear();
+  results.assign(requests_.size(), RequestStepResult{});
   if (transaction_uses_batched_sampler_) {
-    if (sampling_plan_->requests.size() != requests_.size())
-      throw std::logic_error("Batched sampling plan does not match the scheduled requests.");
-
     sampling_plan_->logits.clear();
+    size_t sampling_index = 0;
     for (size_t i = 0; i < requests_.size(); ++i) {
+      if (!requests_[i]->IsChunkComplete())
+        continue;
+      if (sampling_index >= sampling_plan_->requests.size() ||
+          sampling_plan_->requests[sampling_index] != requests_[i].get()) {
+        throw std::logic_error("Batched sampling plan does not match the scheduled requests.");
+      }
       sampling_plan_->logits.push_back(logits[i]);
       requests_[i]->PrepareGenerationForTransaction(logits[i]);
+      ++sampling_index;
     }
+    if (sampling_index != sampling_plan_->requests.size())
+      throw std::logic_error("Batched sampling plan does not match the scheduled requests.");
 
     auto next_tokens = batched_sampler_->Sample(
         sampling_plan_->logits, sampling_plan_->params,
         sampling_plan_->states, model_->config_->model.vocab_size);
-    for (size_t i = 0; i < requests_.size(); ++i) {
-      if (!requests_[i]->BindNextTokensSlot(next_tokens.subspan(i, 1)))
+    for (size_t i = 0; i < sampling_plan_->requests.size(); ++i) {
+      if (!sampling_plan_->requests[i]->BindNextTokensSlot(next_tokens.subspan(i, 1)))
         throw std::runtime_error("The request search rejected the batched sampler output.");
-      requests_[i]->OnNextTokensSampled();
+      sampling_plan_->requests[i]->OnNextTokensSampled();
     }
     next_tokens.CopyDeviceToCpu();
+    sampling_index = 0;
     for (size_t i = 0; i < requests_.size(); ++i) {
-      results.push_back(
-          requests_[i]->StageGenerationForTransaction(plan.requests[i]));
+      if (!requests_[i]->IsChunkComplete())
+        continue;
+      results[i] = requests_[i]->StageGenerationForTransaction(plan.requests[i]);
+      ++sampling_index;
     }
     return;
   }
 
   for (size_t i = 0; i < requests_.size(); ++i) {
-    results.push_back(requests_[i]->ApplyLogitsForTransaction(logits[i]));
+    if (requests_[i]->IsChunkComplete())
+      results[i] = requests_[i]->ApplyLogitsForTransaction(logits[i]);
   }
 }
 

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -32,14 +32,10 @@ struct BatchedSamplingPlan {
 };
 
 struct ScheduledRequests {
-  // `allow_chunked_prefill` lets a request spread a prompt longer than its `search.chunk_size` over
-  // several steps. Only the paged cache can serve that, since it is the only one that can hold a
-  // partly written sequence.
   ScheduledRequests(std::vector<std::shared_ptr<Request>> requests,
                     std::shared_ptr<Model> model,
                     BatchedSampler* batched_sampler,
-                    BatchedSamplingPlan* sampling_plan,
-                    bool allow_chunked_prefill = false);
+                    BatchedSamplingPlan* sampling_plan);
 
   ExecutionContext& CreateExecutionContext();
 

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -10,8 +10,12 @@ namespace Generators {
 struct DecoderIO;
 
 struct ScheduledRequests {
+  // `allow_chunked_prefill` lets a request spread a prompt longer than its `search.chunk_size` over
+  // several steps. Only the paged cache can serve that, since it is the only one that can hold a
+  // partly written sequence.
   ScheduledRequests(std::vector<std::shared_ptr<Request>> requests,
-                    std::shared_ptr<Model> model);
+                    std::shared_ptr<Model> model,
+                    bool allow_chunked_prefill = false);
 
   std::unique_ptr<OrtRunOptions> RunOptions();
 

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -32,10 +32,14 @@ struct BatchedSamplingPlan {
 };
 
 struct ScheduledRequests {
+  // `allow_chunked_prefill` lets a request spread a prompt longer than its `search.chunk_size` over
+  // several steps. Only the paged cache can serve that, since it is the only one that can hold a
+  // partly written sequence.
   ScheduledRequests(std::vector<std::shared_ptr<Request>> requests,
                     std::shared_ptr<Model> model,
                     BatchedSampler* batched_sampler,
-                    BatchedSamplingPlan* sampling_plan);
+                    BatchedSamplingPlan* sampling_plan,
+                    bool allow_chunked_prefill = false);
 
   ExecutionContext& CreateExecutionContext();
 

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -198,8 +198,8 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     entry.request_id = request.get();
     entry.sequence_length_before = snapshot.current_sequence_length;
     entry.unprocessed_token_count = ScheduledTokenCount(
-      static_cast<size_t>(remaining_token_count), request->SearchOptions().chunk_size,
-      /*allow_chunking=*/true);
+        static_cast<size_t>(remaining_token_count), request->SearchOptions().chunk_size,
+        /*allow_chunking=*/true);
     entry.target_cache_slots = RequiredSlots(
         static_cast<size_t>(snapshot.processed_sequence_length),
         entry.unprocessed_token_count);

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -29,13 +29,19 @@ ScheduledRequests Scheduler::CreateScheduledRequests(const StepPlan& plan) {
     requests.push_back(entry.request);
   }
   return ScheduledRequests{std::move(requests), model_, GetBatchedSampler(),
-                           GetBatchedSamplingPlan(), /*allow_chunked_prefill=*/true};
+                           GetBatchedSamplingPlan()};
 }
 
 StaticBatchScheduler::StaticBatchScheduler(std::shared_ptr<Model> model, std::shared_ptr<CacheManager> cache_manager)
     : Scheduler{model}, model_{model}, cache_manager_{cache_manager} {}
 
 void StaticBatchScheduler::AddRequest(std::shared_ptr<Request> request) {
+  // The static batch decoder rebuilds its contiguous cache from the whole sequence every step, so it
+  // cannot resume a half written prompt. Only the paged cache can hold one.
+  if (request->SearchOptions().chunk_size.value_or(0) != 0) {
+    throw std::runtime_error(
+        "search.chunk_size requires dynamic batching; the static batch scheduler cannot chunk a prefill.");
+  }
   if (auto* sampler = GetBatchedSampler())
     request->SamplingState(*sampler);
   requests_pool_.push_back(request);
@@ -147,7 +153,7 @@ ScheduledRequests DynamicBatchScheduler::Schedule() {
     requests.push_back(entry.request);
   }
   return ScheduledRequests{std::move(requests), model_, GetBatchedSampler(),
-                           GetBatchedSamplingPlan(), /*allow_chunked_prefill=*/true};
+                           GetBatchedSamplingPlan()};
 }
 
 void DynamicBatchScheduler::ReapCompletedRequests() {
@@ -198,11 +204,12 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     entry.request_id = request.get();
     entry.sequence_length_before = snapshot.current_sequence_length;
     entry.unprocessed_token_count = ScheduledTokenCount(
-        static_cast<size_t>(remaining_token_count), request->SearchOptions().chunk_size,
-        /*allow_chunking=*/true);
+        static_cast<size_t>(remaining_token_count), request->SearchOptions().chunk_size);
     entry.target_cache_slots = RequiredSlots(
         static_cast<size_t>(snapshot.processed_sequence_length),
         entry.unprocessed_token_count);
+    entry.whole_sequence_cache_slots =
+        SlotsForWholeSequence(snapshot.current_sequence_length);
     entry.is_prefill = snapshot.is_prefill;
     entry.newly_admitted = newly_admitted;
     plan.requests.push_back(std::move(entry));

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -54,7 +54,7 @@ ScheduledRequests StaticBatchScheduler::Schedule() {
     }
   }
 
-  ScheduledRequests scheduled_requests(cache_manager_->AllocatedRequests(), model_);
+  ScheduledRequests scheduled_requests(cache_manager_->AllocatedRequests(), model_, /*allow_chunked_prefill=*/false);
 
   if (!scheduled_requests) {
     throw std::runtime_error("Unable to schedule requests: no requests available or all requests are completed.");
@@ -118,7 +118,7 @@ ScheduledRequests DynamicBatchScheduler::Schedule() {
     }
   }
 
-  ScheduledRequests scheduled_requests(cache_manager_->AllocatedRequests(), model_);
+  ScheduledRequests scheduled_requests(cache_manager_->AllocatedRequests(), model_, /*allow_chunked_prefill=*/true);
 
   if (!scheduled_requests) {
     throw std::runtime_error("Unable to schedule requests: no requests available or all requests are completed.");

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -3,6 +3,7 @@
 
 #include "engine.h"
 #include "admission.h"
+#include "sequence_positions.h"
 
 namespace Generators {
 
@@ -28,7 +29,7 @@ ScheduledRequests Scheduler::CreateScheduledRequests(const StepPlan& plan) {
     requests.push_back(entry.request);
   }
   return ScheduledRequests{std::move(requests), model_, GetBatchedSampler(),
-                           GetBatchedSamplingPlan()};
+                           GetBatchedSamplingPlan(), /*allow_chunked_prefill=*/true};
 }
 
 StaticBatchScheduler::StaticBatchScheduler(std::shared_ptr<Model> model, std::shared_ptr<CacheManager> cache_manager)
@@ -146,7 +147,7 @@ ScheduledRequests DynamicBatchScheduler::Schedule() {
     requests.push_back(entry.request);
   }
   return ScheduledRequests{std::move(requests), model_, GetBatchedSampler(),
-                           GetBatchedSamplingPlan()};
+                           GetBatchedSamplingPlan(), /*allow_chunked_prefill=*/true};
 }
 
 void DynamicBatchScheduler::ReapCompletedRequests() {
@@ -186,9 +187,9 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     if (snapshot.status != expected_status) {
       throw std::runtime_error("Request status is invalid for dynamic step planning.");
     }
-    const auto unprocessed_token_count =
+    const auto remaining_token_count =
         snapshot.current_sequence_length - snapshot.processed_sequence_length;
-    if (unprocessed_token_count <= 0) {
+    if (remaining_token_count <= 0) {
       throw std::runtime_error("Cannot plan a request with no unprocessed tokens.");
     }
 
@@ -196,8 +197,9 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     entry.request = request;
     entry.request_id = request.get();
     entry.sequence_length_before = snapshot.current_sequence_length;
-    entry.unprocessed_token_count =
-        static_cast<size_t>(unprocessed_token_count);
+    entry.unprocessed_token_count = ScheduledTokenCount(
+      static_cast<size_t>(remaining_token_count), request->SearchOptions().chunk_size,
+      /*allow_chunking=*/true);
     entry.target_cache_slots = RequiredSlots(
         static_cast<size_t>(snapshot.processed_sequence_length),
         entry.unprocessed_token_count);

--- a/src/engine/sequence_positions.h
+++ b/src/engine/sequence_positions.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace Generators {
+
+// Absolute-position arithmetic shared by the varlen decoder and the paged KV cache.
+//
+// PagedAttention writes token j of sequence i at absolute position `past_sequence_lengths[i] + j`,
+// so the decoder and the cache have to agree on what that base is. Both derive it from the number
+// of tokens whose keys and values are already in the cache -- never from the sequence length, which
+// is one longer on a decode step because the search has already appended the token that is about to
+// be processed.
+
+// Slots the cache must own once the pending step has run: the step writes at absolute positions
+// [processed_length, processed_length + scheduled_tokens).
+constexpr size_t SlotsAfterStep(int64_t processed_length, size_t scheduled_tokens) {
+  return static_cast<size_t>(processed_length) + scheduled_tokens;
+}
+
+// Slots the request will need once its whole sequence is in the cache. Used for admission, so that
+// a request is never accepted and then left stalled part way through its prefill.
+constexpr size_t SlotsForWholeSequence(int64_t sequence_length) {
+  return static_cast<size_t>(sequence_length);
+}
+
+}  // namespace Generators

--- a/src/engine/sequence_positions.h
+++ b/src/engine/sequence_positions.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 namespace Generators {
 
@@ -26,6 +28,20 @@ constexpr size_t SlotsAfterStep(int64_t processed_length, size_t scheduled_token
 // a request is never accepted and then left stalled part way through its prefill.
 constexpr size_t SlotsForWholeSequence(int64_t sequence_length) {
   return static_cast<size_t>(sequence_length);
+}
+
+// Tokens a request contributes to the step that is about to run, out of the `unprocessed` tokens it
+// still has to push through the model.
+//
+// With chunking enabled and a `search.chunk_size` configured, a prompt longer than the chunk size
+// is spread over several steps, which bounds the activation footprint and the latency of a single
+// step. Everything downstream -- the cache sizing, the decoder inputs and the logits row selection
+// -- has to agree on this count, hence one definition of it.
+constexpr size_t ScheduledTokenCount(size_t unprocessed, std::optional<size_t> chunk_size, bool allow_chunking) {
+  if (!allow_chunking || !chunk_size.has_value() || *chunk_size == 0) {
+    return unprocessed;
+  }
+  return std::min(*chunk_size, unprocessed);
 }
 
 }  // namespace Generators

--- a/src/engine/sequence_positions.h
+++ b/src/engine/sequence_positions.h
@@ -33,12 +33,12 @@ constexpr size_t SlotsForWholeSequence(int64_t sequence_length) {
 // Tokens a request contributes to the step that is about to run, out of the `unprocessed` tokens it
 // still has to push through the model.
 //
-// With chunking enabled and a `search.chunk_size` configured, a prompt longer than the chunk size
-// is spread over several steps, which bounds the activation footprint and the latency of a single
-// step. Everything downstream -- the cache sizing, the decoder inputs and the logits row selection
-// -- has to agree on this count, hence one definition of it.
-constexpr size_t ScheduledTokenCount(size_t unprocessed, std::optional<size_t> chunk_size, bool allow_chunking) {
-  if (!allow_chunking || !chunk_size.has_value() || *chunk_size == 0) {
+// With a `search.chunk_size` configured, a prompt longer than the chunk size is spread over several
+// steps, which bounds the activation footprint and the latency of a single step. Everything
+// downstream -- the cache sizing, the decoder inputs and the logits row selection -- has to agree on
+// this count, hence one definition of it.
+constexpr size_t ScheduledTokenCount(size_t unprocessed, std::optional<size_t> chunk_size) {
+  if (!chunk_size.has_value() || *chunk_size == 0) {
     return unprocessed;
   }
   return std::min(*chunk_size, unprocessed);

--- a/src/engine/step_plan.h
+++ b/src/engine/step_plan.h
@@ -48,11 +48,12 @@ struct StepPlanningResult {
 struct RequestStepPlan {
   std::shared_ptr<Request> request;
   const void* request_id{};
-  int64_t sequence_length_before{};  // Search length before this transaction appends a token.
-  size_t unprocessed_token_count{};  // Prompt chunk or single decode token sent to the model.
-  size_t packed_token_offset{};      // First row for this request in the flat varlen input.
-  size_t logits_row_index{};         // Last packed row; its logits produce this request's next token.
-  size_t target_cache_slots{};       // Committed KV slots required after the model run succeeds.
+  int64_t sequence_length_before{};     // Search length before this transaction appends a token.
+  size_t unprocessed_token_count{};     // Prompt chunk or single decode token sent to the model.
+  size_t packed_token_offset{};         // First row for this request in the flat varlen input.
+  size_t logits_row_index{};            // Last packed row; its logits produce this request's next token.
+  size_t target_cache_slots{};          // Committed KV slots required after the model run succeeds.
+  size_t whole_sequence_cache_slots{};  // KV slots for the whole sequence; admission is decided on this.
   bool is_prefill{};
   bool newly_admitted{};
 };

--- a/src/engine/step_plan.h
+++ b/src/engine/step_plan.h
@@ -53,7 +53,7 @@ struct RequestStepPlan {
   size_t packed_token_offset{};         // First row for this request in the flat varlen input.
   size_t logits_row_index{};            // Last packed row; its logits produce this request's next token.
   size_t target_cache_slots{};          // Committed KV slots required after the model run succeeds.
-  size_t whole_sequence_cache_slots{};  // KV slots for the whole sequence; admission is decided on this.
+  size_t whole_sequence_cache_slots{};  // KV slots the whole sequence needs; admitted and reserved on this.
   bool is_prefill{};
   bool newly_admitted{};
 };

--- a/test/engine/paged_cache_reservation_tests.cpp
+++ b/test/engine/paged_cache_reservation_tests.cpp
@@ -133,5 +133,38 @@ TEST(PagedCacheReservationTest, CommitPublishesNewOwnershipExactlyOnce) {
   EXPECT_THROW(reservation.Release(), std::logic_error);
 }
 
+// A newly admitted chunked prefill takes the blocks for its whole prompt up front, so the rest of
+// the pool cannot be handed to another request between chunks, but only the chunk is committed.
+TEST(PagedCacheReservationTest, ChunkedPrefillHoldsWholePromptButCommitsOnlyTheChunk) {
+  BlockPool pool{kBlockSize, 3};
+  std::vector<PagedCacheBlockTable> tables;
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, /*target_slots=*/2, /*newly_admitted=*/true,
+                                   /*reserved_slots=*/9},
+  };
+
+  PagedCacheReservation reservation{pool, tables, requests};
+  EXPECT_EQ(reservation.ReservedBlockCount(), 3u);
+  EXPECT_EQ(pool.AvailableBlocks(), 0u);
+
+  reservation.Commit();
+
+  ASSERT_EQ(tables.size(), 1u);
+  EXPECT_EQ(tables[0].committed_slots, 2u);
+  EXPECT_EQ(tables[0].blocks.size(), 3u);
+
+  // The next chunk finds its capacity already owned and needs no new block.
+  const std::array next_requests{
+      PagedCacheReservationRequest{kRequestA, /*target_slots=*/6, /*newly_admitted=*/false,
+                                   /*reserved_slots=*/9},
+  };
+  PagedCacheReservation next{pool, tables, next_requests};
+  EXPECT_EQ(next.ReservedBlockCount(), 0u);
+
+  next.Commit();
+  EXPECT_EQ(tables[0].committed_slots, 6u);
+  EXPECT_EQ(tables[0].blocks.size(), 3u);
+}
+
 }  // namespace
 }  // namespace Generators

--- a/test/engine/paged_key_value_cache_tests.cpp
+++ b/test/engine/paged_key_value_cache_tests.cpp
@@ -40,11 +40,13 @@ class PagedKeyValueCacheTest : public ::testing::Test {
   static RequestStepPlan PlanEntry(
       const std::shared_ptr<Request>& request,
       size_t target_cache_slots,
-      bool newly_admitted = false) {
+      bool newly_admitted = false,
+      size_t whole_sequence_cache_slots = 0) {
     RequestStepPlan entry;
     entry.request = request;
     entry.request_id = request.get();
     entry.target_cache_slots = target_cache_slots;
+    entry.whole_sequence_cache_slots = whole_sequence_cache_slots;
     entry.newly_admitted = newly_admitted;
     return entry;
   }
@@ -136,6 +138,49 @@ TEST_F(PagedKeyValueCacheTest, DeferredActiveRequestsStillConsumeAdmissionCapaci
   ASSERT_EQ(plan.requests.size(), 1u);
   EXPECT_EQ(plan.requests[0].request, fitting);
   EXPECT_FALSE(plan.requests[0].newly_admitted);
+}
+
+// A chunked prefill asks for one chunk at a time, but admission has to be decided on the whole
+// prompt: the pool is three blocks of four slots, so a prompt of thirteen slots can never fit even
+// though its first chunk would.
+TEST_F(PagedKeyValueCacheTest, PromptTooLargeForThePoolIsUnserviceableEvenWhenItsChunkFits) {
+  auto pending = MintAssignedRequest(
+      assign_target_, *model_, std::array<int32_t, 1>{10});
+
+  StepPlan plan;
+  plan.requests.push_back(PlanEntry(pending, /*target_cache_slots=*/1, /*newly_admitted=*/true,
+                                    /*whole_sequence_cache_slots=*/13));
+
+  const auto result =
+      cache_->PlanStepResources(plan, /*committed_request_count=*/0);
+
+  EXPECT_FALSE(result.executable);
+  EXPECT_EQ(result.unserviceable_request_id, pending.get());
+  EXPECT_TRUE(plan.requests.empty());
+}
+
+// Admission also has to wait for enough free blocks to hold the whole prompt, so a request never
+// starts a chunked prefill it cannot finish.
+TEST_F(PagedKeyValueCacheTest, AdmissionWaitsUntilTheWholePromptFits) {
+  auto committed = AddCommittedRequest({2, 3, 4, 5});
+  auto pending = MintAssignedRequest(
+      assign_target_, *model_, std::array<int32_t, 1>{10});
+
+  StepPlan plan;
+  plan.requests.push_back(PlanEntry(committed, /*target_cache_slots=*/4));
+  // One block is already taken, leaving two of the three: the chunk needs one, the prompt needs
+  // three.
+  plan.requests.push_back(PlanEntry(pending, /*target_cache_slots=*/1, /*newly_admitted=*/true,
+                                    /*whole_sequence_cache_slots=*/9));
+
+  const auto result =
+      cache_->PlanStepResources(plan, /*committed_request_count=*/1);
+
+  ASSERT_TRUE(result.executable);
+  EXPECT_TRUE(result.capacity_deferred);
+  EXPECT_EQ(result.unserviceable_request_id, nullptr);
+  ASSERT_EQ(plan.requests.size(), 1u);
+  EXPECT_EQ(plan.requests[0].request, committed);
 }
 
 }  // namespace

--- a/test/engine/request_lifecycle_tests.cpp
+++ b/test/engine/request_lifecycle_tests.cpp
@@ -220,7 +220,8 @@ TEST_F(RequestLifecycleTest, PartialPrefillAdvancesOnlyAtCommit) {
   EXPECT_EQ(committed.status, RequestStatus::InProgress);
   EXPECT_EQ(committed.current_sequence_length, before.current_sequence_length);
   EXPECT_EQ(committed.processed_sequence_length, 2);
-  EXPECT_FALSE(committed.is_prefill);
+  // Two of the three prompt tokens are in the cache, so the request is still prefilling.
+  EXPECT_TRUE(committed.is_prefill);
   EXPECT_FALSE(request->HasUnseenTokens());
 }
 

--- a/test/engine/request_lifecycle_tests.cpp
+++ b/test/engine/request_lifecycle_tests.cpp
@@ -157,6 +157,7 @@ TEST_F(RequestLifecycleTest, TransactionalLogitsStageUntilCommit) {
   plan.request = request;
   plan.request_id = request.get();
   plan.sequence_length_before = before.current_sequence_length;
+  plan.target_cache_slots = static_cast<size_t>(before.current_sequence_length);
   const int32_t next_token = 5;
   auto logits = LogitsForToken(*model_, next_token);
 
@@ -200,6 +201,29 @@ TEST_F(RequestLifecycleTest, TransactionalLogitsRollbackRestoresSearchState) {
   EXPECT_FALSE(request->HasUnseenTokens());
 }
 
+TEST_F(RequestLifecycleTest, PartialPrefillAdvancesOnlyAtCommit) {
+  auto prompt = Prompt();
+  auto request = MintAssignedRequest(engine_.engine, *model_, prompt);
+  const auto before = request->Snapshot();
+  RequestStepPlan plan;
+  plan.request = request;
+  plan.request_id = request.get();
+  plan.sequence_length_before = before.current_sequence_length;
+  plan.unprocessed_token_count = 2;
+  plan.target_cache_slots = 2;
+
+  request->SaveStateForTransaction();
+  request->CommitStateForTransaction();
+  request->CommitStep(plan, RequestStepResult{});
+
+  const auto committed = request->Snapshot();
+  EXPECT_EQ(committed.status, RequestStatus::InProgress);
+  EXPECT_EQ(committed.current_sequence_length, before.current_sequence_length);
+  EXPECT_EQ(committed.processed_sequence_length, 2);
+  EXPECT_FALSE(committed.is_prefill);
+  EXPECT_FALSE(request->HasUnseenTokens());
+}
+
 TEST_F(RequestLifecycleTest, FirstTransactionalStepCanCommitDirectlyToCompleted) {
   auto prompt = Prompt();
   auto request = MintAssignedRequest(engine_.engine, *model_, prompt);
@@ -208,6 +232,7 @@ TEST_F(RequestLifecycleTest, FirstTransactionalStepCanCommitDirectlyToCompleted)
   plan.request = request;
   plan.request_id = request.get();
   plan.sequence_length_before = before.current_sequence_length;
+  plan.target_cache_slots = static_cast<size_t>(before.current_sequence_length);
   auto logits = LogitsForToken(*model_, EosToken(*model_));
 
   request->SaveStateForTransaction();

--- a/test/prefill_chunking_test.cpp
+++ b/test/prefill_chunking_test.cpp
@@ -35,8 +35,8 @@ struct RequestSimulator {
 
   size_t Unprocessed() const { return static_cast<size_t>(sequence_length - processed_length); }
 
-  void ScheduleTokens(std::optional<size_t> chunk_size, bool allow_chunking) {
-    scheduled = ScheduledTokenCount(Unprocessed(), chunk_size, allow_chunking);
+  void ScheduleTokens(std::optional<size_t> chunk_size) {
+    scheduled = ScheduledTokenCount(Unprocessed(), chunk_size);
   }
 
   bool IsChunkComplete() const {
@@ -47,14 +47,13 @@ struct RequestSimulator {
 };
 
 // Runs `num_steps` engine steps over a prompt and returns what the model was told on each one.
-std::vector<Step> RunSteps(int64_t prompt_length, std::optional<size_t> chunk_size, int num_steps,
-                           bool allow_chunking = true) {
+std::vector<Step> RunSteps(int64_t prompt_length, std::optional<size_t> chunk_size, int num_steps) {
   RequestSimulator request;
   request.AddTokens(prompt_length);
 
   std::vector<Step> steps;
   for (int i = 0; i < num_steps; ++i) {
-    request.ScheduleTokens(chunk_size, allow_chunking);
+    request.ScheduleTokens(chunk_size);
     steps.emplace_back(request.processed_length, request.scheduled);
 
     const bool selects_token = request.IsChunkComplete();
@@ -67,12 +66,6 @@ std::vector<Step> RunSteps(int64_t prompt_length, std::optional<size_t> chunk_si
 }
 
 }  // namespace
-
-TEST(PrefillChunkingTest, WholePromptWhenChunkingIsDisabled) {
-  // The static batch path never chunks, whatever search.chunk_size says.
-  EXPECT_EQ(RunSteps(512, 128, 3, /*allow_chunking=*/false),
-            (std::vector<Step>{{0, 512}, {512, 1}, {513, 1}}));
-}
 
 TEST(PrefillChunkingTest, WholePromptWhenNoChunkSizeIsConfigured) {
   EXPECT_EQ(RunSteps(512, std::nullopt, 3), (std::vector<Step>{{0, 512}, {512, 1}, {513, 1}}));

--- a/test/prefill_chunking_test.cpp
+++ b/test/prefill_chunking_test.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for the chunked prefill schedule: how many tokens a request contributes to one engine
+// step, and where in the KV cache the model writes them.
+//
+// The schedule and the cache accounting come from the same two helpers the engine uses
+// (`ScheduledTokenCount` and `SlotsAfterStep`), so a step can never be sized differently from the
+// tokens it carries. The simulation below mirrors what Request does with them: schedule a chunk,
+// run it, advance the cursor, and -- once the prompt is exhausted -- append the predicted token.
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine/sequence_positions.h"
+
+namespace Generators::test {
+namespace {
+
+// (past_sequence_length, query_length) as the model sees them on one step.
+using Step = std::pair<int64_t, size_t>;
+
+// Mirrors the cursors Request keeps: the search's sequence length, which grows as soon as a token
+// is selected, and the processed length, which only grows once tokens have been through the model.
+struct RequestSimulator {
+  int64_t sequence_length{};
+  int64_t processed_length{};
+  size_t scheduled{};
+
+  void AddTokens(int64_t count) { sequence_length += count; }
+
+  size_t Unprocessed() const { return static_cast<size_t>(sequence_length - processed_length); }
+
+  void ScheduleTokens(std::optional<size_t> chunk_size, bool allow_chunking) {
+    scheduled = ScheduledTokenCount(Unprocessed(), chunk_size, allow_chunking);
+  }
+
+  bool IsChunkComplete() const {
+    return processed_length + static_cast<int64_t>(scheduled) >= sequence_length;
+  }
+
+  void AdvanceChunk() { processed_length += static_cast<int64_t>(scheduled); }
+};
+
+// Runs `num_steps` engine steps over a prompt and returns what the model was told on each one.
+std::vector<Step> RunSteps(int64_t prompt_length, std::optional<size_t> chunk_size, int num_steps,
+                           bool allow_chunking = true) {
+  RequestSimulator request;
+  request.AddTokens(prompt_length);
+
+  std::vector<Step> steps;
+  for (int i = 0; i < num_steps; ++i) {
+    request.ScheduleTokens(chunk_size, allow_chunking);
+    steps.emplace_back(request.processed_length, request.scheduled);
+
+    const bool selects_token = request.IsChunkComplete();
+    request.AdvanceChunk();
+    if (selects_token) {
+      request.AddTokens(1);  // The step's last logits row predicted a token.
+    }
+  }
+  return steps;
+}
+
+}  // namespace
+
+TEST(PrefillChunkingTest, WholePromptWhenChunkingIsDisabled) {
+  // The static batch path never chunks, whatever search.chunk_size says.
+  EXPECT_EQ(RunSteps(512, 128, 3, /*allow_chunking=*/false),
+            (std::vector<Step>{{0, 512}, {512, 1}, {513, 1}}));
+}
+
+TEST(PrefillChunkingTest, WholePromptWhenNoChunkSizeIsConfigured) {
+  EXPECT_EQ(RunSteps(512, std::nullopt, 3), (std::vector<Step>{{0, 512}, {512, 1}, {513, 1}}));
+  // A chunk size of zero means "not configured", matching how Config parses it.
+  EXPECT_EQ(RunSteps(512, 0, 3), (std::vector<Step>{{0, 512}, {512, 1}, {513, 1}}));
+}
+
+TEST(PrefillChunkingTest, PromptIsSpreadOverSteps) {
+  // A 512 token prompt at chunk 128: four full chunks, then decode one token at a time.
+  EXPECT_EQ(RunSteps(512, 128, 6),
+            (std::vector<Step>{{0, 128}, {128, 128}, {256, 128}, {384, 128}, {512, 1}, {513, 1}}));
+}
+
+TEST(PrefillChunkingTest, LastChunkIsShort) {
+  EXPECT_EQ(RunSteps(300, 128, 4), (std::vector<Step>{{0, 128}, {128, 128}, {256, 44}, {300, 1}}));
+}
+
+TEST(PrefillChunkingTest, ChunkLargerThanPromptRunsInOneStep) {
+  EXPECT_EQ(RunSteps(10, 128, 3), (std::vector<Step>{{0, 10}, {10, 1}, {11, 1}}));
+}
+
+TEST(PrefillChunkingTest, ChunkOfOneDegradesToTokenAtATime) {
+  EXPECT_EQ(RunSteps(4, 1, 6),
+            (std::vector<Step>{{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}}));
+}
+
+TEST(PrefillChunkingTest, EveryPositionIsWrittenExactlyOnce) {
+  // Whatever the chunk size, the steps tile the sequence: no position is skipped and none is
+  // written twice. This is what makes a chunked prefill produce the same KV cache as an unchunked
+  // one.
+  for (size_t chunk_size : {size_t{1}, size_t{7}, size_t{37}, size_t{64}, size_t{128}, size_t{512}}) {
+    int64_t next_expected_position = 0;
+    for (const auto& [past, query_length] : RunSteps(551, chunk_size, 24)) {
+      EXPECT_EQ(past, next_expected_position) << "chunk_size=" << chunk_size;
+      EXPECT_GT(query_length, 0u) << "chunk_size=" << chunk_size;
+      EXPECT_LE(query_length, chunk_size) << "chunk_size=" << chunk_size;
+      next_expected_position = past + static_cast<int64_t>(query_length);
+    }
+  }
+}
+
+TEST(PrefillChunkingTest, CacheIsSizedForExactlyTheScheduledTokens) {
+  // The slots the cache must own after a step cover the tokens the step actually writes, never the
+  // whole remaining prompt. A chunked prefill therefore grows the cache one chunk at a time.
+  const auto chunked = RunSteps(551, 128, 6);
+  const auto unchunked = RunSteps(551, std::nullopt, 6);
+
+  EXPECT_EQ(SlotsAfterStep(chunked[0].first, chunked[0].second), 128u);
+  EXPECT_EQ(SlotsAfterStep(unchunked[0].first, unchunked[0].second), 551u);
+
+  // Both reach the same total once the prompt is in: five chunks, then one decoded token.
+  EXPECT_EQ(SlotsAfterStep(chunked.back().first, chunked.back().second), 552u);
+}
+
+}  // namespace Generators::test

--- a/test/sequence_positions_test.cpp
+++ b/test/sequence_positions_test.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for the absolute-position arithmetic in `src/engine/sequence_positions.h`, which the
+// varlen decoder and the paged KV cache both use to place a step's tokens in the cache.
+//
+// The invariant under test is that the base position is the number of tokens already written to
+// the cache, not the length of the sequence. The two differ on every decode step, because token
+// selection appends the next token before the step that processes it runs. Deriving the base from
+// the sequence length left every generated token one slot too high, skipped the slot below it and
+// shifted the rotary positions of every decode token by one.
+
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine/sequence_positions.h"
+
+namespace Generators::test {
+namespace {
+
+// Mirrors the two cursors a Request keeps over its own sequence: the search's sequence length,
+// which grows as soon as a token is selected, and the processed length, which only grows once the
+// tokens have been through the model.
+struct SequenceCursor {
+  int64_t sequence_length{};
+  int64_t processed_length{};
+
+  void AppendPrompt(int64_t prompt_length) { sequence_length += prompt_length; }
+
+  size_t Unprocessed() const { return static_cast<size_t>(sequence_length - processed_length); }
+
+  // One engine step: the tokens between the two cursors go through the model, then the token the
+  // step predicted is appended to the sequence.
+  void Step() {
+    processed_length = sequence_length;
+    sequence_length += 1;
+  }
+};
+
+// The absolute positions a step writes to, as the operator resolves them.
+std::vector<int64_t> WrittenPositions(const SequenceCursor& cursor) {
+  std::vector<int64_t> positions;
+  for (size_t j = 0; j < cursor.Unprocessed(); ++j) {
+    positions.push_back(cursor.processed_length + static_cast<int64_t>(j));
+  }
+  return positions;
+}
+
+}  // namespace
+
+TEST(SequencePositionsTest, PrefillStartsAtZero) {
+  SequenceCursor cursor;
+  cursor.AppendPrompt(5);
+
+  EXPECT_EQ(cursor.processed_length, 0);
+  EXPECT_EQ(cursor.Unprocessed(), 5u);
+  EXPECT_EQ(SlotsAfterStep(cursor.processed_length, cursor.Unprocessed()), 5u);
+}
+
+TEST(SequencePositionsTest, DecodeStepsWriteConsecutivePositions) {
+  // The regression: on a five token prompt the operator used to be told 0, 6, 7, 8 where it should
+  // have been told 0, 5, 6, 7.
+  SequenceCursor cursor;
+  cursor.AppendPrompt(5);
+
+  std::vector<int64_t> reported_past;
+  std::vector<int64_t> all_written;
+  for (int step = 0; step < 4; ++step) {
+    reported_past.push_back(cursor.processed_length);
+    for (int64_t position : WrittenPositions(cursor)) {
+      all_written.push_back(position);
+    }
+    cursor.Step();
+  }
+
+  EXPECT_EQ(reported_past, (std::vector<int64_t>{0, 5, 6, 7}));
+  // Every position from 0 up to the last one written is covered exactly once: no gap, no overlap.
+  EXPECT_EQ(all_written, (std::vector<int64_t>{0, 1, 2, 3, 4, 5, 6, 7}));
+}
+
+TEST(SequencePositionsTest, SlotsAfterStepCoversEveryWrittenPosition) {
+  SequenceCursor cursor;
+  cursor.AppendPrompt(3);
+
+  for (int step = 0; step < 6; ++step) {
+    const size_t slots = SlotsAfterStep(cursor.processed_length, cursor.Unprocessed());
+    for (int64_t position : WrittenPositions(cursor)) {
+      // A slot count that does not cover the highest position written is an out-of-bounds block
+      // table entry as soon as that position lands on a block boundary.
+      EXPECT_LT(static_cast<size_t>(position), slots);
+    }
+    cursor.Step();
+  }
+}
+
+TEST(SequencePositionsTest, AdmissionCoversTheWholePrompt) {
+  SequenceCursor cursor;
+  cursor.AppendPrompt(7);
+
+  // Admission reserves for the whole sequence, which the pending step must never exceed.
+  for (int step = 0; step < 5; ++step) {
+    EXPECT_LE(SlotsAfterStep(cursor.processed_length, cursor.Unprocessed()),
+              SlotsForWholeSequence(cursor.sequence_length));
+    cursor.Step();
+  }
+}
+
+}  // namespace Generators::test


### PR DESCRIPTION
### Description

> Stacked on #2354. Review the top commit only; the base PR is the first commit in the diff.

A prompt currently has to be prefilled in a single step, so a long prompt produces one enormous forward pass: a latency spike for whoever is decoding alongside it, a batch that has to be sized for the worst-case prompt, and a KV allocation that lands all at once.

This lets the scheduler hand a request its prompt a chunk at a time. `Config::Search::chunk_size` already exists and is already parsed; this is what makes it do something.

- `Request::ScheduleTokens(allow_chunking)` decides once per step how many unprocessed tokens the request will offer, and `UnprocessedTokens()` returns exactly that many. Everything downstream — the cache, the decoder inputs, the position arithmetic — already works off `UnprocessedTokens()`, so nothing else needs to know that chunking exists.
- `IsChunkComplete()` says whether the step finished the prompt. `ScheduledRequests::GenerateNextTokens()` samples a token only for the requests where it did; the rest just advance to the next chunk. That is the one place the distinction matters.
- The decision itself is `ScheduledTokenCount(unprocessed, chunk_size, allow_chunking)` in `src/engine/sequence_positions.h`, next to the position arithmetic it has to stay consistent with.

`DynamicBatchScheduler` enables it; `StaticBatchScheduler` does not, since it has no other requests to protect. With no `chunk_size` configured the behaviour is unchanged.

### Motivation and Context

Chunked prefill is the usual answer to prefill/decode interference in a continuous-batching engine. It is also a hard prerequisite for the paged sliding-window ring cache, which can only bound its memory if a step's token count is bounded.

### Tests

`test/prefill_chunking_test.cpp` drives a simulated request through the same arithmetic the engine uses and checks the resulting `(past, query_len)` sequence:

- a 512-token prompt at `chunk_size` 128 produces `{0,128} {128,128} {256,128} {384,128} {512,1} {513,1}` — four prefill steps, then decode,
- a short final chunk, a chunk larger than the prompt, and `chunk_size` 1 all behave,
- chunking off or `chunk_size` unset still prefills in one step,
- every position is written exactly once across the whole run, and the cache is asked for exactly the scheduled tokens at each step, never the whole prompt.

```
8 tests from PrefillChunkingTest — PASSED
4 tests from SequencePositionsTest — PASSED
```
