### PR TITLE
Retry smaller plans after execution capacity failures

### DIFF
--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -402,7 +402,9 @@ Rollback performs both parts:
 1. Restore request search state and sampler state from their checkpoints.
 2. Release every block held by the paged-cache reservation.
 
-After a successful rollback, committed request state and committed cache state match the state before the step began. The caller receives an `EngineStepError` with either `RetryableBatchAbort` or `ExecutionCapacityExceeded`, and the engine remains healthy. Calling `Step()` again with unchanged memory availability and workload composition may produce the same capacity failure.
+After a successful rollback, committed request state and committed cache state match the state before the step began. For an execution-capacity failure that included prefill work, the Engine makes one internal attempt with fewer prefill tokens and requests. The retry uses a new transaction and does not change request configuration. If no smaller plan exists or the smaller attempt also exceeds capacity, the caller receives `ExecutionCapacityExceeded` and the engine remains healthy.
+
+Decode-only capacity failures, unrelated execution failures, validation failures, and rollback failures are not retried. The bounded retry applies only to execution-capacity failures that reach the Engine as typed exceptions; it cannot recover a process or device failure that prevents control from returning to the Engine.
 
 The model may have written data into reserved cache memory before the failure. Releasing the reservation is still safe because those blocks were never added to committed block tables. Future users of those blocks overwrite the relevant slots before treating them as valid cache contents.
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -19,6 +19,45 @@ std::string AddExceptionCause(std::string message, std::exception_ptr error) {
   return message;
 }
 
+std::optional<StepPlanningLimits> CreateCapacityRetryLimits(
+    const StepPlan& failed_plan) {
+  // Keep the token cap positive. A zero prefill cap is valid only when the failed
+  // plan has decode work that can form the complete retry plan.
+  size_t decode_token_count = 0;
+  size_t prefill_token_count = 0;
+  size_t prefill_request_count = 0;
+  for (const auto& entry : failed_plan.requests) {
+    if (entry.is_prefill) {
+      prefill_token_count += entry.unprocessed_token_count;
+      ++prefill_request_count;
+    } else {
+      decode_token_count += entry.unprocessed_token_count;
+    }
+  }
+
+  if (prefill_request_count == 0 || prefill_token_count == 0) {
+    return std::nullopt;
+  }
+
+  size_t retry_prefill_requests = prefill_request_count / 2;
+  if (retry_prefill_requests == 0 && decode_token_count == 0) {
+    retry_prefill_requests = 1;
+  }
+  const size_t retry_prefill_tokens =
+      retry_prefill_requests == 0
+          ? 0
+          : std::max<size_t>(1, prefill_token_count / 2);
+  if (retry_prefill_tokens == prefill_token_count &&
+      retry_prefill_requests == prefill_request_count) {
+    return std::nullopt;
+  }
+
+  return StepPlanningLimits{
+      decode_token_count + retry_prefill_tokens,
+      retry_prefill_requests,
+  };
+}
+
 }  // namespace
 
 Engine::Engine(std::shared_ptr<Model> model)
@@ -95,12 +134,16 @@ std::shared_ptr<Request> Engine::StepStatic() {
 }
 
 std::shared_ptr<Request> Engine::StepDynamic() {
+  bool capacity_retry_used = false;
+  bool capacity_retry_in_progress = false;
+  std::optional<StepPlanningLimits> planning_limits;
   while (scheduler_->HasPendingRequests()) {
     // A dynamic step is a transaction with six phases:
     // plan -> reserve cache -> checkpoint request state -> execute -> stage sampled tokens -> commit.
     // Nothing becomes externally visible until the final commit succeeds.
     step_plan_.transaction_id = next_transaction_id_++;
-    auto planning_result = scheduler_->PlanStep(step_plan_);
+    auto planning_result = scheduler_->PlanStep(
+        step_plan_, planning_limits.value_or(StepPlanningLimits{}));
     if (planning_result.capacity_deferred) {
       ++transaction_metrics_.capacity_deferrals;
     }
@@ -210,15 +253,31 @@ std::shared_ptr<Request> Engine::StepDynamic() {
     } catch (const ModelExecutionError& error) {
       const auto execution_error = std::current_exception();
       rollback_transaction();
-      if (error.FailureKind() == ExecutionFailureKind::RetryableAbort ||
-          error.FailureKind() == ExecutionFailureKind::CapacityExceeded) {
+      if (error.FailureKind() == ExecutionFailureKind::CapacityExceeded) {
+        ++transaction_metrics_.retryable_aborts;
+        if (!capacity_retry_used) {
+          if (auto retry_limits = CreateCapacityRetryLimits(step_plan_)) {
+            planning_limits = *retry_limits;
+            capacity_retry_used = true;
+            capacity_retry_in_progress = true;
+            ++transaction_metrics_.capacity_retry_attempts;
+            continue;
+          }
+          ++transaction_metrics_.capacity_no_retry_plan;
+        } else {
+          ++transaction_metrics_.capacity_retry_exhausted;
+        }
+        throw EngineStepError{
+            {StepOutcomeKind::ExecutionCapacityExceeded,
+             step_plan_.transaction_id, nullptr},
+            error.what(),
+        };
+      }
+      if (error.FailureKind() == ExecutionFailureKind::RetryableAbort) {
         ++transaction_metrics_.retryable_aborts;
         throw EngineStepError{
-            {error.FailureKind() == ExecutionFailureKind::CapacityExceeded
-                 ? StepOutcomeKind::ExecutionCapacityExceeded
-                 : StepOutcomeKind::RetryableBatchAbort,
-             step_plan_.transaction_id,
-             nullptr},
+            {StepOutcomeKind::RetryableBatchAbort,
+             step_plan_.transaction_id, nullptr},
             error.what(),
         };
       }
@@ -290,6 +349,11 @@ std::shared_ptr<Request> Engine::StepDynamic() {
     ready_requests_.swap(staged_ready_requests_);
     ready_request_index_ = 0;
     ++transaction_metrics_.committed_steps;
+    if (capacity_retry_in_progress) {
+      ++transaction_metrics_.capacity_retry_commits;
+      capacity_retry_in_progress = false;
+      planning_limits.reset();
+    }
     if (auto request = DrainReadyRequest()) {
       return request;
     }

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -45,6 +45,10 @@ struct EngineTransactionMetrics {
   uint64_t reservation_failures{};
   uint64_t rollbacks{};
   uint64_t retryable_aborts{};
+  uint64_t capacity_retry_attempts{};
+  uint64_t capacity_retry_commits{};
+  uint64_t capacity_retry_exhausted{};
+  uint64_t capacity_no_retry_plan{};
   uint64_t post_processing_aborts{};
   uint64_t fatal_execution_failures{};
 };

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -144,7 +144,8 @@ void DynamicBatchScheduler::ReapCompletedRequests() {
   }
 }
 
-StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
+StepPlanningResult DynamicBatchScheduler::PlanStep(
+    StepPlan& plan, const StepPlanningLimits& limits) {
   // Completed requests release their blocks before admission, making that capacity available to
   // requests waiting in Assigned state during this same planning pass.
   ReapCompletedRequests();
@@ -213,19 +214,59 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
   for (const auto& candidate : candidates)
     budget_candidates.push_back(candidate.budget);
   const auto order = DecodeFirstCandidateOrder(budget_candidates);
+  const auto& dynamic_batching = *model_->config_->engine.dynamic_batching;
+  const size_t max_scheduled_tokens = std::min(
+      dynamic_batching.max_scheduled_tokens,
+      limits.max_scheduled_tokens.value_or(
+          dynamic_batching.max_scheduled_tokens));
+  const size_t max_prefill_requests = std::min(
+      dynamic_batching.max_batch_size,
+      limits.max_prefill_requests.value_or(
+          dynamic_batching.max_batch_size));
+  if (max_scheduled_tokens == 0) {
+    throw std::invalid_argument("The step token limit must be positive.");
+  }
+  const bool has_decode_candidate = std::any_of(
+      candidates.begin(), candidates.end(),
+      [](const Candidate& candidate) {
+        return !candidate.budget.is_prefill;
+      });
+  if (max_prefill_requests == 0 && !has_decode_candidate) {
+    throw std::invalid_argument(
+        "A zero prefill limit requires runnable decode work.");
+  }
+
   plan.requests.reserve(candidates.size());
   for (size_t candidate_index : order) {
     plan.requests.push_back(candidates[candidate_index].entry);
   }
 
-  const auto& dynamic_batching = *model_->config_->engine.dynamic_batching;
   plan.scheduled_request_limit = DecodeFirstProvisionalRequestLimit(
-      dynamic_batching.max_scheduled_tokens,
+      max_scheduled_tokens,
       dynamic_batching.max_batch_size);
 
   auto result = cache_manager_->PlanStepResources(plan);
   if (!result.executable) {
     return result;
+  }
+
+  size_t selected_prefill_requests = 0;
+  const auto first_deferred = std::remove_if(
+      plan.requests.begin(), plan.requests.end(),
+      [&selected_prefill_requests,
+       max_prefill_requests](const RequestStepPlan& entry) {
+        if (!entry.is_prefill) {
+          return false;
+        }
+        if (selected_prefill_requests < max_prefill_requests) {
+          ++selected_prefill_requests;
+          return false;
+        }
+        return true;
+      });
+  if (first_deferred != plan.requests.end()) {
+    plan.requests.erase(first_deferred, plan.requests.end());
+    result.capacity_deferred = true;
   }
 
   std::vector<DecodeFirstBudgetCandidate> selected_candidates;
@@ -241,7 +282,7 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     selected_candidates.push_back(candidate->budget);
   }
   const auto token_counts = AllocateDecodeFirstTokenBudget(
-      selected_candidates, dynamic_batching.max_scheduled_tokens);
+      selected_candidates, max_scheduled_tokens);
 
   // VarlenDecoderIO concatenates every request's pending tokens into one flat input. These offsets
   // describe that packed layout and identify the last logits row for each request, which is the row

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -268,6 +268,17 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(
     plan.requests.erase(first_deferred, plan.requests.end());
     result.capacity_deferred = true;
   }
+  if (plan.requests.empty()) {
+    result.executable = false;
+    result.outcome = {
+        result.unserviceable_request_id
+            ? StepOutcomeKind::UnserviceableRequest
+            : StepOutcomeKind::CapacityDeferred,
+        plan.transaction_id,
+        result.unserviceable_request_id,
+    };
+    return result;
+  }
 
   std::vector<DecodeFirstBudgetCandidate> selected_candidates;
   selected_candidates.reserve(plan.requests.size());

--- a/src/engine/scheduler.h
+++ b/src/engine/scheduler.h
@@ -52,7 +52,8 @@ struct Scheduler {
    */
   virtual ScheduledRequests Schedule() = 0;
 
-  virtual StepPlanningResult PlanStep(StepPlan&) {
+  virtual StepPlanningResult PlanStep(
+      StepPlan&, const StepPlanningLimits& = {}) {
     throw std::logic_error("Scheduler does not support transactional step planning.");
   }
 
@@ -106,7 +107,8 @@ struct DynamicBatchScheduler : Scheduler {
 
   ScheduledRequests Schedule() override;
 
-  StepPlanningResult PlanStep(StepPlan& plan) override;
+  StepPlanningResult PlanStep(
+      StepPlan& plan, const StepPlanningLimits& limits = {}) override;
 
   bool HasPendingRequests() const override;
 

--- a/src/engine/step_plan.h
+++ b/src/engine/step_plan.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -45,6 +46,11 @@ struct StepPlanningResult {
   bool capacity_deferred{};
   const void* unserviceable_request_id{};
   StepOutcome outcome;
+};
+
+struct StepPlanningLimits {
+  std::optional<size_t> max_scheduled_tokens;  // Temporary cap for this planning attempt.
+  std::optional<size_t> max_prefill_requests;  // Decodes do not consume this row cap.
 };
 
 struct RequestStepPlan {

--- a/test/engine/engine_step_tests.cpp
+++ b/test/engine/engine_step_tests.cpp
@@ -207,34 +207,212 @@ TEST_F(EngineStepTest, RetryableExecutionFailureRollsBackAndCanRetry) {
   EXPECT_TRUE(request->IsDone());
 }
 
-TEST_F(EngineStepTest, ExecutionCapacityFailureRollsBackWithoutPoisoningEngine) {
+TEST_F(EngineStepTest, ExecutionCapacityFailureRetriesSmallerPlan) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
-  auto prompt = Prompt(10);
-  auto request = MintRequest(*model_, prompt);
-  engine.engine->AddRequest(request);
-  const auto before = request->Snapshot();
+  std::vector<std::shared_ptr<Request>> requests;
+  for (int32_t seed : {10, 20, 30, 40}) {
+    auto prompt = Prompt(seed);
+    auto request = MintRequest(*model_, prompt);
+    engine.engine->AddRequest(request);
+    requests.push_back(request);
+  }
   engine.executor->SetNextFailure(ScriptedExecutionFailure::CapacityExceeded);
+
+  auto ready = engine.engine->Step();
+
+  EXPECT_EQ(ready, requests[0]);
+  ASSERT_EQ(engine.executor->decoded_batch_sizes,
+            (std::vector<size_t>{4, 2}));
+  ASSERT_EQ(engine.executor->decoded_token_counts,
+            (std::vector<size_t>{12, 6}));
+  ASSERT_EQ(engine.executor->decoded_transaction_ids.size(), 2u);
+  EXPECT_NE(engine.executor->decoded_transaction_ids[0],
+            engine.executor->decoded_transaction_ids[1]);
+  EXPECT_EQ(engine.cache->AllocatedCount(), 2u);
+  EXPECT_TRUE(requests[0]->IsDone());
+  EXPECT_TRUE(requests[1]->IsDone());
+  EXPECT_EQ(requests[2]->status_, RequestStatus::Assigned);
+  EXPECT_EQ(requests[3]->status_, RequestStatus::Assigned);
+  EXPECT_TRUE(engine.engine->HasPendingRequests());
+}
+
+TEST_F(EngineStepTest, ExhaustedCapacityRetryPreservesStateAndEngineHealth) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  std::vector<std::shared_ptr<Request>> requests;
+  std::vector<RequestStateSnapshot> before;
+  for (int32_t seed : {10, 20, 30, 40}) {
+    auto prompt = Prompt(seed);
+    auto request = MintRequest(*model_, prompt);
+    engine.engine->AddRequest(request);
+    requests.push_back(request);
+    before.push_back(request->Snapshot());
+  }
+  engine.executor->SetFailures({
+      ScriptedExecutionFailure::CapacityExceeded,
+      ScriptedExecutionFailure::CapacityExceeded,
+  });
 
   try {
     static_cast<void>(engine.engine->Step());
-    FAIL() << "Expected execution capacity failure.";
+    FAIL() << "Expected the smaller capacity retry to fail.";
   } catch (const EngineStepError& error) {
     EXPECT_EQ(error.Outcome().kind,
               StepOutcomeKind::ExecutionCapacityExceeded);
   }
 
-  const auto rolled_back = request->Snapshot();
-  EXPECT_EQ(rolled_back.status, before.status);
-  EXPECT_EQ(rolled_back.current_sequence_length,
-            before.current_sequence_length);
-  EXPECT_EQ(rolled_back.processed_sequence_length,
-            before.processed_sequence_length);
+  ASSERT_EQ(engine.executor->decoded_batch_sizes,
+            (std::vector<size_t>{4, 2}));
   EXPECT_EQ(engine.cache->AllocatedCount(), 0u);
+  for (size_t i = 0; i < requests.size(); ++i) {
+    const auto after = requests[i]->Snapshot();
+    EXPECT_EQ(after.status, before[i].status);
+    EXPECT_EQ(after.current_sequence_length,
+              before[i].current_sequence_length);
+    EXPECT_EQ(after.processed_sequence_length,
+              before[i].processed_sequence_length);
+  }
   EXPECT_TRUE(engine.engine->HasPendingRequests());
 
-  auto ready = engine.engine->Step();
-  EXPECT_EQ(ready, request);
+  EXPECT_EQ(engine.engine->Step(), requests[0]);
+  EXPECT_TRUE(requests[0]->IsDone());
+}
+
+TEST_F(EngineStepTest, CapacityRetryIsUsedOnlyOnceAcrossInternalCycles) {
+  auto engine =
+      MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  auto prompt = Prompt(10);
+  auto request = MintRequest(*model_, prompt);
+  engine.engine->AddRequest(request);
+  engine.executor->SetFailures({
+      ScriptedExecutionFailure::CapacityExceeded,
+      ScriptedExecutionFailure::None,
+      ScriptedExecutionFailure::CapacityExceeded,
+  });
+
+  try {
+    static_cast<void>(engine.engine->Step());
+    FAIL() << "Expected the later capacity failure to be surfaced.";
+  } catch (const EngineStepError& error) {
+    EXPECT_EQ(error.Outcome().kind,
+              StepOutcomeKind::ExecutionCapacityExceeded);
+  }
+
+  EXPECT_EQ(engine.executor->decoded_token_counts,
+            (std::vector<size_t>{3, 1, 2}));
+  EXPECT_EQ(request->ProcessedSequenceLength(), 1);
+  EXPECT_TRUE(request->IsPrefill());
+  EXPECT_EQ(engine.cache->AllocatedCount(), 1u);
+
+  EXPECT_EQ(engine.engine->Step(), request);
   EXPECT_TRUE(request->IsDone());
+}
+
+TEST_F(EngineStepTest, DecodeOnlyCapacityFailureIsNotRetried) {
+  auto engine =
+      MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
+  auto prompt = Prompt(10);
+  auto request = MintRequest(*model_, prompt);
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  ASSERT_FALSE(request->IsPrefill());
+  const int calls_before_failure = engine.executor->decode_calls;
+  engine.executor->SetNextFailure(ScriptedExecutionFailure::CapacityExceeded);
+
+  try {
+    static_cast<void>(engine.engine->Step());
+    FAIL() << "Expected decode execution capacity failure.";
+  } catch (const EngineStepError& error) {
+    EXPECT_EQ(error.Outcome().kind,
+              StepOutcomeKind::ExecutionCapacityExceeded);
+  }
+
+  EXPECT_EQ(engine.executor->decode_calls, calls_before_failure + 1);
+  EXPECT_EQ(engine.engine->Step(), request);
+}
+
+TEST_F(EngineStepTest, CapacityRetryPreservesDecodeAndDropsFinalPrefill) {
+  model_->config_->engine.dynamic_batching->max_scheduled_tokens = 2;
+  auto engine =
+      MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
+  auto decode_prompt = Prompt(10);
+  auto decode = MintRequest(*model_, decode_prompt);
+  engine.engine->AddRequest(decode);
+  ASSERT_EQ(engine.engine->Step(), decode);
+  ASSERT_FALSE(decode->IsPrefill());
+  const size_t calls_before_failure =
+      engine.executor->decoded_batch_sizes.size();
+
+  const std::array<int32_t, 1> prefill_prompt{2};
+  auto prefill = MintRequest(*model_, prefill_prompt);
+  engine.engine->AddRequest(prefill);
+  engine.executor->SetNextFailure(ScriptedExecutionFailure::CapacityExceeded);
+
+  EXPECT_EQ(engine.engine->Step(), decode);
+
+  ASSERT_EQ(engine.executor->decoded_batch_sizes.size(),
+            calls_before_failure + 2);
+  EXPECT_EQ(engine.executor->decoded_batch_sizes[calls_before_failure], 2u);
+  EXPECT_EQ(engine.executor->decoded_batch_sizes[calls_before_failure + 1], 1u);
+  ASSERT_EQ(engine.executor->decoded_token_counts.size(),
+            calls_before_failure + 2);
+  EXPECT_EQ(engine.executor->decoded_token_counts[calls_before_failure], 2u);
+  EXPECT_EQ(engine.executor->decoded_token_counts[calls_before_failure + 1],
+            1u);
+  ASSERT_EQ(
+      engine.executor->decoded_request_ids[calls_before_failure + 1].size(),
+      1u);
+  EXPECT_EQ(
+      engine.executor->decoded_request_ids[calls_before_failure + 1][0],
+      decode.get());
+  EXPECT_EQ(prefill->status_, RequestStatus::Assigned);
+}
+
+TEST_F(EngineStepTest, FailedDecodeOnlyRetryPreservesMixedBatchState) {
+  model_->config_->engine.dynamic_batching->max_scheduled_tokens = 2;
+  auto engine =
+      MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
+  auto decode_prompt = Prompt(10);
+  auto decode = MintRequest(*model_, decode_prompt);
+  engine.engine->AddRequest(decode);
+  ASSERT_EQ(engine.engine->Step(), decode);
+  ASSERT_FALSE(decode->IsPrefill());
+
+  const std::array<int32_t, 1> prefill_prompt{2};
+  auto prefill = MintRequest(*model_, prefill_prompt);
+  engine.engine->AddRequest(prefill);
+  const auto decode_before = decode->Snapshot();
+  const auto prefill_before = prefill->Snapshot();
+  const size_t calls_before_failure =
+      engine.executor->decoded_batch_sizes.size();
+  engine.executor->SetFailures({
+      ScriptedExecutionFailure::CapacityExceeded,
+      ScriptedExecutionFailure::CapacityExceeded,
+  });
+
+  try {
+    static_cast<void>(engine.engine->Step());
+    FAIL() << "Expected the decode-only retry to fail.";
+  } catch (const EngineStepError& error) {
+    EXPECT_EQ(error.Outcome().kind,
+              StepOutcomeKind::ExecutionCapacityExceeded);
+  }
+
+  ASSERT_EQ(engine.executor->decoded_batch_sizes.size(),
+            calls_before_failure + 2);
+  EXPECT_EQ(engine.executor->decoded_batch_sizes[calls_before_failure], 2u);
+  EXPECT_EQ(engine.executor->decoded_batch_sizes[calls_before_failure + 1], 1u);
+  const auto decode_after = decode->Snapshot();
+  const auto prefill_after = prefill->Snapshot();
+  EXPECT_EQ(decode_after.current_sequence_length,
+            decode_before.current_sequence_length);
+  EXPECT_EQ(decode_after.processed_sequence_length,
+            decode_before.processed_sequence_length);
+  EXPECT_EQ(prefill_after.status, prefill_before.status);
+  EXPECT_EQ(prefill_after.processed_sequence_length,
+            prefill_before.processed_sequence_length);
+  EXPECT_EQ(engine.cache->AllocatedCount(), 1u);
+
+  EXPECT_EQ(engine.engine->Step(), decode);
 }
 
 TEST_F(EngineStepTest, PostProcessingFailureRestoresSearchAndCanRetry) {

--- a/test/engine/engine_test_doubles.h
+++ b/test/engine/engine_test_doubles.h
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <deque>
 #include <memory>
 #include <string>
 #include <utility>
@@ -287,9 +288,14 @@ struct RecordingModelExecutor : ModelExecutor {
       for (const auto& entry : context.plan->requests)
         request_ids.push_back(entry.request_id);
       decoded_request_ids.push_back(std::move(request_ids));
+      decoded_transaction_ids.push_back(context.plan->transaction_id);
     }
     if (trace_) trace_->Record("Decode");
-    const auto failure = std::exchange(next_failure_, ScriptedExecutionFailure::None);
+    ScriptedExecutionFailure failure = ScriptedExecutionFailure::None;
+    if (!failures_.empty()) {
+      failure = failures_.front();
+      failures_.pop_front();
+    }
     if (failure == ScriptedExecutionFailure::RetryableBeforeExecution) {
       throw ModelExecutionError{ExecutionFailureKind::RetryableAbort,
                                 "Injected retryable execution failure."};
@@ -312,19 +318,27 @@ struct RecordingModelExecutor : ModelExecutor {
     static_cast<void>(context);
   }
 
-  void SetNextFailure(ScriptedExecutionFailure failure) { next_failure_ = failure; }
+  void SetNextFailure(ScriptedExecutionFailure failure) {
+    failures_ = {failure};
+  }
+
+  void SetFailures(
+      std::initializer_list<ScriptedExecutionFailure> failures) {
+    failures_ = failures;
+  }
 
   int decode_calls{0};
   std::vector<size_t> decoded_batch_sizes;
   std::vector<size_t> decoded_token_counts;
   std::vector<std::vector<const void*>> decoded_request_ids;
+  std::vector<StepTransactionId> decoded_transaction_ids;
 
  private:
   std::shared_ptr<Model> model_;
   std::shared_ptr<CacheManager> cache_manager_;
   int32_t forced_token_;
   std::shared_ptr<CallTrace> trace_;
-  ScriptedExecutionFailure next_failure_{ScriptedExecutionFailure::None};
+  std::deque<ScriptedExecutionFailure> failures_;
 };
 
 // An Engine wired with the recording doubles above, together with non-owning observers of those

--- a/test/engine/scheduler_contract_tests.cpp
+++ b/test/engine/scheduler_contract_tests.cpp
@@ -121,6 +121,52 @@ TEST_F(SchedulerContractTest, DynamicPreservesRequestOrder) {
   EXPECT_EQ(plan.requests[2].request, third);
 }
 
+TEST_F(SchedulerContractTest, DynamicHonorsTemporaryPlanningLimits) {
+  auto cache = std::make_shared<RecordingCacheManager>(model_, /*capacity=*/8);
+  DynamicBatchScheduler scheduler(model_, cache);
+
+  const std::vector<int32_t> long_prompt{2, 3, 4, 5, 6};
+  auto first = MintAssignedRequest(
+      assign_target_, *model_, long_prompt);
+  auto second = MintAssignedRequest(
+      assign_target_, *model_, long_prompt);
+  scheduler.AddRequest(first);
+  scheduler.AddRequest(second);
+  StepPlan plan;
+
+  const auto result = scheduler.PlanStep(
+      plan, StepPlanningLimits{/*max_scheduled_tokens=*/4,
+                               /*max_prefill_requests=*/1});
+
+  ASSERT_TRUE(result.executable);
+  EXPECT_TRUE(result.capacity_deferred);
+  ASSERT_EQ(plan.requests.size(), 1u);
+  EXPECT_EQ(plan.requests[0].request, first);
+  EXPECT_EQ(plan.requests[0].unprocessed_token_count, 4u);
+  EXPECT_EQ(plan.token_count, 4u);
+}
+
+TEST_F(SchedulerContractTest, TemporaryPrefillLimitKeepsLaterFittingRequest) {
+  auto cache = std::make_shared<RecordingCacheManager>(model_, /*capacity=*/8);
+  DynamicBatchScheduler scheduler(model_, cache);
+
+  auto blocked = Assigned(10);
+  auto fitting = Assigned(20);
+  scheduler.AddRequest(blocked);
+  scheduler.AddRequest(fitting);
+  cache->SetCapacityDeferredRequest(blocked);
+  StepPlan plan;
+
+  const auto result = scheduler.PlanStep(
+      plan, StepPlanningLimits{/*max_scheduled_tokens=*/2,
+                               /*max_prefill_requests=*/1});
+
+  ASSERT_TRUE(result.executable);
+  EXPECT_TRUE(result.capacity_deferred);
+  ASSERT_EQ(plan.requests.size(), 1u);
+  EXPECT_EQ(plan.requests[0].request, fitting);
+}
+
 TEST_F(SchedulerContractTest, DynamicHonorsCapacityBackpressure) {
   auto cache = std::make_shared<RecordingCacheManager>(model_, /*capacity=*/2);
   DynamicBatchScheduler scheduler(model_, cache);

--- a/test/engine/scheduler_contract_tests.cpp
+++ b/test/engine/scheduler_contract_tests.cpp
@@ -167,6 +167,27 @@ TEST_F(SchedulerContractTest, TemporaryPrefillLimitKeepsLaterFittingRequest) {
   EXPECT_EQ(plan.requests[0].request, fitting);
 }
 
+TEST_F(SchedulerContractTest, ZeroPrefillLimitDefersEmptyPlan) {
+  auto cache = std::make_shared<RecordingCacheManager>(model_, /*capacity=*/8);
+  DynamicBatchScheduler scheduler(model_, cache);
+
+  auto decode = Assigned(10);
+  MakeDecodeResident(scheduler, *cache, decode);
+  auto prefill = Assigned(20);
+  scheduler.AddRequest(prefill);
+  cache->SetCapacityDeferredRequest(decode);
+  StepPlan plan;
+
+  const auto result = scheduler.PlanStep(
+      plan, StepPlanningLimits{/*max_scheduled_tokens=*/1,
+                               /*max_prefill_requests=*/0});
+
+  EXPECT_FALSE(result.executable);
+  EXPECT_TRUE(result.capacity_deferred);
+  EXPECT_EQ(result.outcome.kind, StepOutcomeKind::CapacityDeferred);
+  EXPECT_TRUE(plan.requests.empty());
+}
+
 TEST_F(SchedulerContractTest, DynamicHonorsCapacityBackpressure) {
   auto cache = std::make_shared<RecordingCacheManager>(model_, /*capacity=*/2);
   DynamicBatchScheduler scheduler(model_, cache);


### PR DESCRIPTION
## Summary

- Retry one smaller plan after a typed execution-capacity failure.
- Fully roll back before replanning with a new transaction ID.
- Reduce prefill tokens and rows while preserving decode work where possible.
- Surface the failure without poisoning the Engine if no smaller plan succeeds.

## Code flow

```text
Engine::Step()
    |
    v
Plan and reserve work
    |
    v
Execute model
    |
    +---------------- Success ----------------+
    |                                         |
    |                                         v
    |                                Stage and commit results
    |
    +--- ExecutionCapacityExceeded
                  |
                  v
          Roll back transaction
                  |
                  v
          Smaller plan available?
             /           \
           no             yes
           |               |
           v               v
     Surface error    Apply temporary limits
                           |
                           v
                    Plan new transaction
                           |
                           v
                    Execute one retry
                       /         \
                  success         failure
                     |               |
                     v               v
                   Commit       Surface error
```

The retry is limited to one attempt and applies only to typed capacity failures containing prefill work. Decode-only and unrelated failures are not retried.

