### PR TITLE
Use params instead of model's config for chunked prefill

### DIFF
--- a/src/models/decoder_only.cpp
+++ b/src/models/decoder_only.cpp
@@ -33,7 +33,7 @@ void DecoderOnly_State::SetExtraInputs(const std::vector<ExtraInput>& extra_inpu
 
 DeviceSpan<float> DecoderOnly_State::Run(int total_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices) {
   size_t num_tokens = next_tokens.size();
-  const auto& chunk_size_opt = model_.config_->search.chunk_size;
+  const auto& chunk_size_opt = params_->search.chunk_size;
 
   if (chunk_size_opt.has_value() && chunk_size_opt.value() > 0 && num_tokens > chunk_size_opt.value()) {
     return RunWithChunking(total_length, next_tokens, next_indices, chunk_size_opt.value());


### PR DESCRIPTION
`model_.config_->search.chunk_size` requires config overlay.
`params_->search.chunk_size` can be set using SetSearchNumber api