### PR TITLE
Add recompute preemption to the continuous-batching engine

### DIFF
--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -17,6 +17,7 @@ The main implementation is under `src/engine/`:
 | Top-level orchestration and transaction handling | `engine.h`, `engine.cpp` |
 | Request lifecycle and per-request search state | `request.h`, `request.cpp` |
 | Batch planning and request admission | `scheduler.h`, `scheduler.cpp`, `decode_first_scheduler_policy.*` |
+| Recompute preemption policy | `recompute_preemption_policy.h`, `recompute_preemption_policy.cpp` |
 | KV-cache capacity planning and ownership | `cache_manager.h`, `cache_manager.cpp`, `paged_key_value_cache.h`, `paged_key_value_cache.cpp` |
 | Speculative cache reservation | `paged_cache_reservation.h`, `paged_cache_reservation.cpp` |
 | Packed model inputs and logits selection | `decoders/varlen_decoder_io.h`, `decoders/varlen_decoder_io.cpp` |
@@ -77,6 +78,8 @@ Dynamic batching limits scheduled rows with `max_batch_size` and limits the tota
 query tokens in one model run with `max_scheduled_tokens`. The token limit defaults
 to 2048. Both limits are positive and independent.
 
+Recompute preemption is configured by four further `engine.dynamic_batching` values and is off by default; see [Recompute preemption](#recompute-preemption).
+
 Without dynamic batching, the engine uses the older static batching path. Static batching allocates and advances a batch as a unit. It does not use the transaction flow described below.
 
 ## Request lifecycle
@@ -93,7 +96,10 @@ The important request states are:
 
 ```text
 Unassigned -> Assigned -> InProgress -> Completed
-     ^           |            |            |
+     ^           |            |  ^         |
+     |           |            v  |         |
+     |           |        Suspended        |
+     |           |            |            |
      +-----------+------------+------------+
                   Remove()
 ```
@@ -112,11 +118,17 @@ Assignment moves the prompt into the request's `Search`, creates the host-side t
 
 The request has completed at least one committed engine transaction and belongs to the active engine workload. It normally has one unprocessed token at the beginning of a decode step: the token sampled by the previous step.
 
+### `Suspended`
+
+The request was resident and was preempted to reclaim its paged-cache blocks. It keeps its complete logical token sequence, its `Search` and sampler state, the tokens the application has already seen, and its generation limits, but it owns no cache blocks and its processed cursor is back at the beginning of the sequence.
+
+A suspended request waits in the scheduler pool alongside `Assigned` requests and is re-admitted the same way. Its whole sequence is prefill work again, so the ordinary chunked-prefill path rebuilds its key-value entries before it decodes. `AddTokens()` is rejected while suspended, exactly as it is while `InProgress`.
+
 ### `Completed`
 
 The search has reached an end condition, such as an EOS token or maximum length. The request can be returned to the caller immediately, but its cache blocks are normally reclaimed by `DynamicBatchScheduler::ReapCompletedRequests()` at the beginning of the next planning pass.
 
-`Remove()` is legal from `Assigned`, `InProgress`, and `Completed`, and returns the request to `Unassigned`. On the dynamic path, removal immediately erases scheduler membership and releases committed paged-cache ownership.
+`Remove()` is legal from `Assigned`, `InProgress`, `Suspended`, and `Completed`, and returns the request to `Unassigned`. On the dynamic path, removal immediately erases scheduler membership and releases committed paged-cache ownership; a suspended request already owns none.
 
 This removal does not purge an entry already placed in `Engine::ready_requests_`. Because `Engine::Step()` drains that queue before scheduling new work, a removed request that was already ready can still be returned by a later `Step()` call.
 
@@ -191,7 +203,7 @@ Completed requests that still own paged-cache blocks are deallocated and removed
 
 The scheduler snapshots all requests that already belong to the paged cache. These requests are expected to be `InProgress`.
 
-It then snapshots waiting requests from the scheduler pool. These requests are expected to be `Assigned` and are marked as newly admitted candidates.
+It then snapshots waiting requests from the scheduler pool. These requests are expected to be `Assigned` or `Suspended` and are marked as newly admitted candidates. Both own no cache blocks, so they are admitted the same way; a suspended request differs only in that its sequence already contains generated tokens.
 
 The scheduler orders candidates with decodes first. Order remains stable among
 decodes and among prefills. Each candidate initially contributes one provisional
@@ -241,6 +253,8 @@ The planner distinguishes temporary capacity pressure from a request that can ne
 
 - `CapacityDeferred` means the request could run later if capacity becomes available.
 - `UnserviceableRequest` means the request would exceed the total cache or supported block-table width even if the cache were otherwise empty.
+
+The planner also reports, separately for waiting requests and for residents, the first request it deferred *only* because the block pool was short of free blocks, together with how many more blocks that request needs. Row limits and residency limits are excluded from that report, because returning blocks to the pool does not relieve either of them. `Engine` does not use these values; the scheduler uses them to decide whether recompute preemption would unblock anything.
 
 If at least one request fits, the step is executable even when other requests were deferred or found unserviceable. This allows useful work to continue instead of letting one request block the whole engine.
 
@@ -457,7 +471,9 @@ A request's `PagedCacheBlockTable` owns these blocks. The table records:
 - The number of slots containing committed tokens.
 - The ordered physical blocks used by the request.
 
-Every physical block must be in exactly one of these states. The invariant helpers under `engine_invariants.*` validate total accounting, single ownership, valid block identifiers, reservation accounting, and consistency between request progress and cache progress.
+Every physical block must be in exactly one of these states. The invariant helpers under `engine_invariants.*` validate total accounting, single ownership, valid block identifiers, reservation accounting, consistency between request progress and cache progress, and that a suspended request owns nothing.
+
+`PagedKeyValueCache::Reclaim()` is the single way a request's committed ownership is released without the request leaving the engine. `Remove()` is implemented in terms of it, and `PagedCacheManager::ReclaimRequestCache()` exposes it through the `CacheManager` interface so the scheduler never reaches into the cache's block tables directly.
 
 ## Prefill, decode, and mixed batches
 
@@ -528,9 +544,84 @@ The current ordering policy is:
 2. Consider prefills afterward, preserving resident order and then scheduler-pool order.
 3. Give every feasible selected row one token before expanding selected prefills in stable order.
 
-Requests skipped because of token, row, or temporary cache capacity remain pending for a later step. Phase 1 does not rotate service or promote waiting prefills, so sustained decode demand can starve prefill work.
+Requests skipped because of token, row, or temporary cache capacity remain pending for a later step. The ordering policy does not rotate service or promote waiting prefills, so sustained decode demand can starve prefill work unless recompute preemption is enabled.
 
 If no request can run because of temporary capacity, `StepDynamic()` reports `CapacityDeferred` instead of returning `nullptr`. Returning `nullptr` would incorrectly tell the caller that no work remains.
+
+## Recompute preemption
+
+Recompute preemption lets the scheduler take a resident request's paged-cache blocks back so a request that free blocks alone are holding up can run. The victim is suspended rather than dropped: it keeps everything except its cache residency and rebuilds its key-value entries later through the ordinary chunked-prefill path. Nothing is swapped to host memory or disk.
+
+It is off by default. When `engine.dynamic_batching.enable_recompute_preemption` is absent or false the engine behaves exactly as it did before: a blocked request waits.
+
+### Configuration
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `enable_recompute_preemption` | `false` | Turns the whole mechanism on |
+| `max_preemptions_per_step` | `1` | Victims one planning pass may suspend |
+| `max_preemptions_per_request` | `0` (unbounded) | Suspensions one request may accumulate |
+| `min_decode_steps_before_preemption` | `8` | Committed decode steps a resident earns before it can be suspended again |
+
+Enabling preemption with a cache manager that cannot release one request's blocks independently of the batch, or on the static batching path, is rejected at construction. There is no silent fallback that reports a preemption that did not happen.
+
+### When it triggers
+
+Preemption runs during planning, after the first planning attempt, and only in two situations:
+
+- A resident cannot grow, no other request can run, and the step would otherwise report `CapacityDeferred`. Suspending another resident keeps the engine making progress instead of stalling.
+- No resident is short of blocks, and a waiting request was deferred only because the block pool is short of free blocks. This is the head-of-line case the feature exists for: short requests arriving behind long residents.
+
+A starved resident is considered before any waiting request, so it would take the reclaimed blocks first. When one exists and the step can still run other work, nothing is preempted: capacity that cannot reach the waiting request is not worth a resident's committed key-value entries. Row limits and residency limits are left alone for the same reason, and a resident is never its own victim.
+
+The pass that preempts admits at most one more request than the attempt before it did. Without that cap, surplus reclaimed capacity could pull in several waiting requests and push the victim further back in the queue for blocks it released itself.
+
+Admission remains first-come-first-served, so the reclaimed capacity is guaranteed to reach blocked work but not necessarily the exact request whose shortfall was measured: an earlier waiting request held back by the residency limit can take it once the victim leaves the cache.
+
+### Choosing a victim
+
+`SelectRecomputeVictims()` in `recompute_preemption_policy.*` takes plain counters, so the policy is unit-testable without a model or a cache. A resident is a candidate when it is `InProgress`, past prefill, owns at least one block, has not reached `max_preemptions_per_request`, has committed at least `min_decode_steps_before_preemption` decode steps since it was admitted, and its committed cache slots agree with its committed sequence length.
+
+Every one of those conditions derives from counters that only a committed transaction advances, so a resident never becomes a victim on the strength of work that has not committed. The last one is a consistency gate: a resident whose cache and sequence already disagree is left alone so the invariant checks report the disagreement instead of the scheduler rewinding on bad accounting.
+
+Candidates are ordered by:
+
+1. Fewest previous preemptions first, so no request is suspended twice while a resident that has never been suspended still holds capacity. This is what bounds unfairness between requests.
+2. Latest resident position first, preserving the accumulated work of the requests that have been resident longest.
+
+Victims are taken in that order until their combined blocks cover the shortfall, bounded by `max_preemptions_per_step`. If the eligible candidates within that bound cannot cover the shortfall, nothing is preempted: discarding committed key-value entries without unblocking anything is the churn the policy exists to avoid.
+
+### What suspension changes
+
+For the victim, in this order:
+
+1. `CacheManager::ReclaimRequestCache()` releases every block table the cache holds for the request and reports the blocks and slots that returned to the pool. Doing this first means a pool that rejects the release leaves the request untouched. The scheduler then checks the released slot count against the request's committed sequence length, so a cache and a request that disagree fail loudly instead of diverging.
+2. `Request::SuspendForRecompute()` moves the processed cursor to zero, marks the whole current sequence as prefill work, resets the request's decode-step credit, increments its preemption count, and sets the status to `Suspended`. It cannot fail, because the eligibility check already established its preconditions.
+
+The `Search` is not touched, so the token sequence, the random stream, the logits-processor history, the completion state, and the maximum-length bookkeeping all survive. The token the last committed step sampled is still the final token of the sequence, so the last recompute chunk ends exactly where the interrupted decode step would have, and the request resumes from the identical logical context.
+
+The guarantee is context equivalence, not bitwise output equality. A resume replays tokens that were previously single-token decodes as a multi-token prefill query, which changes the query length the attention operator sees, disables decode graph capture for those steps, and can select a different attention backend. On a provider whose results do not depend on query length or batch composition the emitted tokens are identical, and the deterministic tests assert exactly that; on a provider where they do, a near-tied logit can resolve differently. If bit-exact output across a suspension is required, this mechanism is the wrong one - it recomputes rather than preserving the original activations.
+
+Victims are excluded from the whole engine step that suspended them, including the capacity-retry planning attempts inside `Engine::StepDynamic()`, so a retry cannot hand the reclaimed capacity straight back to the request the step just suspended.
+
+Waiting requests are considered suspended-first and then in arrival order within each group, so a victim is ahead of every request that has never been admitted.
+
+### Relationship to the transaction
+
+Preemption happens at a step boundary, during planning, before `BeginTransaction()` checkpoints anything. It is therefore a complete, self-consistent state change of its own and is never undone by a transaction rollback. A step that preempts a resident and then fails during execution leaves the victim suspended, the newly admitted request unchanged, and the reclaimed blocks free.
+
+### Metrics
+
+`DynamicBatchScheduler::PreemptionMetrics()` counts block-starved planning passes, passes that preempted, victims suspended, declined preemptions, blocks reclaimed, and tokens queued for recomputation. Each `Request` also reports its own `PreemptionCount()` and `RecomputedTokenCount()`, and its snapshot carries both.
+
+### Limits
+
+- Only the dynamic paged path supports it.
+- Only whole-request reclamation is supported; partial reclamation of a sequence's blocks is not.
+- The invariant validator still expects one block table per request. `PagedKeyValueCache::Reclaim()` deliberately releases every table it holds for a request rather than the first, so a future windowed layout that splits a sequence across tables reclaims correctly, but that layout is not present on this branch and is not covered by the invariant checks. Releasing several tables is not atomic; a pool that rejected the second release would leave the first one freed.
+- A suspended request is re-admitted ahead of never-admitted requests, but it can still wait behind requests already admitted with the capacity it released. That wait is bounded by those requests completing, not by a deadline.
+- Nothing is swapped to host memory or disk, so the cost of a suspension is exactly the recomputation of the victim's sequence.
+- This is not context shifting. No prompt token is ever discarded and the model sees the same context after a resume as before the suspension.
 
 ## Static engine path
 
@@ -577,4 +668,4 @@ The document needs review when a change affects any of the following:
 
 Prefer describing current behavior directly. If a design is proposed but not implemented, label it clearly as future work or keep it in a separate design document. Remove or revise statements that stop matching the code.
 
-Tests under `test/engine/` provide focused coverage for scheduler planning, paged-cache resources, request and cache invariants, transaction rollback, fatal failures, and ready-result draining. When behavior changes, update both the tests and this document so they continue to describe the same contract.
+Tests under `test/engine/` provide focused coverage for scheduler planning, paged-cache resources, request and cache invariants, transaction rollback, fatal failures, and ready-result draining. `recompute_preemption_tests.cpp` covers victim selection, reclamation, rebuild by chunked prefill, token-stream continuity across a suspension, fairness, rollback behavior, cancellation while suspended, and default-off compatibility. `recompute_preemption_benchmark.cpp` compares the wait-only and preemptive policies on a fixed key-value budget; it drives the production scheduler and cache but fabricates model output, so its unit of time is one engine tick rather than wall-clock latency. When behavior changes, update both the tests and this document so they continue to describe the same contract.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1507,6 +1507,23 @@ struct DynamicBatching_Element : JSON::Element {
       if (parsed_value <= 0)
         throw std::out_of_range("max_scheduled_tokens must be > 0");
       v_->max_scheduled_tokens = static_cast<size_t>(parsed_value);
+    } else if (name == "enable_recompute_preemption") {
+      v_->enable_recompute_preemption = JSON::Get<bool>(value);
+    } else if (name == "max_preemptions_per_step") {
+      const auto parsed_value = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (parsed_value <= 0)
+        throw std::out_of_range("max_preemptions_per_step must be > 0");
+      v_->max_preemptions_per_step = static_cast<size_t>(parsed_value);
+    } else if (name == "max_preemptions_per_request") {
+      const auto parsed_value = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (parsed_value < 0)
+        throw std::out_of_range("max_preemptions_per_request must be >= 0");
+      v_->max_preemptions_per_request = static_cast<size_t>(parsed_value);
+    } else if (name == "min_decode_steps_before_preemption") {
+      const auto parsed_value = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (parsed_value < 0)
+        throw std::out_of_range("min_decode_steps_before_preemption must be >= 0");
+      v_->min_decode_steps_before_preemption = static_cast<size_t>(parsed_value);
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.h
+++ b/src/config.h
@@ -516,6 +516,17 @@ struct Config {
       std::optional<float> gpu_utilization_factor;  // Fraction of free GPU memory to use for key-value cache.
       size_t max_batch_size{16};                    // Maximum batch size for dynamically batching requests.
       size_t max_scheduled_tokens{2048};            // Maximum tokens in one dynamically batched model run.
+      // Recompute preemption suspends a resident request, returns its key-value blocks to the pool,
+      // and rebuilds them later through chunked prefill. It is off by default because it trades
+      // recomputation for admission latency; without it the engine keeps waiting for capacity.
+      bool enable_recompute_preemption{false};
+      size_t max_preemptions_per_step{1};     // Victims one planning pass may suspend.
+      size_t max_preemptions_per_request{0};  // Suspensions allowed per request; 0 is unbounded.
+      // Committed decode steps a resident earns before it can be suspended again. Raising it damps
+      // residency churn between requests competing for the same blocks, at the cost of admission
+      // latency for the requests waiting behind them. Eight keeps most of the admission-latency
+      // benefit at roughly a fifth of the recomputation a quantum of one produces.
+      size_t min_decode_steps_before_preemption{8};
     };
     std::optional<DynamicBatching> dynamic_batching;  // Dynamic batching settings
 

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -233,6 +233,15 @@ void PagedCacheManager::Deallocate(std::vector<std::shared_ptr<Request>>& reques
 
 bool PagedCacheManager::SupportsDynamicBatching() const { return true; }
 
+ReclaimedCacheOwnership PagedCacheManager::ReclaimRequestCache(
+    const std::shared_ptr<Request>& request) {
+  const auto reclaimed = key_value_cache_->Reclaim(request);
+  cache_allocated_requests_.erase(
+      std::remove(cache_allocated_requests_.begin(), cache_allocated_requests_.end(), request),
+      cache_allocated_requests_.end());
+  return reclaimed;
+}
+
 std::vector<std::shared_ptr<Request>> PagedCacheManager::AllocatedRequests() const {
   return cache_allocated_requests_;
 }

--- a/src/engine/cache_manager.h
+++ b/src/engine/cache_manager.h
@@ -48,6 +48,19 @@ struct CacheManager {
 
   virtual void Deallocate(std::vector<std::shared_ptr<Request>>& requests) = 0;
 
+  // True when the manager can end one request's cache residency independently of the rest of the
+  // batch, which is what recompute preemption needs. A cache that allocates and releases the batch
+  // as a unit cannot, and says so instead of pretending the reclamation happened.
+  virtual bool SupportsRecomputePreemption() const { return false; }
+
+  // Releases everything the request owns in the cache and reports what returned to the pool. The
+  // request's logical sequence, search state, and lifecycle counters are not touched here: the
+  // caller moves the request to its suspended boundary.
+  virtual ReclaimedCacheOwnership ReclaimRequestCache(const std::shared_ptr<Request>&) {
+    throw std::logic_error(
+        "Cache manager does not support reclaiming a single request's committed cache.");
+  }
+
   virtual bool SupportsDynamicBatching() const = 0;
 
   virtual size_t MaxBatchSize() const { return 4; }
@@ -112,6 +125,11 @@ struct PagedCacheManager : CacheManager {
                    ExecutionContext& context) override;
 
   void Deallocate(std::vector<std::shared_ptr<Request>>& requests) override;
+
+  bool SupportsRecomputePreemption() const override { return true; }
+
+  ReclaimedCacheOwnership ReclaimRequestCache(
+      const std::shared_ptr<Request>& request) override;
 
   bool SupportsDynamicBatching() const override;
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -258,6 +258,7 @@ std::shared_ptr<Request> Engine::StepDynamic() {
         if (!capacity_retry_used) {
           if (auto retry_limits = CreateCapacityRetryLimits(step_plan_)) {
             planning_limits = *retry_limits;
+            planning_limits->retry_of_current_step = true;
             capacity_retry_used = true;
             capacity_retry_in_progress = true;
             ++transaction_metrics_.capacity_retry_attempts;

--- a/src/engine/engine_invariants.cpp
+++ b/src/engine/engine_invariants.cpp
@@ -177,6 +177,21 @@ std::vector<InvariantViolation> ValidateRequestInvariants(const RequestStateSnap
         ") exceeds current length (" + std::to_string(request.current_sequence_length) + ").");
   }
 
+  // A suspended Request gave up its cache residency: nothing of its sequence is in the cache, and
+  // every token it holds has to go back through the model as prefill before it can decode again.
+  if (request.status == RequestStatus::Suspended) {
+    if (request.processed_sequence_length != 0) {
+      add("Suspended Request " + id + " still reports processed length (" +
+          std::to_string(request.processed_sequence_length) + ").");
+    }
+    if (request.current_sequence_length > 0 && !request.is_prefill) {
+      add("Suspended Request " + id + " is not marked as prefill work.");
+    }
+    if (request.preemption_count == 0) {
+      add("Suspended Request " + id + " has no recorded preemption.");
+    }
+  }
+
   return violations;
 }
 
@@ -192,13 +207,20 @@ std::vector<InvariantViolation> ValidateInvariants(const PagedCacheSnapshot& cac
   // Block tables exist only for known Requests: every block-owning id must be a Request we were
   // handed. (The reverse does not hold: an Assigned-but-unallocated Request owns no blocks yet.)
   std::set<const void*> known_requests;
+  std::set<const void*> suspended_requests;
   for (const auto& request : requests) {
     known_requests.insert(request.request_id);
+    if (request.status == RequestStatus::Suspended)
+      suspended_requests.insert(request.request_id);
   }
   for (const auto& owner : cache.requests) {
     if (known_requests.find(owner.request_id) == known_requests.end()) {
       violations.push_back(InvariantViolation{
           "Cache holds a block table for unknown Request " + PtrId(owner.request_id) + "."});
+    }
+    if (suspended_requests.find(owner.request_id) != suspended_requests.end()) {
+      violations.push_back(InvariantViolation{
+          "Cache still holds a block table for suspended Request " + PtrId(owner.request_id) + "."});
     }
   }
 

--- a/src/engine/engine_invariants.h
+++ b/src/engine/engine_invariants.h
@@ -37,6 +37,8 @@ struct RequestStateSnapshot {
   int64_t processed_sequence_length{};  // Tokens the model has already processed into the cache.
   int64_t seen_sequence_length{};       // Tokens already streamed to (seen by) the application.
   bool is_prefill{};
+  size_t preemption_count{};        // Times the Request was suspended to reclaim cache capacity.
+  size_t recomputed_token_count{};  // Committed tokens discarded by those suspensions.
 };
 
 // Immutable view of one Request's block ownership within the paged cache.

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -171,13 +171,25 @@ void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
 }
 
 void PagedKeyValueCache::Remove(std::shared_ptr<Request> request) {
-  for (auto request_it = block_tables_.begin(); request_it != block_tables_.end(); ++request_it) {
-    if (request_it->request_id == request.get()) {
-      block_pool_->Free(request_it->blocks);
-      block_tables_.erase(request_it);
-      return;
+  Reclaim(request);
+}
+
+ReclaimedCacheOwnership PagedKeyValueCache::Reclaim(
+    const std::shared_ptr<Request>& request) {
+  ReclaimedCacheOwnership reclaimed;
+  const void* request_id = request.get();
+  for (auto table_it = block_tables_.begin(); table_it != block_tables_.end();) {
+    if (table_it->request_id != request_id) {
+      ++table_it;
+      continue;
     }
+
+    reclaimed.released_blocks += table_it->blocks.size();
+    reclaimed.released_slots += table_it->committed_slots;
+    block_pool_->Free(table_it->blocks);
+    table_it = block_tables_.erase(table_it);
   }
+  return reclaimed;
 }
 
 PagedCacheReservation PagedKeyValueCache::Reserve(std::span<const PagedCacheReservationRequest> requests) {
@@ -196,6 +208,8 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
   if (scheduled_request_limit > max_batch_size_) {
     throw std::runtime_error("Step plan request limit exceeds the configured batch size.");
   }
+  const size_t new_admission_limit =
+      plan.new_admission_limit == 0 ? max_batch_size_ : plan.new_admission_limit;
 
   const size_t available_blocks = block_pool_->AvailableBlocks();
   size_t planned_blocks = 0;
@@ -204,6 +218,8 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
   size_t max_blocks_per_request = 0;
   bool capacity_deferred = false;
   const void* unserviceable_request_id = nullptr;
+  BlockCapacityShortfall blocked_admission;
+  BlockCapacityShortfall blocked_resident;
 
   struct CacheGrowth {
     size_t proposed_blocks{};
@@ -282,9 +298,28 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
 
     if (selected_requests >= scheduled_request_limit ||
         (candidate.newly_admitted &&
-         committed_request_count + selected_new_requests >= max_batch_size_) ||
+         (committed_request_count + selected_new_requests >= max_batch_size_ ||
+          selected_new_requests >= new_admission_limit)) ||
         planned_blocks + growth.new_blocks > available_blocks) {
       capacity_deferred = true;
+      // Record the first request of each kind that only the block pool is holding up. Reclaiming
+      // blocks from a resident can run it; it cannot relieve the scheduled-row limit, the residency
+      // limit, or the per-plan admission limit, so those deferrals deliberately leave this unset.
+      const bool row_limited = selected_requests >= scheduled_request_limit;
+      const bool residency_limited =
+          candidate.newly_admitted &&
+          (committed_request_count + selected_new_requests >= max_batch_size_ ||
+           selected_new_requests >= new_admission_limit);
+      if (!row_limited && !residency_limited) {
+        auto& shortfall =
+            candidate.newly_admitted ? blocked_admission : blocked_resident;
+        if (!shortfall.Any()) {
+          shortfall = BlockCapacityShortfall{
+              candidate.request_id,
+              planned_blocks + growth.new_blocks - available_blocks,
+          };
+        }
+      }
       continue;
     }
 
@@ -312,6 +347,8 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
         true,
         capacity_deferred,
         unserviceable_request_id,
+        blocked_admission,
+        blocked_resident,
         {StepOutcomeKind::Committed, plan.transaction_id, nullptr},
     };
   }
@@ -320,6 +357,8 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
         false,
         capacity_deferred,
         unserviceable_request_id,
+        blocked_admission,
+        blocked_resident,
         {StepOutcomeKind::UnserviceableRequest, plan.transaction_id, unserviceable_request_id},
     };
   }
@@ -328,6 +367,8 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
         false,
         true,
         nullptr,
+        blocked_admission,
+        blocked_resident,
         {StepOutcomeKind::CapacityDeferred, plan.transaction_id, nullptr},
     };
   }
@@ -335,6 +376,8 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
       false,
       false,
       nullptr,
+      {},
+      {},
       {StepOutcomeKind::NoWork, plan.transaction_id, nullptr},
   };
 }

--- a/src/engine/paged_key_value_cache.h
+++ b/src/engine/paged_key_value_cache.h
@@ -15,6 +15,12 @@
 
 namespace Generators {
 
+// What a request returned to the block pool when it gave up its cache residency.
+struct ReclaimedCacheOwnership {
+  size_t released_blocks{};
+  size_t released_slots{};
+};
+
 /*
  * PagedKeyValueCache manages a paged key-value cache for models that use the PagedAttention operator.
  * The cache is divided into blocks, each containing a fixed number of slots. Each slot holds
@@ -38,6 +44,15 @@ struct PagedKeyValueCache {
   void AppendTokens(std::shared_ptr<Request> request);
 
   void Remove(std::shared_ptr<Request> request);
+
+  // Releases every block the request owns and reports what went back to the pool. The request's
+  // logical sequence is untouched; only its cache residency ends, so the caller can either drop the
+  // request or have it rebuild its key-value entries later.
+  //
+  // The cache is free to spread one request over several block tables -- a windowed layout keeps a
+  // sliding region separate from the rest of the sequence -- so this releases every table held for
+  // the request rather than assuming there is exactly one.
+  ReclaimedCacheOwnership Reclaim(const std::shared_ptr<Request>& request);
 
   PagedCacheReservation Reserve(std::span<const PagedCacheReservationRequest> requests);
 

--- a/src/engine/recompute_preemption_policy.cpp
+++ b/src/engine/recompute_preemption_policy.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "recompute_preemption_policy.h"
+
+#include <algorithm>
+
+namespace Generators {
+
+std::vector<size_t> RecomputeVictimOrder(
+    std::span<const RecomputePreemptionCandidate> candidates) {
+  std::vector<size_t> order;
+  order.reserve(candidates.size());
+  for (size_t i = 0; i < candidates.size(); ++i) {
+    if (candidates[i].eligible)
+      order.push_back(i);
+  }
+
+  std::sort(order.begin(), order.end(),
+            [&candidates](size_t left, size_t right) {
+              if (candidates[left].preemption_count !=
+                  candidates[right].preemption_count) {
+                return candidates[left].preemption_count <
+                       candidates[right].preemption_count;
+              }
+              return left > right;
+            });
+  return order;
+}
+
+RecomputePreemptionDecision SelectRecomputeVictims(
+    std::span<const RecomputePreemptionCandidate> candidates,
+    size_t required_blocks,
+    const RecomputePreemptionSettings& settings) {
+  RecomputePreemptionDecision decision;
+  if (!settings.enabled || required_blocks == 0 ||
+      settings.max_victims_per_step == 0) {
+    return decision;
+  }
+
+  const auto order = RecomputeVictimOrder(candidates);
+  for (const size_t index : order) {
+    const auto& candidate = candidates[index];
+    if (settings.max_preemptions_per_request != 0 &&
+        candidate.preemption_count >= settings.max_preemptions_per_request) {
+      continue;
+    }
+    // Every admission has to buy the request a minimum amount of committed decoding, otherwise two
+    // requests competing for the same blocks would trade residency every step and recompute far
+    // more than they produce.
+    if (candidate.decode_steps_since_admission <
+        settings.min_decode_steps_before_preemption) {
+      continue;
+    }
+    // A candidate that owns nothing frees nothing; suspending it would restart its prefill for no
+    // capacity gain.
+    if (candidate.committed_blocks == 0) {
+      continue;
+    }
+
+    decision.victims.push_back(index);
+    decision.reclaimed_blocks += candidate.committed_blocks;
+    if (decision.reclaimed_blocks >= required_blocks) {
+      return decision;
+    }
+    if (decision.victims.size() == settings.max_victims_per_step) {
+      break;
+    }
+  }
+
+  // Suspending this set would not unblock the waiting request, so keep every resident intact.
+  decision.victims.clear();
+  decision.reclaimed_blocks = 0;
+  return decision;
+}
+
+}  // namespace Generators

--- a/src/engine/recompute_preemption_policy.h
+++ b/src/engine/recompute_preemption_policy.h
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "../span.h"
+
+/**
+ * @file recompute_preemption_policy.h
+ * @brief Pure victim-selection arithmetic for recompute preemption on the dynamic engine path.
+ *
+ * Recompute preemption suspends a resident request, returns its committed paged-cache blocks to the
+ * pool, and rebuilds that request's KV later through the ordinary chunked-prefill path. The policy
+ * here decides *whether* preempting helps and *which* residents to suspend; it deliberately takes
+ * plain counters rather than a Request or a cache so it can be unit-tested without a model, a
+ * device, or a block pool. The scheduler wraps it with request-derived and cache-derived values.
+ */
+
+namespace Generators {
+
+/**
+ * @brief Bounded knobs controlling how aggressively the dynamic scheduler may preempt residents.
+ *
+ * Preemption is off by default. Enabling it changes which requests hold KV blocks across steps, so
+ * an engine keeps its previous wait-only behavior unless the model configuration asks for it.
+ */
+struct RecomputePreemptionSettings {
+  bool enabled{};
+  // Upper bound on victims suspended within one planning pass, which bounds the recompute work a
+  // single step can create.
+  size_t max_victims_per_step{1};
+  // Upper bound on how many times one request may be suspended. Zero leaves it unbounded; a
+  // positive value protects a repeatedly chosen victim from unbounded recompute amplification.
+  size_t max_preemptions_per_request{};
+  // Committed decode steps a resident must complete after being admitted before it can be
+  // suspended again. This is the anti-churn quantum: without it two requests competing for the same
+  // blocks can trade residency every step, each recomputing its whole sequence to produce one
+  // token. Raising it damps that trade at the cost of admission latency for waiting requests.
+  size_t min_decode_steps_before_preemption{8};
+};
+
+/**
+ * @brief One resident request the scheduler could suspend, described by the counters the policy
+ *        needs.
+ *
+ * `committed_blocks` is the number of physical blocks the request would return to the pool. It is
+ * summed over every block table the cache holds for the request, so a cache that splits a request
+ * across more than one table still reports a single reclaimable total.
+ */
+struct RecomputePreemptionCandidate {
+  const void* request_id{};
+  size_t committed_blocks{};
+  size_t preemption_count{};
+  // Decode steps this request has committed since it was last admitted. Only a committed
+  // transaction advances it, so a resident never becomes a victim on the strength of work that has
+  // not been committed.
+  size_t decode_steps_since_admission{};
+  // False when suspending the request would waste in-flight work or could not make progress: a
+  // request that is still (re)building its KV owns blocks for a prefill it has not finished, so
+  // discarding it would trade one stalled request for another without freeing durable capacity.
+  bool eligible{};
+};
+
+struct RecomputePreemptionDecision {
+  std::vector<size_t> victims;  // Indices into the candidate span, in the order they are suspended.
+  size_t reclaimed_blocks{};
+
+  bool Empty() const { return victims.empty(); }
+};
+
+/**
+ * @brief Deterministic order in which eligible candidates are considered for suspension.
+ *
+ * The order is:
+ *   1. Fewest previous preemptions first, so no request is suspended twice while a peer that has
+ *      never been suspended is still resident. This bounds unfairness and is what keeps a single
+ *      victim from being starved by repeated recomputation.
+ *   2. Latest resident position first, preserving the accumulated work of the requests that have
+ *      been resident longest.
+ *
+ * Candidate indices are unique, so the order is total and the result is reproducible.
+ */
+std::vector<size_t> RecomputeVictimOrder(
+    std::span<const RecomputePreemptionCandidate> candidates);
+
+/**
+ * @brief Chooses the victims whose combined committed blocks satisfy `required_blocks`.
+ *
+ * Returns an empty decision -- meaning "do not preempt" -- when preemption is disabled, when
+ * nothing is blocked, or when the eligible candidates within `max_victims_per_step` cannot cover
+ * the demand. Preempting without covering the demand would discard committed KV without unblocking
+ * anything, which is exactly the churn this policy exists to avoid.
+ */
+RecomputePreemptionDecision SelectRecomputeVictims(
+    std::span<const RecomputePreemptionCandidate> candidates,
+    size_t required_blocks,
+    const RecomputePreemptionSettings& settings);
+
+}  // namespace Generators

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -53,6 +53,7 @@ void Request::Assign(std::shared_ptr<Engine> engine) {
 
   auto device_tokens = AllocateOnDevice(*params_, prefill_input_ids_);
   processed_sequence_length_ = 0;
+  decode_steps_since_admission_ = 0;
   search_->AppendTokens(device_tokens);
   prompt_sequence_length_ = CurrentSequenceLength();
   seen_sequence_length_ = CurrentSequenceLength();
@@ -93,12 +94,15 @@ void Request::AddTokens(std::span<const int32_t> tokens) {
 
   if (status_ == RequestStatus::Unassigned) {
     std::copy(tokens.begin(), tokens.end(), std::back_inserter(prefill_input_ids_));
-  } else if (status_ == RequestStatus::InProgress) {
+  } else if (status_ == RequestStatus::InProgress || status_ == RequestStatus::Suspended) {
     throw std::runtime_error("Cannot add tokens to a request that is in progress.");
   } else if (status_ == RequestStatus::Completed) {
     auto device_tokens = AllocateOnDevice(*params_, tokens);
     search_->AppendTokens(device_tokens);
     prompt_sequence_length_ = CurrentSequenceLength();
+    // Continuing the conversation re-admits the request, so it has to earn its residency again
+    // rather than carry over the service credit of the turn that just finished.
+    decode_steps_since_admission_ = 0;
     tokens_host_.insert(tokens_host_.end(), tokens.begin(), tokens.end());
   }
 }
@@ -116,6 +120,8 @@ RequestStateSnapshot Request::Snapshot() const {
   snapshot.processed_sequence_length = processed_sequence_length_;
   snapshot.seen_sequence_length = seen_sequence_length_;
   snapshot.is_prefill = IsPrefill();
+  snapshot.preemption_count = preemption_count_;
+  snapshot.recomputed_token_count = recomputed_token_count_;
   return snapshot;
 }
 
@@ -182,6 +188,37 @@ bool Request::IsDone() const {
 
 bool Request::IsPrefill() const {
   return processed_sequence_length_ < prompt_sequence_length_;
+}
+
+bool Request::IsPreemptible() const {
+  // A prefilling request owns blocks for a prompt it has not finished pushing through the model.
+  // Suspending it would discard that in-flight work and immediately ask for the same blocks back,
+  // so only requests that have reached the decode phase are eligible.
+  return status_ == RequestStatus::InProgress && !IsPrefill() &&
+         processed_sequence_length_ > 0;
+}
+
+void Request::SuspendForRecompute() {
+  if (status_ != RequestStatus::InProgress) {
+    throw std::runtime_error(
+        "Only an in-progress request can be suspended for recompute.");
+  }
+  if (processed_sequence_length_ <= 0) {
+    throw std::runtime_error(
+        "Cannot suspend a request that has no committed key-value entries.");
+  }
+
+  // The search keeps the whole sequence, the random stream, and the completion state. Only the
+  // cache cursor moves: every committed token becomes prefill work again, so the trailing token
+  // sampled by the last committed step still ends the final recompute chunk and the request
+  // resumes decoding exactly where it left off.
+  recomputed_token_count_ += static_cast<size_t>(processed_sequence_length_);
+  processed_sequence_length_ = 0;
+  prompt_sequence_length_ = CurrentSequenceLength();
+  scheduled_token_count_ = 0;
+  decode_steps_since_admission_ = 0;
+  ++preemption_count_;
+  status_ = RequestStatus::Suspended;
 }
 
 void Request::GenerateNextTokens(DeviceSpan<float> logits) {
@@ -269,6 +306,11 @@ void Request::CommitStep(const RequestStepPlan& plan,
                          const RequestStepResult& result) noexcept {
   if (result.token_appended) {
     tokens_host_.push_back(result.token);
+  }
+  // A step that finished the (re)build of this request's key-value entries is the one that leaves
+  // prefill; only the steps after that count as service delivered by its residency.
+  if (!IsPrefill() && result.token_appended) {
+    ++decode_steps_since_admission_;
   }
   processed_sequence_length_ = static_cast<int64_t>(plan.target_cache_slots);
   status_ = result.done ? RequestStatus::Completed : RequestStatus::InProgress;

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -133,6 +133,49 @@ struct Request : std::enable_shared_from_this<Request>,
   void CompleteGeneration();
 
   /**
+   * @brief Suspends a resident request so its committed key-value blocks can be reclaimed.
+   *
+   * The request keeps its complete logical token sequence, its Search and sampler state (including
+   * the random stream), the tokens the application has already seen, and its generation limits. It
+   * loses only its cache residency: the processed cursor returns to the beginning of the sequence
+   * and the whole sequence becomes prefill work again, so the ordinary chunked-prefill path rebuilds
+   * the key-value entries before decoding resumes.
+   *
+   * The caller is responsible for releasing the request's cache ownership; this call only moves the
+   * request's own state to the suspended boundary. Only an `InProgress` request can be suspended.
+   */
+  void SuspendForRecompute();
+
+  /**
+   * @brief True when suspending this request would free durable capacity and make progress.
+   *
+   * A request that is still building its key-value entries (its first prefill, or a recompute that
+   * has not finished) is excluded: discarding it would restart work that is already in flight
+   * without leaving the freed capacity available for long, which is how preemption starts to churn.
+   */
+  bool IsPreemptible() const;
+
+  /**
+   * @brief Number of times this request has been suspended for recompute.
+   */
+  size_t PreemptionCount() const { return preemption_count_; }
+
+  /**
+   * @brief Total tokens whose key-value entries were discarded by suspensions and must be, or have
+   *        been, recomputed.
+   */
+  size_t RecomputedTokenCount() const { return recomputed_token_count_; }
+
+  /**
+   * @brief Decode steps this request has committed since it was last admitted to the cache.
+   *
+   * Only CommitStep advances it and only for a step that produced a token past prefill, so it
+   * describes service the engine has actually delivered rather than work it planned. Suspension
+   * resets it, because the request has to earn its residency again.
+   */
+  size_t DecodeStepsSinceAdmission() const { return decode_steps_since_admission_; }
+
+  /**
    * @brief Checks if the termination condition for the request has been met.
    * @return True if the request is done, false otherwise.
    */
@@ -276,9 +319,14 @@ struct Request : std::enable_shared_from_this<Request>,
   int64_t seen_sequence_length_{};
   int64_t processed_sequence_length_{};
   // Sequence length the application's tokens reach up to. Everything below it is prompt, so the
-  // request is still prefilling while processed_sequence_length_ has not caught up with it.
+  // request is still prefilling while processed_sequence_length_ has not caught up with it. A
+  // suspended request moves this to its whole committed sequence, because every one of those tokens
+  // has to go back through the model before the request can decode again.
   int64_t prompt_sequence_length_{};
   size_t scheduled_token_count_{};
+  size_t preemption_count_{};
+  size_t recomputed_token_count_{};
+  size_t decode_steps_since_admission_{};
   std::shared_ptr<GeneratorParams> params_;
   std::unique_ptr<Search> search_;
   std::unique_ptr<BatchedSamplerState> batched_sampler_state_;

--- a/src/engine/request_status.h
+++ b/src/engine/request_status.h
@@ -19,6 +19,10 @@ enum class RequestStatus {
                // This is the state of a request when it is first created.
   Assigned,    // The request has been added to the engine and is waiting to be scheduled.
   InProgress,  // The request has been scheduled and is currently being processed.
+  Suspended,   // The request was resident, was preempted to free key-value cache capacity, and is
+               // waiting to be re-admitted. It keeps its complete logical token sequence, search
+               // and sampler state, and lifecycle counters, but owns no cache blocks: the engine
+               // rebuilds its key-value entries through chunked prefill before decoding resumes.
   Completed,   // The request has been completed successfully.
 };
 

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -29,7 +29,17 @@ ScheduledRequests Scheduler::CreateScheduledRequests(const StepPlan& plan) {
 }
 
 StaticBatchScheduler::StaticBatchScheduler(std::shared_ptr<Model> model, std::shared_ptr<CacheManager> cache_manager)
-    : Scheduler{model}, model_{model}, cache_manager_{cache_manager} {}
+    : Scheduler{model}, model_{model}, cache_manager_{cache_manager} {
+  // Static batching allocates and releases the whole batch as a unit, so it cannot hand one
+  // request's cache back to the pool. Say so instead of quietly ignoring the setting.
+  const auto& engine_config = model->config_->engine;
+  if (engine_config.dynamic_batching &&
+      engine_config.dynamic_batching->enable_recompute_preemption) {
+    throw std::runtime_error(
+        "engine.dynamic_batching.enable_recompute_preemption requires dynamic batching; "
+        "the static batch scheduler cannot suspend a single request.");
+  }
+}
 
 void StaticBatchScheduler::AddRequest(std::shared_ptr<Request> request) {
   // The static batch decoder rebuilds its contiguous cache from the whole sequence every step, so it
@@ -105,7 +115,27 @@ bool StaticBatchScheduler::HasPendingRequests() const {
 }
 
 DynamicBatchScheduler::DynamicBatchScheduler(std::shared_ptr<Model> model, std::shared_ptr<CacheManager> cache_manager)
-    : Scheduler{model}, model_{model}, cache_manager_{cache_manager} {}
+    : Scheduler{model}, model_{model}, cache_manager_{cache_manager} {
+  const auto& dynamic_batching = *model_->config_->engine.dynamic_batching;
+  preemption_settings_ = RecomputePreemptionSettings{
+      dynamic_batching.enable_recompute_preemption,
+      dynamic_batching.max_preemptions_per_step,
+      dynamic_batching.max_preemptions_per_request,
+      dynamic_batching.min_decode_steps_before_preemption,
+  };
+  if (preemption_settings_.enabled &&
+      !cache_manager_->SupportsRecomputePreemption()) {
+    throw std::runtime_error(
+        "engine.dynamic_batching.enable_recompute_preemption requires a cache manager that can "
+        "release one request's blocks independently of the rest of the batch.");
+  }
+  if (preemption_settings_.enabled &&
+      preemption_settings_.max_victims_per_step == 0) {
+    throw std::invalid_argument(
+        "engine.dynamic_batching.max_preemptions_per_step must be positive when recompute "
+        "preemption is enabled.");
+  }
+}
 
 void DynamicBatchScheduler::AddRequest(std::shared_ptr<Request> request) {
   if (auto* sampler = GetBatchedSampler())
@@ -150,6 +180,140 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(
   // requests waiting in Assigned state during this same planning pass.
   ReapCompletedRequests();
 
+  // A capacity retry is another attempt at the same engine step, so the requests this step already
+  // suspended stay out of admission. Clearing the set there would let the retry hand the reclaimed
+  // capacity straight back to the victim and leave the request it was taken for still blocked.
+  if (!limits.retry_of_current_step)
+    suspended_this_step_.clear();
+
+  plan.new_admission_limit = 0;
+  auto result = PlanStepOnce(plan, limits);
+  if (!preemption_settings_.enabled) {
+    return result;
+  }
+
+  // Two situations justify giving up a resident's committed cache:
+  //   * a resident that cannot grow while nothing else can run, where the alternative is telling
+  //     the caller the engine is out of capacity and making no progress at all; and
+  //   * a waiting request that only free blocks are holding back, which is the head-of-line case
+  //     recompute preemption exists to fix.
+  // A starved resident is considered before any waiting request, so it would take the reclaimed
+  // blocks first. When one exists and the step can still run other work, nothing is preempted:
+  // reclaiming capacity that cannot reach the waiting request would discard committed work for
+  // nothing. Row limits and residency limits are left alone for the same reason.
+  const BlockCapacityShortfall shortfall =
+      result.blocked_resident.Any()
+          ? (result.executable ? BlockCapacityShortfall{} : result.blocked_resident)
+          : result.blocked_admission;
+  if (!shortfall.Any()) {
+    return result;
+  }
+
+  // Preemption happens here, at a step boundary: the transaction has not been checkpointed yet, so
+  // suspending a resident is a complete, self-consistent state change that a later rollback never
+  // has to undo. It runs at most once per pass and only when the reclaimed blocks would cover the
+  // shortfall, which is what keeps capacity from being traded back and forth.
+  ++preemption_metrics_.block_starved_passes;
+  const size_t new_admissions_before = CountNewAdmissions(plan);
+  if (PreemptForBlockShortfall(shortfall) == 0) {
+    return result;
+  }
+  // Spend the reclaimed capacity on the one blocked request it was measured for. Admitting more
+  // waiting work would push the victim further back in the queue for blocks it released itself.
+  plan.new_admission_limit = new_admissions_before + 1;
+  return PlanStepOnce(plan, limits);
+}
+
+size_t DynamicBatchScheduler::CountNewAdmissions(const StepPlan& plan) {
+  return static_cast<size_t>(
+      std::count_if(plan.requests.begin(), plan.requests.end(),
+                    [](const RequestStepPlan& entry) { return entry.newly_admitted; }));
+}
+
+size_t DynamicBatchScheduler::PreemptForBlockShortfall(
+    const BlockCapacityShortfall& shortfall) {
+  const auto residents = cache_manager_->AllocatedRequests();
+  const auto cache_snapshot = cache_manager_->Snapshot();
+
+  struct ResidentOwnership {
+    size_t blocks{};
+    size_t used_slots{};
+  };
+  const auto ownership_of = [&cache_snapshot](const void* request_id) {
+    // Sum every table the cache holds for the request: a layout that splits one sequence across
+    // more than one table still reports a single reclaimable total here.
+    ResidentOwnership ownership;
+    for (const auto& owner : cache_snapshot.requests) {
+      if (owner.request_id == request_id) {
+        ownership.blocks += owner.block_ids.size();
+        ownership.used_slots += owner.used_slots;
+      }
+    }
+    return ownership;
+  };
+
+  std::vector<RecomputePreemptionCandidate> candidates;
+  candidates.reserve(residents.size());
+  for (const auto& request : residents) {
+    // A blocked resident cannot pay for its own growth by giving up the blocks it is growing from.
+    if (request.get() == shortfall.request_id)
+      continue;
+
+    const auto ownership = ownership_of(request.get());
+    // Only a request whose committed cache matches its committed sequence can be rewound to a
+    // clean boundary. A mismatch means the cache and the request already disagree, so leave it
+    // resident and let the invariant checks report it rather than rewinding on bad accounting.
+    const bool ownership_agrees =
+        ownership.used_slots == static_cast<size_t>(request->ProcessedSequenceLength());
+    candidates.push_back(RecomputePreemptionCandidate{
+        request.get(),
+        ownership.blocks,
+        request->PreemptionCount(),
+        request->DecodeStepsSinceAdmission(),
+        request->IsPreemptible() && ownership_agrees,
+    });
+  }
+
+  const auto decision =
+      SelectRecomputeVictims(candidates, shortfall.blocks, preemption_settings_);
+  if (decision.Empty()) {
+    ++preemption_metrics_.declined_preemptions;
+    return 0;
+  }
+
+  for (const size_t index : decision.victims) {
+    const auto victim = std::find_if(
+        residents.begin(), residents.end(),
+        [id = candidates[index].request_id](const std::shared_ptr<Request>& request) {
+          return request.get() == id;
+        });
+    if (victim == residents.end())
+      throw std::logic_error("Preemption selected a request the cache does not hold.");
+
+    // Reclaim the cache first: if the pool rejects the release, the request has not been touched.
+    // The request transition afterwards cannot fail, because eligibility already established both
+    // its preconditions and that its ownership matches its committed sequence.
+    const size_t committed_slots =
+        static_cast<size_t>((*victim)->ProcessedSequenceLength());
+    const auto reclaimed = cache_manager_->ReclaimRequestCache(*victim);
+    if (reclaimed.released_slots != committed_slots) {
+      throw std::runtime_error(
+          "Reclaimed key-value slots do not match the request's committed sequence length.");
+    }
+    (*victim)->SuspendForRecompute();
+
+    suspended_this_step_.push_back(candidates[index].request_id);
+    ++preemption_metrics_.preemptions;
+    preemption_metrics_.reclaimed_blocks += reclaimed.released_blocks;
+    preemption_metrics_.recomputed_tokens += committed_slots;
+  }
+
+  ++preemption_metrics_.preemption_passes;
+  return decision.victims.size();
+}
+
+StepPlanningResult DynamicBatchScheduler::PlanStepOnce(
+    StepPlan& plan, const StepPlanningLimits& limits) {
   plan.requests.clear();
   plan.scheduled_request_limit = 0;
   plan.token_count = 0;
@@ -166,9 +330,13 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(
   const auto add_candidate = [&candidates](const std::shared_ptr<Request>& request,
                                            bool newly_admitted) {
     const auto snapshot = request->Snapshot();
-    const RequestStatus expected_status =
-        newly_admitted ? RequestStatus::Assigned : RequestStatus::InProgress;
-    if (snapshot.status != expected_status) {
+    // A waiting candidate is either one that has never been admitted or one that was suspended to
+    // free capacity; both own no cache blocks and are admitted the same way.
+    const bool status_valid =
+        newly_admitted ? (snapshot.status == RequestStatus::Assigned ||
+                          snapshot.status == RequestStatus::Suspended)
+                       : snapshot.status == RequestStatus::InProgress;
+    if (!status_valid) {
       throw std::runtime_error("Request status is invalid for dynamic step planning.");
     }
     const auto remaining_token_count =
@@ -203,11 +371,22 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(
     add_candidate(request, false);
   }
 
-  for (const auto& request : requests_pool_) {
-    if (request->status_ == RequestStatus::Assigned) {
+  // Waiting requests are considered suspended-first, then in arrival order within each group. A
+  // request that already held capacity and gave it up is ahead of one that has never been admitted,
+  // which is what stops a victim from falling behind the requests admitted with its own blocks.
+  const auto add_waiting = [&](RequestStatus status) {
+    for (const auto& request : requests_pool_) {
+      if (request->status_ != status)
+        continue;
+      if (std::find(suspended_this_step_.begin(), suspended_this_step_.end(),
+                    request.get()) != suspended_this_step_.end()) {
+        continue;
+      }
       add_candidate(request, true);
     }
-  }
+  };
+  add_waiting(RequestStatus::Suspended);
+  add_waiting(RequestStatus::Assigned);
 
   std::vector<DecodeFirstBudgetCandidate> budget_candidates;
   budget_candidates.reserve(candidates.size());

--- a/src/engine/scheduler.h
+++ b/src/engine/scheduler.h
@@ -6,6 +6,7 @@
 #include "request.h"
 #include "scheduled_requests.h"
 #include "cache_manager.h"
+#include "recompute_preemption_policy.h"
 #include "step_plan.h"
 
 /**
@@ -15,6 +16,18 @@
  */
 
 namespace Generators {
+
+// Counters describing how often the dynamic scheduler had to reclaim resident cache capacity to
+// admit waiting work, and what that cost. They are pure observations: nothing in the scheduler
+// reads them back to make a decision.
+struct SchedulerPreemptionMetrics {
+  uint64_t block_starved_passes{};  // Passes where free blocks alone held a request back.
+  uint64_t preemption_passes{};     // Passes that suspended at least one resident.
+  uint64_t preemptions{};           // Residents suspended.
+  uint64_t declined_preemptions{};  // Starved passes no eligible victim set could relieve.
+  uint64_t reclaimed_blocks{};      // Blocks returned to the pool by those suspensions.
+  uint64_t recomputed_tokens{};     // Committed key-value tokens discarded and queued for rebuild.
+};
 
 struct Scheduler {
   /**
@@ -112,12 +125,30 @@ struct DynamicBatchScheduler : Scheduler {
 
   bool HasPendingRequests() const override;
 
+  const SchedulerPreemptionMetrics& PreemptionMetrics() const {
+    return preemption_metrics_;
+  }
+
  private:
   void ReapCompletedRequests();
+
+  // One complete planning attempt over the current residents and waiting requests. Requests listed
+  // in suspended_this_step_ are skipped so a request suspended by this engine step cannot take back
+  // the capacity the step just reclaimed for someone else.
+  StepPlanningResult PlanStepOnce(StepPlan& plan, const StepPlanningLimits& limits);
+
+  // Suspends residents until the blocked request's shortfall is covered. Returns the number of
+  // residents suspended, which is zero when no eligible victim set could unblock it.
+  size_t PreemptForBlockShortfall(const BlockCapacityShortfall& shortfall);
+
+  static size_t CountNewAdmissions(const StepPlan& plan);
 
   std::shared_ptr<Model> model_;
   std::shared_ptr<CacheManager> cache_manager_;
   std::vector<std::shared_ptr<Request>> requests_pool_;
+  RecomputePreemptionSettings preemption_settings_;
+  SchedulerPreemptionMetrics preemption_metrics_;
+  std::vector<const void*> suspended_this_step_;
 };
 
 std::unique_ptr<Scheduler> CreateScheduler(std::shared_ptr<Model> model, std::shared_ptr<CacheManager> cache_manager);

--- a/src/engine/step_plan.h
+++ b/src/engine/step_plan.h
@@ -41,16 +41,34 @@ struct StepOutcome {
   const void* request_id{};
 };
 
+// One request that free paged-cache blocks alone are holding up, and how many more it needs.
+struct BlockCapacityShortfall {
+  const void* request_id{};
+  size_t blocks{};
+
+  bool Any() const { return request_id != nullptr; }
+};
+
 struct StepPlanningResult {
   bool executable{};
   bool capacity_deferred{};
   const void* unserviceable_request_id{};
+  // A request the planner would otherwise have run and deferred only because the block pool is
+  // short of free blocks. Freeing that many blocks is exactly what would let it run, so it is the
+  // demand a preemption decision has to cover. Row limits and residency limits are deliberately
+  // excluded, because returning blocks to the pool does not relieve either of them.
+  BlockCapacityShortfall blocked_admission;  // First waiting request short of blocks.
+  BlockCapacityShortfall blocked_resident;   // First resident whose growth is short of blocks.
   StepOutcome outcome;
 };
 
 struct StepPlanningLimits {
   std::optional<size_t> max_scheduled_tokens;  // Temporary cap for this planning attempt.
   std::optional<size_t> max_prefill_requests;  // Decodes do not consume this row cap.
+  // True when this is another attempt at the same engine step rather than a fresh one. The
+  // scheduler keeps the requests it suspended earlier in the step out of admission, so a retry
+  // cannot hand the reclaimed capacity straight back to the request the step just suspended.
+  bool retry_of_current_step{};
 };
 
 struct RequestStepPlan {
@@ -70,6 +88,10 @@ struct StepPlan {
   StepTransactionId transaction_id{};
   std::vector<RequestStepPlan> requests;
   size_t scheduled_request_limit{};  // Provisional rows cache feasibility may select.
+  // Cap on requests admitted to the cache by this plan; zero leaves it to the batch size. Used
+  // after a preemption so the reclaimed capacity is not spent on more waiting work than the
+  // preemption was measured for.
+  size_t new_admission_limit{};
   size_t token_count{};
   size_t proposed_block_table_columns{};
   bool graph_capture_eligible{};

--- a/test/engine/engine_test_doubles.h
+++ b/test/engine/engine_test_doubles.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -76,6 +77,43 @@ struct RecordingCacheManager : CacheManager {
     return supports_dynamic_batching_;
   }
 
+  bool SupportsRecomputePreemption() const override {
+    return supports_recompute_preemption_;
+  }
+
+  // Mirrors the paged manager: the request's blocks go back to the pool and it stops being
+  // resident. Each allocated request is modelled as owning `blocks_per_request_` blocks.
+  ReclaimedCacheOwnership ReclaimRequestCache(
+      const std::shared_ptr<Request>& request) override {
+    reclaim_calls++;
+    if (trace_) trace_->Record("ReclaimRequestCache");
+    const auto it = std::find(allocated_.begin(), allocated_.end(), request);
+    if (it == allocated_.end())
+      throw std::runtime_error("Recording cache cannot reclaim an unallocated request.");
+    allocated_.erase(it);
+    return ReclaimedCacheOwnership{
+        blocks_per_request_,
+        static_cast<size_t>(request->ProcessedSequenceLength()),
+    };
+  }
+
+  PagedCacheSnapshot Snapshot() const override {
+    PagedCacheSnapshot snapshot;
+    snapshot.block_size = 1;
+    snapshot.total_blocks = capacity_ * blocks_per_request_;
+    size_t next_block_id = 0;
+    for (const auto& request : allocated_) {
+      RequestBlockSnapshot request_snapshot;
+      request_snapshot.request_id = request.get();
+      for (size_t i = 0; i < blocks_per_request_; ++i)
+        request_snapshot.block_ids.push_back(next_block_id++);
+      request_snapshot.used_slots = blocks_per_request_;
+      snapshot.requests.push_back(std::move(request_snapshot));
+    }
+    snapshot.free_blocks = snapshot.total_blocks - next_block_id;
+    return snapshot;
+  }
+
   size_t MaxBatchSize() const override { return capacity_; }
 
   std::vector<std::shared_ptr<Request>> AllocatedRequests() const override { return allocated_; }
@@ -83,10 +121,13 @@ struct RecordingCacheManager : CacheManager {
   StepPlanningResult PlanStepResources(StepPlan& plan) const override {
     const size_t request_limit =
         plan.scheduled_request_limit == 0 ? capacity_ : plan.scheduled_request_limit;
+    const size_t new_admission_limit =
+        plan.new_admission_limit == 0 ? capacity_ : plan.new_admission_limit;
     size_t selected_requests = 0;
     size_t selected_new_requests = 0;
     bool capacity_deferred = false;
     const void* unserviceable_request_id = nullptr;
+    BlockCapacityShortfall blocked_admission;
     std::vector<const void*> request_ids;
     request_ids.reserve(plan.requests.size());
     for (size_t i = 0; i < plan.requests.size(); ++i) {
@@ -105,11 +146,22 @@ struct RecordingCacheManager : CacheManager {
         unserviceable_request_id = unserviceable_request_id_;
         continue;
       }
+      // Stands in for a waiting request that only the block pool is holding up, which is the one
+      // deferral reason reclaiming a resident's blocks can relieve.
+      if (entry.newly_admitted && entry.request_id == admission_blocked_request_id_) {
+        capacity_deferred = true;
+        if (!blocked_admission.Any()) {
+          blocked_admission =
+              BlockCapacityShortfall{admission_blocked_request_id_, admission_block_shortfall_};
+        }
+        continue;
+      }
       if (entry.request_id == capacity_deferred_request_id_ ||
           selected_requests >= request_limit ||
           (entry.newly_admitted &&
            (!can_allocate_verdict_ ||
-            allocated_.size() + selected_new_requests >= capacity_))) {
+            allocated_.size() + selected_new_requests >= capacity_ ||
+            selected_new_requests >= new_admission_limit))) {
         capacity_deferred = true;
         continue;
       }
@@ -129,6 +181,8 @@ struct RecordingCacheManager : CacheManager {
           true,
           capacity_deferred,
           unserviceable_request_id,
+          blocked_admission,
+          {},
           {StepOutcomeKind::Committed, plan.transaction_id, nullptr},
       };
     }
@@ -137,6 +191,8 @@ struct RecordingCacheManager : CacheManager {
           false,
           capacity_deferred,
           unserviceable_request_id,
+          blocked_admission,
+          {},
           {StepOutcomeKind::UnserviceableRequest,
            plan.transaction_id,
            unserviceable_request_id},
@@ -146,6 +202,8 @@ struct RecordingCacheManager : CacheManager {
         false,
         capacity_deferred,
         nullptr,
+        blocked_admission,
+        {},
         {capacity_deferred ? StepOutcomeKind::CapacityDeferred : StepOutcomeKind::NoWork,
          plan.transaction_id,
          nullptr},
@@ -195,6 +253,20 @@ struct RecordingCacheManager : CacheManager {
   void SetCapacityDeferredRequest(const std::shared_ptr<Request>& request) {
     capacity_deferred_request_id_ = request.get();
   }
+  // Reports `request` as a waiting admission that only free blocks are holding up, needing
+  // `shortfall` more of them.
+  void SetAdmissionBlockedRequest(const std::shared_ptr<Request>& request, size_t shortfall) {
+    admission_blocked_request_id_ = request.get();
+    admission_block_shortfall_ = shortfall;
+  }
+  void ClearAdmissionBlockedRequest() {
+    admission_blocked_request_id_ = nullptr;
+    admission_block_shortfall_ = 0;
+  }
+  void SetSupportsRecomputePreemption(bool supported) {
+    supports_recompute_preemption_ = supported;
+  }
+  void SetBlocksPerRequest(size_t blocks) { blocks_per_request_ = blocks; }
   size_t AllocatedCount() const { return allocated_.size(); }
 
   // Recorded call counts.
@@ -202,6 +274,7 @@ struct RecordingCacheManager : CacheManager {
   int allocate_calls{0};
   int deallocate_calls{0};
   int step_calls{0};
+  int reclaim_calls{0};
 
  private:
   size_t capacity_;
@@ -209,7 +282,11 @@ struct RecordingCacheManager : CacheManager {
   bool can_allocate_verdict_{true};
   const void* unserviceable_request_id_{};
   const void* capacity_deferred_request_id_{};
+  const void* admission_blocked_request_id_{};
+  size_t admission_block_shortfall_{};
   bool supports_dynamic_batching_{true};
+  bool supports_recompute_preemption_{true};
+  size_t blocks_per_request_{1};
   std::vector<std::shared_ptr<Request>> allocated_;
 };
 
@@ -221,11 +298,26 @@ struct ScriptedDecoderIO : DecoderIO {
   ScriptedDecoderIO(std::shared_ptr<Model> model, ScheduledRequests& scheduled_requests,
                     std::shared_ptr<CacheManager> cache_manager, int32_t forced_token,
                     bool fail_process_logits = false)
+      : ScriptedDecoderIO(model, scheduled_requests, cache_manager,
+                          std::vector<int32_t>(scheduled_requests.size(), forced_token),
+                          fail_process_logits) {}
+
+  // Per-request variant: row i's logits peak at forced_tokens[i], so a test can make the "model"
+  // output depend on what each request actually fed in this step.
+  ScriptedDecoderIO(std::shared_ptr<Model> model, ScheduledRequests& scheduled_requests,
+                    std::shared_ptr<CacheManager> cache_manager,
+                    const std::vector<int32_t>& forced_tokens,
+                    bool fail_process_logits = false)
       : DecoderIO(model, scheduled_requests, cache_manager),
         vocab_size_{static_cast<int64_t>(model->config_->model.vocab_size)},
         fail_process_logits_{fail_process_logits} {
-    if (forced_token < 0 || forced_token >= vocab_size_) {
-      throw std::runtime_error("ScriptedDecoderIO: forced_token out of vocabulary range");
+    if (forced_tokens.size() != scheduled_requests.size()) {
+      throw std::runtime_error("ScriptedDecoderIO: one forced token per scheduled request is required");
+    }
+    for (const int32_t forced_token : forced_tokens) {
+      if (forced_token < 0 || forced_token >= vocab_size_) {
+        throw std::runtime_error("ScriptedDecoderIO: forced_token out of vocabulary range");
+      }
     }
     const int64_t batch_size = static_cast<int64_t>(scheduled_requests.size());
     logits_ = std::make_unique<Tensor>(model->p_device_inputs_, Ort::TypeToTensorType<float>);
@@ -235,7 +327,7 @@ struct ScriptedDecoderIO : DecoderIO {
     auto cpu_span = device_span.CpuSpan();
     std::fill(cpu_span.begin(), cpu_span.end(), 0.0f);
     for (int64_t row = 0; row < batch_size; ++row) {
-      cpu_span[row * vocab_size_ + forced_token] = 100.0f;
+      cpu_span[row * vocab_size_ + forced_tokens[static_cast<size_t>(row)]] = 100.0f;
     }
     device_span.CopyCpuToDevice();
   }
@@ -311,11 +403,24 @@ struct RecordingModelExecutor : ModelExecutor {
     if (failure == ScriptedExecutionFailure::Fatal) {
       throw std::runtime_error("Injected fatal execution failure.");
     }
+    std::vector<int32_t> forced_tokens;
+    forced_tokens.reserve(scheduled_requests.size());
+    for (const auto& request : scheduled_requests) {
+      forced_tokens.push_back(next_token_selector_ ? next_token_selector_(*request)
+                                                   : forced_token_);
+    }
     scheduled_requests.AddDecoderState(
         std::make_unique<ScriptedDecoderIO>(
-            model_, scheduled_requests, cache_manager_, forced_token_,
+            model_, scheduled_requests, cache_manager_, forced_tokens,
             failure == ScriptedExecutionFailure::PostProcessing));
     static_cast<void>(context);
+  }
+
+  // Replaces the single forced token with a per-request choice, so a test can make the fabricated
+  // "model" output depend on the tokens a request actually pushed through this step.
+  using NextTokenSelector = std::function<int32_t(Request&)>;
+  void SetNextTokenSelector(NextTokenSelector selector) {
+    next_token_selector_ = std::move(selector);
   }
 
   void SetNextFailure(ScriptedExecutionFailure failure) {
@@ -339,6 +444,7 @@ struct RecordingModelExecutor : ModelExecutor {
   int32_t forced_token_;
   std::shared_ptr<CallTrace> trace_;
   std::deque<ScriptedExecutionFailure> failures_;
+  NextTokenSelector next_token_selector_;
 };
 
 // An Engine wired with the recording doubles above, together with non-owning observers of those
@@ -366,6 +472,35 @@ inline DoublesEngine MakeDoublesEngine(std::shared_ptr<Model> model, size_t capa
   auto engine = std::make_shared<Engine>(std::move(model), std::move(dependencies));
 
   return DoublesEngine{std::move(engine), cache_observer, executor_observer, std::move(trace)};
+}
+
+// An Engine wired with the production paged cache manager and dynamic scheduler, with only model
+// execution replaced. Admission, block accounting, reservation, commit, and preemption all run
+// through the real code, so capacity pressure in a test is real block pressure.
+struct PagedDoublesEngine {
+  std::shared_ptr<Engine> engine;
+  std::shared_ptr<PagedCacheManager> cache;
+  DynamicBatchScheduler* scheduler;
+  RecordingModelExecutor* executor;
+};
+
+inline PagedDoublesEngine MakePagedEngine(std::shared_ptr<Model> model, int32_t forced_token) {
+  if (!model->config_->engine.dynamic_batching)
+    throw std::runtime_error("MakePagedEngine requires engine.dynamic_batching to be configured.");
+
+  auto cache = std::make_shared<PagedCacheManager>(model);
+  auto scheduler = std::make_unique<DynamicBatchScheduler>(model, cache);
+  auto executor = std::make_unique<RecordingModelExecutor>(model, cache, forced_token);
+
+  DynamicBatchScheduler* scheduler_observer = scheduler.get();
+  RecordingModelExecutor* executor_observer = executor.get();
+  std::shared_ptr<PagedCacheManager> cache_observer = cache;
+
+  EngineDependencies dependencies{std::move(cache), std::move(scheduler), std::move(executor)};
+  auto engine = std::make_shared<Engine>(std::move(model), std::move(dependencies));
+
+  return PagedDoublesEngine{std::move(engine), std::move(cache_observer), scheduler_observer,
+                            executor_observer};
 }
 
 }  // namespace test

--- a/test/engine/recompute_preemption_benchmark.cpp
+++ b/test/engine/recompute_preemption_benchmark.cpp
@@ -1,0 +1,343 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// A deterministic microbenchmark for recompute preemption on the continuous-batching dynamic path.
+//
+// It drives the production DynamicBatchScheduler, PagedCacheManager, PagedKeyValueCache, and
+// Request lifecycle. Only model execution is replaced, so scheduling, admission, block accounting,
+// reservation, commit, and preemption are the real code paths. Because there is no model run, the
+// unit of time is one committed model step rather than a wall-clock interval: the numbers below
+// describe scheduling behavior (how long a request waits, how evenly it is served, how much work is
+// recomputed), not kernel or provider performance.
+//
+// What this measures:
+//   * time to first token, in committed steps, per request;
+//   * inter-token latency, in committed steps, per request;
+//   * aggregate tokens per committed step, completions, and total steps;
+//   * scheduler wait, preemption count, blocks reclaimed, tokens recomputed;
+//   * victim slowdown, comparing a preempted request's end-to-end steps with the same request's
+//     end-to-end steps in the wait-only baseline.
+//
+// What it does not measure: kernel time, memory bandwidth, provider behavior, or anything that
+// depends on real attention. A real-model measurement is still required before claiming a
+// throughput or latency result for a deployed configuration.
+//
+// The benchmark runs as an ordinary test so it stays compiled and correct, and prints its table to
+// stdout. It asserts only the properties the policy is supposed to guarantee, never a timing value.
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine/engine.h"
+#include "engine/scheduler.h"
+#include "engine_test_doubles.h"
+#include "engine_test_helpers.h"
+
+namespace Generators {
+namespace test {
+namespace {
+
+struct WorkloadRequest {
+  size_t prompt_length{};
+  int max_length{};
+  size_t arrival_step{};  // Committed step at which the request is handed to the engine.
+};
+
+struct RequestOutcome {
+  size_t prompt_length{};
+  size_t arrival_step{};
+  size_t first_token_step{};
+  size_t completion_step{};
+  size_t tokens{};
+  size_t preemptions{};
+  size_t recomputed_tokens{};
+  std::vector<size_t> inter_token_gaps;
+
+  size_t TimeToFirstToken() const { return first_token_step - arrival_step; }
+  size_t EndToEnd() const { return completion_step - arrival_step; }
+};
+
+struct RunResult {
+  std::vector<RequestOutcome> requests;
+  size_t committed_steps{};       // Engine ticks; the unit of time for every latency below.
+  size_t model_runs{};            // Ticks that actually ran the model rather than draining results.
+  size_t generated_tokens{};
+  size_t completions{};
+  size_t scheduler_wait_steps{};  // Request-ticks spent waiting instead of resident.
+  SchedulerPreemptionMetrics preemption;
+  size_t capacity_deferred_steps{};
+};
+
+double Percentile(std::vector<size_t> values, double percentile) {
+  if (values.empty())
+    return 0.0;
+  std::sort(values.begin(), values.end());
+  const double rank = percentile * static_cast<double>(values.size() - 1);
+  const size_t lower = static_cast<size_t>(rank);
+  const size_t upper = std::min(lower + 1, values.size() - 1);
+  const double fraction = rank - static_cast<double>(lower);
+  return static_cast<double>(values[lower]) +
+         fraction * static_cast<double>(values[upper] - values[lower]);
+}
+
+std::vector<size_t> Collect(const std::vector<RequestOutcome>& outcomes,
+                            size_t (RequestOutcome::*member)() const) {
+  std::vector<size_t> values;
+  values.reserve(outcomes.size());
+  for (const auto& outcome : outcomes)
+    values.push_back((outcome.*member)());
+  return values;
+}
+
+std::vector<size_t> CollectGaps(const std::vector<RequestOutcome>& outcomes) {
+  std::vector<size_t> values;
+  for (const auto& outcome : outcomes)
+    values.insert(values.end(), outcome.inter_token_gaps.begin(),
+                  outcome.inter_token_gaps.end());
+  return values;
+}
+
+// A mixed workload: two long resident requests arrive first and occupy the key-value budget, then
+// short requests arrive behind them. Without preemption the short requests wait for the long ones
+// to finish; with preemption they are admitted by reclaiming a long request's blocks.
+std::vector<WorkloadRequest> MixedWorkload() {
+  std::vector<WorkloadRequest> workload;
+  workload.push_back(WorkloadRequest{12, 56, 0});
+  workload.push_back(WorkloadRequest{12, 56, 0});
+  for (size_t i = 0; i < 6; ++i)
+    workload.push_back(WorkloadRequest{4, 12, 3 + i * 2});
+  return workload;
+}
+
+std::vector<int32_t> Prompt(size_t length, int32_t seed, int32_t vocab_size) {
+  std::vector<int32_t> prompt;
+  prompt.reserve(length);
+  for (size_t i = 0; i < length; ++i)
+    prompt.push_back(2 + (seed + static_cast<int32_t>(i)) % (vocab_size - 3));
+  return prompt;
+}
+
+RunResult RunWorkload(const std::vector<WorkloadRequest>& workload,
+                      size_t num_blocks, size_t block_size,
+                      bool enable_preemption, size_t min_decode_steps) {
+  auto model = LoadDummyDecoderModel();
+  Config::Engine::DynamicBatching dynamic_batching;
+  dynamic_batching.block_size = block_size;
+  dynamic_batching.num_blocks = num_blocks;
+  dynamic_batching.max_batch_size = 8;
+  dynamic_batching.max_scheduled_tokens = 256;
+  dynamic_batching.enable_recompute_preemption = enable_preemption;
+  dynamic_batching.max_preemptions_per_step = 1;
+  dynamic_batching.min_decode_steps_before_preemption = min_decode_steps;
+  model->config_->engine.dynamic_batching = dynamic_batching;
+
+  auto paged = MakePagedEngine(model, /*forced_token=*/5);
+  const auto vocab_size = static_cast<int32_t>(model->config_->model.vocab_size);
+
+  std::vector<std::shared_ptr<Request>> requests;
+  requests.reserve(workload.size());
+  for (size_t i = 0; i < workload.size(); ++i) {
+    auto params = MakeGreedyParams(*model);
+    params->search.max_length = workload[i].max_length;
+    auto request = std::make_shared<Request>(params);
+    const auto prompt = Prompt(workload[i].prompt_length,
+                               static_cast<int32_t>(i * 5), vocab_size);
+    request->AddTokens(prompt);
+    requests.push_back(std::move(request));
+  }
+
+  RunResult result;
+  result.requests.resize(workload.size());
+  std::vector<size_t> last_token_step(workload.size(), 0);
+  std::vector<bool> added(workload.size(), false);
+  std::vector<bool> completed(workload.size(), false);
+  for (size_t i = 0; i < workload.size(); ++i) {
+    result.requests[i].prompt_length = workload[i].prompt_length;
+    result.requests[i].arrival_step = workload[i].arrival_step;
+  }
+
+  // One iteration is one engine tick, which is one Engine::Step() call. Arrival times, time to
+  // first token, and inter-token latency are all expressed in those ticks.
+  size_t step = 0;
+  constexpr size_t kStepBudget = 20000;
+  while (step < kStepBudget) {
+    for (size_t i = 0; i < workload.size(); ++i) {
+      if (!added[i] && workload[i].arrival_step <= step) {
+        paged.engine->AddRequest(requests[i]);
+        added[i] = true;
+        last_token_step[i] = step;
+      }
+    }
+    const bool all_arrived =
+        std::all_of(added.begin(), added.end(), [](bool value) { return value; });
+    if (all_arrived && !paged.engine->HasPendingRequests())
+      break;
+
+    if (paged.engine->HasPendingRequests()) {
+      try {
+        paged.engine->Step();
+      } catch (const EngineStepError& error) {
+        // Capacity exhaustion is a legitimate outcome for the wait-only policy under this budget;
+        // the tick still passes, and later arrivals or completions can change the picture.
+        if (error.Outcome().kind != StepOutcomeKind::CapacityDeferred)
+          throw;
+        ++result.capacity_deferred_steps;
+      }
+    }
+    ++step;
+    ++result.committed_steps;
+
+    for (size_t i = 0; i < workload.size(); ++i) {
+      if (!added[i] || completed[i])
+        continue;
+      auto& outcome = result.requests[i];
+      while (requests[i]->HasUnseenTokens()) {
+        requests[i]->UnseenToken();
+        ++outcome.tokens;
+        if (outcome.tokens == 1) {
+          outcome.first_token_step = step;
+        } else {
+          outcome.inter_token_gaps.push_back(step - last_token_step[i]);
+        }
+        last_token_step[i] = step;
+      }
+      if (requests[i]->status_ == RequestStatus::Completed) {
+        completed[i] = true;
+        outcome.completion_step = step;
+        ++result.completions;
+      } else if (requests[i]->status_ == RequestStatus::Assigned ||
+                 requests[i]->status_ == RequestStatus::Suspended) {
+        ++result.scheduler_wait_steps;
+      }
+    }
+  }
+
+  result.model_runs = static_cast<size_t>(paged.executor->decode_calls);
+  for (size_t i = 0; i < workload.size(); ++i) {
+    result.requests[i].preemptions = requests[i]->PreemptionCount();
+    result.requests[i].recomputed_tokens = requests[i]->RecomputedTokenCount();
+    result.generated_tokens += result.requests[i].tokens;
+    if (!completed[i])
+      result.requests[i].completion_step = step;
+  }
+  result.preemption = paged.scheduler->PreemptionMetrics();
+  return result;
+}
+
+void PrintRun(const char* label, const RunResult& run) {
+  const auto ttft = Collect(run.requests, &RequestOutcome::TimeToFirstToken);
+  const auto gaps = CollectGaps(run.requests);
+  std::printf(
+      "%-18s ticks=%5zu model_runs=%5zu tokens=%5zu completions=%2zu "
+      "ttft_p50=%6.1f ttft_p95=%6.1f itl_p50=%5.2f itl_p95=%5.2f "
+      "tok/run=%5.2f wait=%5zu deferred=%3zu preempt=%3llu recomputed=%5llu reclaimed=%4llu\n",
+      label, run.committed_steps, run.model_runs, run.generated_tokens, run.completions,
+      Percentile(ttft, 0.50), Percentile(ttft, 0.95), Percentile(gaps, 0.50),
+      Percentile(gaps, 0.95),
+      run.model_runs == 0
+          ? 0.0
+          : static_cast<double>(run.generated_tokens) /
+                static_cast<double>(run.model_runs),
+      run.scheduler_wait_steps, run.capacity_deferred_steps,
+      static_cast<unsigned long long>(run.preemption.preemptions),
+      static_cast<unsigned long long>(run.preemption.recomputed_tokens),
+      static_cast<unsigned long long>(run.preemption.reclaimed_blocks));
+}
+
+// Short requests are the ones that arrive behind the long resident requests, so their admission
+// latency is what preemption is supposed to improve.
+std::vector<RequestOutcome> ShortRequests(const RunResult& run) {
+  std::vector<RequestOutcome> shorts;
+  for (const auto& outcome : run.requests) {
+    if (outcome.arrival_step > 0)
+      shorts.push_back(outcome);
+  }
+  return shorts;
+}
+
+TEST(RecomputePreemptionBenchmark, WaitOnlyVersusRecomputePreemptionUnderAFixedKeyValueBudget) {
+  const auto workload = MixedWorkload();
+  // A budget that holds the two long requests and nothing else, so the short requests behind them
+  // are admitted only when capacity is reclaimed.
+  constexpr size_t kNumBlocks = 2;
+  constexpr size_t kBlockSize = 64;
+
+  const auto baseline =
+      RunWorkload(workload, kNumBlocks, kBlockSize, /*enable_preemption=*/false,
+                  /*min_decode_steps=*/1);
+  const auto eager =
+      RunWorkload(workload, kNumBlocks, kBlockSize, /*enable_preemption=*/true,
+                  /*min_decode_steps=*/1);
+  const auto shipped_default =
+      RunWorkload(workload, kNumBlocks, kBlockSize, /*enable_preemption=*/true,
+                  /*min_decode_steps=*/8);
+
+  std::printf(
+      "\n[recompute preemption] unit of time is one engine tick; no model is executed.\n");
+  PrintRun("wait-only", baseline);
+  PrintRun("preempt q=1", eager);
+  PrintRun("preempt q=8 (dflt)", shipped_default);
+
+  const auto baseline_short = ShortRequests(baseline);
+  const auto eager_short = ShortRequests(eager);
+  const auto default_short = ShortRequests(shipped_default);
+  std::printf(
+      "short-request admission: wait-only ttft_p50=%.1f p95=%.1f | q=1 "
+      "ttft_p50=%.1f p95=%.1f | q=8 ttft_p50=%.1f p95=%.1f\n",
+      Percentile(Collect(baseline_short, &RequestOutcome::TimeToFirstToken), 0.50),
+      Percentile(Collect(baseline_short, &RequestOutcome::TimeToFirstToken), 0.95),
+      Percentile(Collect(eager_short, &RequestOutcome::TimeToFirstToken), 0.50),
+      Percentile(Collect(eager_short, &RequestOutcome::TimeToFirstToken), 0.95),
+      Percentile(Collect(default_short, &RequestOutcome::TimeToFirstToken), 0.50),
+      Percentile(Collect(default_short, &RequestOutcome::TimeToFirstToken), 0.95));
+
+  // Victim slowdown: the long requests pay for the short requests' admission.
+  for (size_t i = 0; i < baseline.requests.size(); ++i) {
+    if (shipped_default.requests[i].preemptions == 0)
+      continue;
+    const double slowdown =
+        baseline.requests[i].EndToEnd() == 0
+            ? 0.0
+            : static_cast<double>(shipped_default.requests[i].EndToEnd()) /
+                  static_cast<double>(baseline.requests[i].EndToEnd());
+    std::printf(
+        "victim %zu: preemptions=%zu recomputed_tokens=%zu end_to_end %zu -> %zu (slowdown %.2fx)\n",
+        i, shipped_default.requests[i].preemptions,
+        shipped_default.requests[i].recomputed_tokens, baseline.requests[i].EndToEnd(),
+        shipped_default.requests[i].EndToEnd(), slowdown);
+  }
+
+  // Every request must still finish, whichever policy ran.
+  EXPECT_EQ(baseline.completions, workload.size());
+  EXPECT_EQ(eager.completions, workload.size());
+  EXPECT_EQ(shipped_default.completions, workload.size());
+  // Preemption has to actually engage for the comparison to mean anything.
+  EXPECT_GT(eager.preemption.preemptions, 0u);
+  EXPECT_GT(shipped_default.preemption.preemptions, 0u);
+  EXPECT_EQ(baseline.preemption.preemptions, 0u);
+  // Recomputation is bounded by what was reclaimed, never invented.
+  EXPECT_EQ(eager.preemption.recomputed_tokens > 0,
+            eager.preemption.preemptions > 0);
+  // The service quantum is what bounds churn: the default must recompute less than the eager one.
+  EXPECT_LT(shipped_default.preemption.recomputed_tokens,
+            eager.preemption.recomputed_tokens);
+  // Preemption exists to admit the requests waiting behind the long ones sooner.
+  EXPECT_LT(Percentile(Collect(default_short, &RequestOutcome::TimeToFirstToken), 0.50),
+            Percentile(Collect(baseline_short, &RequestOutcome::TimeToFirstToken), 0.50));
+  EXPECT_LE(Percentile(Collect(default_short, &RequestOutcome::TimeToFirstToken), 0.95),
+            Percentile(Collect(baseline_short, &RequestOutcome::TimeToFirstToken), 0.95));
+  // Aggregate scheduler wait must not get worse for the workload as a whole.
+  EXPECT_LE(shipped_default.scheduler_wait_steps, baseline.scheduler_wait_steps);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace Generators

--- a/test/engine/recompute_preemption_tests.cpp
+++ b/test/engine/recompute_preemption_tests.cpp
@@ -1,0 +1,824 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for recompute preemption on the continuous-batching dynamic path: the policy that picks a
+// victim, the request transition that gives up cache residency, the scheduler that performs the
+// suspension at a step boundary, and the end-to-end guarantee that a suspended request resumes with
+// exactly the token stream it would have produced had it never been preempted.
+//
+// The scheduler and engine cases drive the production PagedCacheManager and DynamicBatchScheduler,
+// with only model execution replaced, so capacity pressure here is real block pressure.
+
+#include <array>
+#include <map>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine/engine.h"
+#include "engine/engine_invariants.h"
+#include "engine/recompute_preemption_policy.h"
+#include "engine/scheduler.h"
+#include "engine_test_doubles.h"
+#include "engine_test_helpers.h"
+
+namespace Generators {
+namespace test {
+namespace {
+
+RecomputePreemptionCandidate Candidate(const void* id, size_t blocks,
+                                       size_t preemptions, bool eligible = true,
+                                       size_t decode_steps = 4) {
+  return RecomputePreemptionCandidate{id, blocks, preemptions, decode_steps, eligible};
+}
+
+RecomputePreemptionSettings EnabledSettings(size_t max_victims_per_step = 1,
+                                            size_t max_per_request = 0,
+                                            size_t min_decode_steps = 1) {
+  return RecomputePreemptionSettings{true, max_victims_per_step, max_per_request,
+                                     min_decode_steps};
+}
+
+// Stand-in request identities for the policy tests, which never dereference them.
+const char kA = 'a';
+const char kB = 'b';
+const char kC = 'c';
+
+// A non-end-of-stream token, so a scripted step advances a request instead of completing it.
+constexpr int32_t kFilledToken = 5;
+
+TEST(RecomputePreemptionPolicyTest, OrdersFewestPreemptionsThenNewestResident) {
+  const std::array candidates{
+      Candidate(&kA, 4, 1),
+      Candidate(&kB, 4, 0),
+      Candidate(&kC, 4, 0),
+  };
+
+  const auto order = RecomputeVictimOrder(candidates);
+
+  // Both never-preempted residents come before the one that has already paid, and between them the
+  // later-admitted one is chosen so the longest-resident request keeps its accumulated work.
+  ASSERT_EQ(order.size(), 3u);
+  EXPECT_EQ(order[0], 2u);
+  EXPECT_EQ(order[1], 1u);
+  EXPECT_EQ(order[2], 0u);
+}
+
+TEST(RecomputePreemptionPolicyTest, SkipsIneligibleCandidates) {
+  const std::array candidates{
+      Candidate(&kA, 4, 0, /*eligible=*/false),
+      Candidate(&kB, 4, 0),
+  };
+
+  const auto order = RecomputeVictimOrder(candidates);
+
+  ASSERT_EQ(order.size(), 1u);
+  EXPECT_EQ(order[0], 1u);
+}
+
+TEST(RecomputePreemptionPolicyTest, SelectsNothingWhenDisabled) {
+  const std::array candidates{Candidate(&kA, 4, 0)};
+
+  const auto decision = SelectRecomputeVictims(
+      candidates, 1, RecomputePreemptionSettings{false, 1, 0, 1});
+
+  EXPECT_TRUE(decision.Empty());
+  EXPECT_EQ(decision.reclaimed_blocks, 0u);
+}
+
+TEST(RecomputePreemptionPolicyTest, DeclinesUntilAResidentHasEarnedItsAdmission) {
+  // A resident that has not decoded since it was admitted has not been paid for the key-value
+  // entries it rebuilt, so suspending it again would be pure churn.
+  const std::array candidates{
+      Candidate(&kA, 4, 0, /*eligible=*/true, /*decode_steps=*/0)};
+
+  EXPECT_TRUE(SelectRecomputeVictims(candidates, 1, EnabledSettings(1, 0, 1)).Empty());
+
+  const std::array served{
+      Candidate(&kA, 4, 0, /*eligible=*/true, /*decode_steps=*/1)};
+  EXPECT_EQ(SelectRecomputeVictims(served, 1, EnabledSettings(1, 0, 1)).victims.size(), 1u);
+  // A larger quantum keeps the same resident protected for longer.
+  EXPECT_TRUE(SelectRecomputeVictims(served, 1, EnabledSettings(1, 0, 4)).Empty());
+}
+
+TEST(RecomputePreemptionPolicyTest, SelectsNothingWhenNothingIsBlocked) {
+  const std::array candidates{Candidate(&kA, 4, 0)};
+
+  EXPECT_TRUE(SelectRecomputeVictims(candidates, 0, EnabledSettings()).Empty());
+}
+
+TEST(RecomputePreemptionPolicyTest, SelectsTheSmallestCoveringVictimSet) {
+  const std::array candidates{
+      Candidate(&kA, 2, 0),
+      Candidate(&kB, 3, 0),
+  };
+
+  const auto decision = SelectRecomputeVictims(candidates, 3, EnabledSettings(2));
+
+  // The newest resident is considered first and already covers the shortfall, so the older one is
+  // left alone.
+  ASSERT_EQ(decision.victims.size(), 1u);
+  EXPECT_EQ(decision.victims[0], 1u);
+  EXPECT_EQ(decision.reclaimed_blocks, 3u);
+}
+
+TEST(RecomputePreemptionPolicyTest, CombinesVictimsUpToTheStepBound) {
+  const std::array candidates{
+      Candidate(&kA, 2, 0),
+      Candidate(&kB, 2, 0),
+  };
+
+  const auto decision = SelectRecomputeVictims(candidates, 4, EnabledSettings(2));
+
+  ASSERT_EQ(decision.victims.size(), 2u);
+  EXPECT_EQ(decision.reclaimed_blocks, 4u);
+}
+
+TEST(RecomputePreemptionPolicyTest, DeclinesWhenTheStepBoundCannotCoverTheShortfall) {
+  const std::array candidates{
+      Candidate(&kA, 2, 0),
+      Candidate(&kB, 2, 0),
+  };
+
+  const auto decision = SelectRecomputeVictims(candidates, 4, EnabledSettings(1));
+
+  EXPECT_TRUE(decision.Empty());
+  EXPECT_EQ(decision.reclaimed_blocks, 0u);
+}
+
+TEST(RecomputePreemptionPolicyTest, DeclinesWhenNoEligibleVictimExists) {
+  const std::array candidates{Candidate(&kA, 8, 0, /*eligible=*/false)};
+
+  EXPECT_TRUE(SelectRecomputeVictims(candidates, 1, EnabledSettings()).Empty());
+}
+
+TEST(RecomputePreemptionPolicyTest, HonorsThePerRequestBound) {
+  const std::array candidates{
+      Candidate(&kA, 4, 2),
+      Candidate(&kB, 4, 0),
+  };
+
+  const auto bounded = SelectRecomputeVictims(candidates, 8, EnabledSettings(2, 2));
+
+  // Only one candidate is still under the per-request bound, so the pair cannot be formed.
+  EXPECT_TRUE(bounded.Empty());
+
+  const auto single = SelectRecomputeVictims(candidates, 4, EnabledSettings(2, 2));
+  ASSERT_EQ(single.victims.size(), 1u);
+  EXPECT_EQ(single.victims[0], 1u);
+}
+
+TEST(RecomputePreemptionPolicyTest, IgnoresCandidatesThatOwnNothing) {
+  const std::array candidates{
+      Candidate(&kA, 4, 0),
+      Candidate(&kB, 0, 0),
+  };
+
+  const auto decision = SelectRecomputeVictims(candidates, 4, EnabledSettings(2));
+
+  ASSERT_EQ(decision.victims.size(), 1u);
+  EXPECT_EQ(decision.victims[0], 0u);
+}
+
+// Fabricates a decoder whose next token depends on every token a request has pushed through it
+// since its key-value entries were last built, which is how a real decoder's output depends on its
+// whole context. A resume that replayed the wrong tokens, dropped any, or replayed them at the
+// wrong offset would produce a different stream, so comparing streams is a real continuity check.
+class ContextDependentDecoder {
+ public:
+  ContextDependentDecoder(int32_t vocab_size, int32_t eos_token)
+      : vocab_size_{vocab_size}, eos_token_{eos_token} {}
+
+  int32_t operator()(Request& request) {
+    auto& context = contexts_[&request];
+    const auto processed = static_cast<size_t>(request.ProcessedSequenceLength());
+    // Truncating to the committed boundary makes this idempotent: a rolled-back attempt's tokens
+    // are dropped before the retry appends them again.
+    if (processed < context.size())
+      context.resize(processed);
+    if (context.size() != processed)
+      throw std::runtime_error("ContextDependentDecoder lost part of a request's context.");
+
+    for (const int32_t token : request.UnprocessedTokensCpu())
+      context.push_back(token);
+
+    uint32_t hash = 2166136261u;
+    for (const int32_t token : context) {
+      hash ^= static_cast<uint32_t>(token);
+      hash *= 16777619u;
+    }
+    // Stay clear of the end-of-stream token so generation length stays under the test's control.
+    const int32_t candidate =
+        static_cast<int32_t>(hash % static_cast<uint32_t>(vocab_size_));
+    return candidate == eos_token_ ? (candidate + 1) % vocab_size_ : candidate;
+  }
+
+ private:
+  int32_t vocab_size_;
+  int32_t eos_token_;
+  std::map<const Request*, std::vector<int32_t>> contexts_;
+};
+
+class RecomputePreemptionTest : public ::testing::Test {
+ protected:
+  // A small block pool with a large block size keeps the arithmetic obvious: one block holds one
+  // request's short sequence, so "one more resident" costs exactly one block.
+  std::shared_ptr<Model> LoadModel(size_t num_blocks, bool enable_preemption,
+                                   size_t max_preemptions_per_step = 1,
+                                   size_t max_preemptions_per_request = 0,
+                                   size_t min_decode_steps = 1,
+                                   size_t block_size = 32) {
+    auto model = LoadDummyDecoderModel();
+    Config::Engine::DynamicBatching dynamic_batching;
+    dynamic_batching.block_size = block_size;
+    dynamic_batching.num_blocks = num_blocks;
+    dynamic_batching.max_batch_size = 8;
+    dynamic_batching.max_scheduled_tokens = 64;
+    dynamic_batching.enable_recompute_preemption = enable_preemption;
+    dynamic_batching.max_preemptions_per_step = max_preemptions_per_step;
+    dynamic_batching.max_preemptions_per_request = max_preemptions_per_request;
+    dynamic_batching.min_decode_steps_before_preemption = min_decode_steps;
+    model->config_->engine.dynamic_batching = dynamic_batching;
+    return model;
+  }
+
+  static std::shared_ptr<Request> Mint(const Model& model,
+                                       std::span<const int32_t> prompt,
+                                       int max_length) {
+    auto params = MakeGreedyParams(model);
+    params->search.max_length = max_length;
+    auto request = std::make_shared<Request>(params);
+    request->AddTokens(prompt);
+    return request;
+  }
+
+  static std::vector<RequestStateSnapshot> Snapshots(
+      const std::vector<std::shared_ptr<Request>>& requests) {
+    std::vector<RequestStateSnapshot> snapshots;
+    snapshots.reserve(requests.size());
+    for (const auto& request : requests)
+      snapshots.push_back(request->Snapshot());
+    return snapshots;
+  }
+
+  // Engine::Step() returns one ready request per call and drains a committed batch before running
+  // the model again, so counting model invocations is how a test advances the engine by a known
+  // number of committed steps.
+  static void RunModelSteps(PagedDoublesEngine& paged, int model_steps) {
+    const int target = paged.executor->decode_calls + model_steps;
+    int guard = 0;
+    while (paged.executor->decode_calls < target && guard++ < 256)
+      paged.engine->Step();
+    if (paged.executor->decode_calls < target)
+      throw std::runtime_error("The engine stopped running the model before the step budget.");
+  }
+
+  static void ExpectConsistent(const PagedDoublesEngine& engine,
+                               const std::vector<std::shared_ptr<Request>>& requests) {
+    const auto violations =
+        ValidateInvariants(engine.cache->Snapshot(), Snapshots(requests));
+    for (const auto& violation : violations)
+      ADD_FAILURE() << violation.message;
+  }
+};
+
+TEST_F(RecomputePreemptionTest, SuspendRewindsTheCacheCursorAndKeepsTheSequence) {
+  auto model = LoadModel(/*num_blocks=*/4, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto request = Mint(*model, prompt, /*max_length=*/32);
+  paged.engine->AddRequest(request);
+
+  ASSERT_NE(paged.engine->Step(), nullptr);
+  const auto resident = request->Snapshot();
+  ASSERT_EQ(resident.status, RequestStatus::InProgress);
+  ASSERT_EQ(resident.processed_sequence_length, 3);
+  ASSERT_EQ(resident.current_sequence_length, 4);
+
+  request->SuspendForRecompute();
+
+  const auto suspended = request->Snapshot();
+  EXPECT_EQ(suspended.status, RequestStatus::Suspended);
+  EXPECT_EQ(suspended.processed_sequence_length, 0);
+  // The whole logical sequence survives, including the token sampled by the last committed step.
+  EXPECT_EQ(suspended.current_sequence_length, resident.current_sequence_length);
+  EXPECT_EQ(suspended.seen_sequence_length, resident.seen_sequence_length);
+  EXPECT_TRUE(suspended.is_prefill);
+  EXPECT_EQ(suspended.preemption_count, 1u);
+  EXPECT_EQ(suspended.recomputed_token_count, 3u);
+}
+
+TEST_F(RecomputePreemptionTest, SuspendRejectsRequestsThatAreNotResident) {
+  auto model = LoadModel(/*num_blocks=*/4, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto request = Mint(*model, prompt, /*max_length=*/32);
+
+  EXPECT_THROW(request->SuspendForRecompute(), std::runtime_error);
+
+  paged.engine->AddRequest(request);
+  EXPECT_FALSE(request->IsPreemptible());
+  EXPECT_THROW(request->SuspendForRecompute(), std::runtime_error);
+}
+
+TEST_F(RecomputePreemptionTest, SuspendedRequestRejectsNewTokens) {
+  auto model = LoadModel(/*num_blocks=*/4, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto request = Mint(*model, prompt, /*max_length=*/32);
+  paged.engine->AddRequest(request);
+  ASSERT_NE(paged.engine->Step(), nullptr);
+  request->SuspendForRecompute();
+
+  const std::array<int32_t, 1> extra{5};
+  EXPECT_THROW(request->AddTokens(extra), std::runtime_error);
+}
+
+TEST_F(RecomputePreemptionTest, InvariantsRejectASuspendedRequestThatStillLooksResident) {
+  RequestStateSnapshot snapshot;
+  snapshot.request_id = &kA;
+  snapshot.status = RequestStatus::Suspended;
+  snapshot.current_sequence_length = 8;
+  snapshot.processed_sequence_length = 8;
+  snapshot.seen_sequence_length = 8;
+  snapshot.is_prefill = false;
+  snapshot.preemption_count = 0;
+
+  const auto violations = ValidateRequestInvariants(snapshot);
+
+  EXPECT_EQ(violations.size(), 3u);
+}
+
+TEST_F(RecomputePreemptionTest, DisabledByDefaultLeavesBlockedRequestsWaiting) {
+  // One block holds one request's whole sequence, so the second request cannot be admitted.
+  auto model = LoadModel(/*num_blocks=*/1, /*enable_preemption=*/false);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto resident = Mint(*model, prompt, /*max_length=*/32);
+  auto waiting = Mint(*model, prompt, /*max_length=*/32);
+  paged.engine->AddRequest(resident);
+  RunModelSteps(paged, 2);
+  paged.engine->AddRequest(waiting);
+
+  RunModelSteps(paged, 3);
+
+  EXPECT_EQ(resident->status_, RequestStatus::InProgress);
+  EXPECT_EQ(waiting->status_, RequestStatus::Assigned);
+  const auto& metrics = paged.scheduler->PreemptionMetrics();
+  EXPECT_EQ(metrics.preemptions, 0u);
+  EXPECT_EQ(metrics.block_starved_passes, 0u);
+  ExpectConsistent(paged, {resident, waiting});
+}
+
+TEST_F(RecomputePreemptionTest, PreemptsAResidentToAdmitABlockedRequest) {
+  auto model = LoadModel(/*num_blocks=*/1, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto resident = Mint(*model, prompt, /*max_length=*/32);
+  auto waiting = Mint(*model, prompt, /*max_length=*/32);
+  paged.engine->AddRequest(resident);
+  // One prefill step plus one decode step, so the resident has earned its admission.
+  RunModelSteps(paged, 2);
+  const auto before = resident->Snapshot();
+  ASSERT_EQ(resident->DecodeStepsSinceAdmission(), 1u);
+  paged.engine->AddRequest(waiting);
+
+  RunModelSteps(paged, 1);
+
+  const auto& metrics = paged.scheduler->PreemptionMetrics();
+  EXPECT_EQ(metrics.block_starved_passes, 1u);
+  EXPECT_EQ(metrics.preemptions, 1u);
+  EXPECT_EQ(metrics.preemption_passes, 1u);
+  EXPECT_EQ(metrics.reclaimed_blocks, 1u);
+  EXPECT_EQ(metrics.recomputed_tokens,
+            static_cast<uint64_t>(before.processed_sequence_length));
+  EXPECT_EQ(metrics.declined_preemptions, 0u);
+
+  // The resident gave up its residency and the waiting request took its place.
+  EXPECT_EQ(resident->status_, RequestStatus::Suspended);
+  EXPECT_EQ(resident->ProcessedSequenceLength(), 0);
+  EXPECT_EQ(resident->PreemptionCount(), 1u);
+  EXPECT_EQ(resident->DecodeStepsSinceAdmission(), 0u);
+  EXPECT_EQ(waiting->status_, RequestStatus::InProgress);
+  const auto snapshot = paged.cache->Snapshot();
+  ASSERT_EQ(snapshot.requests.size(), 1u);
+  EXPECT_EQ(snapshot.requests[0].request_id, waiting.get());
+  ExpectConsistent(paged, {resident, waiting});
+}
+
+TEST_F(RecomputePreemptionTest, PreemptsToUnblockAResidentThatCannotGrow) {
+  // One slot per block means every decode step needs a new block, so the pool runs dry with the
+  // residents mid-sequence and no request able to run.
+  auto model = LoadModel(/*num_blocks=*/6, /*enable_preemption=*/true,
+                         /*max_preemptions_per_step=*/1,
+                         /*max_preemptions_per_request=*/0,
+                         /*min_decode_steps=*/1, /*block_size=*/1);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 2> prompt{2, 3};
+  auto first = Mint(*model, prompt, /*max_length=*/16);
+  auto second = Mint(*model, prompt, /*max_length=*/16);
+  paged.engine->AddRequest(first);
+  paged.engine->AddRequest(second);
+  RunModelSteps(paged, 2);
+  ASSERT_EQ(paged.cache->Snapshot().free_blocks, 0u);
+  ASSERT_EQ(paged.scheduler->PreemptionMetrics().preemptions, 0u);
+
+  RunModelSteps(paged, 1);
+
+  // Rather than reporting that the engine is out of capacity, the newest resident is suspended so
+  // the older one can keep decoding.
+  const auto& metrics = paged.scheduler->PreemptionMetrics();
+  EXPECT_EQ(metrics.preemptions, 1u);
+  EXPECT_EQ(second->status_, RequestStatus::Suspended);
+  EXPECT_EQ(first->status_, RequestStatus::InProgress);
+  EXPECT_GT(first->ProcessedSequenceLength(), 3);
+  ExpectConsistent(paged, {first, second});
+}
+
+TEST_F(RecomputePreemptionTest, SuspendedRequestIsRebuiltByChunkedPrefill) {
+  auto model = LoadModel(/*num_blocks=*/1, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto victim = Mint(*model, prompt, /*max_length=*/10);
+  auto newcomer = Mint(*model, prompt, /*max_length=*/10);
+  paged.engine->AddRequest(victim);
+  RunModelSteps(paged, 2);
+  paged.engine->AddRequest(newcomer);
+  RunModelSteps(paged, 1);
+  ASSERT_EQ(victim->status_, RequestStatus::Suspended);
+  const int64_t sequence_length_when_suspended = victim->CurrentSequenceLength();
+  const size_t recomputed_tokens = victim->RecomputedTokenCount();
+
+  // Drive the engine until the victim's key-value entries have been rebuilt.
+  int steps = 0;
+  while (paged.engine->HasPendingRequests() && steps++ < 128) {
+    paged.engine->Step();
+    if (victim->status_ == RequestStatus::InProgress &&
+        victim->ProcessedSequenceLength() >= sequence_length_when_suspended) {
+      break;
+    }
+  }
+
+  EXPECT_EQ(victim->status_, RequestStatus::InProgress);
+  // Every token it held before the suspension is back in the cache, and no token was lost.
+  EXPECT_GE(victim->ProcessedSequenceLength(), sequence_length_when_suspended);
+  EXPECT_GE(victim->CurrentSequenceLength(), sequence_length_when_suspended);
+  EXPECT_EQ(victim->PreemptionCount(), 1u);
+  EXPECT_EQ(victim->RecomputedTokenCount(), recomputed_tokens);
+  ExpectConsistent(paged, {victim, newcomer});
+}
+
+TEST_F(RecomputePreemptionTest, PrefillingResidentIsNotPreemptible) {
+  // A resident whose key-value entries are only partly built owns blocks for a prefill it has not
+  // finished; suspending it would discard work that is still in flight.
+  auto model = LoadModel(/*num_blocks=*/4, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 6> prompt{2, 3, 4, 5, 6, 7};
+  auto request = Mint(*model, prompt, /*max_length=*/32);
+  paged.engine->AddRequest(request);
+
+  // Commit a partial prefill the way a chunked step would: cache slots advance, no token is
+  // sampled, and the request becomes resident while still in prefill.
+  RequestStepPlan plan;
+  plan.request = request;
+  plan.request_id = request.get();
+  plan.sequence_length_before = request->CurrentSequenceLength();
+  plan.target_cache_slots = 2;
+  request->CommitStep(plan, RequestStepResult{});
+
+  ASSERT_EQ(request->status_, RequestStatus::InProgress);
+  ASSERT_TRUE(request->IsPrefill());
+  EXPECT_FALSE(request->IsPreemptible());
+  EXPECT_EQ(request->DecodeStepsSinceAdmission(), 0u);
+}
+
+TEST_F(RecomputePreemptionTest, DeclinesToPreemptUntilAResidentHasEarnedItsService) {
+  // The resident has decoded once, but the configured quantum asks for more before its residency
+  // can be taken away again.
+  auto model = LoadModel(/*num_blocks=*/1, /*enable_preemption=*/true,
+                         /*max_preemptions_per_step=*/1,
+                         /*max_preemptions_per_request=*/0,
+                         /*min_decode_steps=*/4);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto resident = Mint(*model, prompt, /*max_length=*/32);
+  auto waiting = Mint(*model, prompt, /*max_length=*/32);
+  paged.engine->AddRequest(resident);
+  RunModelSteps(paged, 2);
+  ASSERT_EQ(resident->DecodeStepsSinceAdmission(), 1u);
+  paged.engine->AddRequest(waiting);
+
+  RunModelSteps(paged, 1);
+
+  const auto& metrics = paged.scheduler->PreemptionMetrics();
+  EXPECT_GE(metrics.block_starved_passes, 1u);
+  EXPECT_GE(metrics.declined_preemptions, 1u);
+  EXPECT_EQ(metrics.preemptions, 0u);
+  EXPECT_EQ(resident->status_, RequestStatus::InProgress);
+  EXPECT_EQ(waiting->status_, RequestStatus::Assigned);
+  ExpectConsistent(paged, {resident, waiting});
+
+  // Once the quantum is paid, the same waiting request is admitted by suspending the resident.
+  RunModelSteps(paged, 3);
+  EXPECT_EQ(paged.scheduler->PreemptionMetrics().preemptions, 1u);
+  EXPECT_EQ(resident->status_, RequestStatus::Suspended);
+  ExpectConsistent(paged, {resident, waiting});
+}
+
+TEST_F(RecomputePreemptionTest, SpreadsPreemptionsAcrossResidentsInsteadOfRepeatingOne) {
+  auto model = LoadModel(/*num_blocks=*/2, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto first = Mint(*model, prompt, /*max_length=*/24);
+  auto second = Mint(*model, prompt, /*max_length=*/24);
+  paged.engine->AddRequest(first);
+  paged.engine->AddRequest(second);
+  RunModelSteps(paged, 2);
+  ASSERT_EQ(first->status_, RequestStatus::InProgress);
+  ASSERT_EQ(second->status_, RequestStatus::InProgress);
+
+  auto third = Mint(*model, prompt, /*max_length=*/24);
+  paged.engine->AddRequest(third);
+  RunModelSteps(paged, 1);
+
+  // The newest resident is suspended first, keeping the longest-resident request's work.
+  EXPECT_EQ(second->status_, RequestStatus::Suspended);
+  EXPECT_EQ(first->status_, RequestStatus::InProgress);
+
+  auto fourth = Mint(*model, prompt, /*max_length=*/24);
+  paged.engine->AddRequest(fourth);
+  RunModelSteps(paged, 4);
+
+  // No request is suspended twice while a resident that has never been suspended is still holding
+  // capacity, so the cost is spread instead of falling on one victim.
+  EXPECT_LE(second->PreemptionCount(), first->PreemptionCount() + 1u);
+  EXPECT_GE(paged.scheduler->PreemptionMetrics().preemptions, 2u);
+  ExpectConsistent(paged, {first, second, third, fourth});
+}
+
+TEST_F(RecomputePreemptionTest, SuspendedRequestIsAdmittedBeforeANeverAdmittedNewcomer) {
+  auto model = LoadModel(/*num_blocks=*/1, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto victim = Mint(*model, prompt, /*max_length=*/8);
+  auto newcomer = Mint(*model, prompt, /*max_length=*/8);
+  paged.engine->AddRequest(victim);
+  RunModelSteps(paged, 2);
+  paged.engine->AddRequest(newcomer);
+  RunModelSteps(paged, 1);
+  ASSERT_EQ(victim->status_, RequestStatus::Suspended);
+
+  // A request that arrives after the suspension must not overtake the victim.
+  auto latecomer = Mint(*model, prompt, /*max_length=*/8);
+  paged.engine->AddRequest(latecomer);
+  int steps = 0;
+  while (paged.engine->HasPendingRequests() && steps++ < 128) {
+    paged.engine->Step();
+    if (victim->status_ == RequestStatus::InProgress)
+      break;
+  }
+
+  EXPECT_EQ(victim->status_, RequestStatus::InProgress);
+  EXPECT_EQ(latecomer->status_, RequestStatus::Assigned);
+  ExpectConsistent(paged, {victim, newcomer, latecomer});
+}
+
+TEST_F(RecomputePreemptionTest, CapacityRetryDoesNotReadmitTheRequestTheStepJustSuspended) {
+  auto model = LoadModel(/*num_blocks=*/1, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto victim = Mint(*model, prompt, /*max_length=*/12);
+  auto newcomer = Mint(*model, prompt, /*max_length=*/12);
+  paged.engine->AddRequest(victim);
+  RunModelSteps(paged, 2);
+  paged.engine->AddRequest(newcomer);
+  const size_t decodes_before = paged.executor->decoded_request_ids.size();
+
+  // The step preempts the victim, then the newcomer's execution reports a capacity failure and the
+  // engine replans a smaller batch for the same step.
+  paged.executor->SetNextFailure(ScriptedExecutionFailure::CapacityExceeded);
+  paged.engine->Step();
+
+  ASSERT_EQ(victim->PreemptionCount(), 1u);
+  ASSERT_GT(paged.executor->decoded_request_ids.size(), decodes_before + 1);
+  // The retry must not hand the reclaimed block back to the request this step just suspended.
+  const auto& retry_requests = paged.executor->decoded_request_ids[decodes_before + 1];
+  ASSERT_EQ(retry_requests.size(), 1u);
+  EXPECT_EQ(retry_requests[0], newcomer.get());
+  ExpectConsistent(paged, {victim, newcomer});
+}
+
+TEST_F(RecomputePreemptionTest, PlannerHonorsThePerPlanAdmissionLimit) {
+  auto model = LoadModel(/*num_blocks=*/4, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto first = Mint(*model, prompt, /*max_length=*/16);
+  auto second = Mint(*model, prompt, /*max_length=*/16);
+  paged.engine->AddRequest(first);
+  paged.engine->AddRequest(second);
+
+  StepPlan plan;
+  plan.transaction_id = 1;
+  for (const auto& request : {first, second}) {
+    RequestStepPlan entry;
+    entry.request = request;
+    entry.request_id = request.get();
+    entry.sequence_length_before = request->CurrentSequenceLength();
+    entry.unprocessed_token_count = 1;
+    entry.target_cache_slots = 1;
+    entry.whole_sequence_cache_slots =
+        static_cast<size_t>(request->CurrentSequenceLength());
+    entry.is_prefill = true;
+    entry.newly_admitted = true;
+    plan.requests.push_back(std::move(entry));
+  }
+  // Free blocks are plentiful, so only the per-plan admission cap can hold the second request back.
+  plan.new_admission_limit = 1;
+
+  const auto result = paged.cache->PlanStepResources(plan);
+
+  ASSERT_TRUE(result.executable);
+  ASSERT_EQ(plan.requests.size(), 1u);
+  EXPECT_EQ(plan.requests[0].request, first);
+  EXPECT_TRUE(result.capacity_deferred);
+  // The cap is not a block shortage, so it must not be reported as one.
+  EXPECT_FALSE(result.blocked_admission.Any());
+}
+
+TEST_F(RecomputePreemptionTest, SuspendedRequestCanBeRemoved) {
+  auto model = LoadModel(/*num_blocks=*/1, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto victim = Mint(*model, prompt, /*max_length=*/12);
+  auto newcomer = Mint(*model, prompt, /*max_length=*/12);
+  paged.engine->AddRequest(victim);
+  RunModelSteps(paged, 2);
+  paged.engine->AddRequest(newcomer);
+  RunModelSteps(paged, 1);
+  ASSERT_EQ(victim->status_, RequestStatus::Suspended);
+
+  victim->Remove();
+
+  EXPECT_EQ(victim->status_, RequestStatus::Unassigned);
+  const auto snapshot = paged.cache->Snapshot();
+  ASSERT_EQ(snapshot.requests.size(), 1u);
+  EXPECT_EQ(snapshot.requests[0].request_id, newcomer.get());
+  // The engine keeps serving the surviving request without the removed one reappearing.
+  int steps = 0;
+  while (paged.engine->HasPendingRequests() && steps++ < 128)
+    paged.engine->Step();
+  EXPECT_EQ(newcomer->status_, RequestStatus::Completed);
+  ExpectConsistent(paged, {newcomer});
+}
+
+TEST_F(RecomputePreemptionTest, RejectsEnablingPreemptionOnACacheThatCannotReclaim) {
+  auto model = LoadModel(/*num_blocks=*/4, /*enable_preemption=*/true);
+  auto cache = std::make_shared<RecordingCacheManager>(model, /*capacity=*/4);
+  cache->SetSupportsRecomputePreemption(false);
+
+  EXPECT_THROW(DynamicBatchScheduler(model, cache), std::runtime_error);
+}
+
+TEST_F(RecomputePreemptionTest, RejectsEnablingPreemptionOnTheStaticPath) {
+  auto model = LoadModel(/*num_blocks=*/4, /*enable_preemption=*/true);
+  auto cache = std::make_shared<RecordingCacheManager>(
+      model, /*capacity=*/4, /*trace=*/nullptr, /*supports_dynamic_batching=*/false);
+
+  EXPECT_THROW(StaticBatchScheduler(model, cache), std::runtime_error);
+}
+
+TEST_F(RecomputePreemptionTest, RejectsAZeroPerStepPreemptionBound) {
+  auto model = LoadModel(/*num_blocks=*/4, /*enable_preemption=*/true,
+                         /*max_preemptions_per_step=*/0);
+  auto cache = std::make_shared<RecordingCacheManager>(model, /*capacity=*/4);
+
+  EXPECT_THROW(DynamicBatchScheduler(model, cache), std::invalid_argument);
+}// Drives every request to completion and returns the exact token stream each one produced, which is
+// the observable an application sees.
+std::map<const Request*, std::vector<int32_t>> RunToCompletion(
+    Engine& engine, const std::vector<std::shared_ptr<Request>>& requests,
+    int max_steps) {
+  std::map<const Request*, std::vector<int32_t>> streams;
+  for (const auto& request : requests)
+    streams[request.get()] = {};
+
+  int steps = 0;
+  while (engine.HasPendingRequests()) {
+    if (steps++ > max_steps)
+      throw std::runtime_error("The engine did not drain within the step budget.");
+    auto ready = engine.Step();
+    if (!ready)
+      continue;
+    while (ready->HasUnseenTokens())
+      streams[ready.get()].push_back(ready->UnseenToken());
+  }
+  return streams;
+}
+
+TEST_F(RecomputePreemptionTest, PreemptionPreservesEachRequestsTokenStream) {
+  // The fabricated decoder is a pure function of the context a request pushed through it, so this
+  // proves the resume replays the identical logical context. It cannot prove floating-point
+  // determinism on a real provider, where replaying a decode as part of a longer prefill query can
+  // resolve a near-tied logit differently.
+  const std::array<int32_t, 4> first_prompt{2, 3, 4, 5};
+  const std::array<int32_t, 3> second_prompt{6, 7, 8};
+  const std::array<int32_t, 5> third_prompt{9, 10, 11, 12, 13};
+  // Every sequence stays inside one block, so residency is the only thing capacity decides.
+  constexpr int kMaxLength = 16;
+
+  std::vector<std::vector<int32_t>> baseline_streams;
+  {
+    // Enough blocks for every request to stay resident: nothing is ever preempted.
+    auto model = LoadModel(/*num_blocks=*/8, /*enable_preemption=*/false);
+    auto paged = MakePagedEngine(model, kFilledToken);
+    ContextDependentDecoder decoder{
+        static_cast<int32_t>(model->config_->model.vocab_size), EosToken(*model)};
+    paged.executor->SetNextTokenSelector(decoder);
+
+    std::vector<std::shared_ptr<Request>> requests{
+        Mint(*model, first_prompt, kMaxLength),
+        Mint(*model, second_prompt, kMaxLength),
+        Mint(*model, third_prompt, kMaxLength),
+    };
+    for (const auto& request : requests)
+      paged.engine->AddRequest(request);
+
+    const auto streams = RunToCompletion(*paged.engine, requests, /*max_steps=*/2048);
+    for (const auto& request : requests)
+      baseline_streams.push_back(streams.at(request.get()));
+    ASSERT_EQ(paged.scheduler->PreemptionMetrics().preemptions, 0u);
+  }
+
+  std::vector<std::vector<int32_t>> preempted_streams;
+  uint64_t preemptions = 0;
+  {
+    // The same workload under a key-value budget that cannot hold all three requests at once.
+    auto model = LoadModel(/*num_blocks=*/2, /*enable_preemption=*/true);
+    auto paged = MakePagedEngine(model, kFilledToken);
+    ContextDependentDecoder decoder{
+        static_cast<int32_t>(model->config_->model.vocab_size), EosToken(*model)};
+    paged.executor->SetNextTokenSelector(decoder);
+
+    std::vector<std::shared_ptr<Request>> requests{
+        Mint(*model, first_prompt, kMaxLength),
+        Mint(*model, second_prompt, kMaxLength),
+        Mint(*model, third_prompt, kMaxLength),
+    };
+    for (const auto& request : requests)
+      paged.engine->AddRequest(request);
+
+    const auto streams = RunToCompletion(*paged.engine, requests, /*max_steps=*/2048);
+    for (const auto& request : requests)
+      preempted_streams.push_back(streams.at(request.get()));
+    preemptions = paged.scheduler->PreemptionMetrics().preemptions;
+    ExpectConsistent(paged, requests);
+  }
+
+  EXPECT_GT(preemptions, 0u) << "the constrained run did not exercise preemption";
+  ASSERT_EQ(preempted_streams.size(), baseline_streams.size());
+  for (size_t i = 0; i < baseline_streams.size(); ++i) {
+    EXPECT_FALSE(baseline_streams[i].empty());
+    EXPECT_EQ(preempted_streams[i], baseline_streams[i])
+        << "request " << i << " produced a different stream after preemption";
+  }
+}
+
+TEST_F(RecomputePreemptionTest, RollbackAfterPreemptionLeavesTheVictimSuspended) {
+  auto model = LoadModel(/*num_blocks=*/1, /*enable_preemption=*/true);
+  auto paged = MakePagedEngine(model, kFilledToken);
+  const std::array<int32_t, 3> prompt{2, 3, 4};
+  auto victim = Mint(*model, prompt, /*max_length=*/12);
+  auto newcomer = Mint(*model, prompt, /*max_length=*/12);
+  paged.engine->AddRequest(victim);
+  RunModelSteps(paged, 2);
+  paged.engine->AddRequest(newcomer);
+
+  // The step that preempts the resident then fails during execution and is rolled back.
+  paged.executor->SetNextFailure(ScriptedExecutionFailure::RetryableDuringExecution);
+  EXPECT_THROW(paged.engine->Step(), EngineStepError);
+
+  // Preemption committed at the step boundary before the transaction started, so the rollback does
+  // not resurrect the victim's residency, and no request is left half-advanced.
+  EXPECT_EQ(victim->status_, RequestStatus::Suspended);
+  EXPECT_EQ(victim->ProcessedSequenceLength(), 0);
+  EXPECT_EQ(newcomer->status_, RequestStatus::Assigned);
+  EXPECT_EQ(newcomer->ProcessedSequenceLength(), 0);
+  const auto snapshot = paged.cache->Snapshot();
+  EXPECT_EQ(snapshot.requests.size(), 0u);
+  EXPECT_EQ(snapshot.free_blocks, snapshot.total_blocks);
+  ExpectConsistent(paged, {victim, newcomer});
+
+  // The engine is still healthy and drains both requests afterwards.
+  int steps = 0;
+  while (paged.engine->HasPendingRequests() && steps++ < 512)
+    paged.engine->Step();
+  EXPECT_EQ(victim->status_, RequestStatus::Completed);
+  EXPECT_EQ(newcomer->status_, RequestStatus::Completed);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace Generators


### PR DESCRIPTION
> **Stacked on #2417** (`baijumeswani/bounded-capacity-retry`). **This PR must merge after #2417.** The base ref is set correctly so it merges cleanly, but the head branch lives on a fork and GitHub's native Stacks API does not support cross-fork stacks, so there is no stack navigation or cascading merge on this pair — the dependency is recorded here and in a comment on #2417 instead.

This PR contains only the preemption layer.

> **Read this before enabling it anywhere.** What a resume guarantees is *identical logical context*, **not bit-identical output**. A suspended request replays tokens that were previously single-token decodes as one multi-token prefill query. That changes the attention query length, disables decode graph capture for those steps, and can select a different attention backend — and IEEE-754 does not promise identical results across different reduction decompositions, so a near-tied logit can resolve differently on a real kernel. The deterministic tests here prove the context is replayed exactly; they cannot prove provider-level float determinism, and no real-model CUDA qualification is included. This is why the feature is default-off, and it is the gate on turning it on in production. If bit-exact output across a suspension is a requirement, recompute is the wrong mechanism and KV swapping would be needed instead.

## What this adds

Under key-value pressure the dynamic scheduler can now **suspend a resident request** instead of leaving a blocked request waiting. The victim's committed paged blocks go back to the pool, its processed cursor rewinds to the start of its sequence, and the existing chunked-prefill path rebuilds its key-value entries when it is re-admitted. Nothing is swapped to host memory or disk, and no prompt token is discarded, so the model sees the identical logical context after a resume.

**Preemption is off by default.** With the setting absent the engine behaves exactly as it does on the parent branch.

### Request lifecycle

`RequestStatus::Suspended` is added between `InProgress` and re-admission:

```
Unassigned -> Assigned -> InProgress -> Completed
     ^           |            |  ^         |
     |           |            v  |         |
     |           |        Suspended        |
     +-----------+------------+------------+
                  Remove()
```

A suspended request keeps its complete logical token sequence, `Search`/RNG state, streamed-token cursor, and generation limits. It owns no cache blocks, waits in the scheduler pool, and is admitted through the ordinary `newly_admitted` path. `AddTokens()` is rejected while suspended; `Remove()` works.

### Configuration (`engine.dynamic_batching`)

| Setting | Default | Meaning |
| --- | --- | --- |
| `enable_recompute_preemption` | `false` | Turns the mechanism on |
| `max_preemptions_per_step` | `1` | Victims one planning pass may suspend |
| `max_preemptions_per_request` | `0` (unbounded) | Suspensions one request may accumulate |
| `min_decode_steps_before_preemption` | `8` | Committed decode steps a resident earns before it can be suspended again |

### Triggering and victim selection

Preemption runs during planning, after the first planning attempt, and only when reclaimed blocks would cover a reported shortfall:

- a resident that cannot grow while nothing else can run (the alternative is `CapacityDeferred` and no progress), or
- no resident is block-starved and a waiting request was deferred **only** for free blocks.

Row limits and residency limits never trigger it, because returning blocks does not relieve them. A resident is never its own victim, and the pass that preempts admits at most one more request than the attempt before it, so surplus capacity is not spent on work the preemption was not measured for.

Victims are ordered by **fewest previous preemptions**, then **most recently admitted** — so no request is suspended twice while a resident that has never been suspended still holds capacity, and the longest-resident request keeps its accumulated work. A candidate must additionally be past prefill, own blocks, be under `max_preemptions_per_request`, have earned `min_decode_steps_before_preemption`, and have cache ownership that agrees with its committed sequence length. Every one of those counters is advanced only by a committed transaction.

### Transaction safety

Preemption happens at a step boundary before `BeginTransaction()`, so it is a complete self-consistent state change that a rollback never has to undo. A step that preempts and then fails during execution leaves the victim suspended, the newly admitted request unchanged, and the reclaimed blocks free. Victims stay out of admission for the **whole engine step**, including the capacity-retry planning attempts added by #2417.

Cache reclamation goes through `CacheManager::ReclaimRequestCache` / `PagedKeyValueCache::Reclaim`, which release **every** block table held for a request rather than assuming there is one — the abstraction boundary that #2357/#2358's windowed ring cache will need. `Remove()` is reimplemented in terms of `Reclaim()`.

### Unsupported cases

Enabling preemption on the static batching path, or with a cache manager that cannot release one request's blocks independently, is rejected at scheduler construction. A zero per-step bound is rejected. There is no silent fallback that reports a preemption that did not happen.

## Measured results

There is no checked-in paged-attention model that runs on CPU, so this is a **deterministic production-policy microbenchmark** (`test/engine/recompute_preemption_benchmark.cpp`): it drives the real `DynamicBatchScheduler`, `PagedCacheManager`, `PagedKeyValueCache`, and `Request` lifecycle, replacing only model execution. **The unit of time is one engine tick, not wall-clock latency** — these numbers describe scheduling behavior, not kernel or provider performance. No real-model throughput claim is made.

Workload: 2 long requests (12-token prompt, 56 max length) arriving first, then 6 short requests (4-token prompt, 12 max length) arriving behind them; fixed budget of 2 blocks x 64 slots.

```
wait-only          ticks=136 model_runs=68 tokens=136 completions=8 ttft_p50= 91.0 ttft_p95=109.3 itl_p50=2.00 itl_p95=2.00 tok/run=2.00 wait=576 preempt= 0 recomputed=   0
preempt q=1        ticks=136 model_runs=71 tokens=136 completions=8 ttft_p50= 35.0 ttft_p95=104.3 itl_p50=2.00 itl_p95=4.00 tok/run=1.92 wait=452 preempt=58 recomputed=1517
preempt q=8 (dflt) ticks=136 model_runs=68 tokens=136 completions=8 ttft_p50= 49.0 ttft_p95=109.3 itl_p50=2.00 itl_p95=4.00 tok/run=2.00 wait=472 preempt= 8 recomputed= 272

short-request TTFT: wait-only p50=97.0 p95=109.5 | q=1 p50=57.0 p95=106.5 | q=8 p50=73.0 p95=109.5
victim 0: preemptions=4 recomputed_tokens=138 end-to-end  87 -> 119 (slowdown 1.37x)
victim 1: preemptions=4 recomputed_tokens=134 end-to-end  87 -> 119 (slowdown 1.37x)
```

Note on the two TTFT populations: the per-row `ttft_p50` / `ttft_p95` fields cover **all 8 requests**, while the `short-request TTFT` line covers only the **6 short requests** arriving behind the long ones. The reading below quotes the short-request figures, since those are the ones preemption is meant to help.

Honest reading:

- **Short-request admission improves**: median TTFT for requests arriving behind the long ones drops 97 -> 73 ticks (-25%) at the default quantum, and 97 -> 57 (-41%) at `q=1`. Aggregate scheduler wait drops 576 -> 472 request-ticks.
- **p95 TTFT barely moves** (109.5 -> 109.5 at the default). The tail is dominated by the last-arriving request, which preemption cannot help much in this workload; the gain here is in the median and in admission, not the extreme tail.
- **Victims pay for it**: the two long requests go from 87 to 119 ticks end-to-end, a 1.37x slowdown, and recompute 272 tokens.
- **Aggregate throughput is flat at the default** (2.00 tokens per model run) and regresses ~4% at `q=1` (1.92), which is the recomputation showing up as extra model runs. Total makespan is unchanged because it is bound by total token demand.
- The `min_decode_steps_before_preemption` measurement is why the default is 8 rather than 1: it keeps most of the median-TTFT benefit for roughly a fifth of the recomputation.
- ITL p95 rises from 2 to 4 ticks, which is the recompute pause a victim sees.

## Tests

`test/engine/recompute_preemption_tests.cpp` (31 cases; 168 engine tests pass in total):

- pure policy: ordering, per-step and per-request bounds, service quantum, declining when no victim set covers the shortfall or none is eligible;
- request lifecycle: suspend rewinds the cursor and keeps the sequence, rejects non-resident requests, rejects `AddTokens`, prefilling residents are not preemptible, invariants reject a suspended request that still looks resident;
- scheduler with the **real** paged cache: default-off compatibility, preemption for a blocked admission, preemption to unblock a resident that cannot grow, rebuild by chunked prefill, fairness spreading, suspended-before-newcomer ordering, capacity-retry not re-admitting the just-suspended victim, per-plan admission cap, removal while suspended, unsupported-path rejection;
- end-to-end: **token-stream continuity** — the same workload run with a large budget (no preemption) and a constrained budget (preemption engaged) produces byte-identical token streams per request;
- rollback: a step that preempts and then fails leaves the victim suspended, the cache empty, and the engine healthy and able to drain.

Run: `engine_unit_tests` (168 passed) and the config/engine/search/sampling subset of `unit_tests` (76 passed), Windows CPU Release.

## Known limitations / residual risk

- **Not bitwise output determinism on a real provider.** See the qualification at the top of this description: the guarantee is identical logical context, not identical floating-point output. Real-model CUDA qualification is not included here.
- **No real-model measurement.** See the benchmark caveat above.
- **Reclaimed capacity reaches blocked work, not necessarily the measured request.** Admission stays first-come-first-served, so an earlier waiting request previously held back by the residency limit can take the freed blocks once the victim leaves.
- **A victim's re-admission is bounded by completions, not by a deadline.** It is ordered ahead of never-admitted requests, but can still wait behind requests admitted with the capacity it released.
- **Multi-table reclaim is not atomic.** Only relevant once a windowed layout splits a sequence across tables; the invariant validator still expects one table per request.
- Recurrent/convolutional/model-managed state still does not participate in the transaction, so preemption is scoped to paged KV as before.

Docs: `docs/paged_attention_engine.md` gains a Recompute preemption section and the lifecycle, ownership, fairness, and test sections are updated.
