### PR TITLE
Add validation to prevent buffer overflow in Qwen2VL grid dimensions

### DIFF
--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -650,7 +650,7 @@ void Qwen2VLPositionInputs::SetGridTensors(const std::shared_ptr<Tensor>& image_
                                            const std::shared_ptr<Tensor>& second_per_grid_ts) {
   // Validate grid tensor dimensions to prevent overflow during position computation
   constexpr int64_t kMaxGridDim = 16384;  // Conservative upper bound to prevent overflow
-  
+
   if (image_grid_thw) {
     auto grid_data = image_grid_thw->GetData<int64_t>();
     auto elem_count = image_grid_thw->GetElementCount();
@@ -667,7 +667,7 @@ void Qwen2VLPositionInputs::SetGridTensors(const std::shared_ptr<Tensor>& image_
       }
     }
   }
-  
+
   if (video_grid_thw) {
     auto grid_data = video_grid_thw->GetData<int64_t>();
     auto elem_count = video_grid_thw->GetElementCount();
@@ -684,7 +684,7 @@ void Qwen2VLPositionInputs::SetGridTensors(const std::shared_ptr<Tensor>& image_
       }
     }
   }
-  
+
   image_grid_thw_ = image_grid_thw;
   video_grid_thw_ = video_grid_thw;
   second_per_grid_ts_ = second_per_grid_ts;
@@ -852,17 +852,17 @@ void Qwen2VLPositionInputs::CreateAndInitialize3DPositionIDs(DeviceSpan<int32_t>
       // 2. Fill Vision Part
       st_idx = max_pos_for_batch + 1;
       int64_t vision_len = llm_grid_t * llm_grid_h * llm_grid_w;
-      
+
       // Validate that the vision tokens fit within the sequence
       if (ed + vision_len > seq_len) {
-        throw std::runtime_error("Image/video grid dimensions (t=" + std::to_string(llm_grid_t) + 
-                                 " h=" + std::to_string(llm_grid_h) + 
-                                 " w=" + std::to_string(llm_grid_w) + 
-                                 ") result in " + std::to_string(vision_len) + 
-                                 " tokens but only " + std::to_string(seq_len - ed) + 
+        throw std::runtime_error("Image/video grid dimensions (t=" + std::to_string(llm_grid_t) +
+                                 " h=" + std::to_string(llm_grid_h) +
+                                 " w=" + std::to_string(llm_grid_w) +
+                                 ") result in " + std::to_string(vision_len) +
+                                 " tokens but only " + std::to_string(seq_len - ed) +
                                  " positions available in sequence");
       }
-      
+
       for (int64_t s = 0; s < vision_len; ++s) {
         int64_t gt = s / (llm_grid_h * llm_grid_w);
         int64_t gh = (s / llm_grid_w) % llm_grid_h;

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -76,36 +76,6 @@ struct InitAttentionMaskFunctor {
   }
 };
 
-constexpr int64_t kMaxQwen2VLGridDim = 16384;
-
-void ValidateQwen2VLGridTensorValues(const int64_t* grid_data, size_t elem_count, const char* tensor_name) {
-  if (elem_count % 3 != 0) {
-    throw std::runtime_error(std::string(tensor_name) + " element count must be divisible by 3");
-  }
-
-  for (size_t i = 0; i < elem_count; ++i) {
-    if (grid_data[i] < 0) {
-      throw std::runtime_error(std::string(tensor_name) + " values must be non-negative");
-    }
-    if (grid_data[i] > kMaxQwen2VLGridDim) {
-      throw std::runtime_error(std::string(tensor_name) + " values must be <= " + std::to_string(kMaxQwen2VLGridDim));
-    }
-  }
-}
-
-void ValidateQwen2VLVisionLengthFitsSequence(int64_t llm_grid_t, int64_t llm_grid_h, int64_t llm_grid_w,
-                                             int64_t ed, int64_t seq_len) {
-  const int64_t vision_len = llm_grid_t * llm_grid_h * llm_grid_w;
-  if (ed + vision_len > seq_len) {
-    throw std::runtime_error("Image/video grid dimensions (t=" + std::to_string(llm_grid_t) +
-                             " h=" + std::to_string(llm_grid_h) +
-                             " w=" + std::to_string(llm_grid_w) +
-                             ") result in " + std::to_string(vision_len) +
-                             " tokens but only " + std::to_string(seq_len - ed) +
-                             " positions available in sequence");
-  }
-}
-
 DefaultPositionInputs::DefaultPositionInputs(const Model& model, State& state, DeviceSpan<int32_t> sequence_lengths_unk, const std::string& attention_mask_name)
     : model_{model},
       state_{state},

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -650,40 +650,33 @@ void Qwen2VLPositionInputs::SetGridTensors(const std::shared_ptr<Tensor>& image_
                                            const std::shared_ptr<Tensor>& second_per_grid_ts) {
   // Validate grid tensor dimensions to prevent overflow during position computation
   constexpr int64_t kMaxGridDim = 16384;  // Conservative upper bound to prevent overflow
-
-  if (image_grid_thw) {
-    auto grid_data = image_grid_thw->GetData<int64_t>();
-    auto elem_count = image_grid_thw->GetElementCount();
-    // Each image contributes t, h, w (3 values per image)
-    if (elem_count % 3 != 0) {
-      throw std::runtime_error("image_grid_thw element count must be divisible by 3");
+  const auto validate_grid_tensor = [&](const std::shared_ptr<Tensor>& grid_tensor, const char* tensor_name) {
+    if (!grid_tensor) {
+      return;
     }
+
+    if (grid_tensor->GetType() != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
+      throw std::runtime_error(std::string(tensor_name) + " must be int64.");
+    }
+
+    const auto* grid_data = grid_tensor->GetData<int64_t>();
+    const size_t elem_count = grid_tensor->GetElementCount();
+    if (elem_count % 3 != 0) {
+      throw std::runtime_error(std::string(tensor_name) + " element count must be divisible by 3");
+    }
+
     for (size_t i = 0; i < elem_count; ++i) {
       if (grid_data[i] < 0) {
-        throw std::runtime_error("image_grid_thw values must be non-negative");
+        throw std::runtime_error(std::string(tensor_name) + " values must be non-negative");
       }
       if (grid_data[i] > kMaxGridDim) {
-        throw std::runtime_error("image_grid_thw values must be <= " + std::to_string(kMaxGridDim));
+        throw std::runtime_error(std::string(tensor_name) + " values must be <= " + std::to_string(kMaxGridDim));
       }
     }
-  }
+  };
 
-  if (video_grid_thw) {
-    auto grid_data = video_grid_thw->GetData<int64_t>();
-    auto elem_count = video_grid_thw->GetElementCount();
-    // Each video contributes t, h, w (3 values per video)
-    if (elem_count % 3 != 0) {
-      throw std::runtime_error("video_grid_thw element count must be divisible by 3");
-    }
-    for (size_t i = 0; i < elem_count; ++i) {
-      if (grid_data[i] < 0) {
-        throw std::runtime_error("video_grid_thw values must be non-negative");
-      }
-      if (grid_data[i] > kMaxGridDim) {
-        throw std::runtime_error("video_grid_thw values must be <= " + std::to_string(kMaxGridDim));
-      }
-    }
-  }
+  validate_grid_tensor(image_grid_thw, "image_grid_thw");
+  validate_grid_tensor(video_grid_thw, "video_grid_thw");
 
   image_grid_thw_ = image_grid_thw;
   video_grid_thw_ = video_grid_thw;

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -648,6 +648,43 @@ Qwen2VLPositionInputs::Qwen2VLPositionInputs(const Model& model, State& state, D
 void Qwen2VLPositionInputs::SetGridTensors(const std::shared_ptr<Tensor>& image_grid_thw,
                                            const std::shared_ptr<Tensor>& video_grid_thw,
                                            const std::shared_ptr<Tensor>& second_per_grid_ts) {
+  // Validate grid tensor dimensions to prevent overflow during position computation
+  constexpr int64_t kMaxGridDim = 16384;  // Conservative upper bound to prevent overflow
+  
+  if (image_grid_thw) {
+    auto grid_data = image_grid_thw->GetData<int64_t>();
+    auto elem_count = image_grid_thw->GetElementCount();
+    // Each image contributes t, h, w (3 values per image)
+    if (elem_count % 3 != 0) {
+      throw std::runtime_error("image_grid_thw element count must be divisible by 3");
+    }
+    for (size_t i = 0; i < elem_count; ++i) {
+      if (grid_data[i] < 0) {
+        throw std::runtime_error("image_grid_thw values must be non-negative");
+      }
+      if (grid_data[i] > kMaxGridDim) {
+        throw std::runtime_error("image_grid_thw values must be <= " + std::to_string(kMaxGridDim));
+      }
+    }
+  }
+  
+  if (video_grid_thw) {
+    auto grid_data = video_grid_thw->GetData<int64_t>();
+    auto elem_count = video_grid_thw->GetElementCount();
+    // Each video contributes t, h, w (3 values per video)
+    if (elem_count % 3 != 0) {
+      throw std::runtime_error("video_grid_thw element count must be divisible by 3");
+    }
+    for (size_t i = 0; i < elem_count; ++i) {
+      if (grid_data[i] < 0) {
+        throw std::runtime_error("video_grid_thw values must be non-negative");
+      }
+      if (grid_data[i] > kMaxGridDim) {
+        throw std::runtime_error("video_grid_thw values must be <= " + std::to_string(kMaxGridDim));
+      }
+    }
+  }
+  
   image_grid_thw_ = image_grid_thw;
   video_grid_thw_ = video_grid_thw;
   second_per_grid_ts_ = second_per_grid_ts;
@@ -815,6 +852,17 @@ void Qwen2VLPositionInputs::CreateAndInitialize3DPositionIDs(DeviceSpan<int32_t>
       // 2. Fill Vision Part
       st_idx = max_pos_for_batch + 1;
       int64_t vision_len = llm_grid_t * llm_grid_h * llm_grid_w;
+      
+      // Validate that the vision tokens fit within the sequence
+      if (ed + vision_len > seq_len) {
+        throw std::runtime_error("Image/video grid dimensions (t=" + std::to_string(llm_grid_t) + 
+                                 " h=" + std::to_string(llm_grid_h) + 
+                                 " w=" + std::to_string(llm_grid_w) + 
+                                 ") result in " + std::to_string(vision_len) + 
+                                 " tokens but only " + std::to_string(seq_len - ed) + 
+                                 " positions available in sequence");
+      }
+      
       for (int64_t s = 0; s < vision_len; ++s) {
         int64_t gt = s / (llm_grid_h * llm_grid_w);
         int64_t gh = (s / llm_grid_w) % llm_grid_h;

--- a/src/models/position_inputs.cpp
+++ b/src/models/position_inputs.cpp
@@ -76,6 +76,36 @@ struct InitAttentionMaskFunctor {
   }
 };
 
+constexpr int64_t kMaxQwen2VLGridDim = 16384;
+
+void ValidateQwen2VLGridTensorValues(const int64_t* grid_data, size_t elem_count, const char* tensor_name) {
+  if (elem_count % 3 != 0) {
+    throw std::runtime_error(std::string(tensor_name) + " element count must be divisible by 3");
+  }
+
+  for (size_t i = 0; i < elem_count; ++i) {
+    if (grid_data[i] < 0) {
+      throw std::runtime_error(std::string(tensor_name) + " values must be non-negative");
+    }
+    if (grid_data[i] > kMaxQwen2VLGridDim) {
+      throw std::runtime_error(std::string(tensor_name) + " values must be <= " + std::to_string(kMaxQwen2VLGridDim));
+    }
+  }
+}
+
+void ValidateQwen2VLVisionLengthFitsSequence(int64_t llm_grid_t, int64_t llm_grid_h, int64_t llm_grid_w,
+                                             int64_t ed, int64_t seq_len) {
+  const int64_t vision_len = llm_grid_t * llm_grid_h * llm_grid_w;
+  if (ed + vision_len > seq_len) {
+    throw std::runtime_error("Image/video grid dimensions (t=" + std::to_string(llm_grid_t) +
+                             " h=" + std::to_string(llm_grid_h) +
+                             " w=" + std::to_string(llm_grid_w) +
+                             ") result in " + std::to_string(vision_len) +
+                             " tokens but only " + std::to_string(seq_len - ed) +
+                             " positions available in sequence");
+  }
+}
+
 DefaultPositionInputs::DefaultPositionInputs(const Model& model, State& state, DeviceSpan<int32_t> sequence_lengths_unk, const std::string& attention_mask_name)
     : model_{model},
       state_{state},
@@ -648,8 +678,8 @@ Qwen2VLPositionInputs::Qwen2VLPositionInputs(const Model& model, State& state, D
 void Qwen2VLPositionInputs::SetGridTensors(const std::shared_ptr<Tensor>& image_grid_thw,
                                            const std::shared_ptr<Tensor>& video_grid_thw,
                                            const std::shared_ptr<Tensor>& second_per_grid_ts) {
-  // Validate grid tensor dimensions to prevent overflow during position computation
-  constexpr int64_t kMaxGridDim = 16384;  // Conservative upper bound to prevent overflow
+  // Typical Qwen2-VL grids are far below this threshold (usually <= 10^3); this limit is
+  // intentionally conservative and blocks pathological dimensions that can explode vision_len.
   const auto validate_grid_tensor = [&](const std::shared_ptr<Tensor>& grid_tensor, const char* tensor_name) {
     if (!grid_tensor) {
       return;
@@ -659,24 +689,14 @@ void Qwen2VLPositionInputs::SetGridTensors(const std::shared_ptr<Tensor>& image_
       throw std::runtime_error(std::string(tensor_name) + " must be int64.");
     }
 
-    const auto* grid_data = grid_tensor->GetData<int64_t>();
-    const size_t elem_count = grid_tensor->GetElementCount();
-    if (elem_count % 3 != 0) {
-      throw std::runtime_error(std::string(tensor_name) + " element count must be divisible by 3");
-    }
-
-    for (size_t i = 0; i < elem_count; ++i) {
-      if (grid_data[i] < 0) {
-        throw std::runtime_error(std::string(tensor_name) + " values must be non-negative");
-      }
-      if (grid_data[i] > kMaxGridDim) {
-        throw std::runtime_error(std::string(tensor_name) + " values must be <= " + std::to_string(kMaxGridDim));
-      }
-    }
+    ValidateQwen2VLGridTensorValues(grid_tensor->GetData<int64_t>(), grid_tensor->GetElementCount(), tensor_name);
   };
 
   validate_grid_tensor(image_grid_thw, "image_grid_thw");
   validate_grid_tensor(video_grid_thw, "video_grid_thw");
+  if (second_per_grid_ts && second_per_grid_ts->GetType() != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+    throw std::runtime_error("second_per_grid_ts must be float32.");
+  }
 
   image_grid_thw_ = image_grid_thw;
   video_grid_thw_ = video_grid_thw;
@@ -844,17 +864,8 @@ void Qwen2VLPositionInputs::CreateAndInitialize3DPositionIDs(DeviceSpan<int32_t>
 
       // 2. Fill Vision Part
       st_idx = max_pos_for_batch + 1;
+      ValidateQwen2VLVisionLengthFitsSequence(llm_grid_t, llm_grid_h, llm_grid_w, ed, seq_len);
       int64_t vision_len = llm_grid_t * llm_grid_h * llm_grid_w;
-
-      // Validate that the vision tokens fit within the sequence
-      if (ed + vision_len > seq_len) {
-        throw std::runtime_error("Image/video grid dimensions (t=" + std::to_string(llm_grid_t) +
-                                 " h=" + std::to_string(llm_grid_h) +
-                                 " w=" + std::to_string(llm_grid_w) +
-                                 ") result in " + std::to_string(vision_len) +
-                                 " tokens but only " + std::to_string(seq_len - ed) +
-                                 " positions available in sequence");
-      }
 
       for (int64_t s = 0; s < vision_len; ++s) {
         int64_t gt = s / (llm_grid_h * llm_grid_w);

--- a/src/models/position_inputs.h
+++ b/src/models/position_inputs.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "../generators.h"
+#include "model.h"
+
 namespace Generators {
 
 struct PositionInputs {

--- a/src/models/position_inputs.h
+++ b/src/models/position_inputs.h
@@ -108,6 +108,11 @@ struct WindowedPositionInputs : PositionInputs {
   size_t num_windows_{};
   size_t window_index_{};
 };
+
+void ValidateQwen2VLGridTensorValues(const int64_t* grid_data, size_t elem_count, const char* tensor_name);
+void ValidateQwen2VLVisionLengthFitsSequence(int64_t llm_grid_t, int64_t llm_grid_h, int64_t llm_grid_w,
+                                             int64_t ed, int64_t seq_len);
+
 // Qwen2-VL uses 3D rotary position embeddings (mrope) for multimodal (vision + text) content.
 // Position IDs have shape [3, batch_size, seq_len] where the 3 dimensions represent:
 //   - Dimensions 0: Temporal position

--- a/src/models/position_inputs.h
+++ b/src/models/position_inputs.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -117,9 +120,35 @@ struct WindowedPositionInputs : PositionInputs {
   size_t window_index_{};
 };
 
-void ValidateQwen2VLGridTensorValues(const int64_t* grid_data, size_t elem_count, const char* tensor_name);
-void ValidateQwen2VLVisionLengthFitsSequence(int64_t llm_grid_t, int64_t llm_grid_h, int64_t llm_grid_w,
-                                             int64_t ed, int64_t seq_len);
+inline constexpr int64_t kMaxQwen2VLGridDim = 16384;
+
+inline void ValidateQwen2VLGridTensorValues(const int64_t* grid_data, size_t elem_count, const char* tensor_name) {
+  if (elem_count % 3 != 0) {
+    throw std::runtime_error(std::string(tensor_name) + " element count must be divisible by 3");
+  }
+
+  for (size_t i = 0; i < elem_count; ++i) {
+    if (grid_data[i] < 0) {
+      throw std::runtime_error(std::string(tensor_name) + " values must be non-negative");
+    }
+    if (grid_data[i] > kMaxQwen2VLGridDim) {
+      throw std::runtime_error(std::string(tensor_name) + " values must be <= " + std::to_string(kMaxQwen2VLGridDim));
+    }
+  }
+}
+
+inline void ValidateQwen2VLVisionLengthFitsSequence(int64_t llm_grid_t, int64_t llm_grid_h, int64_t llm_grid_w,
+                                                    int64_t ed, int64_t seq_len) {
+  const int64_t vision_len = llm_grid_t * llm_grid_h * llm_grid_w;
+  if (ed + vision_len > seq_len) {
+    throw std::runtime_error("Image/video grid dimensions (t=" + std::to_string(llm_grid_t) +
+                             " h=" + std::to_string(llm_grid_h) +
+                             " w=" + std::to_string(llm_grid_w) +
+                             ") result in " + std::to_string(vision_len) +
+                             " tokens but only " + std::to_string(seq_len - ed) +
+                             " positions available in sequence");
+  }
+}
 
 // Qwen2-VL uses 3D rotary position embeddings (mrope) for multimodal (vision + text) content.
 // Position IDs have shape [3, batch_size, seq_len] where the 3 dimensions represent:

--- a/test/qwen2vl_position_inputs_test.cpp
+++ b/test/qwen2vl_position_inputs_test.cpp
@@ -14,10 +14,10 @@
 class MockTensor {
  public:
   MockTensor(const std::vector<int64_t>& data) : data_(data) {}
-  
+
   const int64_t* GetData() const { return data_.data(); }
   size_t GetElementCount() const { return data_.size(); }
-  
+
  private:
   std::vector<int64_t> data_;
 };
@@ -27,7 +27,7 @@ TEST(Qwen2VLPositionInputsTest, RejectsNegativeGridDimensions) {
   // Simulating image_grid_thw with negative value
   // Format: [t, h, w] for each image
   std::vector<int64_t> negative_grid = {1, -64, 64};
-  
+
   // This test documents the expected validation behavior
   // In a real test, we would instantiate Qwen2VLPositionInputs and call SetGridTensors
   // For now, this serves as documentation that negative grid values should be rejected
@@ -40,7 +40,7 @@ TEST(Qwen2VLPositionInputsTest, RejectsExcessiveGridDimensions) {
   // Format: [t, h, w] for each image
   constexpr int64_t kMaxGridDim = 16384;
   std::vector<int64_t> excessive_grid = {1, kMaxGridDim + 1, 64};
-  
+
   // This test documents the expected validation behavior
   // Grid dimensions beyond 16384 should be rejected to prevent overflow
   EXPECT_TRUE(true);  // Placeholder for full integration test
@@ -51,14 +51,14 @@ TEST(Qwen2VLPositionInputsTest, RejectsVisionLenExceedingSequenceLength) {
   // This documents the core vulnerability fix:
   // If ed (end position of image placeholder) + vision_len > seq_len,
   // an exception should be thrown before attempting to write out-of-bounds
-  
+
   // Example scenario:
   // - seq_len = 128 (small sequence)
   // - ed = 100 (image placeholder at position 100)
   // - image_grid_thw = [1, 64, 64]  (creates 1024 tokens with spatial_merge_size=2)
   // - vision_len = 1 * (64/2) * (64/2) = 1024
   // - ed + vision_len = 100 + 1024 = 1124 > 128 = seq_len --> OVERFLOW
-  
+
   EXPECT_TRUE(true);  // Placeholder for full integration test
 }
 
@@ -66,7 +66,7 @@ TEST(Qwen2VLPositionInputsTest, RejectsVisionLenExceedingSequenceLength) {
 TEST(Qwen2VLPositionInputsTest, RejectsGridWithIncorrectElementCount) {
   // Grid tensor must have element count divisible by 3 (t, h, w per image/video)
   std::vector<int64_t> bad_grid = {1, 64};  // Only 2 elements, should be 3n
-  
+
   // This should be rejected during SetGridTensors
   EXPECT_TRUE(true);  // Placeholder for full integration test
 }
@@ -76,7 +76,7 @@ TEST(Qwen2VLPositionInputsTest, AcceptsValidGridDimensions) {
   // Valid image_grid_thw: [t=1, h=64, w=64]
   // With spatial_merge_size=2: vision_len = 1 * (64/2) * (64/2) = 1024
   std::vector<int64_t> valid_grid = {1, 64, 64};
-  
+
   // With sufficient seq_len, this should succeed
   EXPECT_TRUE(true);  // Placeholder for full integration test
 }

--- a/test/qwen2vl_position_inputs_test.cpp
+++ b/test/qwen2vl_position_inputs_test.cpp
@@ -2,81 +2,27 @@
 // Licensed under the MIT License.
 
 #include <gtest/gtest.h>
-#include <memory>
-#include <stdexcept>
-#include "models/model.h"
-
-// Test fixture for Qwen2VL position inputs validation
-// These tests verify that bounds checking prevents out-of-bounds writes
-// when processing image/video grid dimensions.
-
-// Mock tensor class for testing
-class MockTensor {
- public:
-  MockTensor(const std::vector<int64_t>& data) : data_(data) {}
-
-  const int64_t* GetData() const { return data_.data(); }
-  size_t GetElementCount() const { return data_.size(); }
-
- private:
-  std::vector<int64_t> data_;
-};
-
 // Test that SetGridTensors rejects negative grid dimensions
 TEST(Qwen2VLPositionInputsTest, RejectsNegativeGridDimensions) {
-  // Simulating image_grid_thw with negative value
-  // Format: [t, h, w] for each image
-  std::vector<int64_t> negative_grid = {1, -64, 64};
-
-  // This test documents the expected validation behavior
-  // In a real test, we would instantiate Qwen2VLPositionInputs and call SetGridTensors
-  // For now, this serves as documentation that negative grid values should be rejected
-  EXPECT_TRUE(true);  // Placeholder for full integration test
+  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
 }
 
 // Test that SetGridTensors rejects grid dimensions exceeding reasonable bounds
 TEST(Qwen2VLPositionInputsTest, RejectsExcessiveGridDimensions) {
-  // Simulating image_grid_thw with excessive dimensions
-  // Format: [t, h, w] for each image
-  constexpr int64_t kMaxGridDim = 16384;
-  std::vector<int64_t> excessive_grid = {1, kMaxGridDim + 1, 64};
-
-  // This test documents the expected validation behavior
-  // Grid dimensions beyond 16384 should be rejected to prevent overflow
-  EXPECT_TRUE(true);  // Placeholder for full integration test
+  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
 }
 
 // Test that CreateAndInitialize3DPositionIDs bounds-checks vision_len
 TEST(Qwen2VLPositionInputsTest, RejectsVisionLenExceedingSequenceLength) {
-  // This documents the core vulnerability fix:
-  // If ed (end position of image placeholder) + vision_len > seq_len,
-  // an exception should be thrown before attempting to write out-of-bounds
-
-  // Example scenario:
-  // - seq_len = 128 (small sequence)
-  // - ed = 100 (image placeholder at position 100)
-  // - image_grid_thw = [1, 64, 64]  (creates 1024 tokens with spatial_merge_size=2)
-  // - vision_len = 1 * (64/2) * (64/2) = 1024
-  // - ed + vision_len = 100 + 1024 = 1124 > 128 = seq_len --> OVERFLOW
-
-  EXPECT_TRUE(true);  // Placeholder for full integration test
+  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
 }
 
 // Test that grid dimensions with inconsistent element count are rejected
 TEST(Qwen2VLPositionInputsTest, RejectsGridWithIncorrectElementCount) {
-  // Grid tensor must have element count divisible by 3 (t, h, w per image/video)
-  std::vector<int64_t> bad_grid = {1, 64};  // Only 2 elements, should be 3n
-
-  // This should be rejected during SetGridTensors
-  EXPECT_TRUE(true);  // Placeholder for full integration test
+  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
 }
 
 // Test that valid grid dimensions within bounds are accepted
 TEST(Qwen2VLPositionInputsTest, AcceptsValidGridDimensions) {
-  // Valid image_grid_thw: [t=1, h=64, w=64]
-  // With spatial_merge_size=2: vision_len = 1 * (64/2) * (64/2) = 1024
-  std::vector<int64_t> valid_grid = {1, 64, 64};
-
-  // With sufficient seq_len, this should succeed
-  EXPECT_TRUE(true);  // Placeholder for full integration test
+  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
 }

--- a/test/qwen2vl_position_inputs_test.cpp
+++ b/test/qwen2vl_position_inputs_test.cpp
@@ -2,27 +2,60 @@
 // Licensed under the MIT License.
 
 #include <gtest/gtest.h>
-// Test that SetGridTensors rejects negative grid dimensions
+#include <vector>
+
+#include "models/position_inputs.h"
+
+namespace Generators::test {
+namespace {
+
+template <typename Fn>
+std::string CaptureThrowMessage(Fn&& fn) {
+  try {
+    fn();
+  } catch (const std::exception& e) {
+    return e.what();
+  }
+  return {};
+}
+
+}  // namespace
+
 TEST(Qwen2VLPositionInputsTest, RejectsNegativeGridDimensions) {
-  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
+  const std::vector<int64_t> grid{1, -1, 2};
+  const std::string message = CaptureThrowMessage([&] {
+    ValidateQwen2VLGridTensorValues(grid.data(), grid.size(), "image_grid_thw");
+  });
+  EXPECT_NE(message.find("non-negative"), std::string::npos) << message;
 }
 
-// Test that SetGridTensors rejects grid dimensions exceeding reasonable bounds
 TEST(Qwen2VLPositionInputsTest, RejectsExcessiveGridDimensions) {
-  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
+  const std::vector<int64_t> grid{1, 1, 20000};
+  const std::string message = CaptureThrowMessage([&] {
+    ValidateQwen2VLGridTensorValues(grid.data(), grid.size(), "video_grid_thw");
+  });
+  EXPECT_NE(message.find("<= 16384"), std::string::npos) << message;
 }
 
-// Test that CreateAndInitialize3DPositionIDs bounds-checks vision_len
 TEST(Qwen2VLPositionInputsTest, RejectsVisionLenExceedingSequenceLength) {
-  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
+  const std::string message = CaptureThrowMessage([&] {
+    ValidateQwen2VLVisionLengthFitsSequence(8, 8, 8, 5, 100);
+  });
+  EXPECT_NE(message.find("positions available in sequence"), std::string::npos) << message;
 }
 
-// Test that grid dimensions with inconsistent element count are rejected
 TEST(Qwen2VLPositionInputsTest, RejectsGridWithIncorrectElementCount) {
-  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
+  const std::vector<int64_t> grid{1, 2};
+  const std::string message = CaptureThrowMessage([&] {
+    ValidateQwen2VLGridTensorValues(grid.data(), grid.size(), "image_grid_thw");
+  });
+  EXPECT_NE(message.find("divisible by 3"), std::string::npos) << message;
 }
 
-// Test that valid grid dimensions within bounds are accepted
 TEST(Qwen2VLPositionInputsTest, AcceptsValidGridDimensions) {
-  GTEST_SKIP() << "TODO: wire this to a real Qwen2VLPositionInputs validation path.";
+  const std::vector<int64_t> grid{1, 8, 8, 2, 4, 4};
+  EXPECT_NO_THROW(ValidateQwen2VLGridTensorValues(grid.data(), grid.size(), "image_grid_thw"));
+  EXPECT_NO_THROW(ValidateQwen2VLVisionLengthFitsSequence(2, 2, 2, 10, 100));
 }
+
+}  // namespace Generators::test

--- a/test/qwen2vl_position_inputs_test.cpp
+++ b/test/qwen2vl_position_inputs_test.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <stdexcept>
+#include "models/model.h"
+
+// Test fixture for Qwen2VL position inputs validation
+// These tests verify that bounds checking prevents out-of-bounds writes
+// when processing image/video grid dimensions.
+
+// Mock tensor class for testing
+class MockTensor {
+ public:
+  MockTensor(const std::vector<int64_t>& data) : data_(data) {}
+  
+  const int64_t* GetData() const { return data_.data(); }
+  size_t GetElementCount() const { return data_.size(); }
+  
+ private:
+  std::vector<int64_t> data_;
+};
+
+// Test that SetGridTensors rejects negative grid dimensions
+TEST(Qwen2VLPositionInputsTest, RejectsNegativeGridDimensions) {
+  // Simulating image_grid_thw with negative value
+  // Format: [t, h, w] for each image
+  std::vector<int64_t> negative_grid = {1, -64, 64};
+  
+  // This test documents the expected validation behavior
+  // In a real test, we would instantiate Qwen2VLPositionInputs and call SetGridTensors
+  // For now, this serves as documentation that negative grid values should be rejected
+  EXPECT_TRUE(true);  // Placeholder for full integration test
+}
+
+// Test that SetGridTensors rejects grid dimensions exceeding reasonable bounds
+TEST(Qwen2VLPositionInputsTest, RejectsExcessiveGridDimensions) {
+  // Simulating image_grid_thw with excessive dimensions
+  // Format: [t, h, w] for each image
+  constexpr int64_t kMaxGridDim = 16384;
+  std::vector<int64_t> excessive_grid = {1, kMaxGridDim + 1, 64};
+  
+  // This test documents the expected validation behavior
+  // Grid dimensions beyond 16384 should be rejected to prevent overflow
+  EXPECT_TRUE(true);  // Placeholder for full integration test
+}
+
+// Test that CreateAndInitialize3DPositionIDs bounds-checks vision_len
+TEST(Qwen2VLPositionInputsTest, RejectsVisionLenExceedingSequenceLength) {
+  // This documents the core vulnerability fix:
+  // If ed (end position of image placeholder) + vision_len > seq_len,
+  // an exception should be thrown before attempting to write out-of-bounds
+  
+  // Example scenario:
+  // - seq_len = 128 (small sequence)
+  // - ed = 100 (image placeholder at position 100)
+  // - image_grid_thw = [1, 64, 64]  (creates 1024 tokens with spatial_merge_size=2)
+  // - vision_len = 1 * (64/2) * (64/2) = 1024
+  // - ed + vision_len = 100 + 1024 = 1124 > 128 = seq_len --> OVERFLOW
+  
+  EXPECT_TRUE(true);  // Placeholder for full integration test
+}
+
+// Test that grid dimensions with inconsistent element count are rejected
+TEST(Qwen2VLPositionInputsTest, RejectsGridWithIncorrectElementCount) {
+  // Grid tensor must have element count divisible by 3 (t, h, w per image/video)
+  std::vector<int64_t> bad_grid = {1, 64};  // Only 2 elements, should be 3n
+  
+  // This should be rejected during SetGridTensors
+  EXPECT_TRUE(true);  // Placeholder for full integration test
+}
+
+// Test that valid grid dimensions within bounds are accepted
+TEST(Qwen2VLPositionInputsTest, AcceptsValidGridDimensions) {
+  // Valid image_grid_thw: [t=1, h=64, w=64]
+  // With spatial_merge_size=2: vision_len = 1 * (64/2) * (64/2) = 1024
+  std::vector<int64_t> valid_grid = {1, 64, 64};
+  
+  // With sufficient seq_len, this should succeed
+  EXPECT_TRUE(true);  // Placeholder for full integration test
+}


### PR DESCRIPTION
This pull request introduces important validation checks for grid tensor dimensions in the Qwen2VL position input logic to prevent out-of-bounds memory access and potential overflows. It also adds a new test file documenting the expected validation behavior for various edge cases, improving the robustness and safety of the code.

**Validation and bounds checking improvements:**

* Added validation in `SetGridTensors` to ensure `image_grid_thw` and `video_grid_thw` tensors have element counts divisible by 3, contain non-negative values, and do not exceed a maximum allowed dimension (`kMaxGridDim = 16384`). This prevents invalid or malicious input from causing overflows or undefined behavior.
* Added a runtime check in `CreateAndInitialize3DPositionIDs` to ensure that the number of vision tokens (`vision_len`) does not exceed the available sequence length, throwing an exception if this would lead to out-of-bounds writes.

**Testing and documentation:**

* Introduced a new test file `test/qwen2vl_position_inputs_test.cpp` with test cases documenting the expected rejection of negative, excessively large, or incorrectly sized grid dimensions, as well as acceptance of valid input. These tests serve as documentation and placeholders for future integration tests.