### PR TITLE
Qwen3.6 MTP: share the embedding and NVFP4 LM head with the main decoder

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -439,6 +439,62 @@ struct IntArray_Element : JSON::Element {
   std::vector<int>& v_;
 };
 
+struct Int64Array_Element : JSON::Element {
+  explicit Int64Array_Element(std::vector<int64_t>& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    v_.push_back(static_cast<int64_t>(JSON::Get<double>(value)));
+  }
+
+ private:
+  std::vector<int64_t>& v_;
+};
+
+struct SharedInitializer_Element : JSON::Element {
+  explicit SharedInitializer_Element(Config::Model::SharedInitializer& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "name") {
+      v_.name = JSON::Get<std::string_view>(value);
+    } else if (name == "data_file") {
+      v_.data_file = JSON::Get<std::string_view>(value);
+    } else if (name == "offset") {
+      v_.offset = JSON::Get<std::string_view>(value);
+    } else if (name == "length") {
+      v_.length = JSON::Get<std::string_view>(value);
+    } else if (name == "data_type") {
+      v_.data_type = SafeDoubleToInt(JSON::Get<double>(value), name);
+    } else {
+      throw JSON::unknown_value_error{};
+    }
+  }
+
+  Element& OnArray(std::string_view name) override {
+    if (name == "shape") {
+      return shape_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
+ private:
+  Config::Model::SharedInitializer& v_;
+  Int64Array_Element shape_{v_.shape};
+};
+
+struct SharedInitializers_Element : JSON::Element {
+  explicit SharedInitializers_Element(std::vector<Config::Model::SharedInitializer>& v) : v_{v} {}
+
+  Element& OnObject(std::string_view /*name*/) override {
+    auto& initializer = v_.emplace_back();
+    element_ = std::make_unique<SharedInitializer_Element>(initializer);
+    return *element_;
+  }
+
+ private:
+  std::vector<Config::Model::SharedInitializer>& v_;
+  std::unique_ptr<SharedInitializer_Element> element_;
+};
+
 struct StringStringMap_Element : JSON::Element {
   explicit StringStringMap_Element(std::unordered_map<std::string, std::string>& v) : v_{v} {}
 
@@ -675,6 +731,9 @@ struct Decoder_Element : JSON::Element {
       layer_types_ = std::make_unique<StringArray_Element>(v_.layer_types);
       return *layer_types_;
     }
+    if (name == "shared_initializers") {
+      return shared_initializers_;
+    }
     throw JSON::unknown_value_error{};
   }
 
@@ -688,6 +747,7 @@ struct Decoder_Element : JSON::Element {
   SlidingWindow_Element sliding_window_{v_.sliding_window};
   std::unique_ptr<PipelineModelObject_Element> pipeline_object_;  // object-style pipeline support
   std::unique_ptr<StringArray_Element> layer_types_;
+  SharedInitializers_Element shared_initializers_{v_.shared_initializers};
 };
 
 struct MtpInputs_Element : JSON::Element {
@@ -778,12 +838,20 @@ struct Mtp_Element : JSON::Element {
     throw JSON::unknown_value_error{};
   }
 
+  Element& OnArray(std::string_view name) override {
+    if (name == "shared_initializers") {
+      return shared_initializers_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
  private:
   Config::Model::Mtp& v_;
   std::unique_ptr<SessionOptions_Element> session_options_;
   std::unique_ptr<RunOptions_Element> run_options_;
   MtpInputs_Element inputs_{v_.inputs};
   MtpOutputs_Element outputs_{v_.outputs};
+  SharedInitializers_Element shared_initializers_{v_.shared_initializers};
 };
 
 struct VisionInputs_Element : JSON::Element {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -16,6 +16,8 @@
 
 namespace Generators {
 
+int64_t SafeDoubleToInt64(double x, std::string_view name);
+
 // Normalizes historical casings, short aliases, and full ORT names (e.g.
 // "CUDAExecutionProvider") to the canonical dispatch-table name; unknown names pass through.
 std::string_view NormalizeProviderName(std::string_view name) {
@@ -443,7 +445,7 @@ struct Int64Array_Element : JSON::Element {
   explicit Int64Array_Element(std::vector<int64_t>& v) : v_{v} {}
 
   void OnValue(std::string_view name, JSON::Value value) override {
-    v_.push_back(static_cast<int64_t>(JSON::Get<double>(value)));
+    v_.push_back(SafeDoubleToInt64(JSON::Get<double>(value), name));
   }
 
  private:
@@ -1463,6 +1465,31 @@ int SafeDoubleToInt(double x, std::string_view name) {
 
   // 4. Perform the cast.
   return static_cast<int>(x);
+}
+
+int64_t SafeDoubleToInt64(double x, std::string_view name) {
+  if (!std::isfinite(x)) {
+    throw std::runtime_error("Field '" + std::string(name) +
+                             "' cannot be converted to int64 (NaN or Inf)");
+  }
+
+  // int64_t::max() rounds up to 2^63 as a double, so use an exclusive upper bound.
+  constexpr double min_int64_val = -9223372036854775808.0;
+  constexpr double max_int64_exclusive = 9223372036854775808.0;
+  if (x < min_int64_val || x >= max_int64_exclusive) {
+    std::stringstream ss;
+    ss << "Field '" << name << "' value " << x << " is out of int64 range ["
+       << std::numeric_limits<int64_t>::min() << ", " << std::numeric_limits<int64_t>::max() << "]";
+    throw std::runtime_error(ss.str());
+  }
+
+  if (x != std::trunc(x)) {
+    std::stringstream ss;
+    ss << "Field '" << name << "' value " << x << " is not an integer";
+    throw std::runtime_error(ss.str());
+  }
+
+  return static_cast<int64_t>(x);
 }
 
 struct Search_Element : JSON::Element {

--- a/src/config.h
+++ b/src/config.h
@@ -335,10 +335,20 @@ struct Config {
       std::optional<RunOptions> run_options;
     } vad;
 
+    struct SharedInitializer {
+      std::string name;
+      std::string data_file;
+      std::string offset;
+      std::string length;
+      int data_type{};
+      std::vector<int64_t> shape;
+    };
+
     struct Decoder {
       std::string filename;
       SessionOptions session_options;
       std::optional<RunOptions> run_options;
+      std::vector<SharedInitializer> shared_initializers;
 
       int hidden_size{};          // Not currently used, potentially useful for embeddings in the future
       int num_attention_heads{};  // Not currently used, potentially useful if num_key_value_heads isn't set
@@ -457,6 +467,7 @@ struct Config {
       std::string filename;  // e.g. "mtp.onnx"; used by model packaging/building tools
       std::optional<SessionOptions> session_options;
       std::optional<RunOptions> run_options;
+      std::vector<SharedInitializer> shared_initializers;
 
       int num_hidden_layers{1};  // The MTP head has a single decoder layer.
       int num_key_value_heads{};

--- a/src/cuda/interface.cpp
+++ b/src/cuda/interface.cpp
@@ -64,6 +64,11 @@ struct GpuMemory final : DeviceBuffer {
     CUDA_CHECK(::cudaMemcpyAsync(p_device_, p_cpu_, size_in_bytes_, ::cudaMemcpyHostToDevice, GetStream()));
   }
 
+  void CopyFromCpu(const void* source, size_t size_in_bytes) override {
+    assert(size_in_bytes == size_in_bytes_);
+    CUDA_CHECK(::cudaMemcpy(p_device_, source, size_in_bytes, ::cudaMemcpyHostToDevice));
+  }
+
   void CopyFrom(size_t begin_dest, DeviceBuffer& source, size_t begin_source, size_t size_in_bytes) override {
     if (source.GetType() == device_label)
       CUDA_CHECK(::cudaMemcpyAsync(p_device_ + begin_dest, source.p_device_ + begin_source, size_in_bytes,

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -8,8 +8,11 @@
 #include <climits>
 #include <filesystem>
 #include <functional>
+#include <fstream>
+#include <mutex>
 #include <random>
 #include <set>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -49,6 +52,24 @@ namespace {
 constexpr const char* kOrtSessionOptionsModelExternalInitializersFileFolderPath =
     "session.model_external_initializers_file_folder_path";
 constexpr const char* kOrtSessionOptionEpContextFilePath = "ep.context_file_path";
+
+struct SharedInitializerEntry {
+  DeviceSpan<uint8_t> device_data;
+  std::unique_ptr<OrtValue> shared_view;
+};
+
+std::mutex g_shared_initializers_mutex;
+std::unordered_map<std::string, std::weak_ptr<SharedInitializerEntry>> g_shared_initializers;
+
+std::string SharedInitializerFileIdentity(const fs::path& path) {
+#ifndef _WIN32
+  struct stat file_info{};
+  if (::stat(path.c_str(), &file_info) == 0) {
+    return std::to_string(file_info.st_dev) + ":" + std::to_string(file_info.st_ino);
+  }
+#endif
+  return path.string();
+}
 
 // Session-option config keys whose values are file/folder path references. When a model is loaded
 // from a package these may be sha256: shared-asset URIs or relative paths, so their values are
@@ -613,6 +634,7 @@ std::vector<const char*> SessionInfo::GetOutputSymbolicShape(const std::string& 
 Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
   CreateSessionOptions();
   EnsureDeviceOrtInit(*p_device_, *config_);
+  AddSharedInitializers();
 
   // Inputs-only interface backed by a host-accessible allocation, so the CPU updates the small
   // decode inputs in place with no per-step roundtrip. Null if the device offers no such allocator.
@@ -642,6 +664,62 @@ Model::Model(std::unique_ptr<Config> config) : config_{std::move(config)} {
 
   // The kvcache is always allocated in device memory
   p_device_kvcache_ = p_device_;
+}
+
+void Model::AddSharedInitializers() {
+  for (const auto& initializer : config_->model.decoder.shared_initializers) {
+    if (initializer.name.empty() || initializer.data_file.empty() || initializer.length.empty() ||
+        initializer.shape.empty() || initializer.data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED) {
+      throw std::runtime_error("Invalid shared initializer metadata for '" + initializer.name + "'.");
+    }
+
+    const fs::path data_path = config_->ResolvePath(initializer.data_file);
+    const std::string data_path_string = data_path.string();
+    const uint64_t offset = initializer.offset.empty() ? 0 : std::stoull(initializer.offset);
+    const size_t length = static_cast<size_t>(std::stoull(initializer.length));
+    const auto data_type = static_cast<ONNXTensorElementDataType>(initializer.data_type);
+    auto memory_info = p_device_->GetMemoryInfo();
+
+    std::ostringstream key;
+    key << SharedInitializerFileIdentity(data_path) << ':' << offset << ':' << length << ':'
+        << initializer.data_type << ':'
+        << memory_info->GetDeviceType() << ':' << memory_info->GetDeviceId();
+    for (int64_t dimension : initializer.shape) {
+      key << ':' << dimension;
+    }
+
+    std::shared_ptr<SharedInitializerEntry> entry;
+    {
+      std::lock_guard lock{g_shared_initializers_mutex};
+      if (auto it = g_shared_initializers.find(key.str()); it != g_shared_initializers.end()) {
+        entry = it->second.lock();
+      }
+
+      if (!entry) {
+        std::ifstream input{data_path_string, std::ios::binary};
+        if (!input) {
+          throw std::runtime_error("Failed to open shared initializer data file: " + data_path_string);
+        }
+        input.seekg(static_cast<std::streamoff>(offset));
+        std::vector<uint8_t> bytes(length);
+        input.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(length));
+        if (input.gcount() != static_cast<std::streamsize>(length)) {
+          throw std::runtime_error("Failed to read shared initializer '" + initializer.name + "' from " +
+                                   data_path_string);
+        }
+
+        entry = std::make_shared<SharedInitializerEntry>();
+        entry->device_data = p_device_->Allocate<uint8_t>(length);
+        entry->device_data.CopyFromCpu(bytes);
+        entry->shared_view = OrtValue::CreateTensor(
+            *memory_info, entry->device_data.Span().data(), length, initializer.shape, data_type);
+        g_shared_initializers[key.str()] = entry;
+      }
+    }
+
+    session_options_->AddInitializer(initializer.name.c_str(), *entry->shared_view);
+    shared_initializer_entries_.push_back(std::move(entry));
+  }
 }
 
 Model::~Model() {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -18,6 +18,10 @@
 #include <thread>
 #include <unordered_map>
 
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif
+
 #include "../generators.h"
 #include "../search.h"
 #include "../tracing.h"

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -220,6 +220,7 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model>, External
 
   std::unique_ptr<Config> config_;
   std::unique_ptr<OrtSessionOptions> session_options_;
+  std::vector<std::shared_ptr<void>> shared_initializer_entries_;
 
   DeviceInterface* p_device_{};          // The device we're running on (matches device_type_) used for things that work the same on all devices
   DeviceInterface* p_device_inputs_{};   // For some model inputs, the device might be the CPU device (all but KV cache currently for WebGPU and DML)
@@ -242,6 +243,7 @@ struct Model : std::enable_shared_from_this<Model>, LeakChecked<Model>, External
 
  protected:
   void CreateSessionOptions();
+  void AddSharedInitializers();
 
   std::map<std::string, std::unique_ptr<OrtSessionOptions>> pipeline_session_options_;
 };

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -2273,6 +2273,10 @@ class Qwen35TextModel(Model):
             },
         }
 
+        if self.mtp_shared_initializers:
+            genai_config["model"]["decoder"]["shared_initializers"] = self.mtp_shared_initializers
+            genai_config["model"]["mtp"]["shared_initializers"] = self.mtp_shared_initializers
+
         with open(config_path, "w") as f:
             json.dump(genai_config, f, indent=4)
         print("Added 'mtp' section to genai_config.json")
@@ -2374,6 +2378,7 @@ class Qwen35MoeTextModel(Qwen35TextModel):
         # alongside the main model (see ``Qwen35MtpHead``). It is disabled for the
         # MTP head itself (``is_mtp_head``) to avoid infinite recursion.
         self.mtp_head = None
+        self.mtp_shared_initializers = []
         self.enable_mtp = str(extra_options.get("enable_mtp", "false")).lower() in ("1", "true", "yes")
         self.enable_mtp = self.enable_mtp and not getattr(self, "is_mtp_head", False)
         if self.enable_mtp:
@@ -2460,7 +2465,9 @@ class Qwen35MoeTextModel(Qwen35TextModel):
             # bit-identically with the main model: redirect mtp.onnx's copies to the
             # main model's external data file and pack them out of mtp.onnx.data
             # (~2 GB on disk; the two sessions then mmap the same bytes on the host).
-            self._share_mtp_embedding_lm_head(out_dir, self.filename)
+            self.mtp_shared_initializers = self._share_mtp_embedding_lm_head(
+                out_dir, self.filename, self.mtp_head.filename
+            )
 
     @staticmethod
     def _share_mtp_embedding_lm_head(out_dir, main_file, mtp_file="mtp.onnx"):
@@ -2472,7 +2479,7 @@ class Qwen35MoeTextModel(Qwen35TextModel):
         lm_head vs an fp16 MTP lm_head) is left untouched. Failures are non-fatal —
         the exported models remain valid (just larger) if sharing is skipped.
         """
-        import onnx
+        import onnx  # noqa: PLC0415
 
         main_onnx = os.path.join(out_dir, main_file)
         mtp_onnx = os.path.join(out_dir, mtp_file)
@@ -2486,7 +2493,7 @@ class Qwen35MoeTextModel(Qwen35TextModel):
             and os.path.exists(main_data)
             and os.path.exists(mtp_data)
         ):
-            return
+            return []
 
         def ext_info(tensor):
             d = {e.key: e.value for e in tensor.external_data}
@@ -2529,12 +2536,11 @@ class Qwen35MoeTextModel(Qwen35TextModel):
             mtp_inits = {t.name: t for t in mtp.graph.initializer}
 
             redirect, remove = {}, set()
-            for name in main_info:
-                if name not in mtp_inits or name not in main_info:
+            for name, (m_dt, m_dims, m_off, m_len) in main_info.items():
+                if name not in mtp_inits:
                     continue
                 t = mtp_inits[name]
                 loc, off, ln = ext_info(t)
-                m_dt, m_dims, m_off, m_len = main_info[name]
                 if loc != mtp_data_name or t.data_type != m_dt or tuple(t.dims) != m_dims or ln != m_len:
                     continue
                 if not external_data_equal(main_data, m_off, mtp_data, off, ln):
@@ -2543,7 +2549,7 @@ class Qwen35MoeTextModel(Qwen35TextModel):
                 remove.add((off, ln))
 
             if not redirect:
-                return
+                return []
 
             # Rebuild mtp.onnx.data with the redirected tensors packed out, in
             # ascending-offset order, assigning tight new offsets.
@@ -2583,7 +2589,7 @@ class Qwen35MoeTextModel(Qwen35TextModel):
                 f"Warning: could not share MTP embedding/lm_head weights ({exc}); "
                 f"the duplicated copies remain in {mtp_data_name}."
             )
-            return
+            return []
 
         # Keep the original pair recoverable until both staged files are installed.
         backup_data = mtp_data + ".bak"
@@ -2610,11 +2616,22 @@ class Qwen35MoeTextModel(Qwen35TextModel):
                 f"Warning: could not commit shared MTP embedding/lm_head weights ({exc}); "
                 f"the duplicated copies remain in {mtp_data_name}."
             )
-            return
+            return []
         os.remove(backup_data)
         os.remove(backup_onnx)
         saved_mb = sum(ln for _, ln in redirect.values()) / 1e6
         print(f"Shared MTP embedding + lm_head with the main model (saved {saved_mb:.0f} MB from {mtp_data_name})")
+        return [
+            {
+                "name": name,
+                "data_file": main_data_name,
+                "offset": str(offset),
+                "length": str(length),
+                "data_type": main_info[name][0],
+                "shape": list(main_info[name][1]),
+            }
+            for name, (offset, length) in redirect.items()
+        ]
 
     def make_layer(self, layer_id, layer):
         """Override to use MoE instead of dense MLP."""

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -6,6 +6,7 @@
 #include <algorithm>  // for std::copy
 #include <assert.h>
 #include <atomic>
+#include <cstring>
 #include <memory>
 #include <type_traits>  // for std::remove_const_t
 #include <utility>
@@ -34,6 +35,12 @@ struct DeviceBuffer : std::enable_shared_from_this<DeviceBuffer> {
   virtual void CopyCpuToDevice() = 0;
   virtual void CopyFrom(size_t begin_dest, DeviceBuffer& source, size_t begin_source, size_t size_in_bytes) = 0;
   virtual void Zero() = 0;  // Zero out the device memory
+  virtual void CopyFromCpu(const void* source, size_t size_in_bytes) {
+    assert(size_in_bytes == size_in_bytes_);
+    AllocateCpu();
+    std::memcpy(p_cpu_, source, size_in_bytes);
+    CopyCpuToDevice();
+  }
 
   uint8_t* p_device_{};
   uint8_t* p_cpu_{};
@@ -75,6 +82,11 @@ struct DeviceSpan {
 
   // Copy CPU memory to device memory, typically used after calling CpuSpan or CopyDeviceToCpu to update the device memory with the modifications made
   void CopyCpuToDevice() { p_device_memory_->CopyCpuToDevice(); }
+
+  void CopyFromCpu(std::span<const T> source) {
+    assert(source.size() == size());
+    p_device_memory_->CopyFromCpu(source.data(), source.size_bytes());
+  }
 
   // Zero out the device memory
   void Zero() { p_device_memory_->Zero(); }

--- a/test/mtp_config_test.cpp
+++ b/test/mtp_config_test.cpp
@@ -35,6 +35,26 @@ fs_std::path WriteMtpConfig(const std::string& output_name) {
   return root;
 }
 
+fs_std::path WriteSharedInitializerConfig(const std::string& suffix, const std::string& shape) {
+  const auto root = fs_std::temp_directory_path() / ("ortgenai_shared_initializer_config_" + suffix);
+  std::error_code ec;
+  fs_std::remove_all(root, ec);
+  fs_std::create_directories(root);
+
+  const std::string config =
+      "{ \"model\": { \"type\": \"tiny-test-model\","
+      " \"vocab_size\": 16, \"context_length\": 32,"
+      " \"decoder\": { \"filename\": \"model.onnx\","
+      " \"shared_initializers\": [{ \"name\": \"weight\", \"data_file\": \"weights.bin\","
+      " \"length\": \"1\", \"data_type\": 2, \"shape\": [" +
+      shape +
+      "] }] } },"
+      " \"search\": {} }";
+  std::ofstream out(root / "genai_config.json", std::ios::binary);
+  out << config;
+  return root;
+}
+
 }  // namespace
 
 TEST(MtpConfigTest, AcceptsConfigurableFeedbackOutput) {
@@ -44,6 +64,21 @@ TEST(MtpConfigTest, AcceptsConfigurableFeedbackOutput) {
 
 TEST(MtpConfigTest, RejectsMisspelledFeedbackOutput) {
   const auto root = WriteMtpConfig("hidden_state");
+  EXPECT_THROW(OgaConfig::Create(root.string().c_str()), std::exception);
+}
+
+TEST(MtpConfigTest, AcceptsInt64SharedInitializerDimension) {
+  const auto root = WriteSharedInitializerConfig("int64", "4294967296");
+  EXPECT_NO_THROW(OgaConfig::Create(root.string().c_str()));
+}
+
+TEST(MtpConfigTest, RejectsFractionalSharedInitializerDimension) {
+  const auto root = WriteSharedInitializerConfig("fractional", "1.5");
+  EXPECT_THROW(OgaConfig::Create(root.string().c_str()), std::exception);
+}
+
+TEST(MtpConfigTest, RejectsOutOfRangeSharedInitializerDimension) {
+  const auto root = WriteSharedInitializerConfig("overflow", "9223372036854775808");
   EXPECT_THROW(OgaConfig::Create(root.string().c_str()), std::exception);
 }
 

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -501,9 +501,7 @@ def test_paged_attention_uses_flat_hidden_states_output_shape(extra_options, log
         (False, "num_tokens", [0, 1, 2, 3, 4, 5]),
     ],
 )
-def test_paged_attention_lm_head_pruning(
-    monkeypatch, tmp_path, prune_lm_head, logits_first_dim, expected_rows
-):
+def test_paged_attention_lm_head_pruning(monkeypatch, tmp_path, prune_lm_head, logits_first_dim, expected_rows):
     model = Model.__new__(Model)
     model.use_paged_attention = True
     model.prune_lm_head = prune_lm_head
@@ -526,9 +524,7 @@ def test_paged_attention_lm_head_pruning(
     )
     model.model = ir.Model(graph, ir_version=10)
     graph.inputs.append(model.make_value("hidden_states", ir.DataType.FLOAT, ["num_tokens", model.hidden_size]))
-    graph.inputs.append(
-        model.make_value("cumulative_sequence_lengths", ir.DataType.INT32, ["batch_size + 1"])
-    )
+    graph.inputs.append(model.make_value("cumulative_sequence_lengths", ir.DataType.INT32, ["batch_size + 1"]))
 
     def make_matmul(_lm_head, name, root_input, **_kwargs):
         model.make_node("Identity", inputs=[root_input], outputs=["logits"], name=name)

--- a/test/python/builder/test_qwen_mtp_export.py
+++ b/test/python/builder/test_qwen_mtp_export.py
@@ -63,7 +63,7 @@ def test_share_mtp_weights_repacks_data_after_staging_metadata(tmp_path):
         ],
     )
 
-    Qwen35MoeTextModel._share_mtp_embedding_lm_head(tmp_path, "model.onnx")
+    shared_initializers = Qwen35MoeTextModel._share_mtp_embedding_lm_head(tmp_path, "model.onnx")
 
     assert (tmp_path / "mtp.onnx.data").read_bytes() == b"keep"
     model = onnx.load(tmp_path / "mtp.onnx", load_external_data=False)
@@ -73,6 +73,40 @@ def test_share_mtp_weights_repacks_data_after_staging_metadata(tmp_path):
     assert _external_info(initializers["lm_head.MatMul.nvfp4_weight_scale"]) == ("model.onnx.data", 8, 4)
     assert _external_info(initializers["lm_head.MatMul.nvfp4_weight_scale_2"]) == ("model.onnx.data", 12, 4)
     assert _external_info(initializers["mtp.fc.weight"]) == ("mtp.onnx.data", 0, 4)
+    assert shared_initializers == [
+        {
+            "name": "model.embed_tokens.weight",
+            "data_file": "model.onnx.data",
+            "offset": "0",
+            "length": "4",
+            "data_type": onnx.TensorProto.FLOAT,
+            "shape": [1],
+        },
+        {
+            "name": "lm_head.MatMul.nvfp4_weight",
+            "data_file": "model.onnx.data",
+            "offset": "4",
+            "length": "4",
+            "data_type": onnx.TensorProto.FLOAT,
+            "shape": [1],
+        },
+        {
+            "name": "lm_head.MatMul.nvfp4_weight_scale",
+            "data_file": "model.onnx.data",
+            "offset": "8",
+            "length": "4",
+            "data_type": onnx.TensorProto.FLOAT,
+            "shape": [1],
+        },
+        {
+            "name": "lm_head.MatMul.nvfp4_weight_scale_2",
+            "data_file": "model.onnx.data",
+            "offset": "12",
+            "length": "4",
+            "data_type": onnx.TensorProto.FLOAT,
+            "shape": [1],
+        },
+    ]
 
 
 def test_share_mtp_weights_leaves_originals_on_truncated_data(tmp_path):
@@ -90,12 +124,13 @@ def test_share_mtp_weights_leaves_originals_on_truncated_data(tmp_path):
     )
     original_model = (tmp_path / "mtp.onnx").read_bytes()
 
-    Qwen35MoeTextModel._share_mtp_embedding_lm_head(tmp_path, "model.onnx")
+    shared_initializers = Qwen35MoeTextModel._share_mtp_embedding_lm_head(tmp_path, "model.onnx")
 
     assert (tmp_path / "mtp.onnx.data").read_bytes() == b"samexx"
     assert (tmp_path / "mtp.onnx").read_bytes() == original_model
     assert not (tmp_path / "mtp.onnx.data.tmp").exists()
     assert not (tmp_path / "mtp.onnx.tmp").exists()
+    assert shared_initializers == []
 
 
 def test_share_mtp_weights_restores_originals_when_metadata_replace_fails(tmp_path, monkeypatch):
@@ -122,9 +157,10 @@ def test_share_mtp_weights_restores_originals_when_metadata_replace_fails(tmp_pa
 
     monkeypatch.setattr(os, "replace", fail_metadata_replace)
 
-    Qwen35MoeTextModel._share_mtp_embedding_lm_head(tmp_path, "model.onnx")
+    shared_initializers = Qwen35MoeTextModel._share_mtp_embedding_lm_head(tmp_path, "model.onnx")
 
     assert (tmp_path / "mtp.onnx.data").read_bytes() == original_data
     assert (tmp_path / "mtp.onnx").read_bytes() == original_model
     for suffix in ("mtp.onnx.data.tmp", "mtp.onnx.tmp", "mtp.onnx.data.bak", "mtp.onnx.bak"):
         assert not (tmp_path / suffix).exists()
+    assert shared_initializers == []

--- a/test/python/create/create_synthetic_paged_model.py
+++ b/test/python/create/create_synthetic_paged_model.py
@@ -205,9 +205,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--output_dir",
-        default=os.path.join(
-            os.path.dirname(__file__), "..", "..", "models", "engine", "synthetic-paged"
-        ),
+        default=os.path.join(os.path.dirname(__file__), "..", "..", "models", "engine", "synthetic-paged"),
     )
     args = parser.parse_args()
     output_dir = os.path.normpath(args.output_dir)


### PR DESCRIPTION
## Description

Share the token embedding and NVFP4 LM head between the Qwen3.6 main decoder and its MTP head, both on disk and in CUDA memory. These tensors are identical today, so keeping separate copies in `text.onnx.data` and `mtp.onnx.data` also makes the second ONNX Runtime session allocate and upload them again.

The builder now emits a validated `shared_initializers` manifest, and the runtime uses the public ONNX Runtime `AddInitializer` API to bind each session to one process-wide device allocation. This reduces model size and peak CUDA memory without changing quality or throughput.

## Summary of Changes

### Qwen MTP Export

- Allow `use_original_nvfp4_weights=true` for the MTP head while restricting original NVFP4 reuse to `/lm_head/MatMul`; MTP layer weights remain on their configured `mtp_head_quant_type` path.
- Deduplicate `model.embed_tokens.weight` and the three NVFP4 LM-head tensors (`nvfp4_weight`, `nvfp4_weight_scale`, and `nvfp4_weight_scale_2`). The MTP graph redirects them to `text.onnx.data` and removes their bytes from `mtp.onnx.data`.
- Record each tensor's name, external-data file, offset, length, data type, and shape under both `decoder.shared_initializers` and `mtp.shared_initializers` in `genai_config.json`.
- Repack external data transactionally: malformed/truncated ranges leave the original files unchanged, and a metadata replacement failure restores the original data and metadata.

### Runtime Sharing and Lifetime

- Parse shared-initializer manifests for decoder and MTP sessions, including strict `int64` shape validation that rejects fractional, non-finite, and out-of-range dimensions.
- Resolve external-data files relative to the model directory and identify shared ranges by file identity, offset, length, data type, shape, and device. Linux uses device and inode identity so hard-linked model files share the same entry.
- Read and upload each uncached range once, wrap the device pointer in a non-owning `OrtValue`, and call `OrtSessionOptions::AddInitializer` before creating the session.
- Hold weak references in the process-wide map and strong references in each participating `Model`, keeping the caller-owned buffers alive until their sessions are destroyed without adding ONNX Runtime global state.
- Add a `DeviceBuffer::CopyFromCpu` path for uploading shared initializer data to CUDA allocations.

## Results

Measured on Qwen3.6-35B-A3B-NVFP4 (40 layers, 256 experts, vocabulary 248320), built with `enable_mtp=true mtp_head_quant_type=int8` and run on one H200 with CUDA 13.0.

### Shared Payload

| Initializer | Type | Shape | Length (bytes) |
|---|---|---|---:|
| `model.embed_tokens.weight` | FLOAT16 | `[248320, 2048]` | 1,017,118,720 |
| `lm_head.MatMul.nvfp4_weight` | UINT8 | `[248320, 1024]` | 254,279,680 |
| `lm_head.MatMul.nvfp4_weight_scale` | UINT8 | `[248320, 128]` | 31,784,960 |
| `lm_head.MatMul.nvfp4_weight_scale_2` | FLOAT | `[1]` | 4 |

`mtp.onnx.data` decreases from 2,524,119,040 to 966,616,132 bytes, a reduction of 1.45 GiB. The reduction exceeds the shared ranges because the MTP head's previous Q8 LM head is replaced by a reference to the smaller NVFP4 representation.

### CUDA Memory

Loading the main model and then the standalone MTP head in one process with the default arena:

| Configuration | Main | Head | Total |
|---|---:|---:|---:|
| Manifest removed | 43,290 MiB | 3,194 MiB | 46,484 MiB |
| `AddInitializer` sharing | 44,314 MiB | **1,148 MiB** | 45,462 MiB |

The MTP head's incremental allocation decreases by 2,046 MiB. This is larger than the 1,242.81 MiB explicit shared payload because the second session also avoids arena growth caused by those tensors.

### Quality and Throughput

| Metric | Result |
|---|---:|
| MMLU-Pro, 800 samples, MTP N=3, greedy, thinking enabled | 681/800 (**85.12%**) |
| Decode, plain, 1024-token prompt / 256 new tokens | 222.0 tok/s |
| Decode, MTP N=3 | 348.7 tok/s |

## Testing

- `python -m ruff check` and `python -m ruff format --check` on the modified Python files.
- `clang-format --dry-run --Werror` on the modified C++ files.
- `PYTHONPATH=src/python/py python -m pytest -q test/python/builder/test_qwen_mtp_export.py test/python/builder/test_qwen_mtp_head_quant.py` (16 tests).
- `cmake --build build/ci_fix_check --target onnxruntime-genai --parallel 8`.
- `cmake --build build/cu130_mtp/Release --target unit_tests`.
- `./build/cu130_mtp/Release/unit_tests --gtest_filter=MtpConfigTest.*` (5 tests).

## Context

This continues the Qwen MTP builder and runtime work from #2352, #2353, and #2426. The builder and runtime changes must land together because the GenAI config parser rejects unknown keys; a builder that emits `shared_initializers` without matching runtime support would produce models that fail to load.

## Checklist

- [x] Tests added and updated
- [x] No public API breaking changes
- [x] Builder output and runtime config parsing updated together