### PR TITLE
Fix engine_unit_tests segfault at process exit on CUDA builds

### DIFF
--- a/test/engine/engine_test_main.cpp
+++ b/test/engine/engine_test_main.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include "generators.h"
 #include "telemetry_test_environment.h"
 
 int main(int argc, char** argv) {
@@ -25,5 +26,9 @@ int main(int argc, char** argv) {
   Generators::test::SuppressTelemetryForTests();
 
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  const int result = RUN_ALL_TESTS();
+  // Tear genai down while ORT and CUDA are still alive. Left to the process-exit static
+  // destructor, releasing the CUDA trivial session faults inside the CUDA EP.
+  Generators::Shutdown();
+  return result;
 }


### PR DESCRIPTION
`engine_unit_tests` segfaults at process exit on a CUDA build. All 130 tests pass, then the
process dies with signal 11, so `ctest` reports:

```
5 - EngineUnitTests (SEGFAULT)
80% tests passed, 1 tests failed out of 5
```

## Root cause

`test/engine/engine_test_main.cpp` returns straight out of `RUN_ALL_TESTS()` and never calls
`Generators::Shutdown()`. Teardown is therefore left to the `EnsureShutdown` static destructor,
which runs from `__run_exit_handlers`. By that point ORT and CUDA static state is partially
finalized, and releasing the CUDA trivial session faults.

Backtrace:

```
__run_exit_handlers
  Generators::EnsureShutdown::~EnsureShutdown()
    Generators::Shutdown()
      Generators::OrtGlobals::~OrtGlobals()
        libonnxruntime.so                      (3 frames)
          libonnxruntime_providers_cuda.so     (6 frames)  <- SIGSEGV
```

The libraries are stripped, so I located the faulting statement by disassembling `~OrtGlobals`
around the return address. It lands in a loop over ten 32-byte entries starting at `this + 8`,
which is `for (auto& a : device_allocators_) a = {};` — ten entries matches `DeviceType::MAX`.
Reading the loop cursor at the fault gives entry index 1, i.e. `DeviceType::CUDA`. So the crash is
`ReleaseSession` on `device_allocators_[DeviceType::CUDA].session_`.

This is the same process-exit hazard `Shutdown()` already documents for `OrtEnv`, which it
deliberately leaks rather than destroy because releasing it from `__cxa_finalize` drives ORT's
`Environment`/`LoggingManager` destructor into a mutex whose backing static may already be
finalized. The env was guarded; the device sessions were not.

Every other binary that creates CUDA state already avoids this by shutting down while ORT is still
alive — `test/main.cpp` calls `OgaShutdown()` after `RUN_ALL_TESTS()`, as do `reinit_tests`,
`cuda_batched_sampler_tests`, and the Python binding. `engine_unit_tests` is the only CUDA-touching
binary that does not, which is why it is the only one that crashes.

## Reproducer

Before this change, any single Engine test plus any single CUDA test is enough:

```bash
./engine_unit_tests --gtest_filter=\
"EngineStepTest.SingleRequestSchedulesThenDecodesThenReturns:\
CudaSearchCheckpointTest.RollbackRestoresDoneEosAndLengthState"
# 2 tests pass, then: Segmentation fault (core dumped), exit 139
```

Either suite on its own exits 0. A CUDA device allocator has to exist for the faulting entry to be
populated, which is why the CUDA suite is required, and one Engine case is enough to complete the
combination. One pairing (`EngineStepTest.StepWithNoRequestsReturnsNull`) aborts with 134 instead
of 139 — the same finalized-static failure surfacing as the documented "mutex lock failed" abort.

## Fix

Call `Generators::Shutdown()` after `RUN_ALL_TESTS()`, matching the other native test binaries.

## Verification

Built and run on this branch (CUDA 13.0, H200):

| | before | after |
|---|---|---|
| `./engine_unit_tests` | 130 passed, exit 139 | 130 passed, **exit 0** |
| minimal 2-test reproducer | exit 139 | **exit 0** |
| `ctest` | 4/5, `EngineUnitTests (SEGFAULT)` | **5/5** |

I also tested one alternative first and am recording it so it is not retried: reordering
`~OrtGlobals` so `cuda_library_.reset()` happens after the `device_allocators_` release does **not**
help. The add-on library being unloaded is not what breaks the session release.

## Follow-up (not in this PR)

`Shutdown()` still releases device sessions and allocators on the `g_process_exiting` path, which is
unsafe for the same reason it already refuses to destroy the `OrtEnv` there. Hardening that branch to
also skip the device sessions would make the library robust for embedders that never call
`OgaShutdown()`, rather than relying on every caller to do so. That is a library change with wider
blast radius, so it is worth its own PR.
