### PR TITLE
Reuse the host’s loaded ONNX Runtime on Linux and macOS

### DIFF
--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -201,7 +201,7 @@ inline void* LoadDynamicLibraryIfExists(const std::string& path) {
   return ort_lib_handle;
 }
 
-#if defined(__linux__)
+#if (defined(__linux__) || defined(MACOS_USE_DLOPEN)) && defined(RTLD_NOLOAD)
 inline void* GetLoadedDynamicLibraryIfExists(const std::string& path) {
   LOG_INFO("Attempting to reuse loaded library %s", path.c_str());
   void* ort_lib_handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL | RTLD_NOLOAD);
@@ -289,6 +289,7 @@ inline void InitApi() {
   }
 
 #if defined(__linux__)
+#if defined(RTLD_NOLOAD)
   if (ort_lib_handle == nullptr) {
     // Reuse any ORT image already loaded by the host before resolving a new path. In particular,
     // a host may depend on the versioned SONAME while the unversioned sibling is also present.
@@ -300,6 +301,7 @@ inline void InitApi() {
   if (ort_lib_handle == nullptr) {
     ort_lib_handle = GetLoadedDynamicLibraryIfExists("libonnxruntime.so.1");
   }
+#endif
 
   if (ort_lib_handle == nullptr) {
     // For Android and NuGet Linux package, the file name is libonnxruntime.so
@@ -314,6 +316,16 @@ inline void InitApi() {
 #endif
 
 #if defined(MACOS_USE_DLOPEN)
+#if defined(RTLD_NOLOAD)
+  if (ort_lib_handle == nullptr) {
+    ort_lib_handle = GetLoadedDynamicLibraryIfExists("libonnxruntime.dylib");
+  }
+
+  if (ort_lib_handle == nullptr) {
+    ort_lib_handle = GetLoadedDynamicLibraryIfExists("libonnxruntime.1.dylib");
+  }
+#endif
+
   if (ort_lib_handle == nullptr) {
     ort_lib_handle = LoadDynamicLibraryIfExists("libonnxruntime.dylib");
   }

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -201,6 +201,21 @@ inline void* LoadDynamicLibraryIfExists(const std::string& path) {
   return ort_lib_handle;
 }
 
+#if defined(__linux__)
+inline void* GetLoadedDynamicLibraryIfExists(const std::string& path) {
+  LOG_INFO("Attempting to reuse loaded library %s", path.c_str());
+  void* ort_lib_handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL | RTLD_NOLOAD);
+  if (ort_lib_handle) {
+#if defined(RTLD_DI_ORIGIN)
+    char pathname[PATH_MAX];
+    dlinfo(ort_lib_handle, RTLD_DI_ORIGIN, &pathname);
+    LOG_INFO("Reusing loaded native library at %s", pathname);
+#endif
+  }
+  return ort_lib_handle;
+}
+#endif
+
 inline void InitApiWithDynamicFn(OrtApiBaseFn ort_api_base_fn) {
   if (ort_api_base_fn == nullptr) {
     throw std::runtime_error("OrtGetApiBase not found");
@@ -274,6 +289,18 @@ inline void InitApi() {
   }
 
 #if defined(__linux__)
+  if (ort_lib_handle == nullptr) {
+    // Reuse any ORT image already loaded by the host before resolving a new path. In particular,
+    // a host may depend on the versioned SONAME while the unversioned sibling is also present.
+    // Loading the sibling first would create a second ORT environment that cannot see EPs the host
+    // registered with the original image.
+    ort_lib_handle = GetLoadedDynamicLibraryIfExists("libonnxruntime.so");
+  }
+
+  if (ort_lib_handle == nullptr) {
+    ort_lib_handle = GetLoadedDynamicLibraryIfExists("libonnxruntime.so.1");
+  }
+
   if (ort_lib_handle == nullptr) {
     // For Android and NuGet Linux package, the file name is libonnxruntime.so
     // "libonnxruntime4j_jni.so" is also an option on Android if we have issues

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -204,14 +204,18 @@ inline void* LoadDynamicLibraryIfExists(const std::string& path) {
 #if (defined(__linux__) || defined(MACOS_USE_DLOPEN)) && defined(RTLD_NOLOAD)
 inline void* GetLoadedDynamicLibraryIfExists(const std::string& path) {
   LOG_INFO("Attempting to reuse loaded library %s", path.c_str());
+  dlerror();
   void* ort_lib_handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL | RTLD_NOLOAD);
-  if (ort_lib_handle) {
-#if defined(RTLD_DI_ORIGIN)
-    char pathname[PATH_MAX];
-    dlinfo(ort_lib_handle, RTLD_DI_ORIGIN, &pathname);
-    LOG_INFO("Reusing loaded native library at %s", pathname);
-#endif
+  if (!ort_lib_handle) {
+    dlerror();
+    return nullptr;
   }
+
+#if defined(RTLD_DI_ORIGIN)
+  char pathname[PATH_MAX];
+  dlinfo(ort_lib_handle, RTLD_DI_ORIGIN, &pathname);
+  LOG_INFO("Reusing loaded native library at %s", pathname);
+#endif
   return ort_lib_handle;
 }
 #endif

--- a/src/models/onnxruntime_api.h
+++ b/src/models/onnxruntime_api.h
@@ -201,6 +201,8 @@ inline void* LoadDynamicLibraryIfExists(const std::string& path) {
   return ort_lib_handle;
 }
 
+// RTLD_NOLOAD is a dlfcn extension available on Linux and macOS, but not on every POSIX platform.
+// Platforms without it continue through the existing dlopen fallback below.
 #if (defined(__linux__) || defined(MACOS_USE_DLOPEN)) && defined(RTLD_NOLOAD)
 inline void* GetLoadedDynamicLibraryIfExists(const std::string& path) {
   LOG_INFO("Attempting to reuse loaded library %s", path.c_str());


### PR DESCRIPTION
## Summary

Reuse an ONNX Runtime library already loaded by the host before attempting to load another copy on Linux or macOS.

## Why

Hosts such as Foundry Local load ONNX Runtime before ONNX Runtime GenAI and register execution provider plugins on its environment.

GenAI could subsequently load ONNX Runtime using a different filename:

- `libonnxruntime.so` versus `libonnxruntime.so.1` on Linux
- `libonnxruntime.dylib` versus `libonnxruntime.1.dylib` on macOS

This could load a second ONNX Runtime image with a separate environment. Execution providers registered by the host would then be unavailable to GenAI.

## Changes

- Check for resident versioned and unversioned ONNX Runtime libraries using `RTLD_NOLOAD`.
- Reuse the resident library when found.
- Preserve the existing dynamic-loading fallback when ONNX Runtime has not already been loaded.
- Apply the behavior to Linux and macOS.
