### PR TITLE
Fix package feed isolation

### DIFF
--- a/.github/workflows/win-webgpu-x64-build.yml
+++ b/.github/workflows/win-webgpu-x64-build.yml
@@ -126,9 +126,10 @@ jobs:
         run: |
           # ONNX Runtime comes from the ORT-Nightly ADO feed. Passing EPDir is the single switch that
           # turns on the EP-plugin registration code path; the tests enumerate and register every EP
-          # plugin in that directory (the one the pipeline downloaded them to).
+          # plugin in that directory (the one the pipeline downloaded them to). The matching ORT
+          # package is already in the global NuGet cache, so keep its feed out of dependency restore.
           cd test\csharp
-          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:EPDir="$env:GITHUB_WORKSPACE\ort\ep" --verbosity normal
+          dotnet test /p:Configuration=Release /p:NativeBuildOutputDir="$env:GITHUB_WORKSPACE\$env:binaryDir\Release" /p:EPDir="$env:GITHUB_WORKSPACE\ort\ep" /p:RestoreSources="https://api.nuget.org/v3/index.json" --verbosity normal
 
       - name: Verify Build Artifacts
         if: always()

--- a/.pipelines/stages/jobs/steps/utils/pull-manylinux-image.yml
+++ b/.pipelines/stages/jobs/steps/utils/pull-manylinux-image.yml
@@ -10,7 +10,12 @@ parameters:
 
 steps:
 - bash: |
-    set -e -x
+    set -e
+    if [ -z "${PIP_INDEX_URL:-}" ]; then
+      echo "PIP_INDEX_URL is not configured; authenticate the Python package feed before building the image."
+      exit 1
+    fi
+    set -x
     python3 -m pip install requests
     if [ '${{ parameters.ep }}' = 'cuda' ]; then
       cudaDockerVer='${{ parameters.cuda_version }}'

--- a/.pipelines/stages/jobs/steps/utils/pull-manylinux-image.yml
+++ b/.pipelines/stages/jobs/steps/utils/pull-manylinux-image.yml
@@ -26,7 +26,7 @@ steps:
     python3 tools/ci_build/get_docker_image.py \
       --dockerfile "$dockerfile" \
       --context tools/ci_build/github/linux/docker/manylinux \
-      --docker-build-args "--build-arg BUILD_UID=$(id -u)" \
+      --docker-build-args "--build-arg BUILD_UID=$(id -u) --secret id=pip_index_url,env=PIP_INDEX_URL" \
       --container-registry onnxruntimebuildcache.azurecr.io \
       --repository "ortgenai${{ parameters.ep }}build${{ parameters.arch }}"
   displayName: 'Pull manylinux Docker image (${{ parameters.ep }}, ${{ parameters.arch }})'

--- a/.pipelines/stages/jobs/steps/utils/pull-manylinux-image.yml
+++ b/.pipelines/stages/jobs/steps/utils/pull-manylinux-image.yml
@@ -11,12 +11,8 @@ parameters:
 steps:
 - bash: |
     set -e
-    if [ -z "${PIP_INDEX_URL:-}" ]; then
-      echo "PIP_INDEX_URL is not configured; authenticate the Python package feed before building the image."
-      exit 1
-    fi
-    set -x
     python3 -m pip install requests
+    dockerBuildArgs="--build-arg BUILD_UID=$(id -u)"
     if [ '${{ parameters.ep }}' = 'cuda' ]; then
       cudaDockerVer='${{ parameters.cuda_version }}'
       if [[ '${{ parameters.cuda_version }}' == 13.* ]]; then
@@ -24,14 +20,20 @@ steps:
       fi
       dockerfile="tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cuda_${cudaDockerVer}"
     elif [ '${{ parameters.arch }}' = 'arm64' ]; then
+      if [ -z "${PIP_INDEX_URL:-}" ]; then
+        echo "PIP_INDEX_URL is not configured; authenticate the Python package feed before building the ARM64 image."
+        exit 1
+      fi
       dockerfile='tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_aarch64'
+      dockerBuildArgs="$dockerBuildArgs --secret id=pip_index_url,env=PIP_INDEX_URL"
     else
       dockerfile='tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_x64'
     fi
+    set -x
     python3 tools/ci_build/get_docker_image.py \
       --dockerfile "$dockerfile" \
       --context tools/ci_build/github/linux/docker/manylinux \
-      --docker-build-args "--build-arg BUILD_UID=$(id -u) --secret id=pip_index_url,env=PIP_INDEX_URL" \
+      --docker-build-args "$dockerBuildArgs" \
       --container-registry onnxruntimebuildcache.azurecr.io \
       --repository "ortgenai${{ parameters.ep }}build${{ parameters.arch }}"
   displayName: 'Pull manylinux Docker image (${{ parameters.ep }}, ${{ parameters.arch }})'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,8 +330,9 @@ if(USE_DML)
   get_filename_component(PACKAGES_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps ABSOLUTE)
   set(DXC_PACKAGE_DIR ${PACKAGES_DIR}/Microsoft.Direct3D.DXC.1.7.2308.12)
   set(PACKAGES_CONFIG ${PROJECT_SOURCE_DIR}/packages.config)
+  find_program(NUGET_PATH NAMES nuget nuget.exe REQUIRED)
   set(NUGET_RESTORE_COMMAND
-    ${CMAKE_CURRENT_BINARY_DIR}/nuget/src/nuget restore
+    ${NUGET_PATH} restore
     ${PACKAGES_CONFIG}
     -PackagesDirectory ${PACKAGES_DIR}
   )
@@ -354,7 +355,6 @@ if(USE_DML)
     ${DXC_PACKAGE_DIR}/build/native/bin/x64/dxc.exe
   )
 
-  add_dependencies(RESTORE_PACKAGES nuget)
   add_dependencies(${ORTGENAI_COMPILE_TARGET} RESTORE_PACKAGES)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,12 +332,12 @@ if(USE_DML)
   set(PACKAGES_CONFIG ${PROJECT_SOURCE_DIR}/packages.config)
   find_program(NUGET_PATH NAMES nuget nuget.exe REQUIRED)
   set(NUGET_RESTORE_COMMAND
-    ${NUGET_PATH} restore
-    ${PACKAGES_CONFIG}
-    -PackagesDirectory ${PACKAGES_DIR}
+    "${NUGET_PATH}" restore
+    "${PACKAGES_CONFIG}"
+    -PackagesDirectory "${PACKAGES_DIR}"
   )
   if(NUGET_PACKAGE_SOURCE)
-    list(APPEND NUGET_RESTORE_COMMAND -Source ${NUGET_PACKAGE_SOURCE})
+    list(APPEND NUGET_RESTORE_COMMAND -Source "${NUGET_PACKAGE_SOURCE}")
   endif()
 
   add_custom_command(

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -66,17 +66,6 @@ if(USE_DML)
 
   onnxruntime_fetchcontent_makeavailable(directx_headers)
   set(DIRECTX_HEADERS_TARGET "DirectX-Headers")
-
-  include(ExternalProject)
-  ExternalProject_Add(nuget
-    PREFIX nuget
-    URL "https://dist.nuget.org/win-x86-commandline/v5.3.0/nuget.exe"
-    DOWNLOAD_NO_EXTRACT 1
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    UPDATE_COMMAND ""
-    INSTALL_COMMAND ""
-  )
 endif()
 
 

--- a/src/java/src/test/android/app/build.gradle
+++ b/src/java/src/test/android/app/build.gradle
@@ -31,6 +31,11 @@ android {
 	kotlinOptions {
 		jvmTarget = '1.8'
 	}
+	packagingOptions {
+		resources {
+			pickFirsts += 'META-INF/LICENSE-1DS'
+		}
+	}
 	namespace 'ai.onnxruntime.genai.example.javavalidator'
 }
 

--- a/tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_aarch64
+++ b/tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_aarch64
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 FROM onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cpu_aarch64_almalinux8_gcc14:20251017.1
 
 ADD scripts /tmp/scripts

--- a/tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_aarch64
+++ b/tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_aarch64
@@ -3,7 +3,7 @@
 FROM onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cpu_aarch64_almalinux8_gcc14:20251017.1
 
 ADD scripts /tmp/scripts
-RUN --mount=type=secret,id=pip_index_url \
+RUN --mount=type=secret,id=pip_index_url,required=true \
     export PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" && \
     cd /tmp/scripts && \
     /tmp/scripts/install_centos.sh && \

--- a/tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_aarch64
+++ b/tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_aarch64
@@ -1,7 +1,12 @@
 FROM onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cpu_aarch64_almalinux8_gcc14:20251017.1
 
 ADD scripts /tmp/scripts
-RUN cd /tmp/scripts && /tmp/scripts/install_centos.sh && /tmp/scripts/install_deps.sh && rm -rf /tmp/scripts
+RUN --mount=type=secret,id=pip_index_url \
+    export PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" && \
+    cd /tmp/scripts && \
+    /tmp/scripts/install_centos.sh && \
+    /tmp/scripts/install_deps.sh && \
+    rm -rf /tmp/scripts
 RUN yum update -y && yum install -y pkgconfig openssl-devel
 ENV PATH="/usr/.cargo/bin:$PATH"
 ENV RUSTUP_HOME="/usr/.rustup"


### PR DESCRIPTION
## Summary
- remove an unused CMake external project that downloaded a NuGet executable
- pass the configured Python package index into the ARM64 manylinux image build using a BuildKit secret
- keep package credentials out of Docker build arguments and image history
- correct a malformed-grid test fixture so it reaches the intended layout validation

## Testing
- `git diff --check`