### PR TITLE
Enable externally managed CUDA add-ons and align CUDA architecture packaging

### DIFF
--- a/.pipelines/stages/jobs/steps/core-linux-step.yml
+++ b/.pipelines/stages/jobs/steps/core-linux-step.yml
@@ -83,12 +83,12 @@ steps:
     if [ '${{ parameters.ep }}' = 'cuda' ]; then
       if [[ '${{ parameters.cuda_version }}' == 13.* ]]; then
         if [ '${{ parameters.arch }}' = 'arm64' ]; then
-          cuda_archs='110-real;120-real;121-real;120-virtual'
+          cuda_archs='89-real;90-real;100-real;103-real;120-real;121-real'
         else
-          cuda_archs='75-real;80-real;86-real;89-real;90-real;120-real;120-virtual'
+          cuda_archs='75-real;80-real;86-real;89-real;90-real;120-real'
         fi
       else
-        cuda_archs='61-real;75-real;86-real;89-real;120-real;120-virtual'
+        cuda_archs='75-real;80-real;86-real;89-real;90-real;120-real'
       fi
       docker_args+=(-e "CUDA_EXTRA_ARGS=--use_cuda --cuda_home /usr/local/cuda --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=${cuda_archs}")
     fi

--- a/.pipelines/stages/jobs/steps/core-win-step.yml
+++ b/.pipelines/stages/jobs/steps/core-win-step.yml
@@ -203,12 +203,12 @@ steps:
       $args += '--use_cuda', '--cuda_home', $cudaHome
       if ('${{ parameters.cuda_version }}' -like '13.*') {
         if ('${{ parameters.arch }}' -eq 'arm64') {
-          $cudaArchs = '110-real;120-real;121-real;120-virtual'
+          $cudaArchs = '120-real;121-real'
         } else {
-          $cudaArchs = '75-real;80-real;86-real;89-real;90-real;120-real;120-virtual'
+          $cudaArchs = '75-real;80-real;86-real;89-real;120-real'
         }
       } else {
-        $cudaArchs = '61-real;75-real;86-real;89-real;120-real;120-virtual'
+        $cudaArchs = '61-real;75-real;86-real;89-real;120-real'
       }
       $args += '--cmake_extra_defines', "CMAKE_CUDA_ARCHITECTURES=$cudaArchs"
     }

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -242,8 +242,12 @@ struct LibraryHandle {
 #elif defined(__linux__) && !defined(__ANDROID__)
 struct LibraryHandle {
   LibraryHandle(const char* filename) {
-    auto path = Ort::GetCurrentModuleDir() + "/" + filename;
-    handle_ = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    // Hosts such as Foundry Local may preload the add-on from a managed bundle outside this module's directory.
+    handle_ = dlopen(filename, RTLD_NOW | RTLD_LOCAL | RTLD_NOLOAD);
+    if (!handle_) {
+      auto path = Ort::GetCurrentModuleDir() + "/" + filename;
+      handle_ = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    }
     if (!handle_)
       throw std::runtime_error(std::string("Failed to load library: ") + dlerror());  // dlerror() includes the path
   }
@@ -313,8 +317,11 @@ DeviceInterface* OrtGlobals::LoadCudaInterface(DeviceType type) {
       throw std::runtime_error("Shared library load failure (see first error)");
 
     Generators::DeviceInterface* GetInterface(GenaiInterface * p_genai, const char* deviceType, const OrtApi* ort_api);
-    return reinterpret_cast<decltype(&GetInterface)>(
-        cuda_library_->GetSymbol("GetInterface"))(&g_genai, to_string(type).c_str(), Ort::api);
+    auto get_interface = reinterpret_cast<decltype(&GetInterface)>(cuda_library_->GetSymbol("GetInterface"));
+    if (!get_interface)
+      throw std::runtime_error("CUDA add-on library does not export GetInterface");
+
+    return get_interface(&g_genai, to_string(type).c_str(), Ort::api);
   } catch (const std::exception& e) {
     throw std::runtime_error("Cuda interface not available: " + std::string(e.what()));
   }


### PR DESCRIPTION
## Summary

This change allows applications such as Foundry Local to supply `libonnxruntime-genai-cuda.so` from a managed download location instead of requiring it beside `libonnxruntime-genai.so`.

On Linux, GenAI first looks for an already-loaded CUDA add-on by its SONAME using `RTLD_NOLOAD`. If none is loaded, it preserves the existing sibling-directory fallback. It also reports a clear error if the loaded add-on does not export `GetInterface`.

The CUDA packaging architecture lists are aligned with the ONNX Runtime CUDA plugin packages:

| Platform | Architecture | CUDA toolkit | Packaged real SMs | Virtual PTX |
|---|---|---|---|---|
| Linux | x64 | 12.8 | `75`, `80`, `86`, `89`, `90`, `120` | None |
| Linux | x64 | 13.x | `75`, `80`, `86`, `89`, `90`, `120` | None |
| Linux | ARM64 | 13.x | `89`, `90`, `100`, `103`, `120`, `121` | None |
| Windows | x64 | 12.8 | `61`, `75`, `86`, `89`, `120` | None |
| Windows | x64 | 13.x | `75`, `80`, `86`, `89`, `120` | None |
| Windows | ARM64 | 13.x | `120`, `121` | None |

Virtual `compute_120` PTX is removed to reduce package size. The explicit lists retain A100 and H100 support on Linux while targeting the GPU families expected on each platform.

## Motivation

Foundry Local downloads and verifies its CUDA binaries independently. Previously, GenAI always constructed an absolute path beside its core library, so it could not use the verified add-on preloaded by Foundry Local. Copying the add-on into an SDK package directory is unreliable because that directory may be read-only or shared.

Reusing an already-loaded module lets the host own installation and verification without requiring `LD_LIBRARY_PATH` changes or mutable package directories.

## Compatibility

The existing sibling-loading behavior remains the fallback, so standalone GenAI packages continue to work as before.

Because the packages no longer contain virtual PTX, GPUs must match one of the explicitly packaged SM targets.
