### PR TITLE
Increase MTP prefill chunk default to 1024

### DIFF
--- a/src/mtp_generator.cpp
+++ b/src/mtp_generator.cpp
@@ -108,8 +108,9 @@ MtpGenerator::MtpGenerator(const Model& main_model, const Model& mtp_model, cons
     num_speculative_tokens_ = std::min(num_speculative_tokens_, static_cast<int>(window) - 1);
   }
   // Default the chunking on for windowed-state models only (they are the ones running long
-  // prompts through the MTP loop); 256 tokens/chunk costs a handful of extra forwards.
-  if (!prefill_chunk_explicit_ && main_->CanCropRecurrentState()) prefill_chunk_ = 256;
+  // prompts through the MTP loop). A 1024-token chunk keeps activation memory bounded without
+  // splitting common 1K prompts into several underfilled forwards.
+  if (!prefill_chunk_explicit_ && main_->CanCropRecurrentState()) prefill_chunk_ = 1024;
   mtp_params_ = std::make_shared<GeneratorParams>(mtp_model_);
   mtp_params_->search = params.search;
   // CUDA-graph capture on the MTP head: the head is a single standard-attention layer (KV

--- a/src/mtp_generator.h
+++ b/src/mtp_generator.h
@@ -157,9 +157,8 @@ struct MtpGenerator {
   // existing host-token path.
   bool device_draft_chain_{false};
   // search.chunk_size: max tokens per prompt forward. A one-shot forward over a long prompt
-  // drives the ORT activation arena far past what the chunked path needs (measured 94 GB vs 54 GB
-  // on a 2.8k-token prompt), so 0 = single forward; defaults to 256 on a windowed-state model,
-  // off otherwise.
+  // grows the ORT activation arena, so 0 = single forward; defaults to 1024 on a windowed-state
+  // model and stays off otherwise.
   int prefill_chunk_{0};
   bool prefill_chunk_explicit_{false};
   // Head KV length invariant (multi-token path): number of committed generated tokens currently


### PR DESCRIPTION
## Description

Raises the default MTP prefill chunk from 256 to 1024 tokens for models with windowed recurrent state. `ORT_MTP_PREFILL_CHUNK` remains authoritative, including `0` for a single forward.

The larger default avoids splitting common 1K prompts into four full chunks plus a tail while retaining bounded activation memory for longer prompts.

## H200 results

INT8 head, N=3, CUDA graph enabled:

| Prompt | Chunk | TTFT | Prefill tok/s | Peak GPU |
|---:|---:|---:|---:|---:|
| 1029 | 256 | 378.3 ms | 2719.9 | 50809 MiB |
| 1029 | 1024 | **178.7 ms** | **5758.8** | 52851 MiB |
| 2829 | 256 | 1033.5 ms | 2737.4 | 50721 MiB |
| 2829 | 1024 | **432.9 ms** | **6535.2** | 52797 MiB |

This improves prefill throughput by 111.7% at 1K and 138.7% at 2.8K, at a roughly 2.0 GiB peak-memory cost. Decode throughput is unchanged within variance. With the environment variable unset, the rebuilt default measured 177.6 ms / 5795.5 tok/s, matching the explicit-1024 control at 178.6 ms / 5760.9 tok/s.

## Accuracy

800-sample MMLU-Pro:

| Run | Score |
|---|---:|
| Original baseline | 681/800 (85.12%) |
| Explicit single-forward control | 679/800 (84.88%) |
| Default 1024 | 680/800 (85.00%) |

The result is within observed same-model run-to-run variation and shows no accuracy regression.

## Validation

- Native `UnitTests` passed on the benchmarked source revision.
- `clang-format --dry-run --Werror` passes for both touched files.
- The isolated patch is byte-identical to the source revision used for the performance and accuracy runs.

## Stack note

This PR is stacked on runtime PR #2352. It is independent of engine chunked-prefill PR #2355 and GatedAdd PR #2390.