### PR TITLE
Migrate CI builds from CMake presets to build.py

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -94,12 +94,12 @@ jobs:
         run: |
           set -e -x
           rm -rf build
-          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --update --skip_wheel
+          python3 build.py --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --update --skip_wheel
 
       - name: Run Android build
         run: |
           set -e -x
-          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --build --skip_wheel
+          python3 build.py --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --build --skip_wheel
 
       - name: Enable KVM group perms so Android emulator can run
         run: |
@@ -110,4 +110,4 @@ jobs:
       - name: Run Android tests
         run: |
           set -e -x
-          ./build.sh --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --android_run_emulator --test
+          python3 build.py --android --android_api=27 --android_ndk_path=${ANDROID_NDK_HOME} --config=RelWithDebInfo --android_abi=${{ env.ANDROID_ABI }} --parallel --build_java --android_run_emulator --test

--- a/.github/workflows/linux-cpu-arm64-build.yml
+++ b/.github/workflows/linux-cpu-arm64-build.yml
@@ -11,9 +11,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
-  ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
+  ORT_BUILD_VERSION: "1.26.0"
+  ORT_RUNTIME_VERSION: "1.28.0"
+  ORT_BUILD_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
+  ORT_RUNTIME_SOURCE: "https://api.nuget.org/v3/index.json"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime"
-  ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
   DOTNET_INSTALL_DIR: "${{ github.workspace }}/dotnet"
 
 jobs:
@@ -44,18 +46,11 @@ jobs:
           rustup component add rust-src
           rustup show active-toolchain
 
-      - name: Get the Latest OnnxRuntime Nightly Version
-        shell: pwsh
-        run: |
-          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
-          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
-          Write-Host "$ORT_NIGHTLY_VERSION"
-          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Download OnnxRuntime Nightly
+      - name: Download build-time and runtime OnnxRuntime
         run: |
           dotnet new console
-          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_BUILD_VERSION }} --source ${{ env.ORT_BUILD_SOURCE }} --package-directory .
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_RUNTIME_VERSION }} --source ${{ env.ORT_RUNTIME_SOURCE }} --package-directory .
 
       - name: list files
         shell: bash
@@ -67,9 +62,11 @@ jobs:
       # TODO: Find out why do we need to to have libonnxruntime.so.$ort_version
       - name: Extract OnnxRuntime library and header files
         run: |
-          mkdir -p ort/lib
-          mv microsoft.ml.onnxruntime/**/build/native/include ort/
-          mv microsoft.ml.onnxruntime/**/runtimes/linux-arm64/native/* ort/lib/
+          mkdir -p ort-build/lib ort/lib
+          mv microsoft.ml.onnxruntime/${{ env.ORT_BUILD_VERSION }}/build/native/include ort-build/
+          mv microsoft.ml.onnxruntime/${{ env.ORT_BUILD_VERSION }}/runtimes/linux-arm64/native/* ort-build/lib/
+          mv microsoft.ml.onnxruntime/${{ env.ORT_RUNTIME_VERSION }}/runtimes/linux-arm64/native/* ort/lib/
+          cp ort-build/lib/libonnxruntime.so ort-build/lib/libonnxruntime.so.1
           cp ort/lib/libonnxruntime.so ort/lib/libonnxruntime.so.1
 
       - name: Download Docker Image
@@ -94,7 +91,7 @@ jobs:
               --config Release \
               --build_dir build/cpu \
               --cmake_generator Ninja \
-              --ort_home /onnxruntime_src/ort \
+              --ort_home /onnxruntime_src/ort-build \
               --use_guidance \
               --update --build \
               --skip_examples \
@@ -114,8 +111,8 @@ jobs:
           -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c " \
             /usr/bin/cmake -S examples/c -B examples/c/build \
               -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-              -DORT_INCLUDE_DIR=/onnxruntime_src/ort/include \
-              -DORT_LIB_DIR=/onnxruntime_src/ort/lib \
+              -DORT_INCLUDE_DIR=/onnxruntime_src/ort-build/include \
+              -DORT_LIB_DIR=/onnxruntime_src/ort-build/lib \
               -DOGA_INCLUDE_DIR=/onnxruntime_src/src \
               -DOGA_LIB_DIR=/onnxruntime_src/build/cpu/Release && \
             /usr/bin/cmake --build examples/c/build --config Release"

--- a/.github/workflows/linux-cpu-arm64-build.yml
+++ b/.github/workflows/linux-cpu-arm64-build.yml
@@ -56,7 +56,6 @@ jobs:
         run: |
           dotnet new console
           dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
-        continue-on-error: true
 
       - name: list files
         shell: bash
@@ -95,6 +94,7 @@ jobs:
               --config Release \
               --build_dir build/cpu \
               --cmake_generator Ninja \
+              --ort_home /onnxruntime_src/ort \
               --use_guidance \
               --update --build \
               --skip_examples \
@@ -114,8 +114,8 @@ jobs:
           -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c " \
             /usr/bin/cmake -S examples/c -B examples/c/build \
               -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-              -DORT_INCLUDE_DIR=/onnxruntime_src/build/cpu/Release/_deps/ortlib-src/build/native/include \
-              -DORT_LIB_DIR=/onnxruntime_src/build/cpu/Release/_deps/ortlib-src/runtimes/linux-arm64/native \
+              -DORT_INCLUDE_DIR=/onnxruntime_src/ort/include \
+              -DORT_LIB_DIR=/onnxruntime_src/ort/lib \
               -DOGA_INCLUDE_DIR=/onnxruntime_src/src \
               -DOGA_LIB_DIR=/onnxruntime_src/build/cpu/Release && \
             /usr/bin/cmake --build examples/c/build --config Release"

--- a/.github/workflows/linux-cpu-arm64-build.yml
+++ b/.github/workflows/linux-cpu-arm64-build.yml
@@ -90,6 +90,7 @@ jobs:
           docker run --rm \
           --volume $GITHUB_WORKSPACE:/onnxruntime_src \
           -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c " \
+            python3 -m pip install -r requirements-dev.txt && \
             CC=gcc CXX=g++ python3 build.py \
               --config Release \
               --build_dir build/cpu \

--- a/.github/workflows/linux-cpu-arm64-build.yml
+++ b/.github/workflows/linux-cpu-arm64-build.yml
@@ -85,17 +85,26 @@ jobs:
           --docker-build-args "--build-arg BUILD_UID=$( id -u )" \
           --repository ort_genai_linux_arm64_gha
 
-      - name: Docker -- Configure with CMake and GCC
+      - name: Docker -- Build with build.py and GCC
         run: |
           docker run --rm \
           --volume $GITHUB_WORKSPACE:/onnxruntime_src \
-          -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c "python3 --version && /usr/bin/cmake --preset linux_gcc_cpu_release -DUSE_GUIDANCE=ON"
-
-      - name: Docker -- Build with CMake and GCC
-        run: |
-          docker run --rm \
-          --volume $GITHUB_WORKSPACE:/onnxruntime_src \
-          -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c "/usr/bin/cmake --build --preset linux_gcc_cpu_release && /usr/bin/cmake --build --preset linux_gcc_cpu_release --target PyPackageBuild"
+          -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c " \
+            CC=gcc CXX=g++ python3 build.py \
+              --config Release \
+              --build_dir build/cpu \
+              --cmake_generator Ninja \
+              --use_guidance \
+              --update --build \
+              --skip_examples \
+              --cmake_path /usr/bin/cmake \
+              --ctest_path /usr/bin/ctest \
+              --cmake_extra_defines \
+                'CMAKE_EXE_LINKER_FLAGS_INIT=-Wl,-z,now' \
+                'CMAKE_MODULE_LINKER_FLAGS_INIT=-Wl,-z,now' \
+                'CMAKE_SHARED_LINKER_FLAGS_INIT=-Wl,-z,now' \
+                'CMAKE_C_FLAGS=-DNDEBUG -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe' \
+                'CMAKE_CXX_FLAGS=-DNDEBUG -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe'"
 
       - name: Docker -- Build the C Examples
         run: |
@@ -104,23 +113,23 @@ jobs:
           -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c " \
             /usr/bin/cmake -S examples/c -B examples/c/build \
               -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-              -DORT_INCLUDE_DIR=/onnxruntime_src/build/cpu/_deps/ortlib-src/build/native/include \
-              -DORT_LIB_DIR=/onnxruntime_src/build/cpu/_deps/ortlib-src/runtimes/linux-arm64/native \
+              -DORT_INCLUDE_DIR=/onnxruntime_src/build/cpu/Release/_deps/ortlib-src/build/native/include \
+              -DORT_LIB_DIR=/onnxruntime_src/build/cpu/Release/_deps/ortlib-src/runtimes/linux-arm64/native \
               -DOGA_INCLUDE_DIR=/onnxruntime_src/src \
-              -DOGA_LIB_DIR=/onnxruntime_src/build/cpu && \
+              -DOGA_LIB_DIR=/onnxruntime_src/build/cpu/Release && \
             /usr/bin/cmake --build examples/c/build --config Release"
 
       - name: Docker -- Check test directory
         run: |
           docker run --rm \
           --volume $GITHUB_WORKSPACE:/onnxruntime_src \
-          -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c "ls -l /onnxruntime_src/build/cpu/test/"
+          -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c "ls -l /onnxruntime_src/build/cpu/Release/test/"
 
       - name: Docker -- Run tests
         run: |
           docker run --rm \
           --volume $GITHUB_WORKSPACE:/onnxruntime_src \
-          -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/onnxruntime_src/ort/lib/ /onnxruntime_src/build/cpu/unit_tests"
+          -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/onnxruntime_src/ort/lib/ /onnxruntime_src/build/cpu/Release/unit_tests"
 
       - name: Docker -- Install Python Wheel and Run Python Tests
         run: |
@@ -130,7 +139,7 @@ jobs:
             python3 -m pip install -r test/python/requirements.txt --user && \
             python3 -m pip install -r test/python/cpu/torch/requirements.txt --user && \
             python3 -m pip install -r test/python/cpu/ort/requirements.txt --user && \
-            python3 -m pip install --user --no-index --no-deps --find-links build/cpu/wheel onnxruntime_genai && \
+            python3 -m pip install --user --no-index --no-deps --find-links build/cpu/Release/wheel onnxruntime_genai && \
             export ORTGENAI_LOG_ORT_LIB=1 && \
             export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/onnxruntime_src/ort/lib && \
             python3 test/python/test_onnxruntime_genai.py --cwd test/python --test_models test/models"
@@ -146,7 +155,7 @@ jobs:
           -w /onnxruntime_src ort_genai_linux_arm64_gha bash -c " \
             export ORTGENAI_LOG_ORT_LIB=1 && \
             cd /onnxruntime_src/test/csharp && \
-            dotnet test /p:Configuration=Release /p:NativeBuildOutputDir=../../build/cpu/ /p:OrtLibDir=../../ort/lib/ --verbosity normal"
+            dotnet test /p:Configuration=Release /p:NativeBuildOutputDir=../../build/cpu/Release/ /p:OrtLibDir=../../ort/lib/ --verbosity normal"
 
       - name: Docker -- Build the C# Examples
         run: |

--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -93,23 +93,34 @@ jobs:
           mv microsoft.ml.onnxruntime/${{ env.ORT_NIGHTLY_VERSION }}/runtimes/linux-x64/native/* ort/lib/
           cp ort/lib/libonnxruntime.so ort/lib/libonnxruntime.so.1
 
-      - name: Build with CMake and GCC
+      - name: Build with build.py and GCC
         run: |
           set -e -x
           rm -rf build
-          cmake --preset linux_gcc_cpu_release -DENABLE_JAVA=ON -DUSE_GUIDANCE=ON
-          cmake --build --preset linux_gcc_cpu_release
-          cmake --build --preset linux_gcc_cpu_release --target PyPackageBuild
+          CC=gcc CXX=g++ python3 build.py \
+            --config Release \
+            --build_dir build/cpu \
+            --cmake_generator Ninja \
+            --build_java \
+            --use_guidance \
+            --update --build \
+            --skip_examples \
+            --cmake_extra_defines \
+              'CMAKE_EXE_LINKER_FLAGS_INIT=-Wl,-z,now' \
+              'CMAKE_MODULE_LINKER_FLAGS_INIT=-Wl,-z,now' \
+              'CMAKE_SHARED_LINKER_FLAGS_INIT=-Wl,-z,now' \
+              'CMAKE_C_FLAGS=-DNDEBUG -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe' \
+              'CMAKE_CXX_FLAGS=-DNDEBUG -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe'
 
       - name: Build the C Examples
         run: |
           set -e -x
           cmake -S examples/c -B examples/c/build \
             -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/build/cpu/_deps/ortlib-src/build/native/include \
-            -DORT_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/_deps/ortlib-src/runtimes/linux-x64/native \
+            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/build/cpu/Release/_deps/ortlib-src/build/native/include \
+            -DORT_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release/_deps/ortlib-src/runtimes/linux-x64/native \
             -DOGA_INCLUDE_DIR=$GITHUB_WORKSPACE/src \
-            -DOGA_LIB_DIR=$GITHUB_WORKSPACE/build/cpu
+            -DOGA_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release
           cmake --build examples/c/build --config Release
 
       - name: Install the Python wheel and test dependencies
@@ -117,19 +128,19 @@ jobs:
           python3 -m pip install -r test/python/requirements.txt --user
           python3 -m pip install -r test/python/cpu/torch/requirements.txt --user
           python3 -m pip install -r test/python/cpu/ort/requirements.txt --user
-          python3 -m pip install --user --no-index --no-deps --find-links build/cpu/wheel onnxruntime_genai
+          python3 -m pip install --user --no-index --no-deps --find-links build/cpu/Release/wheel onnxruntime_genai
 
       - name: Verify Build Artifacts
         if: always()
         continue-on-error: true
         run: |
-          ls -l ${{ github.workspace }}/build/cpu
-          ls -l ${{ github.workspace }}/build/cpu/wheel
+          ls -l ${{ github.workspace }}/build/cpu/Release
+          ls -l ${{ github.workspace }}/build/cpu/Release/wheel
 
       - name: Run the Java tests
         run: |
           set -e -x
-          ctest --test-dir build/cpu/src/java --build-config Release --verbose --timeout 10800
+          ctest --test-dir build/cpu/Release/src/java --build-config Release --verbose --timeout 10800
 
       # This will also download all the test models to the test/models directory
       # These models are used by the python tests as well as C#, C++ and others.
@@ -142,7 +153,7 @@ jobs:
         run: |
           export ORTGENAI_LOG_ORT_LIB=1
           cd test/csharp
-          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/" /p:OrtLibDir="../../ort/lib/" --verbosity normal
+          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/Release/" /p:OrtLibDir="../../ort/lib/" --verbosity normal
 
       - name: Build the C# Examples
         run: |
@@ -163,5 +174,5 @@ jobs:
           set -e -x
           export ORTGENAI_LOG_ORT_LIB=1
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/ort/lib
-          ./build/cpu/unit_tests
-          ./build/cpu/engine_unit_tests
+          ./build/cpu/Release/unit_tests
+          ./build/cpu/Release/engine_unit_tests

--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -10,9 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
-  ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
+  ORT_BUILD_VERSION: "1.26.0"
+  ORT_RUNTIME_VERSION: "1.28.0"
+  ORT_BUILD_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
+  ORT_RUNTIME_SOURCE: "https://api.nuget.org/v3/index.json"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime"
-  ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
   DOTNET_INSTALL_DIR: "${{ github.workspace }}/dotnet"
 jobs:
   linux_cpu_x64:
@@ -63,18 +65,11 @@ jobs:
           rustup component add rust-src
           rustup show active-toolchain
 
-      - name: Get the Latest OnnxRuntime Nightly Version
-        shell: pwsh
-        run: |
-          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
-          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
-          Write-Host "$ORT_NIGHTLY_VERSION"
-          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Download OnnxRuntime Nightly
+      - name: Download build-time and runtime OnnxRuntime
         run: |
           dotnet new console
-          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_BUILD_VERSION }} --source ${{ env.ORT_BUILD_SOURCE }} --package-directory .
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_RUNTIME_VERSION }} --source ${{ env.ORT_RUNTIME_SOURCE }} --package-directory .
 
       - name: list files
         shell: bash
@@ -87,9 +82,11 @@ jobs:
       - name: Extract OnnxRuntime library and header files
         run: |
           set -e -x
-          mkdir -p ort/lib
-          mv microsoft.ml.onnxruntime/${{ env.ORT_NIGHTLY_VERSION }}/build/native/include ort/
-          mv microsoft.ml.onnxruntime/${{ env.ORT_NIGHTLY_VERSION }}/runtimes/linux-x64/native/* ort/lib/
+          mkdir -p ort-build/lib ort/lib
+          mv microsoft.ml.onnxruntime/${{ env.ORT_BUILD_VERSION }}/build/native/include ort-build/
+          mv microsoft.ml.onnxruntime/${{ env.ORT_BUILD_VERSION }}/runtimes/linux-x64/native/* ort-build/lib/
+          mv microsoft.ml.onnxruntime/${{ env.ORT_RUNTIME_VERSION }}/runtimes/linux-x64/native/* ort/lib/
+          cp ort-build/lib/libonnxruntime.so ort-build/lib/libonnxruntime.so.1
           cp ort/lib/libonnxruntime.so ort/lib/libonnxruntime.so.1
 
       - name: Build with build.py and GCC
@@ -102,7 +99,7 @@ jobs:
             --build_dir build/cpu \
             --cmake_generator Ninja \
             --build_java \
-            --ort_home "$GITHUB_WORKSPACE/ort" \
+            --ort_home "$GITHUB_WORKSPACE/ort-build" \
             --use_guidance \
             --update --build \
             --skip_examples \
@@ -118,8 +115,8 @@ jobs:
           set -e -x
           cmake -S examples/c -B examples/c/build \
             -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/ort/include \
-            -DORT_LIB_DIR=$GITHUB_WORKSPACE/ort/lib \
+            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/ort-build/include \
+            -DORT_LIB_DIR=$GITHUB_WORKSPACE/ort-build/lib \
             -DOGA_INCLUDE_DIR=$GITHUB_WORKSPACE/src \
             -DOGA_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release
           cmake --build examples/c/build --config Release
@@ -141,7 +138,8 @@ jobs:
       - name: Run the Java tests
         run: |
           set -e -x
-          ctest --test-dir build/cpu/Release/src/java --build-config Release --verbose --timeout 10800
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/ort/lib \
+            ctest --test-dir build/cpu/Release/src/java --build-config Release --verbose --timeout 10800
 
       # This will also download all the test models to the test/models directory
       # These models are used by the python tests as well as C#, C++ and others.

--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -75,7 +75,6 @@ jobs:
         run: |
           dotnet new console
           dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
-        continue-on-error: true
 
       - name: list files
         shell: bash
@@ -103,6 +102,7 @@ jobs:
             --build_dir build/cpu \
             --cmake_generator Ninja \
             --build_java \
+            --ort_home "$GITHUB_WORKSPACE/ort" \
             --use_guidance \
             --update --build \
             --skip_examples \
@@ -118,8 +118,8 @@ jobs:
           set -e -x
           cmake -S examples/c -B examples/c/build \
             -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/build/cpu/Release/_deps/ortlib-src/build/native/include \
-            -DORT_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release/_deps/ortlib-src/runtimes/linux-x64/native \
+            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/ort/include \
+            -DORT_LIB_DIR=$GITHUB_WORKSPACE/ort/lib \
             -DOGA_INCLUDE_DIR=$GITHUB_WORKSPACE/src \
             -DOGA_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release
           cmake --build examples/c/build --config Release

--- a/.github/workflows/linux-cpu-x64-build.yml
+++ b/.github/workflows/linux-cpu-x64-build.yml
@@ -97,6 +97,7 @@ jobs:
         run: |
           set -e -x
           rm -rf build
+          python3 -m pip install -r requirements-dev.txt
           CC=gcc CXX=g++ python3 build.py \
             --config Release \
             --build_dir build/cpu \

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -97,18 +97,29 @@ jobs:
         run: |
           git submodule update --init --recursive
 
-      - name: Build with CMake and GCC
+      - name: Build with build.py and GCC
         run: |
           set -e -x
           rm -rf build
-          cmake --preset linux_gcc_cpu_release -DENABLE_JAVA=ON -DUSE_GUIDANCE=ON
-          cmake --build --preset linux_gcc_cpu_release
-          cmake --build --preset linux_gcc_cpu_release --target PyPackageBuild
+          CC=gcc CXX=g++ python3 build.py \
+            --config Release \
+            --build_dir build/cpu \
+            --cmake_generator Ninja \
+            --build_java \
+            --use_guidance \
+            --update --build \
+            --skip_examples \
+            --cmake_extra_defines \
+              'CMAKE_EXE_LINKER_FLAGS_INIT=-Wl,-z,now' \
+              'CMAKE_MODULE_LINKER_FLAGS_INIT=-Wl,-z,now' \
+              'CMAKE_SHARED_LINKER_FLAGS_INIT=-Wl,-z,now' \
+              'CMAKE_C_FLAGS=-DNDEBUG -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe' \
+              'CMAKE_CXX_FLAGS=-DNDEBUG -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe'
 
       - name: Build the C Examples
         run: |
           set -e -x
-          ORT_EXAMPLE_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/_deps/ortlib-src/runtimes/linux-x64/native
+          ORT_EXAMPLE_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release/_deps/ortlib-src/runtimes/linux-x64/native
           if [ -f "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so" ] && [ ! -e "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so.1" ]; then
             ln -s libonnxruntime.so "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so.1" || \
             cp "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so" "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so.1"
@@ -116,10 +127,10 @@ jobs:
 
           cmake -S examples/c -B examples/c/build \
             -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/build/cpu/_deps/ortlib-src/build/native/include \
+            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/build/cpu/Release/_deps/ortlib-src/build/native/include \
             -DORT_LIB_DIR=$ORT_EXAMPLE_LIB_DIR \
             -DOGA_INCLUDE_DIR=$GITHUB_WORKSPACE/src \
-            -DOGA_LIB_DIR=$GITHUB_WORKSPACE/build/cpu
+            -DOGA_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release
           cmake --build examples/c/build --config Release
 
       - name: Install the Python wheel and test dependencies
@@ -127,7 +138,7 @@ jobs:
           python3 -m pip install -r test/python/requirements.txt --user
           python3 -m pip install -r test/python/cpu/torch/requirements.txt --user
           python3 -m pip install -r test/python/cpu/ort/requirements.txt --user
-          python3 -m pip install build/cpu/wheel/onnxruntime_genai*.whl --no-deps
+          python3 -m pip install build/cpu/Release/wheel/onnxruntime_genai*.whl --no-deps
 
       - name: Verify Build Artifacts
         if: always()
@@ -137,7 +148,7 @@ jobs:
       - name: Run the Java tests
         run: |
           set -e -x
-          ctest --test-dir build/cpu/src/java --build-config Release --verbose --timeout 10800
+          ctest --test-dir build/cpu/Release/src/java --build-config Release --verbose --timeout 10800
 
       - name: Run the Python tests
         run: |
@@ -148,7 +159,7 @@ jobs:
         run: |
           export ORTGENAI_LOG_ORT_LIB=1
           cd test/csharp
-          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/" /p:OrtLibDir="../../ort/lib/" --verbosity normal
+          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/Release/" /p:OrtLibDir="../../ort/lib/" --verbosity normal
 
       - name: Build the C# Examples
         run: |

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -12,9 +12,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
-  ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
+  ORT_BUILD_VERSION: "1.26.0"
+  ORT_RUNTIME_VERSION: "1.28.0"
+  ORT_BUILD_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
+  ORT_RUNTIME_SOURCE: "https://api.nuget.org/v3/index.json"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime"
-  ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
   DOTNET_INSTALL_DIR: "${{ github.workspace }}/dotnet"
 jobs:
   job:
@@ -63,18 +65,11 @@ jobs:
           rustup component add rust-src
           rustup show active-toolchain
 
-      - name: Get the Latest OnnxRuntime Nightly Version
-        shell: pwsh
-        run: |
-          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
-          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
-          Write-Host "$ORT_NIGHTLY_VERSION"
-          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Download OnnxRuntime Nightly
+      - name: Download build-time and runtime OnnxRuntime
         run: |
           dotnet new console
-          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_BUILD_VERSION }} --source ${{ env.ORT_BUILD_SOURCE }} --package-directory .
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_RUNTIME_VERSION }} --source ${{ env.ORT_RUNTIME_SOURCE }} --package-directory .
 
       - name: list files
         shell: bash
@@ -87,9 +82,11 @@ jobs:
       - name: Extract OnnxRuntime library and header files
         run: |
           set -e -x
-          mkdir -p ort/lib
-          mv microsoft.ml.onnxruntime/${{ env.ORT_NIGHTLY_VERSION }}/build/native/include ort/
-          mv microsoft.ml.onnxruntime/${{ env.ORT_NIGHTLY_VERSION }}/runtimes/linux-x64/native/* ort/lib/
+          mkdir -p ort-build/lib ort/lib
+          mv microsoft.ml.onnxruntime/${{ env.ORT_BUILD_VERSION }}/build/native/include ort-build/
+          mv microsoft.ml.onnxruntime/${{ env.ORT_BUILD_VERSION }}/runtimes/linux-x64/native/* ort-build/lib/
+          mv microsoft.ml.onnxruntime/${{ env.ORT_RUNTIME_VERSION }}/runtimes/linux-x64/native/* ort/lib/
+          cp ort-build/lib/libonnxruntime.so ort-build/lib/libonnxruntime.so.1
           cp ort/lib/libonnxruntime.so ort/lib/libonnxruntime.so.1
 
       - name: Git Submodule Update
@@ -106,7 +103,7 @@ jobs:
             --build_dir build/cpu \
             --cmake_generator Ninja \
             --build_java \
-            --ort_home "$GITHUB_WORKSPACE/ort" \
+            --ort_home "$GITHUB_WORKSPACE/ort-build" \
             --use_guidance \
             --update --build \
             --skip_examples \
@@ -122,8 +119,8 @@ jobs:
           set -e -x
           cmake -S examples/c -B examples/c/build \
             -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/ort/include \
-            -DORT_LIB_DIR=$GITHUB_WORKSPACE/ort/lib \
+            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/ort-build/include \
+            -DORT_LIB_DIR=$GITHUB_WORKSPACE/ort-build/lib \
             -DOGA_INCLUDE_DIR=$GITHUB_WORKSPACE/src \
             -DOGA_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release
           cmake --build examples/c/build --config Release
@@ -143,7 +140,8 @@ jobs:
       - name: Run the Java tests
         run: |
           set -e -x
-          ctest --test-dir build/cpu/Release/src/java --build-config Release --verbose --timeout 10800
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/ort/lib \
+            ctest --test-dir build/cpu/Release/src/java --build-config Release --verbose --timeout 10800
 
       - name: Run the Python tests
         run: |

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -101,6 +101,7 @@ jobs:
         run: |
           set -e -x
           rm -rf build
+          python3 -m pip install -r requirements-dev.txt
           CC=gcc CXX=g++ python3 build.py \
             --config Release \
             --build_dir build/cpu \

--- a/.github/workflows/linux-cpu-x64-nightly-build.yml
+++ b/.github/workflows/linux-cpu-x64-nightly-build.yml
@@ -75,7 +75,6 @@ jobs:
         run: |
           dotnet new console
           dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
-        continue-on-error: true
 
       - name: list files
         shell: bash
@@ -107,6 +106,7 @@ jobs:
             --build_dir build/cpu \
             --cmake_generator Ninja \
             --build_java \
+            --ort_home "$GITHUB_WORKSPACE/ort" \
             --use_guidance \
             --update --build \
             --skip_examples \
@@ -120,16 +120,10 @@ jobs:
       - name: Build the C Examples
         run: |
           set -e -x
-          ORT_EXAMPLE_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release/_deps/ortlib-src/runtimes/linux-x64/native
-          if [ -f "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so" ] && [ ! -e "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so.1" ]; then
-            ln -s libonnxruntime.so "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so.1" || \
-            cp "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so" "$ORT_EXAMPLE_LIB_DIR/libonnxruntime.so.1"
-          fi
-
           cmake -S examples/c -B examples/c/build \
             -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/build/cpu/Release/_deps/ortlib-src/build/native/include \
-            -DORT_LIB_DIR=$ORT_EXAMPLE_LIB_DIR \
+            -DORT_INCLUDE_DIR=$GITHUB_WORKSPACE/ort/include \
+            -DORT_LIB_DIR=$GITHUB_WORKSPACE/ort/lib \
             -DOGA_INCLUDE_DIR=$GITHUB_WORKSPACE/src \
             -DOGA_LIB_DIR=$GITHUB_WORKSPACE/build/cpu/Release
           cmake --build examples/c/build --config Release

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -124,6 +124,7 @@ jobs:
             --volume $GITHUB_WORKSPACE:/ort_genai_src \
             -w /ort_genai_src onnxruntimecudabuildx64 \
             bash -c " \
+              ${{ env.PYTHON_EXECUTABLE }} -m pip install -r requirements-dev.txt && \
               CC=gcc CXX=g++ ${{ env.PYTHON_EXECUTABLE }} build.py \
                 --config Release \
                 --build_dir build/cuda \

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Linux&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: Microsoft.ML.OnnxRuntime.Gpu.Linux
+  ORT_VERSION: "1.26.0"
   ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
   DOTNET_INSTALL_DIR: "${{ github.workspace }}/dotnet"
 
@@ -71,18 +71,10 @@ jobs:
           rustup component add rust-src
           rustup show active-toolchain
 
-      - name: Get the Latest OnnxRuntime Nightly Version
-        shell: pwsh
-        run: |
-          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
-          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
-          Write-Host "$ORT_NIGHTLY_VERSION"
-          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Download OnnxRuntime Nightly
+      - name: Download OnnxRuntime
         run: |
           dotnet new console
-          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
         continue-on-error: true
 
       - name: list files
@@ -96,8 +88,8 @@ jobs:
         run: |
           set -e -x
           mkdir -p ort/lib
-          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_NIGHTLY_VERSION }}/buildTransitive/native/include ort/
-          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_NIGHTLY_VERSION }}/runtimes/linux-x64/native/* ort/lib/
+          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_VERSION }}/buildTransitive/native/include ort/
+          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_VERSION }}/runtimes/linux-x64/native/* ort/lib/
           cp ort/lib/libonnxruntime.so ort/lib/libonnxruntime.so.1
 
 
@@ -132,6 +124,7 @@ jobs:
                 --build_java \
                 --use_cuda \
                 --cuda_home /usr/local/cuda \
+                --ort_home /ort_genai_src/ort \
                 --use_guidance \
                 --update --build \
                 --skip_examples \
@@ -210,4 +203,4 @@ jobs:
             --rm \
             --volume /data/ortgenai/:/data/ortgenai/ \
             --volume $GITHUB_WORKSPACE:/ort_genai_src \
-            -w /ort_genai_src onnxruntimecudabuildx64 bash -c "ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/build/cuda/Release/ /ort_genai_src/build/cuda/Release/unit_tests && ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/build/cuda/Release/ /ort_genai_src/build/cuda/Release/engine_unit_tests"
+            -w /ort_genai_src onnxruntimecudabuildx64 bash -c "ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/ort/lib:/ort_genai_src/build/cuda/Release/ /ort_genai_src/build/cuda/Release/unit_tests && ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/ort/lib:/ort_genai_src/build/cuda/Release/ /ort_genai_src/build/cuda/Release/engine_unit_tests"

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -15,7 +15,6 @@ env:
   ORT_BUILD_VERSION: "1.26.0"
   ORT_RUNTIME_VERSION: "1.28.0"
   ORT_PACKAGE_NAME: Microsoft.ML.OnnxRuntime.Gpu.Linux
-  ORT_NIGHTLY_SOURCE: "https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/onnxruntime-cuda-12/nuget/v3/index.json"
   DOTNET_INSTALL_DIR: "${{ github.workspace }}/dotnet"
 
 jobs:
@@ -74,24 +73,30 @@ jobs:
 
       - name: Download build-time and runtime CUDA 12 OnnxRuntime
         run: |
-          dotnet new console
-          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_BUILD_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
-          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_RUNTIME_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
+          curl -fsSL \
+            "https://pkgs.dev.azure.com/aiinfra/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_apis/packaging/feeds/7982ae20-ed19-4a35-a362-a96ac99897b7/nuget/packages/${{ env.ORT_PACKAGE_NAME }}/versions/${{ env.ORT_BUILD_VERSION }}/content?api-version=6.0-preview.1" \
+            -o ort-build.zip
+          curl -fsSL \
+            "https://pkgs.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/feeds/onnxruntime-cuda-12/nuget/packages/${{ env.ORT_PACKAGE_NAME }}/versions/${{ env.ORT_RUNTIME_VERSION }}/content?api-version=6.0-preview.1" \
+            -o ort-runtime.zip
+          unzip -q ort-build.zip -d ort-build-package
+          unzip -q ort-runtime.zip -d ort-runtime-package
 
       - name: list files
         shell: bash
         run: |
           ls -l
-          ls -R ${{ env.ORT_PACKAGE_NAME }}
+          ls -R ort-build-package
+          ls -R ort-runtime-package
         continue-on-error: true
 
       - name: Extract OnnxRuntime library and header files
         run: |
           set -e -x
           mkdir -p ort-build/lib ort/lib
-          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_BUILD_VERSION }}/buildTransitive/native/include ort-build/
-          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_BUILD_VERSION }}/runtimes/linux-x64/native/* ort-build/lib/
-          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_RUNTIME_VERSION }}/runtimes/linux-x64/native/* ort/lib/
+          mv ort-build-package/buildTransitive/native/include ort-build/
+          mv ort-build-package/runtimes/linux-x64/native/* ort-build/lib/
+          mv ort-runtime-package/runtimes/linux-x64/native/* ort/lib/
           cp ort-build/lib/libonnxruntime.so ort-build/lib/libonnxruntime.so.1
           cp ort/lib/libonnxruntime.so ort/lib/libonnxruntime.so.1
 

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -115,7 +115,7 @@ jobs:
             --multiple_repos \
             --repository onnxruntimecudabuildx64
 
-      - name: Config with CMake in Docker
+      - name: Build with build.py in Docker
         run: |
           set -e -x
           docker run \
@@ -124,24 +124,29 @@ jobs:
             --volume $GITHUB_WORKSPACE:/ort_genai_src \
             -w /ort_genai_src onnxruntimecudabuildx64 \
             bash -c " \
-              /usr/bin/cmake --preset linux_gcc_cuda_release \
-                -DMANYLINUX=ON \
-                -DPYTHON_EXECUTABLE=${{ env.PYTHON_EXECUTABLE }} \
-                -DENABLE_JAVA=ON \
-                -DUSE_GUIDANCE=ON \
-                -DTEST_PHI2=True \
-                -DTEST_QWEN_2_5=True"
-
-      - name: Build with CMake in Docker
-        run: |
-          set -e -x
-          docker run \
-            --gpus all \
-            --rm \
-            --volume $GITHUB_WORKSPACE:/ort_genai_src \
-            -w /ort_genai_src onnxruntimecudabuildx64 \
-            bash -c " \
-              /usr/bin/cmake --build --preset linux_gcc_cuda_release && /usr/bin/cmake --build --preset linux_gcc_cuda_release --target PyPackageBuild"
+              CC=gcc CXX=g++ ${{ env.PYTHON_EXECUTABLE }} build.py \
+                --config Release \
+                --build_dir build/cuda \
+                --cmake_generator Ninja \
+                --build_java \
+                --use_cuda \
+                --cuda_home /usr/local/cuda \
+                --use_guidance \
+                --update --build \
+                --skip_examples \
+                --cmake_path /usr/bin/cmake \
+                --ctest_path /usr/bin/ctest \
+                --cmake_extra_defines \
+                  MANYLINUX=ON \
+                  PYTHON_EXECUTABLE=${{ env.PYTHON_EXECUTABLE }} \
+                  TEST_PHI2=True \
+                  TEST_QWEN_2_5=True \
+                  'CMAKE_CUDA_ARCHITECTURES=60-real;70-real;75-real;80-real;86-real;89-real;90-real;100-real;120' \
+                  'CMAKE_EXE_LINKER_FLAGS_INIT=-Wl,-z,now' \
+                  'CMAKE_MODULE_LINKER_FLAGS_INIT=-Wl,-z,now' \
+                  'CMAKE_SHARED_LINKER_FLAGS_INIT=-Wl,-z,now' \
+                  'CMAKE_C_FLAGS=-DNDEBUG -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe' \
+                  'CMAKE_CXX_FLAGS=-DNDEBUG -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe'"
 
       - name: Build the C Examples in Docker
         run: |
@@ -157,7 +162,7 @@ jobs:
                 -DORT_INCLUDE_DIR=/ort_genai_src/ort/include \
                 -DORT_LIB_DIR=/ort_genai_src/ort/lib \
                 -DOGA_INCLUDE_DIR=/ort_genai_src/src \
-                -DOGA_LIB_DIR=/ort_genai_src/build/cuda && \
+                -DOGA_LIB_DIR=/ort_genai_src/build/cuda/Release && \
               /usr/bin/cmake --build examples/c/build --config Release"
 
       - name: Run the Java tests in Docker
@@ -168,7 +173,7 @@ jobs:
             --rm \
             --volume $GITHUB_WORKSPACE:/ort_genai_src \
             -w /ort_genai_src onnxruntimecudabuildx64 bash -c " \
-              /usr/bin/ctest --test-dir build/cuda/src/java --build-config Release --verbose --timeout 10800"
+              /usr/bin/ctest --test-dir build/cuda/Release/src/java --build-config Release --verbose --timeout 10800"
 
       - name: Install the onnxruntime-genai Python wheel and run Python tests
         run: |
@@ -182,7 +187,7 @@ jobs:
               ${{ env.PYTHON_EXECUTABLE }} -m pip install -r test/python/requirements.txt --user && \
               ${{ env.PYTHON_EXECUTABLE }} -m pip install -r test/python/cuda/torch/requirements.txt --user && \
               ${{ env.PYTHON_EXECUTABLE }} -m pip install -r test/python/cuda/ort/requirements.txt --user && \
-              ${{ env.PYTHON_EXECUTABLE }} -m pip install /ort_genai_src/build/cuda/wheel/onnxruntime_genai*manylinux*.whl --no-deps --user && \
+              ${{ env.PYTHON_EXECUTABLE }} -m pip install /ort_genai_src/build/cuda/Release/wheel/onnxruntime_genai*manylinux*.whl --no-deps --user && \
               ${{ env.PYTHON_EXECUTABLE }} test/python/test_onnxruntime_genai.py --cwd test/python --test_models test/models --e2e"
 
       # TODO: Enable this by adding dotnet to the docker image
@@ -194,7 +199,7 @@ jobs:
       #       --rm \
       #       --volume $GITHUB_WORKSPACE:/ort_genai_src \
       #       -w /ort_genai_src/test/csharp onnxruntimecudabuildx64 bash -c " \
-      #         dotnet test /p:NativeBuildOutputDir='/ort_genai_src/build/cuda/'"
+      #         dotnet test /p:NativeBuildOutputDir='/ort_genai_src/build/cuda/Release/'"
 
       - name: Docker -- Run unit tests
         run: |
@@ -204,4 +209,4 @@ jobs:
             --rm \
             --volume /data/ortgenai/:/data/ortgenai/ \
             --volume $GITHUB_WORKSPACE:/ort_genai_src \
-            -w /ort_genai_src onnxruntimecudabuildx64 bash -c "ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/build/cuda/ /ort_genai_src/build/cuda/unit_tests && ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/build/cuda/ /ort_genai_src/build/cuda/engine_unit_tests"
+            -w /ort_genai_src onnxruntimecudabuildx64 bash -c "ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/build/cuda/Release/ /ort_genai_src/build/cuda/Release/unit_tests && ORTGENAI_LOG_ORT_LIB=1 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/ort_genai_src/build/cuda/Release/ /ort_genai_src/build/cuda/Release/engine_unit_tests"

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/onnxruntime-cuda-12/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Linux&api-version=6.0-preview.1"
   ORT_PACKAGE_NAME: Microsoft.ML.OnnxRuntime.Gpu.Linux
-  ORT_VERSION: "1.26.0"
-  ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
+  ORT_NIGHTLY_SOURCE: "https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/onnxruntime-cuda-12/nuget/v3/index.json"
   DOTNET_INSTALL_DIR: "${{ github.workspace }}/dotnet"
 
 jobs:
@@ -71,11 +71,18 @@ jobs:
           rustup component add rust-src
           rustup show active-toolchain
 
-      - name: Download OnnxRuntime
+      - name: Get the Latest CUDA 12 OnnxRuntime Nightly Version
+        shell: pwsh
+        run: |
+          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
+          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
+          Write-Host "$ORT_NIGHTLY_VERSION"
+          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Download CUDA 12 OnnxRuntime Nightly
         run: |
           dotnet new console
-          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
-        continue-on-error: true
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
 
       - name: list files
         shell: bash
@@ -88,8 +95,8 @@ jobs:
         run: |
           set -e -x
           mkdir -p ort/lib
-          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_VERSION }}/buildTransitive/native/include ort/
-          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_VERSION }}/runtimes/linux-x64/native/* ort/lib/
+          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_NIGHTLY_VERSION }}/buildTransitive/native/include ort/
+          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_NIGHTLY_VERSION }}/runtimes/linux-x64/native/* ort/lib/
           cp ort/lib/libonnxruntime.so ort/lib/libonnxruntime.so.1
 
 

--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -12,7 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/onnxruntime-cuda-12/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Linux&api-version=6.0-preview.1"
+  ORT_BUILD_VERSION: "1.26.0"
+  ORT_RUNTIME_VERSION: "1.28.0"
   ORT_PACKAGE_NAME: Microsoft.ML.OnnxRuntime.Gpu.Linux
   ORT_NIGHTLY_SOURCE: "https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/onnxruntime-cuda-12/nuget/v3/index.json"
   DOTNET_INSTALL_DIR: "${{ github.workspace }}/dotnet"
@@ -71,18 +72,11 @@ jobs:
           rustup component add rust-src
           rustup show active-toolchain
 
-      - name: Get the Latest CUDA 12 OnnxRuntime Nightly Version
-        shell: pwsh
-        run: |
-          $resp = Invoke-RestMethod "${{ env.ORT_NIGHTLY_REST_API }}"
-          $ORT_NIGHTLY_VERSION = $resp.value[0].versions[0].normalizedVersion
-          Write-Host "$ORT_NIGHTLY_VERSION"
-          "ORT_NIGHTLY_VERSION=$ORT_NIGHTLY_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Download CUDA 12 OnnxRuntime Nightly
+      - name: Download build-time and runtime CUDA 12 OnnxRuntime
         run: |
           dotnet new console
-          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_NIGHTLY_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_BUILD_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
+          dotnet add package ${{ env.ORT_PACKAGE_NAME }} --version ${{ env.ORT_RUNTIME_VERSION }} --source ${{ env.ORT_NIGHTLY_SOURCE }} --package-directory .
 
       - name: list files
         shell: bash
@@ -94,9 +88,11 @@ jobs:
       - name: Extract OnnxRuntime library and header files
         run: |
           set -e -x
-          mkdir -p ort/lib
-          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_NIGHTLY_VERSION }}/buildTransitive/native/include ort/
-          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_NIGHTLY_VERSION }}/runtimes/linux-x64/native/* ort/lib/
+          mkdir -p ort-build/lib ort/lib
+          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_BUILD_VERSION }}/buildTransitive/native/include ort-build/
+          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_BUILD_VERSION }}/runtimes/linux-x64/native/* ort-build/lib/
+          mv microsoft.ml.onnxruntime.gpu.linux/${{ env.ORT_RUNTIME_VERSION }}/runtimes/linux-x64/native/* ort/lib/
+          cp ort-build/lib/libonnxruntime.so ort-build/lib/libonnxruntime.so.1
           cp ort/lib/libonnxruntime.so ort/lib/libonnxruntime.so.1
 
 
@@ -131,7 +127,7 @@ jobs:
                 --build_java \
                 --use_cuda \
                 --cuda_home /usr/local/cuda \
-                --ort_home /ort_genai_src/ort \
+                --ort_home /ort_genai_src/ort-build \
                 --use_guidance \
                 --update --build \
                 --skip_examples \
@@ -160,8 +156,8 @@ jobs:
             bash -c " \
               /usr/bin/cmake -S examples/c -B examples/c/build \
                 -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-                -DORT_INCLUDE_DIR=/ort_genai_src/ort/include \
-                -DORT_LIB_DIR=/ort_genai_src/ort/lib \
+                -DORT_INCLUDE_DIR=/ort_genai_src/ort-build/include \
+                -DORT_LIB_DIR=/ort_genai_src/ort-build/lib \
                 -DOGA_INCLUDE_DIR=/ort_genai_src/src \
                 -DOGA_LIB_DIR=/ort_genai_src/build/cuda/Release && \
               /usr/bin/cmake --build examples/c/build --config Release"
@@ -174,7 +170,8 @@ jobs:
             --rm \
             --volume $GITHUB_WORKSPACE:/ort_genai_src \
             -w /ort_genai_src onnxruntimecudabuildx64 bash -c " \
-              /usr/bin/ctest --test-dir build/cuda/Release/src/java --build-config Release --verbose --timeout 10800"
+              LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/ort_genai_src/ort/lib \
+                /usr/bin/ctest --test-dir build/cuda/Release/src/java --build-config Release --verbose --timeout 10800"
 
       - name: Install the onnxruntime-genai Python wheel and run Python tests
         run: |

--- a/.github/workflows/win-cpu-arm64-build.yml
+++ b/.github/workflows/win-cpu-arm64-build.yml
@@ -11,7 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
-  binaryDir: 'build/cpu/win-arm64'
+  buildRoot: 'build/cpu/win-arm64'
+  binaryDir: 'build/cpu/win-arm64/Release'
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
   ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime"
@@ -79,16 +80,25 @@ jobs:
           choco install llvm --yes
           Add-Content $env:GITHUB_PATH "C:\Program Files\LLVM\bin"
 
-      - name: Configure CMake
+      - name: Build with build.py
         run: |
           python -m pip install wheel requests
 
-          cmake --preset windows_arm64_cpu_release -DENABLE_JAVA=ON -DUSE_GUIDANCE=ON
-
-      - name: Build with CMake
-        run: |
-          cmake --build --preset windows_arm64_cpu_release --parallel
-          cmake --build --preset windows_arm64_cpu_release --target PyPackageBuild
+          python build.py `
+            --config Release `
+            --build_dir $env:buildRoot `
+            --parallel `
+            --build_java `
+            --use_guidance `
+            --arm64 `
+            --update --build `
+            --skip_examples `
+            --cmake_extra_defines `
+              'CMAKE_EXE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_MODULE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_SHARED_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_C_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG' `
+              'CMAKE_CXX_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG'
 
       - name: Build the C Examples
         run: |

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -11,7 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 env:
-  binaryDir: 'build/cpu/win-x64'
+  buildRoot: 'build/cpu/win-x64'
+  binaryDir: 'build/cpu/win-x64/Release'
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
   ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime"
@@ -94,14 +95,22 @@ jobs:
         with:
           languages: 'cpp'
 
-      - name: Configure CMake
+      - name: Build with build.py
         run: |
-          cmake --preset windows_x64_cpu_release -DENABLE_JAVA=ON -DUSE_GUIDANCE=ON
-
-      - name: Build with CMake
-        run: |
-          cmake --build --preset windows_x64_cpu_release --parallel
-          cmake --build --preset windows_x64_cpu_release --target PyPackageBuild
+          python build.py `
+            --config Release `
+            --build_dir $env:buildRoot `
+            --parallel `
+            --build_java `
+            --use_guidance `
+            --update --build `
+            --skip_examples `
+            --cmake_extra_defines `
+              'CMAKE_EXE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_MODULE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_SHARED_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_C_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG' `
+              'CMAKE_CXX_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG'
 
       - name: Build the C Examples
         run: |

--- a/.github/workflows/win-cpu-x64-build.yml
+++ b/.github/workflows/win-cpu-x64-build.yml
@@ -97,6 +97,7 @@ jobs:
 
       - name: Build with build.py
         run: |
+          python -m pip install -r requirements-dev.txt
           python build.py `
             --config Release `
             --build_dir $env:buildRoot `

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -17,7 +17,8 @@ env:
   cuda_dir: "${{ github.workspace }}\\cuda_sdk"
   cuda_version: "12.8"
   CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v12.8
-  binaryDir: 'build/cuda/win-x64'
+  buildRoot: 'build/cuda/win-x64'
+  binaryDir: 'build/cuda/win-x64/Release'
   ORT_NIGHTLY_NUGET_SOURCE: "https://pkgs.dev.azure.com/aiinfra/PublicPackages/_packaging/onnxruntime-cuda-12/nuget/v3/index.json"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime.Gpu.Windows"
 
@@ -85,7 +86,7 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}\sccache
-          key: sccache-win-cuda-${{ hashFiles('**/CMakePresets.json', '**/CMakeLists.txt') }}
+          key: sccache-win-cuda-${{ hashFiles('build.py', '**/CMakeLists.txt', 'cmake/**/*.cmake') }}
           restore-keys: |
             sccache-win-cuda-
 
@@ -102,22 +103,33 @@ jobs:
           echo $binDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           & "$binDir\sccache.exe" --version
 
-      - name: Configure CMake
+      - name: Build with build.py
         run: |
           $env:SCCACHE_DIR = "${{ github.workspace }}\sccache"
           # Limit CUDA archs to SM 86 (matches the A10 runner GPU) to keep CI build
-          # time and memory usage manageable. The full SM list in CMakePresets.json
-          # is intended for release packaging, not CI validation.
-          cmake --preset windows_x64_cuda_release -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }} -DTEST_PHI2=True -DTEST_QWEN_2_5=True -DENABLE_JAVA=ON -DUSE_GUIDANCE=ON `
-            -DCMAKE_CUDA_ARCHITECTURES=86-real `
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache `
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-
-      - name: Build with CMake
-        run: |
-          $env:SCCACHE_DIR = "${{ github.workspace }}\sccache"
-          cmake --build --preset windows_x64_cuda_release --parallel
-          cmake --build --preset windows_x64_cuda_release --target PyPackageBuild
+          # time and memory usage manageable.
+          python build.py `
+            --config Release `
+            --build_dir $env:buildRoot `
+            --parallel `
+            --build_java `
+            --use_cuda `
+            --cuda_home "${{ env.cuda_dir }}\v${{ env.cuda_version }}" `
+            --use_guidance `
+            --update --build `
+            --skip_examples `
+            --cmake_extra_defines `
+              TEST_PHI2=True `
+              TEST_QWEN_2_5=True `
+              CMAKE_CUDA_ARCHITECTURES=86-real `
+              CMAKE_C_COMPILER_LAUNCHER=sccache `
+              CMAKE_CXX_COMPILER_LAUNCHER=sccache `
+              'CMAKE_EXE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_MODULE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_SHARED_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_C_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG' `
+              'CMAKE_CXX_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG' `
+              'CMAKE_CUDA_FLAGS_INIT=/DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 -Xcompiler=" /MP /guard:cf /Qspectre " -allow-unsupported-compiler'
 
       - name: Show sccache stats
         run: sccache --show-stats
@@ -129,7 +141,7 @@ jobs:
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}\sccache
-          key: sccache-win-cuda-${{ hashFiles('**/CMakePresets.json', '**/CMakeLists.txt') }}
+          key: sccache-win-cuda-${{ hashFiles('build.py', '**/CMakeLists.txt', 'cmake/**/*.cmake') }}
 
       - name: Add CUDA to PATH
         run: |

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -108,6 +108,7 @@ jobs:
           $env:SCCACHE_DIR = "${{ github.workspace }}\sccache"
           # Limit CUDA archs to SM 86 (matches the A10 runner GPU) to keep CI build
           # time and memory usage manageable.
+          python -m pip install -r requirements-dev.txt
           python build.py `
             --config Release `
             --build_dir $env:buildRoot `

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}\sccache
-          key: sccache-win-cuda-${{ hashFiles('build.py', '**/CMakeLists.txt', 'cmake/**/*.cmake') }}
+          key: sccache-win-cuda-${{ hashFiles('.github/workflows/win-cuda-x64-build.yml', 'build.py', '**/CMakeLists.txt', 'cmake/**/*.cmake') }}
           restore-keys: |
             sccache-win-cuda-
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}\sccache
-          key: sccache-win-cuda-${{ hashFiles('build.py', '**/CMakeLists.txt', 'cmake/**/*.cmake') }}
+          key: sccache-win-cuda-${{ hashFiles('.github/workflows/win-cuda-x64-build.yml', 'build.py', '**/CMakeLists.txt', 'cmake/**/*.cmake') }}
 
       - name: Add CUDA to PATH
         run: |

--- a/.github/workflows/win-directml-x64-build.yml
+++ b/.github/workflows/win-directml-x64-build.yml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Build with build.py
         run: |
+          python -m pip install -r requirements-dev.txt
           python build.py `
             --config Release `
             --build_dir $env:buildRoot `

--- a/.github/workflows/win-directml-x64-build.yml
+++ b/.github/workflows/win-directml-x64-build.yml
@@ -23,7 +23,8 @@ env:
   d3d12_dir: "Microsoft.Direct3D.D3D12.1.614.1"
   d3d12_zip: "Microsoft.Direct3D.D3D12.1.614.1.zip"
   d3d12_url: "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.614.1"
-  binaryDir: 'build/directml/win-x64'
+  buildRoot: 'build/directml/win-x64'
+  binaryDir: 'build/directml/win-x64/Release'
 
 
 jobs:
@@ -98,14 +99,25 @@ jobs:
           & $exePath -y --default-toolchain=1.86.0
           Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
 
-      - name: Configure CMake
+      - name: Build with build.py
         run: |
-          cmake --preset windows_x64_directml_release -DTEST_PHI2=True -DENABLE_JAVA=ON -DUSE_GUIDANCE=ON -DTEST_QWEN_2_5=True
-
-      - name: Build with CMake
-        run: |
-          cmake --build --preset windows_x64_directml_release --parallel
-          cmake --build --preset windows_x64_directml_release --target PyPackageBuild
+          python build.py `
+            --config Release `
+            --build_dir $env:buildRoot `
+            --parallel `
+            --build_java `
+            --use_dml `
+            --use_guidance `
+            --update --build `
+            --skip_examples `
+            --cmake_extra_defines `
+              TEST_PHI2=True `
+              TEST_QWEN_2_5=True `
+              'CMAKE_EXE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_MODULE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_SHARED_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_C_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG' `
+              'CMAKE_CXX_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG'
 
       - name: Build the C Examples
         run: |

--- a/.github/workflows/win-webgpu-x64-build.yml
+++ b/.github/workflows/win-webgpu-x64-build.yml
@@ -17,7 +17,8 @@ env:
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1"
   ORT_NIGHTLY_FEED: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime"
-  binaryDir: 'build/cpu/win-x64'
+  buildRoot: 'build/cpu/win-x64'
+  binaryDir: 'build/cpu/win-x64/Release'
   WEBGPU_EP_PACKAGE_NAME: 'Microsoft.ML.OnnxRuntime.EP.WebGpu'
   WEBGPU_EP_PACKAGE_VERSION: '0.2.0-dev.20260610+50c95100'
   # Published ONNX Runtime used at test time (GenAI is built against the cmake-default ORT).
@@ -76,14 +77,24 @@ jobs:
           & $exePath -y --default-toolchain=1.86.0
           Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
 
-      - name: Configure CMake
+      - name: Build with build.py
         run: |
-          cmake --preset windows_x64_cpu_release -DTEST_PHI2=True -DENABLE_JAVA=ON -DUSE_GUIDANCE=ON -DTEST_QWEN_2_5=True
-
-      - name: Build with CMake
-        run: |
-          cmake --build --preset windows_x64_cpu_release --parallel
-          cmake --build --preset windows_x64_cpu_release --target PyPackageBuild
+          python build.py `
+            --config Release `
+            --build_dir $env:buildRoot `
+            --parallel `
+            --build_java `
+            --use_guidance `
+            --update --build `
+            --skip_examples `
+            --cmake_extra_defines `
+              TEST_PHI2=True `
+              TEST_QWEN_2_5=True `
+              'CMAKE_EXE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_MODULE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_SHARED_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_C_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG' `
+              'CMAKE_CXX_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob2 /DNDEBUG'
 
       - name: Build the C Examples
         run: |

--- a/.github/workflows/win-webgpu-x64-build.yml
+++ b/.github/workflows/win-webgpu-x64-build.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Build with build.py
         run: |
+          python -m pip install -r requirements-dev.txt
           python build.py `
             --config Release `
             --build_dir $env:buildRoot `

--- a/.github/workflows/win-winml-x64-build.yml
+++ b/.github/workflows/win-winml-x64-build.yml
@@ -17,7 +17,8 @@ env:
   cuda_dir: "${{ github.workspace }}\\cuda_sdk"
   cuda_version: "12.8"
   CUDA_PATH: ${{ github.workspace }}\\cuda_sdk\\v12.8
-  binaryDir: 'build/winml/win-x64'
+  buildRoot: 'build/winml/win-x64'
+  binaryDir: 'build/winml/win-x64/RelWithDebInfo'
   ORT_NIGHTLY_REST_API: "https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime.Gpu.Windows&api-version=6.0-preview.1"
   ORT_NIGHTLY_SOURCE: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json"
   ORT_PACKAGE_NAME: "Microsoft.ML.OnnxRuntime.Gpu.Windows"
@@ -61,17 +62,32 @@ jobs:
           & $exePath -y --default-toolchain=1.86.0
           Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
 
-      - name: Configure CMake
+      - name: Build with build.py
         run: |
-          # Limit CUDA archs to SM 86 (matches the A10 runner GPU) to keep CI build
-          # time and memory usage manageable. The preset's default arch list is for
-          # release packaging, not CI validation.
-          cmake --preset windows_x64_winml_relwithdebinfo -T cuda=${{ env.cuda_dir }}\\v${{ env.cuda_version }} -DWINML_SDK_VERSION='2.1.1' -DNUGET_PACKAGE_SOURCE='${{ env.ORT_NIGHTLY_SOURCE }}' -DENABLE_JAVA=ON -DUSE_GUIDANCE=ON -DCMAKE_CUDA_ARCHITECTURES=86-real
-
-      - name: Build with CMake
-        run: |
-          cmake --build --preset windows_x64_winml_relwithdebinfo --parallel
-          cmake --build --preset windows_x64_winml_relwithdebinfo --target PyPackageBuild
+          # WinML uses CUDA and DML together. Limit CUDA archs to SM 86 (matches
+          # the A10 runner GPU) to keep CI build time and memory manageable.
+          python build.py `
+            --config RelWithDebInfo `
+            --build_dir $env:buildRoot `
+            --parallel `
+            --build_java `
+            --use_cuda `
+            --cuda_home "${{ env.cuda_dir }}\v${{ env.cuda_version }}" `
+            --use_dml `
+            --use_winml `
+            --winml_sdk_version 2.1.1 `
+            --use_guidance `
+            --update --build `
+            --skip_examples `
+            --cmake_extra_defines `
+              "NUGET_PACKAGE_SOURCE=${{ env.ORT_NIGHTLY_SOURCE }}" `
+              CMAKE_CUDA_ARCHITECTURES=86-real `
+              'CMAKE_EXE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_MODULE_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_SHARED_LINKER_FLAGS_INIT=/profile /DYNAMICBASE' `
+              'CMAKE_C_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob1 /DNDEBUG' `
+              'CMAKE_CXX_FLAGS=/EHsc /Qspectre /MP /guard:cf /DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /O2 /Ob1 /DNDEBUG' `
+              'CMAKE_CUDA_FLAGS_INIT=/DWIN32 /D_WINDOWS /DWINAPI_FAMILY=100 /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 -Xcompiler=" /MP /guard:cf /Qspectre " -allow-unsupported-compiler'
 
       - name: Build the C Examples
         run: |

--- a/.github/workflows/win-winml-x64-build.yml
+++ b/.github/workflows/win-winml-x64-build.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           # WinML uses CUDA and DML together. Limit CUDA archs to SM 86 (matches
           # the A10 runner GPU) to keep CI build time and memory manageable.
+          python -m pip install -r requirements-dev.txt
           python build.py `
             --config RelWithDebInfo `
             --build_dir $env:buildRoot `

--- a/.pipelines/mac-cpu-arm64-build.yml
+++ b/.pipelines/mac-cpu-arm64-build.yml
@@ -125,7 +125,7 @@ jobs:
   - task: Cache@2
     displayName: 'Restore ccache'
     inputs:
-      key: 'ccache | macos-arm64 | "$(Agent.OS)" | **/CMakePresets.json, **/CMakeLists.txt'
+      key: 'ccache | macos-arm64 | "$(Agent.OS)" | build.py, **/CMakeLists.txt, cmake/**/*.cmake'
       restoreKeys: |
         ccache | macos-arm64 | "$(Agent.OS)"
         ccache | macos-arm64
@@ -143,21 +143,25 @@ jobs:
       export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | cut -d. -f1,2)
       export RUSTFLAGS='-C link-arg=-Wl,-undefined,dynamic_lookup -C link-arg=-Wl,-no_dead_strip_inits_and_terms'
       export CCACHE_DIR=$(Build.SourcesDirectory)/.ccache
-      cmake --preset macos_arm64_cpu_release -DENABLE_JAVA=ON -DUSE_GUIDANCE=ON \
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-    displayName: 'Configure CMake'
-    workingDirectory: '$(Build.SourcesDirectory)'
-
-  - bash: |
-      set -e -x
-      export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | cut -d. -f1,2)
-      export RUSTFLAGS='-C link-arg=-Wl,-undefined,dynamic_lookup -C link-arg=-Wl,-no_dead_strip_inits_and_terms'
-      export CCACHE_DIR=$(Build.SourcesDirectory)/.ccache
-      cmake --build --preset macos_arm64_cpu_release --parallel
-      cmake --build --preset macos_arm64_cpu_release --target PyPackageBuild
+      export CC=clang
+      export CXX=clang++
+      python3 build.py \
+        --config Release \
+        --build_dir build/cpu/osx-arm64 \
+        --cmake_generator 'Unix Makefiles' \
+        --parallel \
+        --build_java \
+        --use_guidance \
+        --update --build \
+        --skip_examples \
+        --cmake_extra_defines \
+          CMAKE_OSX_ARCHITECTURES=arm64 \
+          CMAKE_C_COMPILER_LAUNCHER=ccache \
+          CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          'CMAKE_C_FLAGS=-O3 -pipe' \
+          'CMAKE_CXX_FLAGS=-O3 -pipe'
       ccache --show-stats
-    displayName: 'Build with CMake'
+    displayName: 'Build with build.py'
     workingDirectory: '$(Build.SourcesDirectory)'
     continueOnError: false
 
@@ -165,10 +169,10 @@ jobs:
       set -e -x
       cmake -S examples/c -B examples/c/build \
         -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-        -DORT_INCLUDE_DIR=$(Build.SourcesDirectory)/build/cpu/osx-arm64/_deps/ortlib-src/build/native/include \
-        -DORT_LIB_DIR=$(Build.SourcesDirectory)/build/cpu/osx-arm64/_deps/ortlib-src/runtimes/osx-arm64/native \
+        -DORT_INCLUDE_DIR=$(Build.SourcesDirectory)/build/cpu/osx-arm64/Release/_deps/ortlib-src/build/native/include \
+        -DORT_LIB_DIR=$(Build.SourcesDirectory)/build/cpu/osx-arm64/Release/_deps/ortlib-src/runtimes/osx-arm64/native \
         -DOGA_INCLUDE_DIR=$(Build.SourcesDirectory)/src \
-        -DOGA_LIB_DIR=$(Build.SourcesDirectory)/build/cpu/osx-arm64
+        -DOGA_LIB_DIR=$(Build.SourcesDirectory)/build/cpu/osx-arm64/Release
       cmake --build examples/c/build --config Release
     displayName: 'Build the C examples'
     workingDirectory: '$(Build.SourcesDirectory)'
@@ -180,19 +184,19 @@ jobs:
       python3 -m pip install -r test/python/requirements.txt
       python3 -m pip install -r test/python/macos/torch/requirements.txt
       python3 -m pip install -r test/python/macos/ort/requirements.txt
-      python3 -m pip install build/cpu/osx-arm64/wheel/onnxruntime_genai*.whl --no-deps
+      python3 -m pip install build/cpu/osx-arm64/Release/wheel/onnxruntime_genai*.whl --no-deps
     displayName: 'Install the Python wheel and test dependencies'
     workingDirectory: '$(Build.SourcesDirectory)'
 
   - bash: |
       set -e -x
-      ctest --test-dir build/cpu/osx-arm64/src/java --build-config Release --verbose --timeout 10800
+      ctest --test-dir build/cpu/osx-arm64/Release/src/java --build-config Release --verbose --timeout 10800
     displayName: 'Run the Java tests'
     workingDirectory: '$(Build.SourcesDirectory)'
 
   - bash: |
-      ls -l $(Build.SourcesDirectory)/build/cpu/osx-arm64
-      ls -l $(Build.SourcesDirectory)/build/cpu/osx-arm64/wheel
+      ls -l $(Build.SourcesDirectory)/build/cpu/osx-arm64/Release
+      ls -l $(Build.SourcesDirectory)/build/cpu/osx-arm64/Release/wheel
     displayName: 'Verify build artifacts'
     condition: always()
     continueOnError: true
@@ -210,7 +214,7 @@ jobs:
       set -e -x
       export ORTGENAI_LOG_ORT_LIB=1
       cd test/csharp
-      dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/osx-arm64" /p:OrtLibDir="../../ort/lib" --verbosity normal
+      dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="../../build/cpu/osx-arm64/Release" /p:OrtLibDir="../../ort/lib" --verbosity normal
     displayName: 'Build the C# API and run the C# tests'
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -235,7 +239,7 @@ jobs:
   - bash: |
       set -e -x
       export ORTGENAI_LOG_ORT_LIB=1
-      export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(Build.SourcesDirectory)/build/cpu/osx-arm64
-      ./build/cpu/osx-arm64/unit_tests
+      export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(Build.SourcesDirectory)/build/cpu/osx-arm64/Release
+      ./build/cpu/osx-arm64/Release/unit_tests
     displayName: 'Run unit tests'
     workingDirectory: '$(Build.SourcesDirectory)'

--- a/.pipelines/mac-cpu-arm64-build.yml
+++ b/.pipelines/mac-cpu-arm64-build.yml
@@ -145,6 +145,7 @@ jobs:
       export CCACHE_DIR=$(Build.SourcesDirectory)/.ccache
       export CC=clang
       export CXX=clang++
+      python3 -m pip install -r requirements-dev.txt
       python3 build.py \
         --config Release \
         --build_dir build/cpu/osx-arm64 \

--- a/.pipelines/mac-cpu-arm64-build.yml
+++ b/.pipelines/mac-cpu-arm64-build.yml
@@ -125,7 +125,7 @@ jobs:
   - task: Cache@2
     displayName: 'Restore ccache'
     inputs:
-      key: 'ccache | macos-arm64 | "$(Agent.OS)" | build.py, **/CMakeLists.txt, cmake/**/*.cmake'
+      key: 'ccache | macos-arm64 | "$(Agent.OS)" | .pipelines/mac-cpu-arm64-build.yml, build.py, **/CMakeLists.txt, cmake/**/*.cmake'
       restoreKeys: |
         ccache | macos-arm64 | "$(Agent.OS)"
         ccache | macos-arm64

--- a/.pipelines/mac-cpu-arm64-build.yml
+++ b/.pipelines/mac-cpu-arm64-build.yml
@@ -23,8 +23,10 @@ pr:
       - BUILD.md
 
 variables:
-  ORT_NIGHTLY_REST_API: 'https://feeds.dev.azure.com/aiinfra/PublicPackages/_apis/packaging/Feeds/ORT-Nightly/packages?packageNameQuery=Microsoft.ML.OnnxRuntime&api-version=6.0-preview.1'
-  ORT_NIGHTLY_SOURCE: 'https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json'
+  ORT_BUILD_VERSION: '1.26.0'
+  ORT_RUNTIME_VERSION: '1.28.0'
+  ORT_BUILD_SOURCE: 'https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json'
+  ORT_RUNTIME_SOURCE: 'https://api.nuget.org/v3/index.json'
   ORT_PACKAGE_NAME: 'Microsoft.ML.OnnxRuntime'
 
 jobs:
@@ -90,23 +92,18 @@ jobs:
 
   - bash: |
       set -e -x
-      ORT_NIGHTLY_VERSION=$(curl -s "$(ORT_NIGHTLY_REST_API)" | jq -r '.value[0].versions[0].normalizedVersion')
-      echo "$ORT_NIGHTLY_VERSION"
-      echo "##vso[task.setvariable variable=ORT_NIGHTLY_VERSION]$ORT_NIGHTLY_VERSION"
-    displayName: 'Get the latest OnnxRuntime nightly version'
-
-  - bash: |
-      set -e -x
       dotnet new console
-      dotnet add package $(ORT_PACKAGE_NAME) --version $(ORT_NIGHTLY_VERSION) --source $(ORT_NIGHTLY_SOURCE) --package-directory .
-    displayName: 'Download OnnxRuntime nightly'
+      dotnet add package $(ORT_PACKAGE_NAME) --version $(ORT_BUILD_VERSION) --source $(ORT_BUILD_SOURCE) --package-directory .
+      dotnet add package $(ORT_PACKAGE_NAME) --version $(ORT_RUNTIME_VERSION) --source $(ORT_RUNTIME_SOURCE) --package-directory .
+    displayName: 'Download build-time and runtime OnnxRuntime'
     workingDirectory: '$(Build.SourcesDirectory)'
 
   - bash: |
       set -e -x
-      mkdir -p ort/lib
-      mv $(ORT_PACKAGE_NAME)/$(ORT_NIGHTLY_VERSION)/build/native/include ort/
-      mv $(ORT_PACKAGE_NAME)/$(ORT_NIGHTLY_VERSION)/runtimes/osx-arm64/native/* ort/lib/
+      mkdir -p ort-build/lib ort/lib
+      mv $(ORT_PACKAGE_NAME)/$(ORT_BUILD_VERSION)/build/native/include ort-build/
+      mv $(ORT_PACKAGE_NAME)/$(ORT_BUILD_VERSION)/runtimes/osx-arm64/native/* ort-build/lib/
+      mv $(ORT_PACKAGE_NAME)/$(ORT_RUNTIME_VERSION)/runtimes/osx-arm64/native/* ort/lib/
     displayName: 'Extract OnnxRuntime library and header files'
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -152,6 +149,7 @@ jobs:
         --cmake_generator 'Unix Makefiles' \
         --parallel \
         --build_java \
+        --ort_home $(Build.SourcesDirectory)/ort-build \
         --use_guidance \
         --update --build \
         --skip_examples \
@@ -170,8 +168,8 @@ jobs:
       set -e -x
       cmake -S examples/c -B examples/c/build \
         -DMODEL_QA=ON -DMODEL_CHAT=ON -DMODEL_MM=ON -DWHISPER=ON -DNEMOTRON_SPEECH=ON \
-        -DORT_INCLUDE_DIR=$(Build.SourcesDirectory)/build/cpu/osx-arm64/Release/_deps/ortlib-src/build/native/include \
-        -DORT_LIB_DIR=$(Build.SourcesDirectory)/build/cpu/osx-arm64/Release/_deps/ortlib-src/runtimes/osx-arm64/native \
+        -DORT_INCLUDE_DIR=$(Build.SourcesDirectory)/ort-build/include \
+        -DORT_LIB_DIR=$(Build.SourcesDirectory)/ort-build/lib \
         -DOGA_INCLUDE_DIR=$(Build.SourcesDirectory)/src \
         -DOGA_LIB_DIR=$(Build.SourcesDirectory)/build/cpu/osx-arm64/Release
       cmake --build examples/c/build --config Release
@@ -191,7 +189,8 @@ jobs:
 
   - bash: |
       set -e -x
-      ctest --test-dir build/cpu/osx-arm64/Release/src/java --build-config Release --verbose --timeout 10800
+      DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(Build.SourcesDirectory)/ort/lib \
+        ctest --test-dir build/cpu/osx-arm64/Release/src/java --build-config Release --verbose --timeout 10800
     displayName: 'Run the Java tests'
     workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -240,7 +239,7 @@ jobs:
   - bash: |
       set -e -x
       export ORTGENAI_LOG_ORT_LIB=1
-      export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(Build.SourcesDirectory)/build/cpu/osx-arm64/Release
+      export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(Build.SourcesDirectory)/ort/lib:$(Build.SourcesDirectory)/build/cpu/osx-arm64/Release
       ./build/cpu/osx-arm64/Release/unit_tests
     displayName: 'Run unit tests'
     workingDirectory: '$(Build.SourcesDirectory)'

--- a/.pipelines/packaging.yml
+++ b/.pipelines/packaging.yml
@@ -39,7 +39,7 @@ parameters:
 - name: ort_runtime_version
   displayName: 'ONNX Runtime version (runtime dependency)'
   type: string
-  default: '1.27.0'
+  default: '1.28.0'
 
 # ---- WinML SDK version (Microsoft.Windows.AI.MachineLearning) --------------
 - name: winml_sdk_version

--- a/.pipelines/stages/jobs/integration-test-job.yml
+++ b/.pipelines/stages/jobs/integration-test-job.yml
@@ -52,7 +52,7 @@ jobs:
     ${{ else }}:
       value: '$(Agent.TempDirectory)/ortgenai-models'
   - name: cuda_docker_image
-    value: onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc12:20250714.2
+    value: onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14:20251017.1
 
   steps:
   - checkout: self

--- a/.pipelines/stages/jobs/steps/integration-pytest-step.yml
+++ b/.pipelines/stages/jobs/steps/integration-pytest-step.yml
@@ -28,7 +28,12 @@ steps:
       python -m pip install --upgrade pip
       python -m pip install -r test\python\requirements.txt
       python -m pip install pytest
-      python -m pip install onnxruntime-gpu==1.26.0
+      if ("${{ parameters.ep }}" -eq "cuda") {
+        python -m pip install onnxruntime-gpu==1.28.0 `
+          --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/
+      } else {
+        python -m pip install onnxruntime==1.28.0
+      }
       python -m pip install $wheel.FullName
       if ("${{ parameters.ep }}" -eq "webgpu") {
         python -m pip install onnxruntime-ep-webgpu==0.1.0
@@ -74,7 +79,8 @@ steps:
           PYTHON_EXE=/opt/python/cp312-cp312/bin/python3.12
           \$PYTHON_EXE -m pip install -r test/python/requirements.txt
           \$PYTHON_EXE -m pip install pytest
-          \$PYTHON_EXE -m pip install onnxruntime-gpu==1.26.0
+          \$PYTHON_EXE -m pip install onnxruntime-gpu==1.28.0 \
+            --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/
           \$PYTHON_EXE -m pip install /wheel/*.whl
           nvidia-smi --query-gpu=name,compute_cap,driver_version,memory.total,memory.used,memory.free --format=csv
           \$PYTHON_EXE -m pytest test/python/integration -sv \
@@ -112,7 +118,7 @@ steps:
       python -m pip install --upgrade pip
       python -m pip install -r test/python/requirements.txt
       python -m pip install pytest
-      python -m pip install onnxruntime==1.26.0
+      python -m pip install onnxruntime==1.28.0
       python -m pip install ${{ parameters.wheelDir }}/*.whl
       if [ "${{ parameters.ep }}" = "webgpu" ]; then
         python -m pip install onnxruntime-ep-webgpu==0.1.0

--- a/.pipelines/stages/jobs/steps/integration-pytest-step.yml
+++ b/.pipelines/stages/jobs/steps/integration-pytest-step.yml
@@ -36,7 +36,7 @@ steps:
       }
       python -m pip install $wheel.FullName
       if ("${{ parameters.ep }}" -eq "webgpu") {
-        python -m pip install onnxruntime-ep-webgpu==0.1.0
+        python -m pip install onnxruntime-ep-webgpu==0.2.1
       }
     displayName: 'Install source-built wheel and test deps'
     workingDirectory: '$(Build.Repository.LocalPath)'
@@ -121,7 +121,7 @@ steps:
       python -m pip install onnxruntime==1.28.0
       python -m pip install ${{ parameters.wheelDir }}/*.whl
       if [ "${{ parameters.ep }}" = "webgpu" ]; then
-        python -m pip install onnxruntime-ep-webgpu==0.1.0
+        python -m pip install onnxruntime-ep-webgpu==0.2.1
       fi
     displayName: 'Install source-built wheel and test deps'
     workingDirectory: '$(Build.Repository.LocalPath)'

--- a/test/python/cpu/ort/requirements.txt
+++ b/test/python/cpu/ort/requirements.txt
@@ -1,1 +1,1 @@
-onnxruntime==1.26.0
+onnxruntime==1.28.0

--- a/test/python/cuda/ort/requirements.txt
+++ b/test/python/cuda/ort/requirements.txt
@@ -1,1 +1,2 @@
-onnxruntime-gpu==1.26.0
+-i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/
+onnxruntime-gpu==1.28.0

--- a/test/python/macos/ort/requirements.txt
+++ b/test/python/macos/ort/requirements.txt
@@ -1,1 +1,1 @@
-onnxruntime==1.27.0
+onnxruntime==1.28.0


### PR DESCRIPTION
This updates the project’s CI pipelines to use `python build.py` for core builds instead of CMake presets and platform-specific build wrappers.