### PR TITLE
Remove Reasoning Tokens from Qwen2 Fallback Map

### DIFF
--- a/src/models/tokenizer_tag_utils.cpp
+++ b/src/models/tokenizer_tag_utils.cpp
@@ -18,15 +18,15 @@ std::optional<int32_t> ResolveFallbackTokenId(const std::string& model_type,
   // ------------|----------------|-----------------|--------
   // qwen2/qwen3| bot_token_id   | <tool_call>     | 151657
   // qwen2/qwen3| eot_token_id   | </tool_call>    | 151658
-  // qwen2/qwen3| bor_token_id   | <think>         | 151667
-  // qwen2/qwen3| eor_token_id   | </think>        | 151668
+  // qwen3      | bor_token_id   | <think>         | 151667
+  // qwen3      | eor_token_id   | </think>        | 151668
   // phi3        | bot_token_id   | <|tool_call|>   | 200025
   // phi3        | eot_token_id   | <|/tool_call|>  | 200026
 
   using D = Config::Defaults;
   // clang-format off
   static const std::unordered_map<std::string, std::unordered_map<std::string_view, int32_t>> fallback_map = {
-      {"qwen2", {{D::BotTokenIdName, 151657}, {D::EotTokenIdName, 151658}, {D::BorTokenIdName, 151667}, {D::EorTokenIdName, 151668}}},
+      {"qwen2", {{D::BotTokenIdName, 151657}, {D::EotTokenIdName, 151658}}},
       {"qwen3", {{D::BotTokenIdName, 151657}, {D::EotTokenIdName, 151658}, {D::BorTokenIdName, 151667}, {D::EorTokenIdName, 151668}}},
       {"phi3",  {{D::BotTokenIdName, 200025}, {D::EotTokenIdName, 200026}}},
   };


### PR DESCRIPTION
# Remove reasoning tokens from qwen2 fallback map

## Problem

The fallback token ID map in `tokenizer_tag_utils.cpp` assigned `bor_token_id` (`<think>`, 151667) and `eor_token_id` (`</think>`, 151668) to the `qwen2` model type. While these tokens exist in the Qwen2.5 vocabulary, Qwen2.5 models were never trained to produce chain-of-thought reasoning output.

This causes downstream consumers (Foundry Local) to incorrectly flag qwen2.5-0.5b-instruct as a reasoning model, which breaks grammar-guided tool calling — the grammar builder constructs a CoT grammar the model can't satisfy, leading to `finish_reason=length` instead of `tool_calls`.

## Fix

Remove `BorTokenIdName` and `EorTokenIdName` from the `qwen2` fallback entry. Only `qwen3` retains reasoning token fallbacks (qwen3 models genuinely support `<think>...</think>` during inference).

## Before

```cpp
{"qwen2", {{D::BotTokenIdName, 151657}, {D::EotTokenIdName, 151658}, {D::BorTokenIdName, 151667}, {D::EorTokenIdName, 151668}}},
{"qwen3", {{D::BotTokenIdName, 151657}, {D::EotTokenIdName, 151658}, {D::BorTokenIdName, 151667}, {D::EorTokenIdName, 151668}}},
```

## After

```cpp
{"qwen2", {{D::BotTokenIdName, 151657}, {D::EotTokenIdName, 151658}}},
{"qwen3", {{D::BotTokenIdName, 151657}, {D::EotTokenIdName, 151658}, {D::BorTokenIdName, 151667}, {D::EorTokenIdName, 151668}}},
```

## Impact

- Qwen2.5 models: `GetBorTokenId()` / `GetEorTokenId()` will now throw (no fallback) → consumers correctly see `nullopt` → no false reasoning flag
- Qwen3 models: unchanged (still get bor/eor from fallback if not in genai_config.json)
- Models with explicit `bor_token_id`/`eor_token_id` in genai_config.json: unchanged (config values always take priority over the fallback map)
