### PR TITLE
[CUDA] Make Engine sampling scheduler-owned

### DIFF
--- a/docs/paged_attention_batching.md
+++ b/docs/paged_attention_batching.md
@@ -2,7 +2,8 @@
 
 Status: "Phase 1" is [PR #2343](https://github.com/microsoft/onnxruntime-genai/pull/2343);
 "Phase 2" is [PR #2345](https://github.com/microsoft/onnxruntime-genai/pull/2345), stacked on it.
-"Phase 3" is the scheduler-owned sampler stacked on Phase 2. All three are described here as built.
+"Phase 3" is [PR #2361](https://github.com/microsoft/onnxruntime-genai/pull/2361), stacked on Phase 2.
+All three are described here as built.
 
 This document explains how batching works in the two generation paths in onnxruntime-genai, why
 they differ, and what was changed to close most of the remaining throughput gap between them.
@@ -347,7 +348,7 @@ The remaining gap is the two per-request tail launches per step (`CheckForEOSAnd
 
 ---
 
-## 6. Phase 3: scheduler-owned batched sampler
+## 6. Phase 3 ([PR #2361](https://github.com/microsoft/onnxruntime-genai/pull/2361)): scheduler-owned batched sampler
 
 Phase 2 proves the performance value of batching, but its CUDA workspace is cached on the process-
 global device interface and its fast path requires uniform parameters, contiguous logits, and no

--- a/docs/paged_attention_batching.md
+++ b/docs/paged_attention_batching.md
@@ -2,7 +2,7 @@
 
 Status: "Phase 1" is [PR #2343](https://github.com/microsoft/onnxruntime-genai/pull/2343);
 "Phase 2" is [PR #2345](https://github.com/microsoft/onnxruntime-genai/pull/2345), stacked on it.
-Both are described here as built.
+"Phase 3" is the scheduler-owned sampler stacked on Phase 2. All three are described here as built.
 
 This document explains how batching works in the two generation paths in onnxruntime-genai, why
 they differ, and what was changed to close most of the remaining throughput gap between them.
@@ -347,7 +347,42 @@ The remaining gap is the two per-request tail launches per step (`CheckForEOSAnd
 
 ---
 
-## 6. Rejected alternatives
+## 6. Phase 3: scheduler-owned batched sampler
+
+Phase 2 proves the performance value of batching, but its CUDA workspace is cached on the process-
+global device interface and its fast path requires uniform parameters, contiguous logits, and no
+pinned random seeds. Phase 3 makes batching the scheduler's normal sampling architecture:
+
+- Each `Scheduler` owns one `BatchedSampler` and its reusable CUDA workspace. Separate Engines do
+  not share mutable sampling state.
+- Each `Request` owns a sampler state initialized from its configured seed. The state remains with
+  the request when the scheduler reorders rows or requests join and leave, preserving its random
+  stream independently of batch position.
+- The sampler groups rows by resolved `(k, p, temperature)`. It runs one existing `GetSample` call
+  per distinct group, so launch complexity is proportional to the number of parameter groups, not
+  the number of requests.
+- Noncontiguous logits rows, including mixed prefill/decode steps, are gathered into one reusable
+  packed tensor and sampled by group. Results are scattered back to request order before the
+  per-request EOS and sequence tails run.
+- The scheduler and sampler reserve host planning arrays and CUDA workspace from the configured
+  maximum batch size. Steady-state decoding does not allocate memory on the sampling path.
+
+The CUDA top-k local algorithm cache is keyed by both `k` and bucket batch size. This matters for
+heterogeneous batches: an algorithm selected for a single-row bucket is not necessarily valid for
+a multi-row bucket with the same `k`.
+
+The control flow remains device-neutral. `DeviceInterface::CreateBatchedSampler()` returns null on
+providers without a batched implementation, and `ScheduledRequests` retains the Phase 1 fallback.
+Per-request `Search` objects still own sequences, EOS state, and logits processors; Phase 3 does not
+turn ragged request lifecycle into one fixed-width `Search`.
+
+The remaining opportunity is to batch the EOS/pad and sequence-append tails using per-row pointer
+descriptors. Those two launches still run once per request, but sampling itself no longer falls back
+because of heterogeneous parameters, pinned seeds, batch size one, or ragged logits layout.
+
+---
+
+## 7. Rejected alternatives
 
 **Give the Engine one `Search` sized to max_batch, with per-row state.** This is the "just use the
 Generator design" option in its strongest form. It was rejected because it requires reworking
@@ -367,7 +402,7 @@ batching, for a fraction of the win. Deferred.
 
 ---
 
-## 7. Testing
+## 8. Testing
 
 The gate makes this a behaviour-preserving optimization, so the bar is bit-exactness against the
 pre-change build plus coverage of the fallback path.

--- a/src/cuda/cuda_sampling.cu
+++ b/src/cuda/cuda_sampling.cu
@@ -20,15 +20,20 @@ namespace Generators {
 namespace cuda {
 
 // Initializes the cuRAND states for each batch item.
-__global__ void InitCurandStates(unsigned long long seed, curandState* states, int batch_size) {
+__global__ void InitCurandStatesKernel(unsigned long long seed, curandState* states, int batch_size) {
   int index = threadIdx.x + blockIdx.x * blockDim.x;
   if (index >= batch_size) return;
   curand_init(seed, index, 0, &states[index]);
 }
 
+void LaunchInitCurandState(unsigned long long random_seed, curandState* state, cudaStream_t stream) {
+  InitCurandStatesKernel<<<1, 1, 0, stream>>>(random_seed, state, 1);
+  CUDA_CHECK_LAUNCH();
+}
+
 void SamplingData::ReInitCurandStates(unsigned long long random_seed, int batch_size, cudaStream_t stream) {
   random_seed_ = random_seed;
-  InitCurandStates<<<CeilDiv(batch_size, 128), 128, 0, stream>>>(random_seed, curand_states, batch_size);
+  InitCurandStatesKernel<<<CeilDiv(batch_size, 128), 128, 0, stream>>>(random_seed, curand_states, batch_size);
   CUDA_CHECK_LAUNCH();
 }
 
@@ -84,7 +89,8 @@ SamplingData::SamplingData(unsigned long long random_seed, int batch_size, int v
 // It has been empirically shown to be the most performant approach for k <= 256.
 template <int kBlockSize>
 __global__ void FusedSamplingKernel(int32_t* next_token_out, const float* scores, const int* indices, int k,
-                                    float p, float temperature, int stride, curandState* curand_states) {
+                                    float p, float temperature, int stride, curandState* curand_states,
+                                    const int* curand_state_indices) {
   const int batch_idx = blockIdx.x;
   const float* batch_scores = scores + batch_idx * stride;
   const int* batch_indices = indices + batch_idx * stride;
@@ -212,7 +218,8 @@ __global__ void FusedSamplingKernel(int32_t* next_token_out, const float* scores
   if (threadIdx.x == 0) {
     // Use min to prevent multiplying down the random value, which could introduce bias.
     // This robustly handles the case where curand_uniform is exactly 1.0.
-    threshold_smem = min(curand_uniform(&curand_states[batch_idx]), 0.9999999f);
+    const int state_index = curand_state_indices ? curand_state_indices[batch_idx] : batch_idx;
+    threshold_smem = min(curand_uniform(&curand_states[state_index]), 0.9999999f);
     selected_index_smem = k - 1;
   }
   __syncthreads();
@@ -272,11 +279,13 @@ __global__ void FilterOnTopPKernel(float* filtered_logits, const float* original
   }
 }
 
-__global__ void RandomThresholdKernel(curandState* curand_states, float* thresholds, int batch_size) {
+__global__ void RandomThresholdKernel(curandState* curand_states, const int* curand_state_indices,
+                                      float* thresholds, int batch_size) {
   const int i = threadIdx.x + blockIdx.x * blockDim.x;
   if (i < batch_size) {
     // Use min to prevent multiplying down the random value, which could introduce bias.
-    thresholds[i] = min(curand_uniform(&curand_states[i]), 0.9999999f);
+    const int state_index = curand_state_indices ? curand_state_indices[i] : i;
+    thresholds[i] = min(curand_uniform(&curand_states[state_index]), 0.9999999f);
   }
 }
 
@@ -307,7 +316,7 @@ __global__ void SampleKernel(int32_t* next_token_out, const int* indices, const 
 // A multi-stage sampling pipeline that is more efficient for large k.
 void LaunchMultiStageSampleKernel(SamplingData* data, cudaStream_t stream, const float* scores, const int* indices,
                                   int32_t* next_token_out, int k, int batch_size, float p, float temperature,
-                                  int stride) {
+                                  int stride, curandState* curand_states, const int* curand_state_indices) {
   dim3 grid(batch_size);
   dim3 block(256);
 
@@ -330,8 +339,8 @@ void LaunchMultiStageSampleKernel(SamplingData* data, cudaStream_t stream, const
   CorrectPrefixSumKernel<256><<<grid, block, 0, stream>>>(data->prefix_sums_adjusted, data->prefix_sums, k);
 
   // Stage 6: Generate random thresholds.
-  RandomThresholdKernel<<<CeilDiv(batch_size, 256), block, 0, stream>>>(data->curand_states,
-                                                                        data->thresholds, batch_size);
+  RandomThresholdKernel<<<CeilDiv(batch_size, 256), block, 0, stream>>>(
+      curand_states ? curand_states : data->curand_states, curand_state_indices, data->thresholds, batch_size);
 
   // Stage 7: Sample via Parallel Search.
   SampleKernel<256><<<grid, block, 0, stream>>>(next_token_out, indices, data->prefix_sums, k, stride,
@@ -339,7 +348,8 @@ void LaunchMultiStageSampleKernel(SamplingData* data, cudaStream_t stream, const
 }
 
 void LaunchFusedSampleKernel(SamplingData* data, cudaStream_t stream, const float* scores, const int* indices,
-                             int32_t* next_token_out, int k, int batch_size, float p, float temperature, int stride) {
+                             int32_t* next_token_out, int k, int batch_size, float p, float temperature, int stride,
+                             curandState* curand_states, const int* curand_state_indices) {
   assert(k <= kFusedSamplingMaxK);
   dim3 grid(batch_size);
   constexpr int block_size = 256;
@@ -349,11 +359,13 @@ void LaunchFusedSampleKernel(SamplingData* data, cudaStream_t stream, const floa
   constexpr size_t shared_mem_bytes = 2 * block_size * sizeof(float);
 
   FusedSamplingKernel<block_size><<<grid, block, shared_mem_bytes, stream>>>(
-      next_token_out, scores, indices, k, p, temperature, stride, data->curand_states);
+      next_token_out, scores, indices, k, p, temperature, stride,
+      curand_states ? curand_states : data->curand_states, curand_state_indices);
 }
 
 void GetSample(SamplingData* data, cudaStream_t stream, int32_t* next_token_out, const float* scores_in,
-               int vocab_size, int batch_size, int k, float p, float temperature) {
+               int vocab_size, int batch_size, int k, float p, float temperature,
+               curandState* external_curand_states, const int* curand_state_indices) {
   if (k <= 0 || k > vocab_size) {
     k = vocab_size;
   }
@@ -366,12 +378,43 @@ void GetSample(SamplingData* data, cudaStream_t stream, int32_t* next_token_out,
   // The fused kernel is the most performant approach for k up to 256.
   if (k <= kFusedSamplingMaxK) {
     LaunchFusedSampleKernel(data, stream, topk_scores, topk_indices, next_token_out, k, batch_size, p,
-                            temperature, topk_stride);
+                            temperature, topk_stride, external_curand_states, curand_state_indices);
   } else {
     // Fall back to multi-stage sampling pipeline. This is not a typical use case.
     LaunchMultiStageSampleKernel(data, stream, topk_scores, topk_indices, next_token_out, k, batch_size, p,
-                                 temperature, topk_stride);
+                                 temperature, topk_stride, external_curand_states, curand_state_indices);
   }
+  CUDA_CHECK_LAUNCH();
+}
+
+__global__ void GatherSamplingRowsKernel(const float* const* rows, float* packed_scores,
+                                         int batch_size, int vocab_size) {
+  const int row = blockIdx.y;
+  const int column = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row < batch_size && column < vocab_size)
+    packed_scores[static_cast<size_t>(row) * vocab_size + column] = rows[row][column];
+}
+
+void LaunchGatherSamplingRows(const float* const* rows, float* packed_scores, int batch_size, int vocab_size,
+                              cudaStream_t stream) {
+  constexpr int block_size = 256;
+  dim3 grid(CeilDiv(vocab_size, block_size), batch_size);
+  GatherSamplingRowsKernel<<<grid, block_size, 0, stream>>>(rows, packed_scores, batch_size, vocab_size);
+  CUDA_CHECK_LAUNCH();
+}
+
+__global__ void ScatterSamplingTokensKernel(const int32_t* packed_tokens, const int* output_indices,
+                                            int32_t* next_tokens, int batch_size) {
+  const int index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index < batch_size)
+    next_tokens[output_indices[index]] = packed_tokens[index];
+}
+
+void LaunchScatterSamplingTokens(const int32_t* packed_tokens, const int* output_indices,
+                                 int32_t* next_tokens, int batch_size, cudaStream_t stream) {
+  constexpr int block_size = 256;
+  ScatterSamplingTokensKernel<<<CeilDiv(batch_size, block_size), block_size, 0, stream>>>(
+      packed_tokens, output_indices, next_tokens, batch_size);
   CUDA_CHECK_LAUNCH();
 }
 

--- a/src/cuda/cuda_sampling.h
+++ b/src/cuda/cuda_sampling.h
@@ -38,7 +38,14 @@ struct SamplingData : public TopkData {
 // Main entry point for the sampling process.
 // This function orchestrates the Top-K selection followed by Top-P sampling.
 void GetSample(SamplingData* sampling_data, cudaStream_t stream, int32_t* d_next_token, const float* d_scores,
-               int vocab_size, int batch_size, int k, float p, float temperature);
+               int vocab_size, int batch_size, int k, float p, float temperature,
+               curandState* external_curand_states = nullptr, const int* curand_state_indices = nullptr);
+
+void LaunchInitCurandState(unsigned long long random_seed, curandState* state, cudaStream_t stream);
+void LaunchGatherSamplingRows(const float* const* rows, float* packed_scores, int batch_size, int vocab_size,
+                              cudaStream_t stream);
+void LaunchScatterSamplingTokens(const int32_t* packed_tokens, const int* output_indices,
+                                 int32_t* next_tokens, int batch_size, cudaStream_t stream);
 
 // A general-purpose block-wise softmax implementation, needed by beam search.
 template <bool is_log_softmax>
@@ -47,10 +54,12 @@ void DispatchBlockwiseSoftmaxForward(cudaStream_t stream, float* output, const f
 
 // The following are for macro benchmark.
 void LaunchFusedSampleKernel(SamplingData* data, cudaStream_t stream, const float* scores, const int* indices,
-                             int32_t* next_token_out, int k, int batch_size, float p, float temperature, int stride);
+                             int32_t* next_token_out, int k, int batch_size, float p, float temperature, int stride,
+                             curandState* curand_states = nullptr, const int* curand_state_indices = nullptr);
 
 void LaunchMultiStageSampleKernel(SamplingData* data, cudaStream_t stream, const float* scores, const int* indices,
-                                  int32_t* next_token_out, int k, int batch_size, float p, float temperature, int stride);
+                                  int32_t* next_token_out, int k, int batch_size, float p, float temperature, int stride,
+                                  curandState* curand_states = nullptr, const int* curand_state_indices = nullptr);
 
 }  // namespace cuda
 }  // namespace Generators

--- a/src/cuda/cuda_topk.cu
+++ b/src/cuda/cuda_topk.cu
@@ -111,6 +111,7 @@ TopkData::TopkData(int batch_size, int vocab_size, cudaStream_t stream, void* bu
   CUDA_CHECK(cudaGetDevice(&device_id));
 
   local_algo_cache_.fill(TopkAlgo::UNKNOWN);
+  local_algo_cache_batch_size_.fill(0);
 
   if (buffer) {
     // Wrap an externally provided buffer. The caller is responsible for ensuring the size is sufficient.
@@ -165,7 +166,10 @@ void RunTopK(TopkData* topk_data, cudaStream_t stream, const float* scores_in, i
   assert(k > 0 && k <= vocab_size);
 
   // 1. Check the fast, local cache first.
-  TopkAlgo algo = (k <= kMaxBenchmarkLocalCache) ? topk_data->local_algo_cache_[k] : TopkAlgo::UNKNOWN;
+  TopkAlgo algo = (k <= kMaxBenchmarkLocalCache &&
+                   topk_data->local_algo_cache_batch_size_[k] == batch_size)
+                      ? topk_data->local_algo_cache_[k]
+                      : TopkAlgo::UNKNOWN;
 
   if (algo == TopkAlgo::UNKNOWN) {
     // 2. Local cache miss, check the persistent global cache.
@@ -179,6 +183,7 @@ void RunTopK(TopkData* topk_data, cudaStream_t stream, const float* scores_in, i
     // Update the local cache for subsequent calls within this session.
     if (k <= kMaxBenchmarkLocalCache) {
       topk_data->local_algo_cache_[k] = algo;
+      topk_data->local_algo_cache_batch_size_[k] = batch_size;
     }
   }
 

--- a/src/cuda/cuda_topk.h
+++ b/src/cuda/cuda_topk.h
@@ -104,9 +104,10 @@ struct TopkData : public TopkDataDetail {
   // Caching the device_id to avoid repeated calls to cudaGetDevice.
   int device_id;
 
-  // A local, lock-free cache for the best algorithm for each k. This provides a fast path
-  // to algorithm selection within a single TopkData instance.
+  // A local, lock-free cache for the best algorithm for each (k, batch_size) pair. This provides
+  // a fast path to algorithm selection within a single TopkData instance.
   std::array<TopkAlgo, kMaxBenchmarkLocalCache + 1> local_algo_cache_;
+  std::array<int, kMaxBenchmarkLocalCache + 1> local_algo_cache_batch_size_;
 
   // --- Intermediate Buffers for Top-K Algorithms (Pointers into memory_buffer_span_) ---
 

--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -189,15 +189,7 @@ struct CudaBatchedSampler final : BatchedSampler {
         return params[lhs].p < params[rhs].p;
       return params[lhs].temperature < params[rhs].temperature;
     };
-    for (size_t index = 1; index < row_order_.size(); ++index) {
-      const int row = row_order_[index];
-      size_t insertion_index = index;
-      while (insertion_index > 0 && params_less(row, row_order_[insertion_index - 1])) {
-        row_order_[insertion_index] = row_order_[insertion_index - 1];
-        --insertion_index;
-      }
-      row_order_[insertion_index] = row;
-    }
+    std::sort(row_order_.begin(), row_order_.end(), params_less);
 
     for (int packed_row = 0; packed_row < batch_size; ++packed_row) {
       const int row = row_order_[packed_row];

--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -9,6 +9,7 @@
 #include "kernels.h"
 #include <charconv>
 #include <cstdarg>
+#include <random>
 #include <system_error>
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -46,32 +47,256 @@ struct GpuMemory final : DeviceBuffer {
 
   void AllocateCpu() override {
     if (!p_cpu_)
-      ::cudaHostAlloc(&p_cpu_, size_in_bytes_, 0);
+      CUDA_CHECK(::cudaHostAlloc(&p_cpu_, size_in_bytes_, 0));
   }
 
   void CopyDeviceToCpu() override {
     AllocateCpu();
-    ::cudaMemcpyAsync(p_cpu_, p_device_, size_in_bytes_, ::cudaMemcpyDeviceToHost, GetStream());
-    ::cudaStreamSynchronize(GetStream());
+    CUDA_CHECK(::cudaMemcpyAsync(p_cpu_, p_device_, size_in_bytes_, ::cudaMemcpyDeviceToHost, GetStream()));
+    CUDA_CHECK(::cudaStreamSynchronize(GetStream()));
   }
 
   void CopyCpuToDevice() override {
     assert(p_cpu_);
-    ::cudaMemcpyAsync(p_device_, p_cpu_, size_in_bytes_, ::cudaMemcpyHostToDevice, GetStream());
+    CUDA_CHECK(::cudaMemcpyAsync(p_device_, p_cpu_, size_in_bytes_, ::cudaMemcpyHostToDevice, GetStream()));
   }
 
   void CopyFrom(size_t begin_dest, DeviceBuffer& source, size_t begin_source, size_t size_in_bytes) override {
     if (source.GetType() == device_label)
-      ::cudaMemcpyAsync(p_device_ + begin_dest, source.p_device_ + begin_source, size_in_bytes, ::cudaMemcpyDeviceToDevice, GetStream());
+      CUDA_CHECK(::cudaMemcpyAsync(p_device_ + begin_dest, source.p_device_ + begin_source, size_in_bytes,
+                                   ::cudaMemcpyDeviceToDevice, GetStream()));
     else
       gp_genai->CopyThroughCpu(*this, begin_dest, source, begin_source, size_in_bytes);
   }
 
   void Zero() override {
-    ::cudaMemsetAsync(p_device_, 0, size_in_bytes_, GetStream());
+    CUDA_CHECK(::cudaMemsetAsync(p_device_, 0, size_in_bytes_, GetStream()));
   }
 
   bool owned_;  // If we own the memory, we delete it on destruction
+};
+
+template <typename T>
+DeviceSpan<T> AllocateCudaSpan(size_t count) {
+  return DeviceSpan<T>{std::make_shared<GpuMemory>(count * sizeof(T))};
+}
+
+struct CudaSamplerStatePool {
+  explicit CudaSamplerStatePool(int initial_capacity) {
+    if (initial_capacity > 0) {
+      states_ = AllocateCudaSpan<curandState>(initial_capacity);
+      capacity_ = initial_capacity;
+    }
+  }
+
+  int Acquire(int random_seed) {
+    int index;
+    if (free_indices_.empty()) {
+      index = size_++;
+      EnsureCapacity(size_);
+    } else {
+      index = free_indices_.back();
+      free_indices_.pop_back();
+    }
+
+    const unsigned long long seed = random_seed == -1
+                                        ? static_cast<unsigned long long>(std::random_device{}())
+                                        : static_cast<unsigned long long>(random_seed);
+    cuda::LaunchInitCurandState(seed, states_.Span().data() + index, GetStream());
+    return index;
+  }
+
+  void Release(int index) {
+    free_indices_.push_back(index);
+  }
+
+  curandState* Data() { return states_.Span().data(); }
+
+ private:
+  void EnsureCapacity(int required_capacity) {
+    if (required_capacity <= capacity_)
+      return;
+
+    const int new_capacity = std::max(required_capacity, std::max(4, capacity_ * 2));
+    auto new_states = AllocateCudaSpan<curandState>(new_capacity);
+    if (size_ > 1) {
+      CUDA_CHECK(cudaMemcpyAsync(new_states.Span().data(), states_.Span().data(),
+                                 static_cast<size_t>(size_ - 1) * sizeof(curandState),
+                                 cudaMemcpyDeviceToDevice, GetStream()));
+      CUDA_CHECK(cudaStreamSynchronize(GetStream()));
+    }
+    states_ = std::move(new_states);
+    capacity_ = new_capacity;
+  }
+
+  DeviceSpan<curandState> states_;
+  std::vector<int> free_indices_;
+  int size_{};
+  int capacity_{};
+};
+
+struct CudaBatchedSamplerState final : BatchedSamplerState {
+  CudaBatchedSamplerState(std::shared_ptr<CudaSamplerStatePool> pool, int index)
+      : pool_{std::move(pool)}, index_{index} {}
+
+  ~CudaBatchedSamplerState() override { pool_->Release(index_); }
+
+  std::shared_ptr<CudaSamplerStatePool> pool_;
+  int index_{};
+};
+
+struct CudaBatchedSampler final : BatchedSampler {
+  CudaBatchedSampler(int max_batch_size, int vocab_size)
+      : state_pool_{std::make_shared<CudaSamplerStatePool>(max_batch_size)} {
+    EnsureCapacity(max_batch_size, vocab_size);
+  }
+
+  std::unique_ptr<BatchedSamplerState> CreateState(int random_seed) override {
+    return std::make_unique<CudaBatchedSamplerState>(state_pool_, state_pool_->Acquire(random_seed));
+  }
+
+  bool OwnsState(const BatchedSamplerState& state) const override {
+    const auto* cuda_state = dynamic_cast<const CudaBatchedSamplerState*>(&state);
+    return cuda_state && cuda_state->pool_.get() == state_pool_.get();
+  }
+
+  DeviceSpan<int32_t> Sample(std::span<DeviceSpan<float>> scores,
+                             std::span<const BatchedSamplingParams> params,
+                             std::span<BatchedSamplerState* const> states,
+                             int vocab_size) override {
+    const int batch_size = static_cast<int>(scores.size());
+    if (batch_size == 0 || params.size() != scores.size() || states.size() != scores.size())
+      throw std::runtime_error("BatchedSampler requires one parameter set and RNG state per score row.");
+
+    EnsureCapacity(batch_size, vocab_size);
+    row_order_.clear();
+    bucket_offsets_.clear();
+    bucket_params_.clear();
+    for (int row = 0; row < batch_size; ++row) {
+      if (scores[row].size() != static_cast<size_t>(vocab_size))
+        throw std::runtime_error("BatchedSampler score row has the wrong vocabulary size.");
+
+      auto* state = dynamic_cast<CudaBatchedSamplerState*>(states[row]);
+      if (!state || state->pool_.get() != state_pool_.get())
+        throw std::runtime_error("BatchedSampler received an RNG state from a different sampler.");
+      row_order_.push_back(row);
+    }
+
+    const auto params_less = [&](int lhs, int rhs) {
+      if (params[lhs].k != params[rhs].k)
+        return params[lhs].k < params[rhs].k;
+      if (params[lhs].p != params[rhs].p)
+        return params[lhs].p < params[rhs].p;
+      return params[lhs].temperature < params[rhs].temperature;
+    };
+    for (size_t index = 1; index < row_order_.size(); ++index) {
+      const int row = row_order_[index];
+      size_t insertion_index = index;
+      while (insertion_index > 0 && params_less(row, row_order_[insertion_index - 1])) {
+        row_order_[insertion_index] = row_order_[insertion_index - 1];
+        --insertion_index;
+      }
+      row_order_[insertion_index] = row;
+    }
+
+    for (int packed_row = 0; packed_row < batch_size; ++packed_row) {
+      const int row = row_order_[packed_row];
+      if (packed_row == 0 || params[row].k != bucket_params_.back().k ||
+          params[row].p != bucket_params_.back().p ||
+          params[row].temperature != bucket_params_.back().temperature) {
+        bucket_offsets_.push_back(packed_row);
+        bucket_params_.push_back(params[row]);
+      }
+    }
+    bucket_offsets_.push_back(batch_size);
+
+    auto score_ptrs_cpu = score_ptrs_.CpuSpan();
+    auto output_indices_cpu = output_indices_.CpuSpan();
+    auto state_indices_cpu = state_indices_.CpuSpan();
+    for (int packed_row = 0; packed_row < batch_size; ++packed_row) {
+      const int row = row_order_[packed_row];
+      score_ptrs_cpu[packed_row] = scores[row].Span().data();
+      output_indices_cpu[packed_row] = row;
+      state_indices_cpu[packed_row] = static_cast<CudaBatchedSamplerState*>(states[row])->index_;
+    }
+    score_ptrs_.CopyCpuToDevice();
+    output_indices_.CopyCpuToDevice();
+    state_indices_.CopyCpuToDevice();
+
+    bool rows_are_contiguous = bucket_params_.size() == 1;
+    for (int row = 0; row < batch_size && rows_are_contiguous; ++row) {
+      rows_are_contiguous = scores[row].SameBufferAs(scores[0]) &&
+                            scores[row].Span().data() == scores[0].Span().data() +
+                                                             static_cast<size_t>(row) * vocab_size;
+    }
+
+    if (rows_are_contiguous) {
+      const auto& sample_params = bucket_params_.front();
+      cuda::GetSample(sampling_data_.get(), GetStream(), next_tokens_.Span().data(),
+                      scores[0].Span().data(), vocab_size, batch_size,
+                      sample_params.k, sample_params.p, sample_params.temperature,
+                      state_pool_->Data(), state_indices_.Span().data());
+      return next_tokens_.subspan(0, batch_size);
+    }
+
+    cuda::LaunchGatherSamplingRows(score_ptrs_.Span().data(), packed_scores_.Span().data(),
+                                   batch_size, vocab_size, GetStream());
+    for (size_t bucket = 0; bucket < bucket_params_.size(); ++bucket) {
+      const int bucket_offset = bucket_offsets_[bucket];
+      const int bucket_size = bucket_offsets_[bucket + 1] - bucket_offset;
+      const auto& sample_params = bucket_params_[bucket];
+      cuda::GetSample(sampling_data_.get(), GetStream(),
+                      packed_tokens_.Span().data() + bucket_offset,
+                      packed_scores_.Span().data() + static_cast<size_t>(bucket_offset) * vocab_size,
+                      vocab_size, bucket_size, sample_params.k, sample_params.p, sample_params.temperature,
+                      state_pool_->Data(), state_indices_.Span().data() + bucket_offset);
+    }
+    cuda::LaunchScatterSamplingTokens(packed_tokens_.Span().data(), output_indices_.Span().data(),
+                                      next_tokens_.Span().data(), batch_size, GetStream());
+    return next_tokens_.subspan(0, batch_size);
+  }
+
+ private:
+  void EnsureCapacity(int batch_size, int vocab_size) {
+    if (batch_size <= batch_capacity_ && vocab_size == vocab_capacity_)
+      return;
+
+    batch_capacity_ = std::max(batch_size, std::max(4, batch_capacity_ * 2));
+    vocab_capacity_ = vocab_size;
+    score_ptrs_ = AllocateCudaSpan<const float*>(batch_capacity_);
+    output_indices_ = AllocateCudaSpan<int>(batch_capacity_);
+    state_indices_ = AllocateCudaSpan<int>(batch_capacity_);
+    packed_scores_ = AllocateCudaSpan<float>(static_cast<size_t>(batch_capacity_) * vocab_size);
+    packed_tokens_ = AllocateCudaSpan<int32_t>(batch_capacity_);
+    next_tokens_ = AllocateCudaSpan<int32_t>(batch_capacity_);
+    score_ptrs_.CpuSpan();
+    output_indices_.CpuSpan();
+    state_indices_.CpuSpan();
+    next_tokens_.CpuSpan();
+
+    const size_t buffer_size = cuda::SamplingData::CalculateTotalSize(batch_capacity_, vocab_size, GetStream());
+    sampling_buffer_ = AllocateCudaSpan<uint8_t>(buffer_size);
+    sampling_data_ = std::make_unique<cuda::SamplingData>(std::random_device{}(), batch_capacity_, vocab_size,
+                                                          GetStream(), sampling_buffer_.Span().data(), buffer_size);
+    row_order_.reserve(batch_capacity_);
+    bucket_offsets_.reserve(static_cast<size_t>(batch_capacity_) + 1);
+    bucket_params_.reserve(batch_capacity_);
+  }
+
+  std::shared_ptr<CudaSamplerStatePool> state_pool_;
+  DeviceSpan<const float*> score_ptrs_;
+  DeviceSpan<int> output_indices_;
+  DeviceSpan<int> state_indices_;
+  DeviceSpan<float> packed_scores_;
+  DeviceSpan<int32_t> packed_tokens_;
+  DeviceSpan<int32_t> next_tokens_;
+  DeviceSpan<uint8_t> sampling_buffer_;
+  std::unique_ptr<cuda::SamplingData> sampling_data_;
+  std::vector<int> row_order_;
+  std::vector<int> bucket_offsets_;
+  std::vector<BatchedSamplingParams> bucket_params_;
+  int batch_capacity_{};
+  int vocab_capacity_{};
 };
 
 struct CudaInterfaceImplBase : DeviceInterface {
@@ -114,8 +339,12 @@ struct CudaInterfaceImplBase : DeviceInterface {
     return std::make_unique<BeamSearch_Cuda>(params);
   }
 
+  std::unique_ptr<BatchedSampler> CreateBatchedSampler(size_t max_batch_size, int vocab_size) override {
+    return std::make_unique<CudaBatchedSampler>(static_cast<int>(max_batch_size), vocab_size);
+  }
+
   void Synchronize() override {
-    ::cudaStreamSynchronize(GetStream());
+    CUDA_CHECK(::cudaStreamSynchronize(GetStream()));
   }
 
   void* GetCudaStream() override {
@@ -183,36 +412,9 @@ struct CudaInterfaceImplBase : DeviceInterface {
     cuda::LaunchAddLogitsMask(batch_logits, batch_beam_size, vocab_size, logits_mask, GetStream());
   }
 
-  bool SampleTopKTopP(DeviceSpan<float> scores, DeviceSpan<int32_t> next_tokens,
-                      int vocab_size, int batch_size, int k, float p, float temperature) override {
-    if (scores.size() < static_cast<size_t>(batch_size) * vocab_size || next_tokens.size() < static_cast<size_t>(batch_size))
-      throw std::runtime_error("SampleTopKTopP - scores or next_tokens is too small for the batch");
-
-    // The workspace is sized for the largest batch seen so far and reused, since the engine calls
-    // this once per decode step with a batch that changes as requests join and leave.
-    if (!sampling_data_ || batch_size > sampling_cap_batch_ || vocab_size != sampling_cap_vocab_) {
-      const size_t buffer_size = cuda::SamplingData::CalculateTotalSize(batch_size, vocab_size, GetStream());
-      sampling_buffer_ = Allocate<uint8_t>(buffer_size);
-      sampling_data_ = std::make_unique<cuda::SamplingData>(std::random_device{}(), batch_size, vocab_size,
-                                                            GetStream(), sampling_buffer_.Span().data(), buffer_size);
-      sampling_cap_batch_ = batch_size;
-      sampling_cap_vocab_ = vocab_size;
-    }
-
-    cuda::GetSample(sampling_data_.get(), GetStream(), next_tokens.Span().data(), scores.Span().data(),
-                    vocab_size, batch_size, k, p, temperature);
-    return true;
-  }
-
   void GetAvailableMemory(size_t& free_bytes, size_t& total_bytes) override {
     cudaMemGetInfo(&free_bytes, &total_bytes);
   }
-
- private:
-  DeviceSpan<uint8_t> sampling_buffer_;
-  std::unique_ptr<cuda::SamplingData> sampling_data_;
-  int sampling_cap_batch_{};
-  int sampling_cap_vocab_{};
 };
 
 struct CudaInterfaceImpl final : CudaInterfaceImplBase {

--- a/src/cuda/search_cuda.cpp
+++ b/src/cuda/search_cuda.cpp
@@ -34,17 +34,22 @@ GreedySearch_Cuda::GreedySearch_Cuda(const GeneratorParams& params)
   next_tokens_buffer_ = params.p_device->Allocate<int32_t>(params.search.batch_size);
   next_tokens_buffer_.Zero();
   next_tokens_ = gpu_span<int32_t>(next_tokens_buffer_.Span());
+}
+
+void GreedySearch_Cuda::EnsureSamplingData() {
+  if (samplingdata_)
+    return;
 
   unsigned long long random_seed = (params_->search.random_seed != -1)
                                        ? params_->search.random_seed
                                        : std::random_device{}();
 
   // Allocate a single buffer for all sampling data
-  size_t sampling_buffer_size = cuda::SamplingData::CalculateTotalSize(params.search.batch_size, params.config.model.vocab_size, GetStream());
-  sampling_buffer_ = params.p_device->Allocate<uint8_t>(sampling_buffer_size);
+  size_t sampling_buffer_size = cuda::SamplingData::CalculateTotalSize(params_->search.batch_size, params_->config.model.vocab_size, GetStream());
+  sampling_buffer_ = params_->p_device->Allocate<uint8_t>(sampling_buffer_size);
 
   // Create SamplingData with the externally allocated buffer
-  samplingdata_ = std::make_unique<cuda::SamplingData>(random_seed, params.search.batch_size, params.config.model.vocab_size, GetStream(),
+  samplingdata_ = std::make_unique<cuda::SamplingData>(random_seed, params_->search.batch_size, params_->config.model.vocab_size, GetStream(),
                                                        sampling_buffer_.Span().data(), sampling_buffer_size);
 }
 
@@ -156,6 +161,7 @@ void BeamSearch_Cuda::SelectTop() {
 }
 
 void GreedySearch_Cuda::SampleTopKTopP(int k, float p, float temperature) {
+  EnsureSamplingData();
   std::span<float> scores = next_token_scores_.Span();
   assert(scores.size() == params_->search.batch_size * params_->config.model.vocab_size);
   cuda::GetSample(samplingdata_.get(), GetStream(), next_tokens_.data(), scores.data(), int(scores.size() / params_->search.batch_size),
@@ -207,7 +213,6 @@ void GreedySearch_Cuda::LaunchNextTokensTail() {
 void GreedySearch_Cuda::CompleteGeneration() {
   if (!completion_pending_)
     return;
-  completion_pending_ = false;
 
   // done_cpu_ lives in pinned host memory written by CheckForEOSAndPad, so it is only meaningful
   // once the stream has drained. When completion is deferred, every search in the batch has already
@@ -217,6 +222,7 @@ void GreedySearch_Cuda::CompleteGeneration() {
   // sampled into a shared buffer the caller has already done that copy for the whole batch.
   if (!external_host_copy_)
     next_tokens_buffer_.CopyDeviceToCpu();
+  completion_pending_ = false;
   done_pending_ = false;
 
   if (!*done_cpu_) {

--- a/src/cuda/search_cuda.h
+++ b/src/cuda/search_cuda.h
@@ -67,6 +67,7 @@ struct GreedySearch_Cuda : Search_Cuda {
   void DeferCompletion(bool defer) override { defer_completion_ = defer; }
   void CompleteGeneration() override;
   bool BindNextTokensSlot(DeviceSpan<int32_t> slot) override;
+  bool SupportsBatchedSampling() const override { return params_->BatchBeamSize() == 1; }
   void OnNextTokensSampled() override;
 
  private:
@@ -81,6 +82,7 @@ struct GreedySearch_Cuda : Search_Cuda {
   // host itself, so CompleteGeneration() must not copy again.
   bool external_host_copy_{false};
 
+  void EnsureSamplingData();
   void LaunchNextTokensTail();
 };
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -31,11 +31,6 @@ std::shared_ptr<Request> Engine::Step() {
 
     auto scheduled_requests = scheduler_->Schedule();
     model_executor_->Decode(scheduled_requests);
-    // Shared across steps so that a growing batch does not allocate every step. Requests bind to a
-    // slot of it for the step, and they keep the buffer alive if a later step replaces it.
-    if (shared_next_tokens_.size() < scheduled_requests.size())
-      shared_next_tokens_ = model_->p_device_scoring_->Allocate<int32_t>(scheduled_requests.size());
-    scheduled_requests.SetSharedNextTokens(shared_next_tokens_);
     scheduled_requests.GenerateNextTokens();
 
     for (auto& request : scheduled_requests) {

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -71,7 +71,6 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::unique_ptr<Scheduler> scheduler_;                 // The scheduler responsible for managing execution order.
   std::unique_ptr<ModelExecutor> model_executor_;        // The executor responsible for running the model.
   std::queue<std::shared_ptr<Request>> ready_requests_;  // The list of requests that are ready for the application to process.
-  DeviceSpan<int32_t> shared_next_tokens_;               // One token slot per scheduled request, grown as batches get larger.
 };
 
 }  // namespace Generators

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -181,8 +181,18 @@ bool Request::BindNextTokensSlot(DeviceSpan<int32_t> slot) {
   return search_->BindNextTokensSlot(slot);
 }
 
+bool Request::SupportsBatchedSampling() const {
+  return search_->SupportsBatchedSampling();
+}
+
 void Request::OnNextTokensSampled() {
   search_->OnNextTokensSampled();
+}
+
+BatchedSamplerState& Request::SamplingState(BatchedSampler& sampler) {
+  if (!batched_sampler_state_ || !sampler.OwnsState(*batched_sampler_state_))
+    batched_sampler_state_ = sampler.CreateState(search_->params_->search.random_seed);
+  return *batched_sampler_state_;
 }
 
 void Request::CompleteGeneration() {

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -156,6 +156,8 @@ struct Request : std::enable_shared_from_this<Request>,
    */
   bool BindNextTokensSlot(DeviceSpan<int32_t> slot);
 
+  bool SupportsBatchedSampling() const;
+
   /**
    * @brief Runs everything token selection needs before the sampler: sequence bookkeeping,
    *        handing the logits to the search, and applying the logits processors.
@@ -166,6 +168,11 @@ struct Request : std::enable_shared_from_this<Request>,
    * @brief Launches the per-sequence tail after a batched sampler has filled the bound slot.
    */
   void OnNextTokensSampled();
+
+  /**
+   * @brief Returns this request's persistent random state for the given batched sampler.
+   */
+  BatchedSamplerState& SamplingState(BatchedSampler& sampler);
 
   /**
    * @brief Retrieves the generator parameters associated with this request.
@@ -202,6 +209,7 @@ struct Request : std::enable_shared_from_this<Request>,
   int64_t processed_sequence_length_{};
   std::shared_ptr<GeneratorParams> params_;
   std::unique_ptr<Search> search_;
+  std::unique_ptr<BatchedSamplerState> batched_sampler_state_;
   std::weak_ptr<Engine> engine_;
   bool is_prefill_{true};
 

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -5,40 +5,37 @@
 
 #include "engine.h"
 #include "../search.h"
+#include <exception>
 
 namespace Generators {
 
 namespace {
 
-struct SampleArgs {
-  int k{};
-  float p{};
-  float temperature{};
-};
-
 // Collapses Request::GenerateNextTokens' dispatch into the single (k, p, temperature) triple that
 // each branch ends up handing to the sampler on CUDA, where SelectTop() is SampleTopKTopP(1, 0, 1),
 // SampleTopK(k, t) is SampleTopKTopP(k, 1, t) and SampleTopP(p, t) is SampleTopKTopP(-1, p, t).
 // Returns nothing for options the per-request path rejects, so that it keeps raising the error.
-std::optional<SampleArgs> ResolveSampleArgs(const Config::Search& search) {
+std::optional<BatchedSamplingParams> ResolveSampleArgs(const Config::Search& search) {
   if (!search.do_sample || search.top_k == 1 || search.temperature == 0)
-    return SampleArgs{1, 0.0f, 1.0f};
+    return BatchedSamplingParams{1, 0.0f, 1.0f};
 
   if (search.num_beams != 1 || search.top_p < 0.0f || search.top_p > 1.0f || search.top_k < 0)
     return std::nullopt;
 
   if (search.top_p > 0.0f && search.top_p < 1.0f && search.top_k > 1)
-    return SampleArgs{search.top_k, search.top_p, search.temperature};
+    return BatchedSamplingParams{search.top_k, search.top_p, search.temperature};
   if (search.top_k > 1)
-    return SampleArgs{search.top_k, 1.0f, search.temperature};
-  return SampleArgs{-1, search.top_p, search.temperature};
+    return BatchedSamplingParams{search.top_k, 1.0f, search.temperature};
+  return BatchedSamplingParams{-1, search.top_p, search.temperature};
 }
 
 }  // namespace
 
 ScheduledRequests::ScheduledRequests(std::vector<std::shared_ptr<Request>> requests,
-                                     std::shared_ptr<Model> model)
-    : requests_{requests}, model_{model} {
+                                     std::shared_ptr<Model> model,
+                                     BatchedSampler* batched_sampler,
+                                     BatchedSamplingPlan* sampling_plan)
+    : requests_{requests}, model_{model}, batched_sampler_{batched_sampler}, sampling_plan_{sampling_plan} {
 }
 
 std::unique_ptr<OrtRunOptions> ScheduledRequests::RunOptions() {
@@ -61,105 +58,82 @@ void ScheduledRequests::GenerateNextTokens() {
     throw std::runtime_error("Cannot generate next tokens without the decoder state.");
   }
 
-  std::vector<DeviceSpan<float>> logits = decoder_state_->ProcessLogits();
-  if (logits.size() != requests_.size()) {
-    throw std::runtime_error("Logits size does not match the number of requests.");
-  }
-
-  if (TryGenerateNextTokensBatched(logits))
-    return;
-
-  // Every request owns an independent single-sequence search, so token selection runs once per
-  // request. Completing each one inline would block the host on the device once per request and
-  // serialize the whole batch; launching all of them first means only the first completion below
-  // actually waits for the device.
-  for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
-    if (requests_[request_idx]->status_ != RequestStatus::Completed) {
-      requests_[request_idx]->GenerateNextTokens(logits[request_idx]);
+  try {
+    std::vector<DeviceSpan<float>> logits = decoder_state_->ProcessLogits();
+    if (logits.size() != requests_.size()) {
+      throw std::runtime_error("Logits size does not match the number of requests.");
     }
-  }
 
-  for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
-    if (requests_[request_idx]->status_ != RequestStatus::Completed) {
-      requests_[request_idx]->CompleteGeneration();
+    if (TryGenerateNextTokensBatched(logits))
+      return;
+
+    // Every request owns an independent single-sequence search, so token selection runs once per
+    // request. Completing each one inline would block the host on the device once per request and
+    // serialize the whole batch; launching all of them first means only the first completion below
+    // actually waits for the device.
+    for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
+      if (requests_[request_idx]->status_ != RequestStatus::Completed) {
+        requests_[request_idx]->GenerateNextTokens(logits[request_idx]);
+      }
     }
+
+    for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
+      if (requests_[request_idx]->status_ != RequestStatus::Completed) {
+        requests_[request_idx]->CompleteGeneration();
+      }
+    }
+  } catch (...) {
+    const auto error = std::current_exception();
+    try {
+      model_->p_device_scoring_->Synchronize();
+    } catch (...) {
+    }
+    std::rethrow_exception(error);
   }
 }
 
-// Samples every scheduled request in one call instead of once per request. The per-request path
-// costs a sampler launch sequence and a full-vocabulary workspace per sequence, which dominates the
-// decode step once the batch grows. Returns false when the batch does not qualify, leaving the
-// requests untouched so the caller can fall back.
+// Samples all active requests through the scheduler-owned sampler. It owns the reusable workspace
+// and groups rows by resolved sampling parameters, while each Request owns its persistent RNG state.
 bool ScheduledRequests::TryGenerateNextTokensBatched(std::vector<DeviceSpan<float>>& logits) {
-  const size_t batch_size = requests_.size();
-  // A single request has nothing to share, and the engine's scratch buffer has to hold the batch.
-  if (batch_size < 2 || shared_next_tokens_.size() < batch_size)
+  if (!batched_sampler_ || !sampling_plan_)
     return false;
 
-  const auto args = ResolveSampleArgs(requests_[0]->SearchOptions());
-  if (!args)
-    return false;
-  // Argmax ignores the random state, so batching cannot change its result. Sampling shares one
-  // batch-wide generator, which a request that pinned a seed is entitled not to expect.
-  const bool is_argmax = args->k == 1 && args->p == 0.0f;
+  sampling_plan_->Clear();
 
-  const size_t vocab_size = static_cast<size_t>(model_->config_->model.vocab_size);
-  auto* first_row = logits[0].Span().data();
-
-  for (size_t request_idx = 0; request_idx < batch_size; ++request_idx) {
-    // A completed request is skipped by the per-request loops, which would leave a hole in the
-    // logits rows that the batched sampler cannot express.
+  for (size_t request_idx = 0; request_idx < requests_.size(); ++request_idx) {
     if (requests_[request_idx]->status_ == RequestStatus::Completed)
-      return false;
+      continue;
 
-    const auto& search = requests_[request_idx]->SearchOptions();
-    const auto request_args = ResolveSampleArgs(search);
-    if (!request_args || request_args->k != args->k || request_args->p != args->p ||
-        request_args->temperature != args->temperature)
+    const auto args = ResolveSampleArgs(requests_[request_idx]->SearchOptions());
+    if (!args || !requests_[request_idx]->SupportsBatchedSampling())
       return false;
-
-    if (!is_argmax && search.random_seed != -1)
-      return false;
-
-    // The sampler reads one [batch_size, vocab_size] tensor, so the rows have to sit back to back
-    // in request order within a single allocation. This also rules out a step that mixes prefill
-    // and decode, where the rows are picked out of a larger tensor.
-    if (logits[request_idx].size() != vocab_size ||
-        !logits[request_idx].SameBufferAs(logits[0]) ||
-        logits[request_idx].Span().data() != first_row + request_idx * vocab_size)
-      return false;
+    sampling_plan_->requests.push_back(requests_[request_idx].get());
+    sampling_plan_->logits.push_back(logits[request_idx]);
+    sampling_plan_->params.push_back(*args);
+    sampling_plan_->states.push_back(&requests_[request_idx]->SamplingState(*batched_sampler_));
   }
 
-  // Only a CUDA greedy search accepts a shared slot. A partial bind is harmless: a bound search
-  // still samples into its own slot on the per-request path and copies the shared buffer back
-  // itself, so falling back below stays correct.
-  for (size_t request_idx = 0; request_idx < batch_size; ++request_idx) {
-    if (!requests_[request_idx]->BindNextTokensSlot(shared_next_tokens_.subspan(request_idx, 1)))
-      return false;
+  if (sampling_plan_->requests.empty())
+    return true;
+
+  for (size_t request_idx = 0; request_idx < sampling_plan_->requests.size(); ++request_idx) {
+    sampling_plan_->requests[request_idx]->PrepareGeneration(sampling_plan_->logits[request_idx]);
   }
 
-  // Past this point the requests are mutated, so there is no going back to the per-request path:
-  // the logits processors below are not idempotent.
-  for (size_t request_idx = 0; request_idx < batch_size; ++request_idx) {
-    requests_[request_idx]->PrepareGeneration(logits[request_idx]);
+  auto next_tokens = batched_sampler_->Sample(sampling_plan_->logits, sampling_plan_->params,
+                                              sampling_plan_->states,
+                                              model_->config_->model.vocab_size);
+
+  for (size_t request_idx = 0; request_idx < sampling_plan_->requests.size(); ++request_idx) {
+    if (!sampling_plan_->requests[request_idx]->BindNextTokensSlot(next_tokens.subspan(request_idx, 1)))
+      throw std::runtime_error("The scoring device supports batched sampling but the request search does not.");
+    sampling_plan_->requests[request_idx]->OnNextTokensSampled();
   }
 
-  auto batched_logits = logits[0].subspan(0, batch_size * vocab_size);
-  if (!model_->p_device_scoring_->SampleTopKTopP(batched_logits, shared_next_tokens_.subspan(0, batch_size),
-                                                 static_cast<int>(vocab_size), static_cast<int>(batch_size),
-                                                 args->k, args->p, args->temperature))
-    throw std::runtime_error("The scoring device accepted a shared next token buffer but cannot sample a batch.");
+  next_tokens.CopyDeviceToCpu();
 
-  for (size_t request_idx = 0; request_idx < batch_size; ++request_idx) {
-    requests_[request_idx]->OnNextTokensSampled();
-  }
-
-  // The one host/device synchronization of the step. It has to follow the tails above so that it
-  // observes the tokens they pad for sequences that just hit an end-of-sequence token.
-  shared_next_tokens_.CopyDeviceToCpu();
-
-  for (size_t request_idx = 0; request_idx < batch_size; ++request_idx) {
-    requests_[request_idx]->CompleteGeneration();
+  for (auto* request : sampling_plan_->requests) {
+    request->CompleteGeneration();
   }
 
   return true;

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -9,9 +9,32 @@ namespace Generators {
 
 struct DecoderIO;
 
+struct BatchedSamplingPlan {
+  void Reserve(size_t capacity) {
+    requests.reserve(capacity);
+    logits.reserve(capacity);
+    params.reserve(capacity);
+    states.reserve(capacity);
+  }
+
+  void Clear() {
+    requests.clear();
+    logits.clear();
+    params.clear();
+    states.clear();
+  }
+
+  std::vector<Request*> requests;
+  std::vector<DeviceSpan<float>> logits;
+  std::vector<BatchedSamplingParams> params;
+  std::vector<BatchedSamplerState*> states;
+};
+
 struct ScheduledRequests {
   ScheduledRequests(std::vector<std::shared_ptr<Request>> requests,
-                    std::shared_ptr<Model> model);
+                    std::shared_ptr<Model> model,
+                    BatchedSampler* batched_sampler,
+                    BatchedSamplingPlan* sampling_plan);
 
   std::unique_ptr<OrtRunOptions> RunOptions();
 
@@ -38,10 +61,6 @@ struct ScheduledRequests {
 
   void AddDecoderState(std::unique_ptr<DecoderIO> decoder_state);
 
-  // Scratch buffer owned by the engine, big enough for one token per scheduled request. When
-  // supplied, token selection for the whole batch can be sampled in a single call.
-  void SetSharedNextTokens(DeviceSpan<int32_t> next_tokens) { shared_next_tokens_ = next_tokens; }
-
   void GenerateNextTokens();
 
  private:
@@ -51,7 +70,8 @@ struct ScheduledRequests {
   std::shared_ptr<Model> model_;
   std::unique_ptr<DecoderIO> decoder_state_;
   std::shared_ptr<GeneratorParams> params_;
-  DeviceSpan<int32_t> shared_next_tokens_;
+  BatchedSampler* batched_sampler_{};
+  BatchedSamplingPlan* sampling_plan_{};
 };
 
 }  // namespace Generators

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -5,10 +5,26 @@
 
 namespace Generators {
 
+Scheduler::Scheduler(std::shared_ptr<Model> model) {
+  constexpr size_t default_static_batch_size = 4;
+  size_t max_batch_size = default_static_batch_size;
+  const auto& engine_config = model->config_->engine;
+  if (engine_config.dynamic_batching)
+    max_batch_size = std::max(max_batch_size, engine_config.dynamic_batching->max_batch_size);
+  if (engine_config.static_batching)
+    max_batch_size = std::max(max_batch_size, engine_config.static_batching->max_batch_size);
+
+  batched_sampling_plan_.Reserve(max_batch_size);
+  batched_sampler_ = model->p_device_scoring_->CreateBatchedSampler(
+      max_batch_size, model->config_->model.vocab_size);
+}
+
 StaticBatchScheduler::StaticBatchScheduler(std::shared_ptr<Model> model, std::shared_ptr<CacheManager> cache_manager)
-    : model_{model}, cache_manager_{cache_manager} {}
+    : Scheduler{model}, model_{model}, cache_manager_{cache_manager} {}
 
 void StaticBatchScheduler::AddRequest(std::shared_ptr<Request> request) {
+  if (auto* sampler = GetBatchedSampler())
+    request->SamplingState(*sampler);
   requests_pool_.push_back(request);
 }
 
@@ -54,7 +70,8 @@ ScheduledRequests StaticBatchScheduler::Schedule() {
     }
   }
 
-  ScheduledRequests scheduled_requests(cache_manager_->AllocatedRequests(), model_);
+  ScheduledRequests scheduled_requests(cache_manager_->AllocatedRequests(), model_, GetBatchedSampler(),
+                                       GetBatchedSamplingPlan());
 
   if (!scheduled_requests) {
     throw std::runtime_error("Unable to schedule requests: no requests available or all requests are completed.");
@@ -73,9 +90,11 @@ bool StaticBatchScheduler::HasPendingRequests() const {
 }
 
 DynamicBatchScheduler::DynamicBatchScheduler(std::shared_ptr<Model> model, std::shared_ptr<CacheManager> cache_manager)
-    : model_{model}, cache_manager_{cache_manager} {}
+    : Scheduler{model}, model_{model}, cache_manager_{cache_manager} {}
 
 void DynamicBatchScheduler::AddRequest(std::shared_ptr<Request> request) {
+  if (auto* sampler = GetBatchedSampler())
+    request->SamplingState(*sampler);
   requests_pool_.push_back(request);
 }
 
@@ -118,7 +137,8 @@ ScheduledRequests DynamicBatchScheduler::Schedule() {
     }
   }
 
-  ScheduledRequests scheduled_requests(cache_manager_->AllocatedRequests(), model_);
+  ScheduledRequests scheduled_requests(cache_manager_->AllocatedRequests(), model_, GetBatchedSampler(),
+                                       GetBatchedSamplingPlan());
 
   if (!scheduled_requests) {
     throw std::runtime_error("Unable to schedule requests: no requests available or all requests are completed.");

--- a/src/engine/scheduler.h
+++ b/src/engine/scheduler.h
@@ -21,7 +21,7 @@ struct Scheduler {
    * @param model A shared pointer to the Model object to be used by the Scheduler.
    * @param cache_manager A shared pointer to the CacheManager for managing cache states.
    */
-  Scheduler() = default;
+  explicit Scheduler(std::shared_ptr<Model> model);
 
   static std::unique_ptr<Scheduler> Create(std::shared_ptr<Model> model, std::shared_ptr<CacheManager> cache_manager);
 
@@ -61,6 +61,14 @@ struct Scheduler {
   virtual bool HasPendingRequests() const = 0;
 
   virtual ~Scheduler() = default;
+
+ protected:
+  BatchedSampler* GetBatchedSampler() const { return batched_sampler_.get(); }
+  BatchedSamplingPlan* GetBatchedSamplingPlan() { return &batched_sampling_plan_; }
+
+ private:
+  std::unique_ptr<BatchedSampler> batched_sampler_;
+  BatchedSamplingPlan batched_sampling_plan_;
 };
 
 struct StaticBatchScheduler : Scheduler {

--- a/src/search.h
+++ b/src/search.h
@@ -63,6 +63,7 @@ struct Search : LeakChecked<Search> {
   // Returns false if the search cannot use a shared buffer, in which case the caller must fall
   // back to driving each search through SelectTop()/SampleTopKTopP() individually.
   virtual bool BindNextTokensSlot(DeviceSpan<int32_t> /*slot*/) { return false; }
+  virtual bool SupportsBatchedSampling() const { return false; }
   virtual void OnNextTokensSampled() {}
 
   virtual void SelectTop() = 0;

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -93,6 +93,29 @@ struct DeviceSpan {
   friend struct DeviceSpan;  // All DeviceSpans are friends
 };
 
+struct BatchedSamplerState {
+  virtual ~BatchedSamplerState() = default;
+};
+
+struct BatchedSamplingParams {
+  int k{};
+  float p{};
+  float temperature{};
+};
+
+// Owns the reusable workspace for sampling Engine requests as a batch. Each request keeps the
+// state returned by CreateState so its random stream is independent of scheduler batch order.
+struct BatchedSampler {
+  virtual ~BatchedSampler() = default;
+
+  virtual std::unique_ptr<BatchedSamplerState> CreateState(int random_seed) = 0;
+  virtual bool OwnsState(const BatchedSamplerState& state) const = 0;
+  virtual DeviceSpan<int32_t> Sample(std::span<DeviceSpan<float>> scores,
+                                     std::span<const BatchedSamplingParams> params,
+                                     std::span<BatchedSamplerState* const> states,
+                                     int vocab_size) = 0;
+};
+
 enum struct DeviceType {
   CPU,
   CUDA,
@@ -125,6 +148,8 @@ struct DeviceInterface {
 
   virtual std::unique_ptr<Search> CreateGreedy(const GeneratorParams& params) = 0;
   virtual std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) = 0;
+  virtual std::unique_ptr<BatchedSampler> CreateBatchedSampler(size_t /*max_batch_size*/,
+                                                               int /*vocab_size*/) { return {}; }
 
   virtual void Synchronize() = 0;  // Synchronize the device, typically used for timing or debugging
 
@@ -133,13 +158,6 @@ struct DeviceInterface {
   virtual bool UpdatePositionIds(void* /*position_ids*/, int /*batch_beam_size*/, int /*total_length*/, int /*new_kv_length*/, ONNXTensorElementDataType /*type*/) { return false; }
   virtual bool UpdateAttentionMask(void* /*next_mask_data*/, void* /*mask_data*/, int /*batch_beam_size*/, int /*new_kv_length*/, int /*total_length*/, int /*max_length*/, bool /*update_only*/, ONNXTensorElementDataType /*type*/) { return false; }
   virtual void LaunchAddLogitsMask(float* /*batch_logits*/, int /*batch_beam_size*/, int /*vocab_size*/, const uint32_t* /*logits_mask*/) { assert(false); }
-
-  // Selects one token per row from a contiguous [batch_size, vocab_size] score tensor, writing
-  // batch_size tokens. Returns false when the device has no batched sampler, in which case the
-  // caller has to sample one row at a time.
-  virtual bool SampleTopKTopP(DeviceSpan<float> /*scores*/, DeviceSpan<int32_t> /*next_tokens*/,
-                              int /*vocab_size*/, int /*batch_size*/,
-                              int /*k*/, float /*p*/, float /*temperature*/) { return false; }
 
   virtual void UpdateCacheIndirection(int32_t* /*tgt_indir_cache*/, const int32_t* /*src_indir_cache*/, const int32_t* /*beam_ids*/, int /*batch_size*/, int /*beam_width*/, int /*input_seq_length*/, int /*max_seq_length*/, int /*current_length*/) { assert(false); }
   virtual void ReorderPastStates(void* /*out_buffer*/, const void* /*in_buffer*/, int /*batch_size*/, int /*num_heads*/, int /*max_length*/, int /*head_size*/, int /*chunk_size*/) { assert(false); }

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -568,7 +568,7 @@ TEST(SamplingTests, SchedulerOwnedSamplerHandlesHeterogeneousRowsCuda) {
   auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
   config->ClearProviders();
   config->AppendProvider("cuda");
-  auto model = OgaModel::Create(*config);
+[[maybe_unused]] auto model = OgaModel::Create(*config);
 
   auto* device = Generators::GetDeviceInterface(Generators::DeviceType::CUDA);
   auto sampler = device->CreateBatchedSampler(3, vocab_size);

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -14,6 +14,7 @@
 #include <ort_genai.h>
 #include <gtest/gtest.h>
 
+#include "generators.h"
 #include "test_utils.h"
 
 // External global variable from main.cpp for custom model path
@@ -562,6 +563,128 @@ TEST(SamplingTests, NoRepeatNgramCorrectnessCpu) {
 }
 
 #if USE_CUDA
+TEST(SamplingTests, SchedulerOwnedSamplerHandlesHeterogeneousRowsCuda) {
+  constexpr int vocab_size = 5;
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->ClearProviders();
+  config->AppendProvider("cuda");
+  auto model = OgaModel::Create(*config);
+
+  auto* device = Generators::GetDeviceInterface(Generators::DeviceType::CUDA);
+  auto sampler = device->CreateBatchedSampler(3, vocab_size);
+  ASSERT_NE(sampler, nullptr);
+
+  const std::array<std::array<float, vocab_size>, 3> logits{{
+      {{0.0f, 5.0f, 1.0f, 2.0f, 3.0f}},
+      {{0.0f, 1.0f, 6.0f, 2.0f, 3.0f}},
+      {{0.0f, 1.0f, 2.0f, 7.0f, 3.0f}},
+  }};
+  std::vector<Generators::DeviceSpan<float>> rows;
+  for (const auto& row_logits : logits) {
+    auto row = device->Allocate<float>(vocab_size);
+    std::copy(row_logits.begin(), row_logits.end(), row.CpuSpan().begin());
+    row.CopyCpuToDevice();
+    rows.push_back(std::move(row));
+  }
+
+  const std::array<Generators::BatchedSamplingParams, 3> params{{
+      {1, 0.0f, 1.0f},
+      {2, 0.01f, 0.7f},
+      {-1, 0.01f, 1.3f},
+  }};
+  std::array<std::unique_ptr<Generators::BatchedSamplerState>, 3> owned_states;
+  std::array<Generators::BatchedSamplerState*, 3> states;
+  for (size_t i = 0; i < states.size(); ++i) {
+    owned_states[i] = sampler->CreateState(static_cast<int>(10 + i));
+    states[i] = owned_states[i].get();
+  }
+
+  auto tokens = sampler->Sample(rows, params, states, vocab_size).CopyDeviceToCpu();
+  EXPECT_EQ(tokens[0], 1);
+  EXPECT_EQ(tokens[1], 2);
+  EXPECT_EQ(tokens[2], 3);
+}
+
+TEST(SamplingTests, SchedulerOwnedSamplerPreservesRngAcrossBatchReorderCuda) {
+  constexpr int vocab_size = 8;
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->ClearProviders();
+  config->AppendProvider("cuda");
+  auto model = OgaModel::Create(*config);
+
+  auto* device = Generators::GetDeviceInterface(Generators::DeviceType::CUDA);
+  auto sampler_ab = device->CreateBatchedSampler(2, vocab_size);
+  auto sampler_ba = device->CreateBatchedSampler(2, vocab_size);
+  ASSERT_NE(sampler_ab, nullptr);
+  ASSERT_NE(sampler_ba, nullptr);
+
+  std::array<Generators::DeviceSpan<float>, 2> rows;
+  const std::array<float, vocab_size> logits{{0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f}};
+  for (auto& row : rows) {
+    row = device->Allocate<float>(vocab_size);
+    std::copy(logits.begin(), logits.end(), row.CpuSpan().begin());
+    row.CopyCpuToDevice();
+  }
+
+  const std::array<Generators::BatchedSamplingParams, 2> params{{
+      {4, 1.0f, 1.0f},
+      {4, 1.0f, 1.0f},
+  }};
+  auto state_a_ab = sampler_ab->CreateState(11);
+  auto state_b_ab = sampler_ab->CreateState(29);
+  auto state_b_ba = sampler_ba->CreateState(29);
+  auto state_a_ba = sampler_ba->CreateState(11);
+  std::array<Generators::BatchedSamplerState*, 2> states_ab{{state_a_ab.get(), state_b_ab.get()}};
+  std::array<Generators::BatchedSamplerState*, 2> states_ba{{state_b_ba.get(), state_a_ba.get()}};
+  std::array<Generators::DeviceSpan<float>, 2> rows_ba{{rows[1], rows[0]}};
+
+  for (int step = 0; step < 8; ++step) {
+    auto tokens_ab = sampler_ab->Sample(rows, params, states_ab, vocab_size).CopyDeviceToCpu();
+    auto tokens_ba = sampler_ba->Sample(rows_ba, params, states_ba, vocab_size).CopyDeviceToCpu();
+    EXPECT_EQ(tokens_ab[0], tokens_ba[1]);
+    EXPECT_EQ(tokens_ab[1], tokens_ba[0]);
+  }
+}
+
+TEST(SamplingTests, SchedulerOwnedSamplerCachesTopKPerBucketSizeCuda) {
+  constexpr int batch_size = 3;
+  constexpr int vocab_size = 100001;
+  constexpr int top_k = 25;
+  auto config = OgaConfig::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  config->ClearProviders();
+  config->AppendProvider("cuda");
+  auto model = OgaModel::Create(*config);
+
+  auto* device = Generators::GetDeviceInterface(Generators::DeviceType::CUDA);
+  auto sampler = device->CreateBatchedSampler(batch_size, vocab_size);
+  ASSERT_NE(sampler, nullptr);
+
+  std::array<Generators::DeviceSpan<float>, batch_size> rows;
+  for (int row_index = 0; row_index < batch_size; ++row_index) {
+    rows[row_index] = device->Allocate<float>(vocab_size);
+    auto logits = rows[row_index].CpuSpan();
+    std::fill(logits.begin(), logits.end(), 0.0f);
+    logits[row_index + 1] = 100.0f;
+    rows[row_index].CopyCpuToDevice();
+  }
+
+  const std::array<Generators::BatchedSamplingParams, batch_size> params{{
+      {top_k, 0.01f, 1.0f},
+      {top_k, 0.02f, 1.0f},
+      {top_k, 0.02f, 1.0f},
+  }};
+  std::array<std::unique_ptr<Generators::BatchedSamplerState>, batch_size> owned_states;
+  std::array<Generators::BatchedSamplerState*, batch_size> states;
+  for (int row_index = 0; row_index < batch_size; ++row_index) {
+    owned_states[row_index] = sampler->CreateState(row_index);
+    states[row_index] = owned_states[row_index].get();
+  }
+
+  auto tokens = sampler->Sample(rows, params, states, vocab_size).CopyDeviceToCpu();
+  for (int row_index = 0; row_index < batch_size; ++row_index)
+    EXPECT_EQ(tokens[row_index], row_index + 1);
+}
+
 TEST(SamplingTests, BatchedSamplingTopPCuda) {
   std::vector<int32_t> input_ids{0, 1, 2, 3};
   std::vector<int32_t> expected_output{1, 2, 3, 4};


### PR DESCRIPTION
## Description

> Stacked on #2345. This PR targets `tlwu/paged_attention_dynmaic_batching_fast_path` and should be reviewed after #2343 and #2345.

This replaces #2345's process-global, homogeneous sampling fast path with one sampler owned by each Engine scheduler. The sampler handles heterogeneous request options, pinned seeds, scheduler reorder, and noncontiguous logits rows while preserving per-request sequence and EOS state.

## Summary of Changes

### Scheduler-owned sampling

| Area | Change |
|------|--------|
| `src/engine/` | The scheduler owns reusable sampling state and preallocated planning arrays; requests retain stable RNG handles across join, leave, and reorder. |
| `src/smartptrs.h` | Adds a device-neutral `BatchedSampler` interface with provider fallback. |
| `src/cuda/interface.cpp` | Implements a CUDA sampler with reusable packed logits, metadata, output, and sampling workspace. |

### Heterogeneous and ragged batches

- Resolves `(k, p, temperature)` per request and groups rows by identical options.
- Uses one existing `GetSample` invocation per distinct parameter group instead of one per request.
- Gathers noncontiguous rows into reusable packed storage and scatters tokens back to request order.
- Keeps one persistent cuRAND state per request, so pinned seeds do not depend on scheduler position.
- Makes the local Top-K algorithm cache batch-size-aware for differently sized parameter groups.

### Lifecycle and memory

- Preallocates scheduler planning, pinned staging, CUDA output, and sampler workspace from the configured maximum batch size.
- Lazily creates the legacy per-search sampling workspace, so Engine requests do not retain a full-vocabulary sampler per request.
- Checks CUDA copies and synchronization, preserves pending state after copy failures, and drains queued scoring work before propagating generation errors.
- Retains per-request logits processors, EOS/pad handling, sequence append, and completion bookkeeping.

### Tests and documentation

- Adds CUDA tests for heterogeneous noncontiguous rows, seeded RNG stability under reversed batch order, and same-`k` Top-K cache reuse across different bucket sizes.
- Documents the scheduler-owned design as Phase 3 in `docs/paged_attention_batching.md`.

## Testing

- CUDA 13.0 Release build for `sm_80` with tests enabled:
  `cmake --build build/cu130/Release --target unit_tests --parallel 12`
- Full C++ suite: 137 tests ran, 115 passed, 22 environment-dependent tests skipped, 0 failed.
- Focused CUDA sampling and continuous-decoding suite: 11 passed, 0 failed.
- Ruff and Ruff-format passed. C/CUDA files were formatted with ClangFormat 20.1.8; the local lintrunner ClangFormat adapter itself failed before invoking the installed formatter.

## Motivation and Context

#2343 removes per-request synchronization, and #2345 batches sampling only when all requests have uniform parameters and contiguous logits. This phase makes batching the normal scheduler architecture: launch count scales with the number of distinct sampling configurations rather than request count, without coupling request RNG or lifecycle to batch position.

H200 throughput profiling is still needed for this draft. Batching the remaining per-request EOS/pad and sequence-append tails is intentionally left for follow-up work.

## Checklist

- [x] Tests added/updated
- [x] No breaking public API changes
- [x] Documentation updated