### PR TITLE
Add validation for layer_types size in LFM2Cache constructor

### DIFF
--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -824,6 +824,12 @@ LFM2Cache::LFM2Cache(State& state)
     : state_{state},
       layer_types_{model_.config_->model.decoder.layer_types},
       layer_count_{model_.config_->model.decoder.num_hidden_layers} {
+  // Validate layer_types array size matches num_hidden_layers before accessing elements
+  if (static_cast<int>(layer_types_.size()) != layer_count_) {
+    throw std::runtime_error("layer_types array size (" + std::to_string(layer_types_.size()) +
+                             ") does not match num_hidden_layers (" + std::to_string(layer_count_) + ")");
+  }
+
   // Classify layers into attention (KV) and conv types
   for (int i = 0; i < layer_count_; ++i) {
     if (layer_types_[i] == "full_attention") {

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -824,9 +824,9 @@ LFM2Cache::LFM2Cache(State& state)
     : state_{state},
       layer_types_{model_.config_->model.decoder.layer_types},
       layer_count_{model_.config_->model.decoder.num_hidden_layers} {
-  // Validate layer_types array size matches num_hidden_layers before accessing elements
-  if (static_cast<int>(layer_types_.size()) != layer_count_) {
-    throw std::runtime_error("layer_types array size (" + std::to_string(layer_types_.size()) +
+  // Validate layer_types array size matches num_hidden_layers before accessing elements.
+  if (layer_count_ < 0 || layer_types_.size() != static_cast<size_t>(layer_count_)) {
+    throw std::runtime_error("LFM2Cache: layer_types array size (" + std::to_string(layer_types_.size()) +
                              ") does not match num_hidden_layers (" + std::to_string(layer_count_) + ")");
   }
 

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -825,7 +825,12 @@ LFM2Cache::LFM2Cache(State& state)
       layer_types_{model_.config_->model.decoder.layer_types},
       layer_count_{model_.config_->model.decoder.num_hidden_layers} {
   // Validate layer_types array size matches num_hidden_layers before accessing elements.
-  if (layer_count_ < 0 || layer_types_.size() != static_cast<size_t>(layer_count_)) {
+  if (layer_count_ < 0) {
+    throw std::runtime_error("LFM2Cache: num_hidden_layers must be non-negative. Actual: " + std::to_string(layer_count_));
+  }
+
+  const size_t expected_layer_types_size = static_cast<size_t>(layer_count_);
+  if (layer_types_.size() != expected_layer_types_size) {
     throw std::runtime_error("LFM2Cache: layer_types array size (" + std::to_string(layer_types_.size()) +
                              ") does not match num_hidden_layers (" + std::to_string(layer_count_) + ")");
   }

--- a/test/lfm2_cache_layer_types_test.cpp
+++ b/test/lfm2_cache_layer_types_test.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -71,17 +72,29 @@ fs_std::path WriteModelWithLayerTypes(const std::string& suffix, const std::stri
   return dst_dir;
 }
 
-std::string CaptureThrowMessage(const fs_std::path& model_dir) {
+void CreateGeneratorForModel(const fs_std::path& model_dir) {
+  auto model = OgaModel::Create(model_dir.string().c_str());
+  auto params = OgaGeneratorParams::Create(*model);
+  auto generator = OgaGenerator::Create(*model, *params);
+  (void)generator;
+}
+
+std::string CaptureRuntimeErrorMessage(const fs_std::path& model_dir) {
   try {
-    auto model = OgaModel::Create(model_dir.string().c_str());
-    auto params = OgaGeneratorParams::Create(*model);
-    auto generator = OgaGenerator::Create(*model, *params);
-    (void)generator;
-  } catch (const std::exception& e) {
+    CreateGeneratorForModel(model_dir);
+  } catch (const std::runtime_error& e) {
     return e.what();
   }
 
-  return {};
+  throw std::runtime_error("Expected std::runtime_error was not thrown.");
+}
+
+void ExpectLayerTypesValidationMessage(const std::string& message, size_t actual_size, int expected_layers) {
+  EXPECT_NE(message.find("LFM2Cache"), std::string::npos) << message;
+  EXPECT_NE(message.find("layer_types"), std::string::npos) << message;
+  EXPECT_NE(message.find("num_hidden_layers"), std::string::npos) << message;
+  EXPECT_NE(message.find("layer_types array size (" + std::to_string(actual_size) + ")"), std::string::npos) << message;
+  EXPECT_NE(message.find("num_hidden_layers (" + std::to_string(expected_layers) + ")"), std::string::npos) << message;
 }
 
 }  // namespace
@@ -90,12 +103,8 @@ TEST(LFM2CacheLayerTypesValidationTest, UndersizedLayerTypesArray) {
   SkipIfModelUnavailable();
 
   const auto model_dir = WriteModelWithLayerTypes("undersized", "[\"conv\"]");
-  const std::string message = CaptureThrowMessage(model_dir);
-
-  EXPECT_FALSE(message.empty());
-  EXPECT_NE(message.find("LFM2Cache"), std::string::npos) << message;
-  EXPECT_NE(message.find("layer_types"), std::string::npos) << message;
-  EXPECT_NE(message.find("num_hidden_layers"), std::string::npos) << message;
+  const std::string message = CaptureRuntimeErrorMessage(model_dir);
+  ExpectLayerTypesValidationMessage(message, 1, 4);
 }
 
 TEST(LFM2CacheLayerTypesValidationTest, OversizedLayerTypesArray) {
@@ -104,20 +113,16 @@ TEST(LFM2CacheLayerTypesValidationTest, OversizedLayerTypesArray) {
   const auto model_dir = WriteModelWithLayerTypes(
       "oversized",
       "[\"conv\", \"full_attention\", \"conv\", \"full_attention\", \"conv\"]");
-  const std::string message = CaptureThrowMessage(model_dir);
-
-  EXPECT_FALSE(message.empty());
-  EXPECT_NE(message.find("layer_types"), std::string::npos) << message;
+  const std::string message = CaptureRuntimeErrorMessage(model_dir);
+  ExpectLayerTypesValidationMessage(message, 5, 4);
 }
 
 TEST(LFM2CacheLayerTypesValidationTest, EmptyLayerTypesArray) {
   SkipIfModelUnavailable();
 
   const auto model_dir = WriteModelWithLayerTypes("empty", "[]");
-  const std::string message = CaptureThrowMessage(model_dir);
-
-  EXPECT_FALSE(message.empty());
-  EXPECT_NE(message.find("layer_types"), std::string::npos) << message;
+  const std::string message = CaptureRuntimeErrorMessage(model_dir);
+  ExpectLayerTypesValidationMessage(message, 0, 4);
 }
 
 TEST(LFM2CacheLayerTypesValidationTest, ValidMatchingLayers) {
@@ -127,8 +132,7 @@ TEST(LFM2CacheLayerTypesValidationTest, ValidMatchingLayers) {
       "valid",
       "[\"full_attention\", \"conv\", \"full_attention\", \"conv\"]");
 
-  const std::string message = CaptureThrowMessage(model_dir);
-  EXPECT_EQ(message.find("LFM2Cache"), std::string::npos) << message;
-  EXPECT_EQ(message.find("layer_types"), std::string::npos) << message;
-  EXPECT_EQ(message.find("num_hidden_layers"), std::string::npos) << message;
+  EXPECT_NO_THROW({
+    CreateGeneratorForModel(model_dir);
+  });
 }

--- a/test/lfm2_cache_layer_types_test.cpp
+++ b/test/lfm2_cache_layer_types_test.cpp
@@ -130,7 +130,7 @@ TEST(LFM2CacheLayerTypesValidationTest, ValidMatchingLayers) {
 
   const auto model_dir = WriteModelWithLayerTypes(
       "valid",
-      "[\"full_attention\", \"conv\", \"full_attention\", \"conv\"]");
+      "[\"conv\", \"full_attention\", \"conv\", \"full_attention\"]");
 
   EXPECT_NO_THROW({
     CreateGeneratorForModel(model_dir);

--- a/test/lfm2_cache_layer_types_test.cpp
+++ b/test/lfm2_cache_layer_types_test.cpp
@@ -1,36 +1,131 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
 #include <gtest/gtest.h>
-#include <memory>
-#include <stdexcept>
-#include "ort_genai_c_api.h"
 
-namespace Generators {
-namespace Tests {
+#define OGA_USE_SPAN 1
+#include "ort_genai.h"
+#include "test_utils.h"
 
-class LFM2CacheLayerTypesValidationTest : public ::testing::Test {};
+namespace {
 
-// num_hidden_layers=24, layer_types=["conv"] (only 1 element) — size mismatch throws
-TEST_F(LFM2CacheLayerTypesValidationTest, UndersizedLayerTypesArray) {
-  // Full integration test requires LFM2 model with genai_config.json setup.
-  // Validation enforced in LFM2Cache constructor (kv_cache.cpp): layer_types_.size() == layer_count_
+namespace fs_std = std::filesystem;
+
+fs_std::path GetLfm2ModelPath() {
+  return fs_std::path(MODEL_PATH) / "hf-internal-testing" / "tiny-random-lfm2-fp32";
 }
 
-// num_hidden_layers=2, layer_types has more elements than declared layers — throws
-TEST_F(LFM2CacheLayerTypesValidationTest, OversizedLayerTypesArray) {
-  // Constructor validation rejects configs where layer_types.size() != num_hidden_layers
+void SkipIfModelUnavailable() {
+  const auto model_dir = GetLfm2ModelPath();
+  if (!fs_std::exists(model_dir / "genai_config.json") || !fs_std::exists(model_dir / "decoder.onnx")) {
+    GTEST_SKIP() << "tiny-random-lfm2-fp32 test model not found at " << model_dir.string();
+  }
 }
 
-// num_hidden_layers > 0, layer_types=[] — throws before any layer classification
-TEST_F(LFM2CacheLayerTypesValidationTest, EmptyLayerTypesArray) {
-  // Constructor throws when layer_types is empty but num_hidden_layers > 0
+fs_std::path MakeTempDir(const std::string& suffix) {
+  static int counter = 0;
+  ++counter;
+  const auto dir = fs_std::temp_directory_path() /
+                   ("ortgenai_lfm2_layer_types_" + suffix + "_" + std::to_string(counter));
+  std::error_code ec;
+  fs_std::remove_all(dir, ec);
+  fs_std::create_directories(dir);
+  return dir;
 }
 
-// num_hidden_layers=N, layer_types has exactly N elements — succeeds
-TEST_F(LFM2CacheLayerTypesValidationTest, ValidMatchingLayers) {
-  // Layers classified into kv_layer_indices_ and conv_layer_indices_ without error
+std::string ReadFile(const fs_std::path& path) {
+  std::ifstream in(path, std::ios::binary);
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
 }
 
-}  // namespace Tests
-}  // namespace Generators
+void WriteFile(const fs_std::path& path, const std::string& contents) {
+  std::ofstream out(path, std::ios::binary);
+  out << contents;
+}
+
+void ReplaceFirst(std::string& text, const std::string& from, const std::string& to) {
+  const auto pos = text.find(from);
+  if (pos == std::string::npos) {
+    throw std::runtime_error("Could not find expected config fragment: " + from);
+  }
+  text.replace(pos, from.size(), to);
+}
+
+fs_std::path WriteModelWithLayerTypes(const std::string& suffix, const std::string& layer_types_json) {
+  const auto src_dir = GetLfm2ModelPath();
+  const auto dst_dir = MakeTempDir(suffix);
+  fs_std::copy(src_dir, dst_dir, fs_std::copy_options::recursive | fs_std::copy_options::overwrite_existing);
+
+  std::string config = ReadFile(dst_dir / "genai_config.json");
+  ReplaceFirst(config,
+               "\"layer_types\": [\"conv\", \"full_attention\", \"conv\", \"full_attention\"]",
+               "\"layer_types\": " + layer_types_json);
+  WriteFile(dst_dir / "genai_config.json", config);
+  return dst_dir;
+}
+
+std::string CaptureThrowMessage(const fs_std::path& model_dir) {
+  try {
+    auto model = OgaModel::Create(model_dir.string().c_str());
+    auto params = OgaGeneratorParams::Create(*model);
+    auto generator = OgaGenerator::Create(*model, *params);
+    (void)generator;
+  } catch (const std::exception& e) {
+    return e.what();
+  }
+
+  return {};
+}
+
+}  // namespace
+
+TEST(LFM2CacheLayerTypesValidationTest, UndersizedLayerTypesArray) {
+  SkipIfModelUnavailable();
+
+  const auto model_dir = WriteModelWithLayerTypes("undersized", "[\"conv\"]");
+  const std::string message = CaptureThrowMessage(model_dir);
+
+  EXPECT_FALSE(message.empty());
+  EXPECT_NE(message.find("LFM2Cache"), std::string::npos) << message;
+  EXPECT_NE(message.find("layer_types"), std::string::npos) << message;
+  EXPECT_NE(message.find("num_hidden_layers"), std::string::npos) << message;
+}
+
+TEST(LFM2CacheLayerTypesValidationTest, OversizedLayerTypesArray) {
+  SkipIfModelUnavailable();
+
+  const auto model_dir = WriteModelWithLayerTypes(
+      "oversized",
+      "[\"conv\", \"full_attention\", \"conv\", \"full_attention\", \"conv\"]");
+  const std::string message = CaptureThrowMessage(model_dir);
+
+  EXPECT_FALSE(message.empty());
+  EXPECT_NE(message.find("layer_types"), std::string::npos) << message;
+}
+
+TEST(LFM2CacheLayerTypesValidationTest, EmptyLayerTypesArray) {
+  SkipIfModelUnavailable();
+
+  const auto model_dir = WriteModelWithLayerTypes("empty", "[]");
+  const std::string message = CaptureThrowMessage(model_dir);
+
+  EXPECT_FALSE(message.empty());
+  EXPECT_NE(message.find("layer_types"), std::string::npos) << message;
+}
+
+TEST(LFM2CacheLayerTypesValidationTest, ValidMatchingLayers) {
+  SkipIfModelUnavailable();
+
+  const auto model_dir = WriteModelWithLayerTypes(
+      "valid",
+      "[\"full_attention\", \"conv\", \"full_attention\", \"conv\"]");
+
+  EXPECT_TRUE(CaptureThrowMessage(model_dir).empty());
+}

--- a/test/lfm2_cache_layer_types_test.cpp
+++ b/test/lfm2_cache_layer_types_test.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <stdexcept>
+#include "ort_genai_c_api.h"
+
+namespace Generators {
+namespace Tests {
+
+class LFM2CacheLayerTypesValidationTest : public ::testing::Test {};
+
+// num_hidden_layers=24, layer_types=["conv"] (only 1 element) — size mismatch throws
+TEST_F(LFM2CacheLayerTypesValidationTest, UndersizedLayerTypesArray) {
+  // Full integration test requires LFM2 model with genai_config.json setup.
+  // Validation enforced in LFM2Cache constructor (kv_cache.cpp): layer_types_.size() == layer_count_
+}
+
+// num_hidden_layers=2, layer_types has more elements than declared layers — throws
+TEST_F(LFM2CacheLayerTypesValidationTest, OversizedLayerTypesArray) {
+  // Constructor validation rejects configs where layer_types.size() != num_hidden_layers
+}
+
+// num_hidden_layers > 0, layer_types=[] — throws before any layer classification
+TEST_F(LFM2CacheLayerTypesValidationTest, EmptyLayerTypesArray) {
+  // Constructor throws when layer_types is empty but num_hidden_layers > 0
+}
+
+// num_hidden_layers=N, layer_types has exactly N elements — succeeds
+TEST_F(LFM2CacheLayerTypesValidationTest, ValidMatchingLayers) {
+  // Layers classified into kv_layer_indices_ and conv_layer_indices_ without error
+}
+
+}  // namespace Tests
+}  // namespace Generators

--- a/test/lfm2_cache_layer_types_test.cpp
+++ b/test/lfm2_cache_layer_types_test.cpp
@@ -127,5 +127,8 @@ TEST(LFM2CacheLayerTypesValidationTest, ValidMatchingLayers) {
       "valid",
       "[\"full_attention\", \"conv\", \"full_attention\", \"conv\"]");
 
-  EXPECT_TRUE(CaptureThrowMessage(model_dir).empty());
+  const std::string message = CaptureThrowMessage(model_dir);
+  EXPECT_EQ(message.find("LFM2Cache"), std::string::npos) << message;
+  EXPECT_EQ(message.find("layer_types"), std::string::npos) << message;
+  EXPECT_EQ(message.find("num_hidden_layers"), std::string::npos) << message;
 }


### PR DESCRIPTION
This pull request addresses a critical validation gap in the `LFM2Cache` constructor to prevent out-of-bounds memory access when parsing model configuration. It adds a runtime check to ensure the `layer_types` array size matches `num_hidden_layers`, and introduces regression tests to document and enforce this security property.

**Security validation and regression tests:**

* Added a runtime validation in `LFM2Cache::LFM2Cache` (in `kv_cache.cpp`) to throw a `std::runtime_error` if the size of `layer_types_` does not match `layer_count_`, preventing out-of-bounds reads and potential vulnerabilities.
* Introduced a new test file `lfm2_cache_layer_types_test.cpp` with regression tests for various configuration scenarios, including undersized, oversized, empty, and valid `layer_types` arrays, to ensure the constructor enforces the validation and documents the security property (CWE-125, CWE-1284).