### PR TITLE
Fix process-exit teardown crashes (telemetry deadlock + ORT env abort)

### DIFF
--- a/cmake/patches/cpp_client_telemetry/apply_patch.cmake
+++ b/cmake/patches/cpp_client_telemetry/apply_patch.cmake
@@ -119,6 +119,11 @@ ortgenai_replace_required(
 # exits, versus 85/85 clean with this hunk alone). Tolerating the exception is the correct fix.
 # The guard's destructor locks m_pause_mutex, a member of the still-live heap-allocated
 # LogManagerImpl, so it cannot itself throw while unwinding.
+#
+# There is also a distinct rejected-activity path: a scheduled flush sets m_flushPending and resets
+# m_flushComplete before its task starts. If teardown pauses the LogManager first, StartActivity()
+# returns false; returning without signaling completion leaves WaitForFlush() blocked forever.
+# Cancel the scheduled handle and complete the pending flush under m_flushLock on that path.
 # Reported upstream; drop this hunk once the fix is in a pinned release.
 ortgenai_replace_required(
   "${SOURCE_DIR}/lib/offline/OfflineStorageHandler.cpp"
@@ -126,6 +131,12 @@ ortgenai_replace_required(
             return;
         }]=]
   [=[        if (!m_logManager.StartActivity()) {
+            // Teardown can pause the LogManager after a flush has been scheduled but before its task
+            // starts. Complete the rejected flush so WaitForFlush() cannot wait forever.
+            LOCKGUARD(m_flushLock);
+            m_flushHandle.Cancel();
+            m_flushComplete.post();
+            m_flushPending = false;
             return;
         }
         // Balance the activity count on every exit path, including an exception unwinding out of

--- a/cmake/patches/cpp_client_telemetry/apply_patch.cmake
+++ b/cmake/patches/cpp_client_telemetry/apply_patch.cmake
@@ -101,3 +101,76 @@ ortgenai_replace_required(
         curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);]=]
   [=[        // The embedded Linux curl omits nghttp2 to keep the transport self-contained.
         curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);]=])
+
+# OfflineStorageHandler::Flush() brackets its body with ILogManager::StartActivity() /
+# EndActivity() using raw calls rather than a scope guard, so any exception thrown between them
+# permanently leaks one pause-activity count. That is not hypothetical: during process exit,
+# OnStorageRecordsSaved() -> DebugEventSource::DispatchEvent() locks a std::recursive_mutex whose
+# backing static may already have been finalized, which throws std::system_error
+# ("mutex lock failed: Invalid argument"). The leaked count then makes the *next* FlushAndTeardown()
+# call PauseActivity() (state -> Pausing) and block forever in WaitPause(), which waits for the
+# activity count to drain to zero. That is a deterministic, unrecoverable process-exit deadlock.
+#
+# Make the activity strictly scope-bound so the count is balanced on every exit path, including
+# exceptional ones. Note this deliberately does not try to prevent the throw itself: the throwing
+# lock doubles as a circuit breaker that stops DispatchEvent() from walking listener/cascaded
+# containers that are themselves already destroyed. Making that mutex immortal was measured to
+# remove the throw but introduce an intermittent use-after-free crash (3 failures in 75 process
+# exits, versus 85/85 clean with this hunk alone). Tolerating the exception is the correct fix.
+# The guard's destructor locks m_pause_mutex, a member of the still-live heap-allocated
+# LogManagerImpl, so it cannot itself throw while unwinding.
+# Reported upstream; drop this hunk once the fix is in a pinned release.
+ortgenai_replace_required(
+  "${SOURCE_DIR}/lib/offline/OfflineStorageHandler.cpp"
+  [=[        if (!m_logManager.StartActivity()) {
+            return;
+        }]=]
+  [=[        if (!m_logManager.StartActivity()) {
+            return;
+        }
+        // Balance the activity count on every exit path, including an exception unwinding out of
+        // this function; leaking it would deadlock a later FlushAndTeardown() in WaitPause().
+        struct OrtGenAIActivityGuard final {
+            ILogManager& log_manager;
+            ~OrtGenAIActivityGuard() { log_manager.EndActivity(); }
+        } ortgenai_activity_guard{m_logManager};]=])
+
+ortgenai_replace_required(
+  "${SOURCE_DIR}/lib/offline/OfflineStorageHandler.cpp"
+  [=[        m_flushPending = false;
+        m_logManager.EndActivity();]=]
+  [=[        m_flushPending = false;
+        // EndActivity() now runs from ortgenai_activity_guard above, on every exit path.]=])
+
+# LogManagerProvider::Release() walks LogManagerFactory's registries to find and destroy the manager.
+# The factory is a function-local static, so during static destruction it can already be destroyed by
+# the time a host's exit path calls Release() -- the registries are then destroyed std::maps and
+# walking them dereferences freed nodes (observed: EXC_BAD_ACCESS in LogManagerFactory::release()).
+# Make the factory immortal: it is a small, fixed-size object, and leaking it keeps the registries
+# readable so Release() can still perform the *real* teardown (FlushAndTeardown + worker-thread join)
+# it is being asked to do. Reported upstream; drop this hunk once the fix is in a pinned release.
+ortgenai_replace_required(
+  "${SOURCE_DIR}/lib/api/LogManagerFactory.hpp"
+  [=[        static LogManagerFactory& instance() {
+            static LogManagerFactory impl;
+            return impl;
+        }]=]
+  [=[        static LogManagerFactory& instance() {
+            static LogManagerFactory& impl = *new LogManagerFactory();
+            return impl;
+        }]=])
+
+# GetPAL()'s function-local static is destroyed at a point that is not ordered against the host's
+# teardown call: PAL is constructed lazily on first telemetry use, so whether its static outlives the
+# LogManager teardown depends on runtime timing. When it does not, LogManagerImpl::FlushAndTeardown()
+# -> PAL::shutdown() releases shared_ptr members of an already-destroyed PlatformAbstractionLayer and
+# faults (observed: intermittent EXC_BAD_ACCESS in ~shared_ptr<ISystemInformation>, roughly 3 in 25
+# process exits). Make the PAL immortal so shutdown() always operates on live members; it is a single
+# fixed-size object and PAL::shutdown() already performs the real resource teardown explicitly.
+# Reported upstream; drop this hunk once the fix is in a pinned release.
+ortgenai_replace_required(
+  "${SOURCE_DIR}/lib/pal/PAL.cpp"
+  [=[        static PlatformAbstractionLayer pal;
+        return pal;]=]
+  [=[        static PlatformAbstractionLayer& pal = *new PlatformAbstractionLayer();
+        return pal;]=])

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -152,21 +152,30 @@ void Shutdown() {
 
   // Reset g_ort_globals directly (rather than through GetOrtGlobals(), which would lazily construct
   // the globals just to immediately tear them down). If genai was never initialized there is nothing
-  // to do. ~OrtGlobals tears down the device interfaces (including the RyzenAI EP shutdown), unloads
-  // the genai add-on libraries, and finally releases the OrtEnv.
+  // to do. ~OrtGlobals clears the graph session cache and the device allocators, tears down the
+  // device interfaces (including the RyzenAI EP shutdown), unloads the genai add-on libraries, and
+  // finally releases the OrtEnv. All of that runs on both the runtime and the process-exit path; the
+  // only difference at process exit is that the OrtEnv itself is leaked rather than destroyed, for
+  // the reason described below.
   std::scoped_lock lock{g_ort_globals_mutex};
 
-  // At process exit (the EnsureShutdown static destructor sets g_process_exiting under this lock),
-  // running ~OrtGlobals is unsafe: releasing the OrtEnv from within __cxa_finalize drives ORT's
-  // Environment/LoggingManager destructor to lock a mutex whose backing static may already be
-  // finalized, which throws "mutex lock failed: Invalid argument" -- and a throwing destructor at
-  // teardown is uncaught, so the process aborts via std::terminate. Re-init after shutdown is
-  // impossible once the process is exiting, so intentionally leak the globals here and let the OS
-  // reclaim the memory. Runtime OgaShutdown() (g_process_exiting == false) still performs the full
-  // teardown that in-process re-init relies on.
-  if (g_process_exiting) {
-    (void)g_ort_globals.release();
-    return;
+  if (g_ort_globals && g_process_exiting) {
+    // At process exit (the EnsureShutdown static destructor sets g_process_exiting under this lock),
+    // destroying the OrtEnv is unsafe: releasing it from within __cxa_finalize drives ORT's
+    // Environment/LoggingManager destructor to lock a mutex whose backing static may already be
+    // finalized, which throws "mutex lock failed: Invalid argument" -- and a throwing destructor at
+    // teardown is uncaught, so the process aborts via std::terminate. Nothing else ~OrtGlobals does
+    // (clearing the graph session cache, tearing down device interfaces including the RyzenAI EP
+    // shutdown, unloading the CUDA add-on library, or releasing the trivial-session allocators)
+    // touches that ORT static state, so only the env itself needs to be leaked: release it from the
+    // unique_ptr before ~OrtGlobals runs below, so the rest of teardown still happens in full. The
+    // released OrtEnv is simply never destructed -- it stays validly constructed in memory for as
+    // long as the remaining teardown code (or anything else) needs it, and the OS reclaims it when
+    // the process exits. The default OrtEnv owns no thread pools (genai never asks for global ones),
+    // so leaking it keeps no threads alive. g_process_exiting is also set when the genai module is
+    // unloaded at runtime (dlclose / FreeLibrary), where destroying the env would in fact be safe;
+    // the cost there is one leaked OrtEnv per load/unload cycle, which is preferable to aborting.
+    (void)g_ort_globals->env_.release();
   }
 
   g_ort_globals.reset();

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -152,9 +152,23 @@ void Shutdown() {
 
   // Reset g_ort_globals directly (rather than through GetOrtGlobals(), which would lazily construct
   // the globals just to immediately tear them down). If genai was never initialized there is nothing
-  // to do. Delete now because on process exit is too late. ~OrtGlobals tears down the device
-  // interfaces (including the RyzenAI EP shutdown) and unloads the genai add-on libraries.
+  // to do. ~OrtGlobals tears down the device interfaces (including the RyzenAI EP shutdown), unloads
+  // the genai add-on libraries, and finally releases the OrtEnv.
   std::scoped_lock lock{g_ort_globals_mutex};
+
+  // At process exit (the EnsureShutdown static destructor sets g_process_exiting under this lock),
+  // running ~OrtGlobals is unsafe: releasing the OrtEnv from within __cxa_finalize drives ORT's
+  // Environment/LoggingManager destructor to lock a mutex whose backing static may already be
+  // finalized, which throws "mutex lock failed: Invalid argument" -- and a throwing destructor at
+  // teardown is uncaught, so the process aborts via std::terminate. Re-init after shutdown is
+  // impossible once the process is exiting, so intentionally leak the globals here and let the OS
+  // reclaim the memory. Runtime OgaShutdown() (g_process_exiting == false) still performs the full
+  // teardown that in-process re-init relies on.
+  if (g_process_exiting) {
+    (void)g_ort_globals.release();
+    return;
+  }
+
   g_ort_globals.reset();
 }
 

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -283,47 +283,25 @@ void GenAiTelemetry::Shutdown() {
   // new ones from observing the logger while teardown is in progress.
   initialized_.store(false);
 
-  if (!impl_) return;
-  auto impl = std::move(impl_);
-
-  // Explicit runtime shutdown (e.g. OgaShutdown()): tear down synchronously. No threads are being
-  // force-killed here, so FlushAndTeardown() completes promptly, and a synchronous teardown keeps a
-  // subsequent Initialize() from racing a half-torn-down manager over the SDK's process-global state.
-  // OgaShutdown() only reaches here while the singleton is alive (it checks IsDestroyed() first), so
-  // s_instance_destroyed == false is exactly "not at process exit".
-  //
-  // 1DS-recommended shutdown sequence. Each step is independent and best effort so Release() still
-  // runs if flushing or teardown fails; Release() must precede destroying Impl because the SDK holds
-  // a reference to Impl::config.
-  if (!s_instance_destroyed.load()) {
-    if (impl->log_manager) {
-      try {
-        impl->log_manager->Flush();
-      } catch (...) {
-      }
-      try {
-        impl->log_manager->FlushAndTeardown();
-      } catch (...) {
-      }
-      try {
-        MAT::LogManagerProvider::Release(impl->config);
-      } catch (...) {
-      }
-      impl->log_manager = nullptr;
-      impl->logger = nullptr;
+  // 1DS-recommended shutdown sequence. Each operation is independent and best effort so Release()
+  // still runs if flushing or teardown fails.
+  if (impl_ && impl_->log_manager) {
+    try {
+      impl_->log_manager->Flush();
+    } catch (...) {
     }
-    return;  // impl (and the ILogConfiguration it owns) destroyed here, after Release().
+    try {
+      impl_->log_manager->FlushAndTeardown();
+    } catch (...) {
+    }
+    try {
+      MAT::LogManagerProvider::Release(impl_->config);
+    } catch (...) {
+    }
+    impl_->log_manager = nullptr;
+    impl_->logger = nullptr;
   }
-
-  // Process exit (static destructor): deliberately do NOT run the 1DS teardown -- just leak the
-  // manager. FlushAndTeardown() calls an *unbounded* WaitPause() that deadlocks at exit if a logging
-  // activity count was left unbalanced (a thread torn down mid-LogEvent by exit()), which would wedge
-  // the whole process. Leaking is safe here: 1DS does not tear the manager down itself at process
-  // exit (LogManagerFactory keeps managers in a std::set<ILogManager*> of raw pointers and its
-  // destructor is empty), so ~LogManagerImpl never runs and there is no hang; the OS reclaims the
-  // manager and its background threads. Re-init after process exit is impossible, so nothing is lost,
-  // and no teardown work races the surrounding static-destruction sequence.
-  (void)impl.release();
+  impl_.reset();
 #endif
 }
 GenAiTelemetry::~GenAiTelemetry() {

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -10,10 +10,6 @@
 #include "../logging.h"
 
 #if defined(ORTGENAI_ENABLE_TELEMETRY)
-#include <chrono>
-#include <future>
-#include <thread>
-
 #include "Enums.hpp"
 #include "ILogConfiguration.hpp"
 #include "LogManager.hpp"
@@ -290,65 +286,44 @@ void GenAiTelemetry::Shutdown() {
   if (!impl_) return;
   auto impl = std::move(impl_);
 
-  // 1DS-recommended shutdown sequence. Each step is independent and best effort so Release() still
-  // runs if flushing or teardown fails. Release() must precede destroying Impl because the SDK holds
-  // a reference to Impl::config.
-  auto teardown = [](Impl* p) {
-    if (p && p->log_manager) {
-      try {
-        p->log_manager->Flush();
-      } catch (...) {
-      }
-      try {
-        p->log_manager->FlushAndTeardown();
-      } catch (...) {
-      }
-      try {
-        MAT::LogManagerProvider::Release(p->config);
-      } catch (...) {
-      }
-      p->log_manager = nullptr;
-      p->logger = nullptr;
-    }
-  };
-
   // Explicit runtime shutdown (e.g. OgaShutdown()): tear down synchronously. No threads are being
   // force-killed here, so FlushAndTeardown() completes promptly, and a synchronous teardown keeps a
-  // subsequent Initialize() from racing a still-running teardown over the SDK's process-global state.
+  // subsequent Initialize() from racing a half-torn-down manager over the SDK's process-global state.
   // OgaShutdown() only reaches here while the singleton is alive (it checks IsDestroyed() first), so
-  // this branch is exactly "not at process exit".
+  // s_instance_destroyed == false is exactly "not at process exit".
+  //
+  // 1DS-recommended shutdown sequence. Each step is independent and best effort so Release() still
+  // runs if flushing or teardown fails; Release() must precede destroying Impl because the SDK holds
+  // a reference to Impl::config.
   if (!s_instance_destroyed.load()) {
-    teardown(impl.get());
-    return;
+    if (impl->log_manager) {
+      try {
+        impl->log_manager->Flush();
+      } catch (...) {
+      }
+      try {
+        impl->log_manager->FlushAndTeardown();
+      } catch (...) {
+      }
+      try {
+        MAT::LogManagerProvider::Release(impl->config);
+      } catch (...) {
+      }
+      impl->log_manager = nullptr;
+      impl->logger = nullptr;
+    }
+    return;  // impl (and the ILogConfiguration it owns) destroyed here, after Release().
   }
 
-  // Process exit (static destructor): FlushAndTeardown() can deadlock here. The SDK's WaitPause() is
-  // an *unbounded* condition_variable wait; if a logging activity count was left unbalanced (a thread
-  // torn down mid-LogEvent by exit()), the pause state stays 'Pausing' forever and WaitPause never
-  // returns, wedging the whole process. Run teardown on a detached worker with a bounded wait and, on
-  // timeout, leak the manager (reclaimed by the OS at exit) rather than hang — consistent with
-  // CFG_INT_MAX_TEARDOWN_TIME=0, which already declares that teardown must not block process exit.
-  Impl* raw = impl.release();
-  try {
-    auto teardown_done = std::make_shared<std::promise<void>>();
-    std::future<void> teardown_future = teardown_done->get_future();
-
-    std::thread([raw, teardown_done, teardown]() mutable {
-      teardown(raw);
-      delete raw;  // destroys Impl (and the ILogConfiguration it owns) on the worker, after Release.
-      teardown_done->set_value();
-    }).detach();
-
-    // Common case: teardown completes near-instantly. Pathological case: cap the added exit latency
-    // instead of hanging forever. The shared promise keeps set_value() safe even after this times
-    // out, and std::promise/std::thread (unlike std::async) means the future's destructor never joins.
-    constexpr auto kTeardownBudget = std::chrono::seconds(2);
-    (void)teardown_future.wait_for(kTeardownBudget);
-  } catch (...) {
-    // Failed to spawn the teardown worker (e.g. resource exhaustion at exit). Leak 'raw' rather than
-    // let an exception escape ~GenAiTelemetry() (which would std::terminate) or risk a synchronous
-    // teardown that could hang the process. The OS reclaims the memory at exit.
-  }
+  // Process exit (static destructor): deliberately do NOT run the 1DS teardown -- just leak the
+  // manager. FlushAndTeardown() calls an *unbounded* WaitPause() that deadlocks at exit if a logging
+  // activity count was left unbalanced (a thread torn down mid-LogEvent by exit()), which would wedge
+  // the whole process. Leaking is safe here: 1DS does not tear the manager down itself at process
+  // exit (LogManagerFactory keeps managers in a std::set<ILogManager*> of raw pointers and its
+  // destructor is empty), so ~LogManagerImpl never runs and there is no hang; the OS reclaims the
+  // manager and its background threads. Re-init after process exit is impossible, so nothing is lost,
+  // and no teardown work races the surrounding static-destruction sequence.
+  (void)impl.release();
 #endif
 }
 GenAiTelemetry::~GenAiTelemetry() {

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -10,6 +10,10 @@
 #include "../logging.h"
 
 #if defined(ORTGENAI_ENABLE_TELEMETRY)
+#include <chrono>
+#include <future>
+#include <thread>
+
 #include "Enums.hpp"
 #include "ILogConfiguration.hpp"
 #include "LogManager.hpp"
@@ -283,25 +287,68 @@ void GenAiTelemetry::Shutdown() {
   // new ones from observing the logger while teardown is in progress.
   initialized_.store(false);
 
-  // 1DS-recommended shutdown sequence. Each operation is independent and best effort so Release()
-  // still runs if flushing or teardown fails.
-  if (impl_ && impl_->log_manager) {
-    try {
-      impl_->log_manager->Flush();
-    } catch (...) {
+  if (!impl_) return;
+  auto impl = std::move(impl_);
+
+  // 1DS-recommended shutdown sequence. Each step is independent and best effort so Release() still
+  // runs if flushing or teardown fails. Release() must precede destroying Impl because the SDK holds
+  // a reference to Impl::config.
+  auto teardown = [](Impl* p) {
+    if (p && p->log_manager) {
+      try {
+        p->log_manager->Flush();
+      } catch (...) {
+      }
+      try {
+        p->log_manager->FlushAndTeardown();
+      } catch (...) {
+      }
+      try {
+        MAT::LogManagerProvider::Release(p->config);
+      } catch (...) {
+      }
+      p->log_manager = nullptr;
+      p->logger = nullptr;
     }
-    try {
-      impl_->log_manager->FlushAndTeardown();
-    } catch (...) {
-    }
-    try {
-      MAT::LogManagerProvider::Release(impl_->config);
-    } catch (...) {
-    }
-    impl_->log_manager = nullptr;
-    impl_->logger = nullptr;
+  };
+
+  // Explicit runtime shutdown (e.g. OgaShutdown()): tear down synchronously. No threads are being
+  // force-killed here, so FlushAndTeardown() completes promptly, and a synchronous teardown keeps a
+  // subsequent Initialize() from racing a still-running teardown over the SDK's process-global state.
+  // OgaShutdown() only reaches here while the singleton is alive (it checks IsDestroyed() first), so
+  // this branch is exactly "not at process exit".
+  if (!s_instance_destroyed.load()) {
+    teardown(impl.get());
+    return;
   }
-  impl_.reset();
+
+  // Process exit (static destructor): FlushAndTeardown() can deadlock here. The SDK's WaitPause() is
+  // an *unbounded* condition_variable wait; if a logging activity count was left unbalanced (a thread
+  // torn down mid-LogEvent by exit()), the pause state stays 'Pausing' forever and WaitPause never
+  // returns, wedging the whole process. Run teardown on a detached worker with a bounded wait and, on
+  // timeout, leak the manager (reclaimed by the OS at exit) rather than hang — consistent with
+  // CFG_INT_MAX_TEARDOWN_TIME=0, which already declares that teardown must not block process exit.
+  Impl* raw = impl.release();
+  try {
+    auto teardown_done = std::make_shared<std::promise<void>>();
+    std::future<void> teardown_future = teardown_done->get_future();
+
+    std::thread([raw, teardown_done, teardown]() mutable {
+      teardown(raw);
+      delete raw;  // destroys Impl (and the ILogConfiguration it owns) on the worker, after Release.
+      teardown_done->set_value();
+    }).detach();
+
+    // Common case: teardown completes near-instantly. Pathological case: cap the added exit latency
+    // instead of hanging forever. The shared promise keeps set_value() safe even after this times
+    // out, and std::promise/std::thread (unlike std::async) means the future's destructor never joins.
+    constexpr auto kTeardownBudget = std::chrono::seconds(2);
+    (void)teardown_future.wait_for(kTeardownBudget);
+  } catch (...) {
+    // Failed to spawn the teardown worker (e.g. resource exhaustion at exit). Leak 'raw' rather than
+    // let an exception escape ~GenAiTelemetry() (which would std::terminate) or risk a synchronous
+    // teardown that could hang the process. The OS reclaims the memory at exit.
+  }
 #endif
 }
 GenAiTelemetry::~GenAiTelemetry() {


### PR DESCRIPTION
## Summary

A process using ONNX Runtime GenAI can hang or crash during static destruction. Foundry Local exposed two independent failures on macOS-arm64:

1. A deterministic deadlock in the vendored 1DS telemetry library.
2. An abort while destroying the last `OrtEnv`.

The underlying problems are static-destruction-order hazards and are not inherently macOS-specific.

## 1. 1DS telemetry teardown

`OfflineStorageHandler::Flush()` calls `StartActivity()` and later balances it with a raw `EndActivity()` call.

During process exit, `DebugEventSource::DispatchEvent()` can lock a function-local static mutex that has already been finalized. The resulting `std::system_error` escapes `Flush()`, skipping `EndActivity()` and permanently leaving the activity count at one.

The subsequent `FlushAndTeardown()` transitions to `Pausing` and waits indefinitely in `WaitPause()` for that activity count to reach zero.

This was confirmed from a hung process:

- `m_pause_active_count == 1`
- `m_pause_state == Pausing`
- the 1DS worker thread was idle
- the blocked thread was inside `WaitPause()`, not GenAI's telemetry mutex

### Fix

The vendored 1DS source is patched to:

- Balance `StartActivity()` with an RAII guard so exceptions cannot leak the activity count.
- Keep `LogManagerFactory` alive through static destruction so `LogManagerProvider::Release()` can safely locate and destroy the manager.
- Keep `PlatformAbstractionLayer` alive through static destruction so `PAL::shutdown()` operates on live members.

The manager is still genuinely torn down: queued events are flushed or persisted and worker threads are joined. GenAI's telemetry implementation remains unchanged.

The exception from the already-finalized `DebugEventSource` mutex is deliberately tolerated. Making that mutex immortal removed the exception but allowed dispatch to continue into already-destroyed listener containers, producing an intermittent use-after-free.

These patches should be removed after equivalent fixes are available in the pinned `cpp_client_telemetry` release.

## 2. ORT environment teardown

Destroying the final `OrtEnv` from inside `__cxa_finalize` drives ORT's `Environment`/`LoggingManager` destructor to lock a static mutex that may already have been finalized. The exception escapes a destructor and terminates the process.

### Fix

Only the `OrtEnv` is released from its `unique_ptr` during static destruction. `OrtGlobals` is still destroyed normally, preserving:

- graph-session cache cleanup
- device allocator cleanup
- device-interface teardown, including `RyzenAI_Shutdown`
- CUDA add-on unloading

The default GenAI `OrtEnv` does not own global thread pools, so leaking it does not leave threads executing during module unload.

`g_process_exiting` is also set during `dlclose`/`FreeLibrary`. In that case the conservative behavior leaks one `OrtEnv` per module load/unload cycle, but it does not leave background threads running in an unloaded module.

Explicit runtime `OgaShutdown()` remains unchanged and continues to perform complete teardown, including destroying the `OrtEnv` and supporting subsequent reinitialization.