### PR TITLE
Qwen3.6: fuse shared-expert gating with GatedAdd

### DIFF
--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -358,7 +358,12 @@ python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p bf
 
 When `config.json` declares `quant_method=modelopt`, the builder preserves the checkpoint's original quantized data types automatically: routed experts use native NVFP4 `QMoE`, dense NVFP4 modules use `MatMulBlockQuantizedFp4Weight`, and FP8 attention projections use `MatMulBlockQuantizedFp8Weight`. If the checkpoint declares `kv_cache_quant_algo=FP8`, the KV cache is exported as FP8 as well. CUDA linear-attention gate fusion is enabled automatically.
 
-The `--precision` argument controls the unquantized tensors and model I/O; it does not change the checkpoint's native FP8/NVFP4 tensors. ModelOpt export requires the CUDA EP and an ONNX Runtime build that provides the corresponding contrib ops.
+The `--precision` argument controls the unquantized tensors and model I/O; it does not change the checkpoint's native FP8/NVFP4 tensors. ModelOpt export requires the CUDA EP and an ONNX Runtime build that provides the corresponding contrib ops. On CUDA, `fuse_shared_expert_gate` defaults to `true`, replacing each shared-expert output `Mul` and routed/shared `Add` pair with `com.microsoft::GatedAdd`. Set it to `false` to retain the portable ONNX graph or when using an ONNX Runtime build without the CUDA kernel.
+
+```bash
+# Keep the portable Mul + Add graph when exporting from source:
+python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p bf16 -e cuda --extra_options fuse_shared_expert_gate=false
+```
 
 #### Enable MTP Head (Qwen3.6)
 

--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -358,12 +358,7 @@ python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p bf
 
 When `config.json` declares `quant_method=modelopt`, the builder preserves the checkpoint's original quantized data types automatically: routed experts use native NVFP4 `QMoE`, dense NVFP4 modules use `MatMulBlockQuantizedFp4Weight`, and FP8 attention projections use `MatMulBlockQuantizedFp8Weight`. If the checkpoint declares `kv_cache_quant_algo=FP8`, the KV cache is exported as FP8 as well. CUDA linear-attention gate fusion is enabled automatically.
 
-The `--precision` argument controls the unquantized tensors and model I/O; it does not change the checkpoint's native FP8/NVFP4 tensors. ModelOpt export requires the CUDA EP and an ONNX Runtime build that provides the corresponding contrib ops. On CUDA, `fuse_shared_expert_gate` defaults to `true`, replacing each shared-expert output `Mul` and routed/shared `Add` pair with `com.microsoft::GatedAdd`. Set it to `false` to retain the portable ONNX graph or when using an ONNX Runtime build without the CUDA kernel.
-
-```bash
-# Keep the portable Mul + Add graph when exporting from source:
-python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p bf16 -e cuda --extra_options fuse_shared_expert_gate=false
-```
+The `--precision` argument controls the unquantized tensors and model I/O; it does not change the checkpoint's native FP8/NVFP4 tensors. ModelOpt export requires the CUDA EP and an ONNX Runtime build that provides the corresponding contrib ops. For CPU, CUDA, and WebGPU, the builder replaces each shared-expert output `Mul` and routed/shared `Add` pair with `com.microsoft::GatedAdd`; other execution providers retain the portable `Mul` + `Add` graph.
 
 #### Enable MTP Head (Qwen3.6)
 

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -168,6 +168,7 @@ def check_extra_options(
         "fuse_qk_norm_gqa",
         "prune_lm_head",
         "use_paged_attention",
+        "fuse_shared_expert_gate",
         "enable_mtp",
     ]
 
@@ -320,6 +321,12 @@ def check_extra_options(
                 f"Got execution_provider='{execution_provider}'."
             )
         extra_options["kv_cache_quant_type"] = quant_type
+
+    if extra_options.get("fuse_shared_expert_gate", False) and execution_provider != "cuda":
+        raise ValueError(
+            "fuse_shared_expert_gate is only supported on the CUDA EP, "
+            f"got execution_provider='{execution_provider}'."
+        )
 
     # Get Hugging Face details and temporarily set in extra options for use in `create_model`
     hf_details = get_hf_details(model_name, input_path, cache_dir, extra_options)

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -168,7 +168,6 @@ def check_extra_options(
         "fuse_qk_norm_gqa",
         "prune_lm_head",
         "use_paged_attention",
-        "fuse_shared_expert_gate",
         "enable_mtp",
     ]
 
@@ -321,12 +320,6 @@ def check_extra_options(
                 f"Got execution_provider='{execution_provider}'."
             )
         extra_options["kv_cache_quant_type"] = quant_type
-
-    if extra_options.get("fuse_shared_expert_gate", False) and execution_provider != "cuda":
-        raise ValueError(
-            "fuse_shared_expert_gate is only supported on the CUDA EP, "
-            f"got execution_provider='{execution_provider}'."
-        )
 
     # Get Hugging Face details and temporarily set in extra options for use in `create_model`
     hf_details = get_hf_details(model_name, input_path, cache_dir, extra_options)

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -2333,9 +2333,6 @@ class Qwen35MoeTextModel(Qwen35TextModel):
         self.shared_expert_intermediate_size = getattr(
             config, "shared_expert_intermediate_size", self.moe_intermediate_size
         )
-        self.fuse_shared_expert_gate = str(
-            extra_options.get("fuse_shared_expert_gate", "true" if self.ep == "cuda" else "false")
-        ).lower() in ("1", "true", "yes")
 
         # MoE layers use MoE/QMoE ops instead of individual MatMul nodes,
         # so remove any /mlp/ MatMul overrides that don't apply.
@@ -2754,7 +2751,7 @@ class Qwen35MoeTextModel(Qwen35TextModel):
 
     def _combine_routed_and_shared_experts(self, layer_id, routed_output, shared_output, shared_gate):
         output_shape = ["batch_size", "sequence_length", self.hidden_size]
-        if self.fuse_shared_expert_gate:
+        if self.ep in {"cpu", "cuda", "webgpu"}:
             combine_name = f"/model/layers.{layer_id}/moe/GatedAdd"
             combine_output = f"{combine_name}/output_0"
             self.make_node(

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -2333,6 +2333,9 @@ class Qwen35MoeTextModel(Qwen35TextModel):
         self.shared_expert_intermediate_size = getattr(
             config, "shared_expert_intermediate_size", self.moe_intermediate_size
         )
+        self.fuse_shared_expert_gate = str(
+            extra_options.get("fuse_shared_expert_gate", "true" if self.ep == "cuda" else "false")
+        ).lower() in ("1", "true", "yes")
 
         # MoE layers use MoE/QMoE ops instead of individual MatMul nodes,
         # so remove any /mlp/ MatMul overrides that don't apply.
@@ -2742,15 +2745,43 @@ class Qwen35MoeTextModel(Qwen35TextModel):
         )
 
         # --- Shared expert ---
-        shared_output = self.make_shared_expert(layer_id, mlp.shared_expert, mlp.shared_expert_gate, root_input)
-        combine_name = f"{basename}/Add"
+        shared_output, shared_gate = self.make_shared_expert(
+            layer_id, mlp.shared_expert, mlp.shared_expert_gate, root_input
+        )
+        self.layernorm_attrs["skip_input"] = self._combine_routed_and_shared_experts(
+            layer_id, f"{moe_name}/output_0", shared_output, shared_gate
+        )
+
+    def _combine_routed_and_shared_experts(self, layer_id, routed_output, shared_output, shared_gate):
+        output_shape = ["batch_size", "sequence_length", self.hidden_size]
+        if self.fuse_shared_expert_gate:
+            combine_name = f"/model/layers.{layer_id}/moe/GatedAdd"
+            combine_output = f"{combine_name}/output_0"
+            self.make_node(
+                "GatedAdd",
+                inputs=[routed_output, shared_output, shared_gate],
+                outputs=[combine_output],
+                name=combine_name,
+                domain="com.microsoft",
+            )
+            self.make_value(combine_output, self.io_dtype, output_shape)
+            return combine_output
+
+        gated_mul_name = f"/model/layers.{layer_id}/shared_expert/gate/Mul"
+        self.make_mul(
+            gated_mul_name,
+            [shared_output, shared_gate],
+            dtype=self.io_dtype,
+            shape=output_shape,
+        )
+        combine_name = f"/model/layers.{layer_id}/moe/Add"
         self.make_add(
             combine_name,
-            [f"{moe_name}/output_0", shared_output],
+            [routed_output, f"{gated_mul_name}/output_0"],
             dtype=self.io_dtype,
-            shape=["batch_size", "sequence_length", self.hidden_size],
+            shape=output_shape,
         )
-        self.layernorm_attrs["skip_input"] = f"{combine_name}/output_0"
+        return f"{combine_name}/output_0"
 
     def make_nvfp4_moe_initializers(
         self,
@@ -2861,12 +2892,4 @@ class Qwen35MoeTextModel(Qwen35TextModel):
         self.make_sigmoid(
             gate_sigmoid_name, f"{gate_matmul_name}/output_0", self.io_dtype, shape=["batch_size", "sequence_length", 1]
         )
-
-        gated_mul_name = f"{basename}/gate/Mul"
-        self.make_mul(
-            gated_mul_name,
-            [f"{down_matmul}/output_0", f"{gate_sigmoid_name}/output_0"],
-            dtype=self.io_dtype,
-            shape=["batch_size", "sequence_length", self.hidden_size],
-        )
-        return f"{gated_mul_name}/output_0"
+        return f"{down_matmul}/output_0", f"{gate_sigmoid_name}/output_0"

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -216,6 +216,19 @@ def _run_check_extra_options(
     )
 
 
+def test_fuse_shared_expert_gate_is_normalized_on_cuda(monkeypatch):
+    options = {"fuse_shared_expert_gate": "true"}
+
+    _run_check_extra_options(monkeypatch, options, execution_provider="cuda")
+
+    assert options["fuse_shared_expert_gate"] is True
+
+
+def test_fuse_shared_expert_gate_rejects_non_cuda_ep(monkeypatch):
+    with pytest.raises(ValueError, match="fuse_shared_expert_gate is only supported on the CUDA EP"):
+        _run_check_extra_options(monkeypatch, {"fuse_shared_expert_gate": "true"})
+
+
 # ---------------------------------------------------------------------------
 # MTP options are normalized and enforce the main-model output contract.
 # ---------------------------------------------------------------------------
@@ -501,9 +514,7 @@ def test_paged_attention_uses_flat_hidden_states_output_shape(extra_options, log
         (False, "num_tokens", [0, 1, 2, 3, 4, 5]),
     ],
 )
-def test_paged_attention_lm_head_pruning(
-    monkeypatch, tmp_path, prune_lm_head, logits_first_dim, expected_rows
-):
+def test_paged_attention_lm_head_pruning(monkeypatch, tmp_path, prune_lm_head, logits_first_dim, expected_rows):
     model = Model.__new__(Model)
     model.use_paged_attention = True
     model.prune_lm_head = prune_lm_head
@@ -526,9 +537,7 @@ def test_paged_attention_lm_head_pruning(
     )
     model.model = ir.Model(graph, ir_version=10)
     graph.inputs.append(model.make_value("hidden_states", ir.DataType.FLOAT, ["num_tokens", model.hidden_size]))
-    graph.inputs.append(
-        model.make_value("cumulative_sequence_lengths", ir.DataType.INT32, ["batch_size + 1"])
-    )
+    graph.inputs.append(model.make_value("cumulative_sequence_lengths", ir.DataType.INT32, ["batch_size + 1"]))
 
     def make_matmul(_lm_head, name, root_input, **_kwargs):
         model.make_node("Identity", inputs=[root_input], outputs=["logits"], name=name)

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -216,19 +216,6 @@ def _run_check_extra_options(
     )
 
 
-def test_fuse_shared_expert_gate_is_normalized_on_cuda(monkeypatch):
-    options = {"fuse_shared_expert_gate": "true"}
-
-    _run_check_extra_options(monkeypatch, options, execution_provider="cuda")
-
-    assert options["fuse_shared_expert_gate"] is True
-
-
-def test_fuse_shared_expert_gate_rejects_non_cuda_ep(monkeypatch):
-    with pytest.raises(ValueError, match="fuse_shared_expert_gate is only supported on the CUDA EP"):
-        _run_check_extra_options(monkeypatch, {"fuse_shared_expert_gate": "true"})
-
-
 # ---------------------------------------------------------------------------
 # MTP options are normalized and enforce the main-model output contract.
 # ---------------------------------------------------------------------------

--- a/test/python/builder/test_qwen_gated_add.py
+++ b/test/python/builder/test_qwen_gated_add.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License
+
+from types import MethodType
+
+import onnx_ir as ir
+
+from models.builders.qwen import Qwen35MoeTextModel
+
+
+def _make_model(fuse_shared_expert_gate):
+    model = object.__new__(Qwen35MoeTextModel)
+    model.fuse_shared_expert_gate = fuse_shared_expert_gate
+    model.hidden_size = 2048
+    model.io_dtype = ir.DataType.FLOAT16
+    model.calls = []
+
+    def record(name):
+        def call(self, *args, **kwargs):
+            self.calls.append((name, args, kwargs))
+
+        return MethodType(call, model)
+
+    model.make_node = record("make_node")
+    model.make_value = record("make_value")
+    model.make_mul = record("make_mul")
+    model.make_add = record("make_add")
+    return model
+
+
+def test_cuda_fusion_emits_one_gated_add():
+    model = _make_model(True)
+
+    output = model._combine_routed_and_shared_experts(3, "routed", "shared", "gate")
+
+    assert output == "/model/layers.3/moe/GatedAdd/output_0"
+    assert [call[0] for call in model.calls] == ["make_node", "make_value"]
+    _, args, kwargs = model.calls[0]
+    assert args == ("GatedAdd",)
+    assert kwargs["inputs"] == ["routed", "shared", "gate"]
+    assert kwargs["outputs"] == [output]
+    assert kwargs["domain"] == "com.microsoft"
+
+
+def test_fusion_opt_out_preserves_mul_add_graph():
+    model = _make_model(False)
+
+    output = model._combine_routed_and_shared_experts(3, "routed", "shared", "gate")
+
+    assert output == "/model/layers.3/moe/Add/output_0"
+    assert [call[0] for call in model.calls] == ["make_mul", "make_add"]
+    assert model.calls[0][1] == (
+        "/model/layers.3/shared_expert/gate/Mul",
+        ["shared", "gate"],
+    )
+    assert model.calls[1][1] == (
+        "/model/layers.3/moe/Add",
+        ["routed", "/model/layers.3/shared_expert/gate/Mul/output_0"],
+    )

--- a/test/python/builder/test_qwen_gated_add.py
+++ b/test/python/builder/test_qwen_gated_add.py
@@ -4,13 +4,14 @@
 from types import MethodType
 
 import onnx_ir as ir
+import pytest
 
 from models.builders.qwen import Qwen35MoeTextModel
 
 
-def _make_model(fuse_shared_expert_gate):
+def _make_model(ep):
     model = object.__new__(Qwen35MoeTextModel)
-    model.fuse_shared_expert_gate = fuse_shared_expert_gate
+    model.ep = ep
     model.hidden_size = 2048
     model.io_dtype = ir.DataType.FLOAT16
     model.calls = []
@@ -28,8 +29,9 @@ def _make_model(fuse_shared_expert_gate):
     return model
 
 
-def test_cuda_fusion_emits_one_gated_add():
-    model = _make_model(True)
+@pytest.mark.parametrize("ep", ["cpu", "cuda", "webgpu"])
+def test_supported_ep_fusion_emits_one_gated_add(ep):
+    model = _make_model(ep)
 
     output = model._combine_routed_and_shared_experts(3, "routed", "shared", "gate")
 
@@ -42,8 +44,8 @@ def test_cuda_fusion_emits_one_gated_add():
     assert kwargs["domain"] == "com.microsoft"
 
 
-def test_fusion_opt_out_preserves_mul_add_graph():
-    model = _make_model(False)
+def test_unsupported_ep_preserves_mul_add_graph():
+    model = _make_model("dml")
 
     output = model._combine_routed_and_shared_experts(3, "routed", "shared", "gate")
 


### PR DESCRIPTION
## Description

Fuse Qwen3.6 MoE shared-expert scaling and routed/shared addition into the `com.microsoft::GatedAdd` contrib operator.

Qwen3.6 shared-expert Mul+Add is replaced by com.microsoft::GatedAdd for CPU, CUDA, and WebGPU. Unsupported execution providers retain portable ONNX `Mul` + `Add`. No `fuse_shared_expert_gate` option remains.

This PR is stacked on #2353, which is itself stacked on #2351. Dependencies are microsoft/onnxruntime#31835 for CUDA and merged microsoft/onnxruntime#32106 for CPU/WebGPU.

## Changes

- Return the shared-expert projection and scalar gate separately from `make_shared_expert`.
- Emit one `GatedAdd` per MoE layer on CPU, CUDA, and WebGPU.
- Preserve the standard `Mul` + `Add` graph as an explicit fallback for unsupported EPs.
- Add focused tests for fused and fallback graph construction.

## Performance

On Qwen3.6-35B-A3B-NVFP4 with N=3 MTP, the real exported graph replaces 40 main-model pairs plus one MTP pair. Counterbalanced H200 measurements reduced median decode latency from 7.311 to 7.225 ms/round (-1.18%). Graph-off Nsight measured 40.35 fewer launches/round and 1.30% lower GPU kernel time.

## Validation

- `50 passed`: `test_precision.py` plus `test_qwen_gated_add.py`.
- Real graph census: 40 `GatedAdd` nodes in `text.onnx`, one in `mtp.onnx`.
- After normalizing fused edge names, all other nodes, initializers, graph inputs, and graph outputs are unchanged from the baseline export.
- Runtime float, FP16, and BF16 results are bit-exact with separate `Mul` + `Add`.

## Stack note

The source commit `5c35bb02fc` also contained an unrelated MTP prefill chunk default change in `src/mtp_generator.{h,cpp}`. Those files are intentionally excluded here because they depend on runtime PR #2352 rather than builder PR #2353.