### PR TITLE
Disable Phi-2 tests in CUDA CI

### DIFF
--- a/.github/workflows/linux-gpu-x64-build.yml
+++ b/.github/workflows/linux-gpu-x64-build.yml
@@ -141,7 +141,7 @@ jobs:
                 --cmake_extra_defines \
                   MANYLINUX=ON \
                   PYTHON_EXECUTABLE=${{ env.PYTHON_EXECUTABLE }} \
-                  TEST_PHI2=True \
+                  TEST_PHI2=False \
                   TEST_QWEN_2_5=True \
                   'CMAKE_CUDA_ARCHITECTURES=60-real;70-real;75-real;80-real;86-real;89-real;90-real;100-real;120' \
                   'CMAKE_EXE_LINKER_FLAGS_INIT=-Wl,-z,now' \

--- a/.github/workflows/win-cuda-x64-build.yml
+++ b/.github/workflows/win-cuda-x64-build.yml
@@ -120,7 +120,7 @@ jobs:
             --update --build `
             --skip_examples `
             --cmake_extra_defines `
-              TEST_PHI2=True `
+              TEST_PHI2=False `
               TEST_QWEN_2_5=True `
               CMAKE_CUDA_ARCHITECTURES=86-real `
               CMAKE_C_COMPILER_LAUNCHER=sccache `


### PR DESCRIPTION
Recent CI analysis found that the CUDA workflows enable Phi-2 tests on self-hosted GPU runners with limited memory. Linux CUDA had repeated failures in the native unit-test step after Phi-2 was enabled, while Windows CUDA was the least stable workflow overall but mostly failed from self-hosted runner loss before model execution.

This change disables the Phi-2 native test group in the Linux and Windows CUDA workflows. The smaller Qwen 2.5 0.5B tests remain enabled, along with the checked-in tiny CUDA graph-capture model tests, preserving CUDA model and graph coverage without requiring the larger Phi-2 model on 4 GB runners.

**Testing**

- Parsed both edited GitHub Actions workflow files with PyYAML.
- Ran `git diff origin/main...HEAD --check`.
- Ran `lintrunner -a` successfully.

**CI analysis**

- Windows CUDA: 46 failures in 77 `main` push runs over the last 90 days; most were runner/job failures outside model execution.
- Linux CUDA: 15 failures in 77 `main` push runs; 10 were in `Docker -- Run unit tests`, the step exercising the Phi-2-gated native tests.
