### PR TITLE
Fix draft config construction with Clang

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1216,7 +1216,7 @@ struct Model_Element : JSON::Element {
     }
     if (name == "draft") {
       if (!v_.draft)
-        v_.draft.emplace();
+        v_.draft = Config::Model::Decoder{};
       if (!draft_)
         draft_ = std::make_unique<Decoder_Element>(*v_.draft);
       return *draft_;


### PR DESCRIPTION
## Description

Fix the Linux Clang 20 build failure introduced by #2233. With Ubuntu 22.04's libstdc++ 11, the no-argument `std::optional::emplace()` is rejected for the aggregate `Config::Model::Decoder` because its `is_constructible` constraint evaluates to false.

Use explicit aggregate construction instead, matching the existing config parser pattern and preserving behavior.