### PR TITLE
Validate num_return_sequences <= num_beams in BeamSearch

### DIFF
--- a/src/beam_search_scorer.h
+++ b/src/beam_search_scorer.h
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "sequences.h"
+#include <stdexcept>
 #pragma once
 // The implementation is based on huggingface transformers generation_beam_search.py
 namespace Generators {
@@ -20,7 +21,11 @@ struct BeamHypotheses {
   // Return true if this beats the worst score in the hypothesis
   bool CanImprove(float best_sum_logprobs, int current_length) const;
 
-  std::span<int32_t> GetHypothesis(size_t index) const { return beams_[index].hypothesis; }
+  std::span<int32_t> GetHypothesis(size_t index) const {
+    if (index >= beams_.size())
+      throw std::out_of_range("GetHypothesis index out of bounds");
+    return beams_[index].hypothesis;
+  }
 
   // TODO(aciddelgado): Methods to get all hypotheses and scores
 

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -513,6 +513,8 @@ Generator::Generator(const Model& model, const GeneratorParams& params)
                                 : kMaxNumBeams;
   if (params.search.num_beams < 1 || params.search.num_beams > max_num_beams)
     throw std::runtime_error("num_beams (" + std::to_string(params.search.num_beams) + ") must be in [1, " + std::to_string(max_num_beams) + "]");
+  if (params.search.num_return_sequences < 1 || params.search.num_return_sequences > params.search.num_beams)
+    throw std::runtime_error("num_return_sequences (" + std::to_string(params.search.num_return_sequences) + ") must be in [1, " + std::to_string(params.search.num_beams) + "]");
   if (params.config.model.vocab_size < 1)
     throw std::runtime_error("vocab_size must be 1 or greater, is " + std::to_string(params.config.model.vocab_size));
   // Beam search selects the top 2*num_beams (beam, token) candidates out of

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -521,6 +521,39 @@ TEST(ModelTests, BatchSizeZeroThrows) {
 
   EXPECT_THROW(OgaGenerator::Create(*model, *params), std::runtime_error);
 }
+
+TEST(ModelTests, NumReturnSequencesExceedsNumBeamsThrows) {
+  auto model = OgaModel::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 20);
+  params->SetSearchOption("batch_size", 1);
+  params->SetSearchOption("num_beams", 4);
+  params->SetSearchOption("num_return_sequences", 8);  // exceeds num_beams (4)
+
+  EXPECT_THROW(OgaGenerator::Create(*model, *params), std::runtime_error);
+}
+
+TEST(ModelTests, NumReturnSequencesZeroThrows) {
+  auto model = OgaModel::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 20);
+  params->SetSearchOption("batch_size", 1);
+  params->SetSearchOption("num_beams", 4);
+  params->SetSearchOption("num_return_sequences", 0);  // below lower bound of 1
+
+  EXPECT_THROW(OgaGenerator::Create(*model, *params), std::runtime_error);
+}
+
+TEST(ModelTests, NumReturnSequencesValidWithinBounds) {
+  auto model = OgaModel::Create(MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 20);
+  params->SetSearchOption("batch_size", 1);
+  params->SetSearchOption("num_beams", 4);
+  params->SetSearchOption("num_return_sequences", 2);  // valid: 1 <= 2 <= 4
+
+  EXPECT_NO_THROW(OgaGenerator::Create(*model, *params));
+}
 #endif
 // --- Validation tests (no model files required) ---
 


### PR DESCRIPTION
Add validation to reject num_return_sequences values that exceed num_beams, preventing out-of-bounds heap reads in BeamSearch_Cpu::GetSequence and BeamSearch_Cuda::GetSequence. The vulnerability (CWE-125) allowed crafted genai_config.json with num_return_sequences > num_beams to cause index computations exceeding the num_beams-sized beams_ array.

Fixes:
- src/generators.cpp: Add num_return_sequences bounds check in Generator constructor, mirroring existing num_beams validation
- src/beam_search_scorer.h: Add defensive bounds check in GetHypothesis method with proper exception handling
- test/model_tests.cpp: Add regression tests verifying rejection of invalid num_return_sequences values and acceptance of valid ranges