### PR TITLE
webgpu: Shape-free synthetic position_ids for Qwen3.5 VL graph capture

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -419,6 +419,14 @@ class Model:
                 self.make_attention_mask_reformatting_for_gqa = (
                     WebGPU.make_attention_mask_graph_capture_reformatting_for_gqa.__get__(self, self.__class__)
                 )
+                # Qwen3.5 VL: replace the Shape-based synthetic position_ids
+                # subgraph with a Shape-free equivalent so no Memcpy nodes are
+                # inserted. Bound as an instance attribute so the subclass's
+                # class method is shadowed at call time. Harmless for models
+                # that never call _make_synthetic_position_ids.
+                self._make_synthetic_position_ids = (
+                    WebGPU.make_synthetic_position_ids_graph_capture.__get__(self, self.__class__)
+                )
 
         else:
             return
@@ -1514,6 +1522,19 @@ class Model:
     def make_reduce_mean(self, name, inputs, dtype, shape, keepdims=False):
         output = f"{name}/output_0"
         self.make_node("ReduceMean", inputs=inputs, outputs=[output], name=name, keepdims=keepdims)
+        self.make_value(output, dtype, shape=shape)
+
+    def make_cum_sum(self, name, inputs, dtype, shape, exclusive=0, reverse=0):
+        # inputs = [x, axis_scalar_tensor_name]
+        output = f"{name}/output_0"
+        self.make_node(
+            "CumSum",
+            inputs=inputs,
+            outputs=[output],
+            name=name,
+            exclusive=exclusive,
+            reverse=reverse,
+        )
         self.make_value(output, dtype, shape=shape)
 
     def make_sqrt(self, name, inputs, dtype, shape):

--- a/src/python/py/models/builders/expansions/webgpu.py
+++ b/src/python/py/models/builders/expansions/webgpu.py
@@ -53,3 +53,115 @@ class WebGPU:
 
         self.mask_attrs["seqlens_k"] = sub_name
         self.mask_attrs["total_seq_len"] = reduce_max_name
+
+    def make_synthetic_position_ids_graph_capture(self):
+        # Shape-free construction of the [B, S] INT64 tensor of linear indices
+        # r*S + c, replacing Qwen35TextModel._make_synthetic_position_ids for
+        # WebGPU graph capture.
+        #
+        # Standard version emits two Shape ops (Shape -> Slice for [B, S], and
+        # Shape -> Gather for scalar B*S) whose INT64 outputs land on CPU and
+        # force Memcpy nodes that break graph capture.
+        #
+        # Graph-capture version derives everything from the existing 3D
+        # position_ids input using only GPU-native ops (Gather, Squeeze, Mul,
+        # Add, CumSum, ReduceSum). All intermediates keep symbolic [B, S]
+        # shape from data-flow, so no scalar length is ever materialized.
+        #
+        # Layout:
+        #   position_ids [3, B, S]
+        #        |
+        #     Gather(idx=[0], axis=0)  -> [1, B, S]
+        #        |
+        #     Squeeze(axis=[0])        -> [B, S]                (t_positions)
+        #        |
+        #     Mul(*0) then Add(+1)     -> [B, S] all ones       (ones_bs)
+        #        |----------------\
+        #        |                 \
+        #     CumSum(axis=1,        ReduceSum(axes=[1],
+        #            exclusive=1)          keepdims=1)          -> [B, 1] = S per row
+        #        |                        |
+        #     row_idx [B, S]         CumSum(axis=0,
+        #     (values 0..S-1)               exclusive=1)         -> [B, 1] = 0, S, 2S, ...
+        #        |                        |
+        #        +------- Add ------------+                     -> [B, S] = r*S + c
+        basename = "/model/attn/synthetic_pos_ids"
+        pos_ids_input = self.position_ids_reformatted
+
+        # Gather axis-0 slice [0] -> [1, B, S]
+        gather_name = f"{basename}/t/Gather"
+        self.make_gather(
+            gather_name,
+            inputs=[pos_ids_input, "/model/constants/INT64/[0]"],
+            dtype=ir.DataType.INT64,
+            shape=[1, "batch_size", "sequence_length"],
+            axis=0,
+        )
+
+        # Squeeze axis 0 -> [B, S]
+        squeeze_name = f"{basename}/t/Squeeze"
+        self.make_squeeze(
+            squeeze_name,
+            inputs=[f"{gather_name}/output_0", "/model/constants/INT64/[0]"],
+            dtype=ir.DataType.INT64,
+            shape=["batch_size", "sequence_length"],
+        )
+
+        # Zero out and add 1 to get [B, S] of ones. Two-step (Mul 0, Add 1)
+        # avoids needing broadcasted constants of the right shape.
+        zero_name = f"{basename}/zeros/Mul"
+        self.make_mul(
+            zero_name,
+            inputs=[f"{squeeze_name}/output_0", "/model/constants/INT64/0"],
+            dtype=ir.DataType.INT64,
+            shape=["batch_size", "sequence_length"],
+        )
+        ones_name = f"{basename}/ones/Add"
+        self.make_add(
+            ones_name,
+            inputs=[f"{zero_name}/output_0", "/model/constants/INT64/1"],
+            dtype=ir.DataType.INT64,
+            shape=["batch_size", "sequence_length"],
+        )
+        ones_bs = f"{ones_name}/output_0"
+
+        # Per-row indices 0..S-1 via CumSum(axis=1, exclusive=1)
+        row_idx_name = f"{basename}/row_idx/CumSum"
+        self.make_cum_sum(
+            row_idx_name,
+            inputs=[ones_bs, "/model/constants/INT64/1"],
+            dtype=ir.DataType.INT64,
+            shape=["batch_size", "sequence_length"],
+            exclusive=1,
+        )
+
+        # Per-row totals [B, 1] via ReduceSum(axes=[1], keepdims=1)
+        row_sum_name = f"{basename}/row_sum/ReduceSum"
+        self.make_reduce_sum(
+            row_sum_name,
+            inputs=[ones_bs, "/model/constants/INT64/[1]"],
+            dtype=ir.DataType.INT64,
+            shape=["batch_size", 1],
+            keepdims=True,
+        )
+
+        # Batch offsets 0, S, 2S, ... via CumSum(axis=0, exclusive=1) on [B, 1]
+        batch_off_name = f"{basename}/batch_off/CumSum"
+        self.make_cum_sum(
+            batch_off_name,
+            inputs=[f"{row_sum_name}/output_0", "/model/constants/INT64/0"],
+            dtype=ir.DataType.INT64,
+            shape=["batch_size", 1],
+            exclusive=1,
+        )
+
+        # linear = row_idx + batch_offset (broadcast [B, 1] over [B, S])
+        linear_name = f"{basename}/linear/Add"
+        self.make_add(
+            linear_name,
+            inputs=[f"{row_idx_name}/output_0", f"{batch_off_name}/output_0"],
+            dtype=ir.DataType.INT64,
+            shape=["batch_size", "sequence_length"],
+        )
+
+        return f"{linear_name}/output_0"


### PR DESCRIPTION
## Summary

Enable WebGPU graph capture for the Qwen3.5 **VL** model. Text-only Qwen3.5 was already handled by #2245 (mRoPE bypass — GQA does fused RoPE). VL cannot use that bypass because the three position axes (T/H/W) carry genuinely different values, so mRoPE must be computed explicitly.

On the VL export path the only remaining Shape ops live inside `Qwen35TextModel._make_synthetic_position_ids` (`qwen.py` lines 1475 and 1502). Their INT64 outputs land on CPU and force `MemcpyToHost`/`MemcpyFromHost` around every downstream consumer, breaking graph capture.

This PR follows the existing `enable_webgpu_graph` expansion pattern (see `WebGPU.make_attention_mask_graph_capture_reformatting_for_gqa`) and swaps in a Shape-free construction of the same `[B, S]` INT64 linear-index tensor (`r*S + c`) when `--extra_options enable_webgpu_graph=true` is set.

## Approach

Replace `Shape → Slice → Reshape → Shape → Gather → Range → Reshape` with a chain that never materializes a scalar length or a shape tensor:

```
position_ids [3, B, S]
  → Gather(idx=[0], axis=0)      → [1, B, S]
  → Squeeze(axis=[0])            → [B, S]           (t_positions; shape only used)
  → Mul(*0) → Add(+1)            → [B, S] all ones  (ones_bs)
    ├─ CumSum(axis=1, exclusive) → [B, S]           (row_idx = 0..S-1 per row)
    └─ ReduceSum(axis=[1], keepdims)
        → [B, 1] = S per row
        → CumSum(axis=0, exclusive)
        → [B, 1] = 0, S, 2S, …    (batch_offset)
  → Add(row_idx, batch_offset)   → [B, S] = r*S + c
```

Same shape, dtype, and values as before. Consumers unchanged.

## Activation

Only active when the user passes `--extra_options enable_webgpu_graph=true`. Default exports are byte-identical to today.

## Changes

- `src/python/py/models/builders/expansions/webgpu.py`
  - New `make_synthetic_position_ids_graph_capture` method that emits the Shape-free subgraph.
- `src/python/py/models/builders/base.py`
  - New `make_cum_sum` helper (mirrors `make_reduce_sum` style).
  - Under `enable_webgpu_graph`, additionally bind `_make_synthetic_position_ids` to the graph-capture version (same descriptor pattern already used for `make_attention_mask_reformatting_for_gqa`).

## Test plan

- [ ] Export Qwen3.5-VL with and without `enable_webgpu_graph=true`; confirm the default graph is byte-identical to pre-PR and the graph-capture graph has zero `Shape` nodes under `/model/attn/synthetic_pos_ids/`.
- [ ] One-step prefill numerical equivalence: logits match within fp16 tolerance between default (CPU EP reference) and graph-capture (WebGPU EP) graphs.
- [ ] End-to-end: run Qwen3.5-VL with `enable_graph_capture=1` on WebGPU EP; confirm no `Memcpy*` nodes at runtime and capture activates.
- [ ] Regression: Qwen3.5 text-only export unchanged (this code path is not reached).