### PR TITLE
Add prefix-aware paged KV caching to the continuous-batching engine

### DIFF
--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -191,7 +191,7 @@ Completed requests that still own paged-cache blocks are deallocated and removed
 
 The scheduler snapshots all requests that already belong to the paged cache. These requests are expected to be `InProgress`.
 
-It then snapshots waiting requests from the scheduler pool. These requests are expected to be `Assigned` and are marked as newly admitted candidates.
+It then snapshots waiting requests from the scheduler pool. These requests are expected to be `Assigned` and are marked as newly admitted candidates. When prefix caching is enabled, each newly admitted candidate is offered to the prefix cache, which returns the longest run of block-aligned leading prompt tokens that is already resident. The query mutates nothing; the match is carried in the plan and only reaches the request in step 3.
 
 The scheduler orders candidates with decodes first. Order remains stable among
 decodes and among prefills. Each candidate initially contributes one provisional
@@ -204,6 +204,7 @@ For each candidate, the scheduler records a `RequestStepPlan` containing:
 - The sequence length before the transaction.
 - The provisional number of unprocessed tokens.
 - The number of cache slots required after the model run.
+- The resident prefix blocks the request would adopt, if any.
 - Whether the work is prefill.
 - Whether the request is newly admitted.
 
@@ -215,8 +216,9 @@ At this point, the plan contains candidates. It has not yet been reduced to the 
 
 - The configured maximum batch size.
 - The provisional scheduled-row limit.
-- The number of free physical blocks.
+- The number of free physical blocks, plus retained prefix blocks that can be reclaimed on demand.
 - Blocks already committed to active requests.
+- Blocks a newly admitted request would adopt from the prefix cache, which widen its block table without drawing on the free pool.
 - Additional blocks each request needs for this step.
 - The maximum block-table width supported by graph-capture buffers, when graph capture is enabled.
 
@@ -236,6 +238,8 @@ Selected entries are compacted to the beginning of the plan. Deferred entries re
 - An existing request keeps its current block table and stays `InProgress`.
 - A new request stays `Assigned` and owns no cache blocks.
 - Both can be considered again by the next engine step.
+
+Only requests that cache planning actually selected move their processed cursor. A selected request carrying a prefix match calls `Request::StagePrefixAdoption()`, which advances `processed_sequence_length_` to the end of the adopted prefix so the rest of the step -- token budget, packed layout, `past_sequence_lengths`, and cache target -- treats those tokens as already computed. The adoption is staged, not committed: a rolled back step restores the cursor.
 
 The planner distinguishes temporary capacity pressure from a request that can never fit:
 
@@ -281,14 +285,17 @@ The scheduler also marks whether the step is eligible for CUDA graph capture. A 
 The reservation:
 
 - Reserves every new physical block required by the selected plan.
+- Takes a reference on every resident prefix block a newly admitted request adopts, so a rolled back step cannot leak one.
+- Reclaims retained prefix blocks, least recently used first, when the free pool is short of what the plan needs.
 - Records how far each request's committed slot count would advance.
-- Creates provisional block tables for newly admitted requests.
+- Creates provisional block tables for newly admitted requests, seeded with their adopted prefix blocks.
 - Leaves the committed block tables and allocated-request list unchanged.
 
-Reservation is all-or-nothing. If all planned blocks cannot be reserved, the engine treats that as an execution contract failure because planning had already declared the step executable.
+Reservation is all-or-nothing. If all planned blocks cannot be reserved, the engine treats that as an execution contract failure because planning had already declared the step executable. Adopted references are released if any part of the reservation fails, so the pool is left exactly as it was.
 
 While the reservation is active, decoder input preparation can view a combined block table containing:
 
+- Blocks a newly admitted request adopted from the prefix cache.
 - Blocks already committed to each active request.
 - Blocks held by this transaction's reservation.
 
@@ -370,12 +377,13 @@ The commit order in `Engine::StepDynamic()` is deliberate:
 1. Commit the request search checkpoints and sampler checkpoint.
 2. Commit the paged-cache reservation.
 3. Commit each request's lightweight bookkeeping.
-4. Publish the staged ready list.
+4. Give every block that filled up during the step a content identity.
+5. Publish the staged ready list.
 
 Committing the cache reservation:
 
 - Adds reserved blocks to existing block tables.
-- Adds provisional block tables for newly admitted requests.
+- Adds provisional block tables for newly admitted requests, including any adopted prefix blocks.
 - Advances committed cache-slot counts.
 - Adds newly admitted requests to the cache manager's allocated-request list.
 
@@ -384,6 +392,8 @@ Committing request bookkeeping:
 - Appends the staged token to the host token mirror.
 - Sets `processed_sequence_length_` to the sequence length that existed before sampling.
 - Changes the status to `InProgress` or `Completed`.
+
+Blocks are content-addressed only after request bookkeeping commits, because that is the point at which each request's host token mirror covers exactly the slots the cache now holds for it.
 
 For a newly admitted request, this commit is the point where it moves directly from `Assigned` to `InProgress` or `Completed`. The dynamic transaction path does not need a separate visible scheduling state between those two states.
 
@@ -397,10 +407,11 @@ The dynamic path separates failures into recoverable batch failures and fatal en
 
 Request validation and post-processing failures are treated as retryable batch aborts. Model execution can also explicitly report a retryable failure. A recognized execution-memory capacity failure follows the same rollback path but has its own outcome.
 
-Rollback performs both parts:
+Rollback performs three parts:
 
 1. Restore request search state and sampler state from their checkpoints.
-2. Release every block held by the paged-cache reservation.
+2. Undo any staged prefix adoption, so a retried step re-matches from scratch instead of starting from a prefix the released reservation never gave it.
+3. Release every block held by the paged-cache reservation, including references taken on adopted prefix blocks.
 
 After a successful rollback, committed request state and committed cache state match the state before the step began. The caller receives an `EngineStepError` with either `RetryableBatchAbort` or `ExecutionCapacityExceeded`, and the engine remains healthy. Calling `Step()` again with unchanged memory availability and workload composition may produce the same capacity failure.
 
@@ -437,7 +448,8 @@ When some requests fit and others are deferred, the step still executes the fitt
 
 ## Paged KV-cache ownership
 
-The paged cache has three useful ownership states:
+A physical block is reference counted. Several owners can hold the same block at once, and it only
+returns to the pool when the last of them releases it. The useful ownership states are:
 
 ### Free blocks
 
@@ -445,7 +457,7 @@ The block pool owns these blocks. They can be reserved by a future transaction.
 
 ### Transaction-reserved blocks
 
-A `PagedCacheReservation` temporarily owns these blocks. They can appear in model-facing block tables for the current run, but they are not part of committed request ownership.
+A `PagedCacheReservation` temporarily owns these blocks. They can appear in model-facing block tables for the current run, but they are not part of committed request ownership. A reserved block is exclusively the transaction's until it commits.
 
 ### Committed request blocks
 
@@ -454,8 +466,58 @@ A request's `PagedCacheBlockTable` owns these blocks. The table records:
 - The request identity.
 - The number of slots containing committed tokens.
 - The ordered physical blocks used by the request.
+- How many leading blocks the prefix cache has already given a content identity, and the identity the next one chains from.
 
-Every physical block must be in exactly one of these states. The invariant helpers under `engine_invariants.*` validate total accounting, single ownership, valid block identifiers, reservation accounting, and consistency between request progress and cache progress.
+Eviction takes a chain's tail before its head: the head is what every longer match starts from, so losing it would orphan everything chained behind it.
+
+### Prefix-cache retained blocks
+
+The prefix cache holds a reference of its own on every block it indexes, so an indexed block outlives the request that produced it. Retention is bounded and always reclaimable: `PrefixCache::Reclaim()` gives blocks back to the pool in least-recently-used order, skipping any block a request still holds.
+
+Every physical block is either free or held by at least one of these owners. The invariant helpers under `engine_invariants.*` validate total accounting, reference accounting (a block's count must equal the number of owners that list it, so neither a shared adoption nor a rolled back transaction can leak or drop a reference), that only full blocks are shared, valid block identifiers, reservation accounting, and consistency between request progress and cache progress.
+
+## Prefix caching
+
+Serving and agent traffic resends large identical prefixes every turn: system prompts, tool schemas, retrieved context, and the conversation so far. Prefix caching lets a new request point at key-value blocks another sequence already computed instead of recomputing them.
+
+It is **off by default**. Enable it with `engine.dynamic_batching.prefix_caching`.
+
+### Content-addressed blocks
+
+Once a block fills up and its step commits, `PagedKeyValueCache::SealCommittedBlocks()` gives it an identity that chains the identity of the block before it, so a block only matches when the whole token sequence from the start of the prompt through the end of that block matches too. A hash match is never treated as proof of a match: the block's exact tokens are compared, and its parent is compared as the identity object it was computed behind rather than as a hash of it. That means no combination of hash collisions -- including a collision on an ancestor that has since been evicted -- can splice a block onto a prefix it was not computed behind. A collision costs a missed hit and nothing else.
+
+Only full blocks are indexed. A full block is never written again, which is what makes it safe for several requests to point at the same physical block. A request's partially filled tail block stays private to it.
+
+Blocks in a windowed or ring-buffer pool, where entries are overwritten in place, are **not** safely shareable and must never be indexed. Nothing in this design assumes a single uniform block table; a second pool with different overwrite semantics simply gets no prefix cache.
+
+### Admission-time adoption
+
+`DynamicBatchScheduler::PlanStep()` asks the cache manager for a match when a request is admitted. Nothing is mutated by the query: the match only reaches the request once cache planning has selected it, so a request deferred for capacity is left exactly as it was and is reconsidered next step.
+
+A selected request calls `Request::StagePrefixAdoption()`, which moves `processed_sequence_length_` to the end of the adopted prefix. Everything downstream -- `UnprocessedTokens()`, the packed input layout, `past_sequence_lengths`, and the cache target -- already derives from that cursor, so no parallel path exists. The match is always a whole number of blocks and always leaves at least the final token to compute, because that token's logits are what select the next one.
+
+The reservation seeds the new request's block table with the adopted blocks, sets its committed slots to the adopted token count, and reserves only the remainder. The adopted blocks lead the block-table row, so the step writes token `j` at absolute position `adopted + j`, which lands in the first block after them.
+
+### Retention and eviction
+
+A finished request's indexed blocks keep the cache's reference and stay resident, so the next turn of the same conversation can adopt them. `prefix_cache_pool_fraction` (or `prefix_cache_max_blocks`) bounds how many blocks the index may hold, and `PlanStepResources()` counts reclaimable retained blocks as available capacity while charging the ones an adoption claims, so adoption is capacity-neutral: every adopted block removes one from the blocks a step still has to take and adds one back here. Retention therefore never defers a request that could otherwise run, and a prefix hit never makes a request harder to admit than recomputing it would. When a reservation needs more blocks than are free, it reclaims exactly the shortfall in least-recently-used order before taking anything.
+
+### Copy-on-write divergence
+
+`MakeTailBlockExclusive()` gives a request a private copy of the block a step is about to write into when another owner still references it: it takes a fresh block, copies the shared block's key and value data across every layer, swaps it into the request's table, and drops the shared reference. Under the policy above this never fires, because sharing is restricted to full blocks that are never written again. It exists so that "a shared block is never written" is an enforced property rather than an assumption, and `PagedCacheReservation::AdvanceCommittedSlots()` throws rather than writing into a block another owner holds.
+
+### Configuration
+
+| Key (under `engine.dynamic_batching`) | Default | Meaning |
+| --- | --- | --- |
+| `prefix_caching` | `false` | Reuse resident blocks whose token prefix matches a new prompt. |
+| `prefix_cache_pool_fraction` | `0.5` | Share of the block pool the index may hold. |
+| `prefix_cache_max_blocks` | unset | Absolute ceiling on indexed blocks; overrides the fraction. |
+| `prefix_cache_min_blocks` | `1` | Shortest match worth adopting, in blocks. |
+
+### Unsupported configurations
+
+Prefix caching applies only to the dynamic paged path. Static batching keeps a single contiguous cache with no content-addressed blocks and reports no prefix cache rather than pretending a hit occurred. Beam search is rejected by `Request` up front. A model that keeps its own recurrent or hybrid state outside the paged cache has no sound notion of a cached prefix, and the engine does not bind such state today.
 
 ## Prefill, decode, and mixed batches
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1507,6 +1507,23 @@ struct DynamicBatching_Element : JSON::Element {
       if (parsed_value <= 0)
         throw std::out_of_range("max_scheduled_tokens must be > 0");
       v_->max_scheduled_tokens = static_cast<size_t>(parsed_value);
+    } else if (name == "prefix_caching") {
+      v_->prefix_caching = JSON::Get<bool>(value);
+    } else if (name == "prefix_cache_pool_fraction") {
+      const auto parsed_value = JSON::Get<double>(value);
+      if (!std::isfinite(parsed_value) || parsed_value < 0 || parsed_value > 1)
+        throw std::out_of_range("prefix_cache_pool_fraction must be >= 0 and <= 1");
+      v_->prefix_cache_pool_fraction = static_cast<float>(parsed_value);
+    } else if (name == "prefix_cache_max_blocks") {
+      const auto parsed_value = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (parsed_value < 0)
+        throw std::out_of_range("prefix_cache_max_blocks must be >= 0");
+      v_->prefix_cache_max_blocks = static_cast<size_t>(parsed_value);
+    } else if (name == "prefix_cache_min_blocks") {
+      const auto parsed_value = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (parsed_value <= 0)
+        throw std::out_of_range("prefix_cache_min_blocks must be > 0");
+      v_->prefix_cache_min_blocks = static_cast<size_t>(parsed_value);
     } else {
       throw JSON::unknown_value_error{};
     }

--- a/src/config.h
+++ b/src/config.h
@@ -516,6 +516,17 @@ struct Config {
       std::optional<float> gpu_utilization_factor;  // Fraction of free GPU memory to use for key-value cache.
       size_t max_batch_size{16};                    // Maximum batch size for dynamically batching requests.
       size_t max_scheduled_tokens{2048};            // Maximum tokens in one dynamically batched model run.
+      // Reuse resident key-value blocks whose token prefix matches a new prompt, instead of
+      // recomputing them. Off by default: it changes block lifetime and residency, so a deployment
+      // opts into it once it has qualified the memory behaviour for its model and provider.
+      bool prefix_caching{false};
+      // Share of the block pool the prefix cache may hold on to for finished requests. Retained
+      // blocks are always reclaimable, so this bounds retention rather than reserving capacity.
+      float prefix_cache_pool_fraction{0.5f};
+      // Absolute ceiling on retained blocks; overrides the fraction when set.
+      std::optional<size_t> prefix_cache_max_blocks;
+      // Shortest match worth adopting, in blocks.
+      size_t prefix_cache_min_blocks{1};
     };
     std::optional<DynamicBatching> dynamic_batching;  // Dynamic batching settings
 

--- a/src/engine/block.cpp
+++ b/src/engine/block.cpp
@@ -6,6 +6,8 @@
 
 #include <numeric>
 #include <algorithm>
+#include <string>
+#include <utility>
 
 namespace Generators {
 
@@ -50,10 +52,51 @@ std::vector<size_t> Block::SlotIds() const {
   return slot_ids;
 }
 
+const BlockIdentity& Block::Identity() const {
+  if (!identity_) {
+    throw std::runtime_error("Block " + std::to_string(id_) + " carries no content identity.");
+  }
+  return *identity_;
+}
+
+void Block::SetIdentity(std::shared_ptr<const BlockIdentity> identity) {
+  if (!identity) {
+    throw std::runtime_error("Cannot give a block a null content identity.");
+  }
+  if (!IsFull()) {
+    throw std::runtime_error("Only a full block can carry a content identity.");
+  }
+  if (identity->tokens.size() != Capacity()) {
+    throw std::runtime_error("Block content identity does not cover every slot in the block.");
+  }
+  identity_ = std::move(identity);
+}
+
+void Block::ClearIdentity() {
+  identity_.reset();
+}
+
+void Block::AddRef() {
+  ++ref_count_;
+}
+
+size_t Block::ReleaseRef() {
+  if (ref_count_ == 0) {
+    throw std::runtime_error("Cannot release a block that has no remaining references.");
+  }
+  return --ref_count_;
+}
+
 BlockPool::BlockPool(size_t block_size, size_t num_blocks)
     : block_size_(block_size), capacity_(num_blocks) {}
 
 std::vector<std::shared_ptr<Block>> BlockPool::AllocateBlocks(size_t num_slots, bool mark_slots_used) {
+  if (BlocksNeeded(num_slots) > AvailableBlocks()) {
+    throw std::runtime_error("Requested number of blocks " + std::to_string(BlocksNeeded(num_slots)) +
+                             " for number of slots " + std::to_string(num_slots) +
+                             " exceeds available blocks " + std::to_string(AvailableBlocks()) + ".");
+  }
+
   const auto allocate_block = [this](size_t slots) {
     for (size_t i = 0; i < Capacity(); ++i) {
       if (blocks_[i] == nullptr) {
@@ -64,19 +107,23 @@ std::vector<std::shared_ptr<Block>> BlockPool::AllocateBlocks(size_t num_slots, 
     return std::shared_ptr<Block>();
   };
 
-  if (BlocksNeeded(num_slots) > AvailableBlocks()) {
-    throw std::runtime_error("Requested number of blocks " + std::to_string(BlocksNeeded(num_slots)) +
-                             " for number of slots " + std::to_string(num_slots) +
-                             " exceeds available blocks " + std::to_string(AvailableBlocks()) + ".");
-  }
-
   std::vector<std::shared_ptr<Block>> allocated_blocks;
-  for (size_t i = 0; i < num_slots; i += block_size_) {
-    auto block = allocate_block(mark_slots_used ? std::min(block_size_, num_slots - i) : 0);
-    if (!block) {
-      throw std::runtime_error("Failed to allocate a block.");
+  allocated_blocks.reserve(BlocksNeeded(num_slots));
+  try {
+    for (size_t i = 0; i < num_slots; i += block_size_) {
+      auto block = allocate_block(mark_slots_used ? std::min(block_size_, num_slots - i) : 0);
+      if (!block) {
+        throw std::runtime_error("Failed to allocate a block.");
+      }
+      allocated_blocks.push_back(block);
     }
-    allocated_blocks.push_back(block);
+  } catch (...) {
+    // Allocation is all-or-nothing: a block installed before the failure has no owner to release
+    // it, so it would sit in the pool forever.
+    for (const auto& block : allocated_blocks) {
+      blocks_[block->Id()].reset();
+    }
+    throw;
   }
   return allocated_blocks;
 }
@@ -91,40 +138,109 @@ std::vector<std::shared_ptr<Block>> BlockPool::ReserveBlocks(size_t num_slots) {
 
 void BlockPool::Free(const std::vector<std::shared_ptr<Block>>& blocks) {
   // Validate every block before mutating any pool state so that an invalid request (a null block,
-  // an out-of-range id, a block this pool does not currently own, or the same block listed twice)
-  // is rejected without partially freeing the batch. Work stays proportional to the batch size
-  // rather than the pool capacity.
-  std::vector<size_t> ids;
-  ids.reserve(blocks.size());
+  // an out-of-range id, a block this pool does not currently own, or more releases than the block
+  // has references) is rejected without partially freeing the batch. Work stays proportional to the
+  // batch size rather than the pool capacity.
+  const auto occurrences = ValidateOwnership(blocks, "free", /*require_references=*/true);
+
+  for (const auto& [id, count] : occurrences) {
+    size_t remaining = blocks_[id]->RefCount();
+    for (size_t i = 0; i < count; ++i) {
+      remaining = blocks_[id]->ReleaseRef();
+    }
+    if (remaining == 0) {
+      blocks_[id].reset();
+    }
+  }
+}
+
+void BlockPool::AddRef(const std::vector<std::shared_ptr<Block>>& blocks) {
+  // Several owners can take a reference to the same block in one call: one reservation admitting a
+  // batch of requests that all adopt the same prefix does exactly that.
+  const auto occurrences = ValidateOwnership(blocks, "add a reference to",
+                                             /*require_references=*/false);
+
+  for (const auto& [id, count] : occurrences) {
+    for (size_t i = 0; i < count; ++i) {
+      blocks_[id]->AddRef();
+    }
+  }
+}
+
+bool BlockPool::Owns(const std::shared_ptr<Block>& block) const {
+  return block && block->Id() < Capacity() && blocks_[block->Id()] == block;
+}
+
+void BlockPool::AddRef(const std::shared_ptr<Block>& block) {
+  if (!Owns(block)) {
+    throw std::runtime_error("Cannot add a reference to a block this pool does not own.");
+  }
+  block->AddRef();
+}
+
+void BlockPool::Release(const std::shared_ptr<Block>& block) {
+  if (!Owns(block)) {
+    throw std::runtime_error("Cannot release a block this pool does not own.");
+  }
+  if (block->ReleaseRef() == 0) {
+    blocks_[block->Id()].reset();
+  }
+}
+
+std::vector<std::pair<size_t, size_t>> BlockPool::ValidateOwnership(
+    const std::vector<std::shared_ptr<Block>>& blocks,
+    const char* operation,
+    bool require_references) const {
+  std::vector<std::pair<size_t, size_t>> occurrences;
+  occurrences.reserve(blocks.size());
   for (const auto& block : blocks) {
     if (!block) {
-      throw std::runtime_error("Cannot free a null block.");
+      throw std::runtime_error(std::string{"Cannot "} + operation + " a null block.");
     }
 
     const size_t id = block->Id();
     if (id >= Capacity()) {
-      throw std::runtime_error("Cannot free block with out-of-range id " + std::to_string(id) +
-                               " for a pool with capacity " + std::to_string(Capacity()) + ".");
+      throw std::runtime_error(std::string{"Cannot "} + operation + " block with out-of-range id " +
+                               std::to_string(id) + " for a pool with capacity " +
+                               std::to_string(Capacity()) + ".");
     }
 
     if (blocks_[id] != block) {
-      throw std::runtime_error("Cannot free block with id " + std::to_string(id) +
-                               " that is not currently allocated by this pool.");
+      throw std::runtime_error(std::string{"Cannot "} + operation + " block with id " +
+                               std::to_string(id) + " that is not currently allocated by this pool.");
     }
 
-    ids.push_back(id);
+    const auto entry = std::find_if(occurrences.begin(), occurrences.end(),
+                                    [id](const std::pair<size_t, size_t>& value) {
+                                      return value.first == id;
+                                    });
+    if (entry == occurrences.end()) {
+      occurrences.emplace_back(id, size_t{1});
+    } else {
+      ++entry->second;
+    }
   }
 
-  std::sort(ids.begin(), ids.end());
-  const auto duplicate = std::adjacent_find(ids.begin(), ids.end());
-  if (duplicate != ids.end()) {
-    throw std::runtime_error("Cannot free block with id " + std::to_string(*duplicate) +
-                             " more than once in the same call.");
+  for (const auto& [id, count] : occurrences) {
+    if (require_references && blocks_[id]->RefCount() < count) {
+      throw std::runtime_error(std::string{"Cannot "} + operation + " block with id " +
+                               std::to_string(id) + " " + std::to_string(count) +
+                               " times when it only holds " + std::to_string(blocks_[id]->RefCount()) +
+                               " reference(s).");
+    }
   }
 
-  for (const auto& block : blocks) {
-    blocks_[block->Id()].reset();
+  return occurrences;
+}
+
+std::vector<std::shared_ptr<Block>> BlockPool::OwnedBlocks() const {
+  std::vector<std::shared_ptr<Block>> owned;
+  for (const auto& block : blocks_) {
+    if (block) {
+      owned.push_back(block);
+    }
   }
+  return owned;
 }
 
 size_t BlockPool::AvailableBlocks() const {

--- a/src/engine/block.h
+++ b/src/engine/block.h
@@ -3,15 +3,37 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace Generators {
 
 /*
+ * BlockIdentity is the content address of a filled block.
+ *
+ * `hash` chains the identity of the block that precedes this one into the hash of this block's
+ * tokens, so two blocks only carry the same identity when the entire token sequence from the start
+ * of the prompt through the end of the block matches. A hash is never treated as proof of a match:
+ * `tokens` is compared before a block is handed out, and `parent` is the exact identity this block
+ * was computed behind rather than a hash of it, so no combination of collisions can splice a block
+ * onto a prefix it was not computed behind.
+ */
+struct BlockIdentity {
+  uint64_t hash{};
+  std::shared_ptr<const BlockIdentity> parent;  // Null when this block starts the sequence.
+  std::vector<int32_t> tokens;
+};
+
+/*
  * Block represents a contiguous set of slots in the paged key-value cache.
  * Each block has a fixed capacity (number of slots it can hold) and tracks
  * the number of currently used slots.
+ *
+ * A block is reference counted. Several owners -- the committed block tables of different requests,
+ * an in-flight reservation, and the prefix cache -- can hold the same physical block, and the block
+ * only returns to the pool once the last of them releases it.
  */
 struct Block {
   Block(size_t id, size_t slots, size_t block_size);
@@ -32,10 +54,40 @@ struct Block {
 
   std::vector<size_t> SlotIds() const;
 
+  // Owners currently holding this block. Maintained by BlockPool.
+  size_t RefCount() const { return ref_count_; }
+
+  bool IsShared() const { return ref_count_ > 1; }
+
+  // A block is only safe to share once it is full: a full block is never written again, so no owner
+  // can diverge from another. A partially filled tail block stays private to its request.
+  bool IsShareable() const { return IsFull() && HasIdentity(); }
+
+  bool HasIdentity() const { return identity_ != nullptr; }
+
+  // Throws when the block carries no identity.
+  const BlockIdentity& Identity() const;
+
+  // The identity object itself, which is what a chained lookup compares against so that a hash
+  // collision can never splice a block onto a prefix it was not computed behind. Null when unset.
+  const std::shared_ptr<const BlockIdentity>& IdentityPtr() const { return identity_; }
+
+  void SetIdentity(std::shared_ptr<const BlockIdentity> identity);
+
+  void ClearIdentity();
+
  private:
+  friend struct BlockPool;
+
+  void AddRef();
+  // Returns the reference count remaining after the release.
+  size_t ReleaseRef();
+
   size_t id_;
   size_t size_;
   size_t capacity_;
+  size_t ref_count_{1};
+  std::shared_ptr<const BlockIdentity> identity_;
 };
 
 /*
@@ -62,12 +114,37 @@ struct BlockPool {
   // used via Block::AddSlot() as the tokens are actually written to the cache.
   std::vector<std::shared_ptr<Block>> ReserveBlocks(size_t num_slots);
 
+  // True when this pool currently owns `block`, which is the precondition for AddRef and Release.
+  bool Owns(const std::shared_ptr<Block>& block) const;
+
+  // Adds one reference for every listed block so that an additional owner can hold them. Every
+  // block must currently be owned by this pool; the batch is validated before any reference moves.
+  void AddRef(const std::vector<std::shared_ptr<Block>>& blocks);
+
+  // Single-block reference operations. They allocate nothing, so they are safe to call from cleanup
+  // and teardown paths where a failed allocation would otherwise become a hard failure.
+  void AddRef(const std::shared_ptr<Block>& block);
+  void Release(const std::shared_ptr<Block>& block);
+
+  // Releases one reference for every listed block, returning a block to the pool once its last
+  // owner releases it. A block may appear more than once when the caller holds several references
+  // to it, which happens when one reservation admits two requests that adopt the same prefix.
   void Free(const std::vector<std::shared_ptr<Block>>& blocks);
 
   size_t BlocksNeeded(size_t num_slots);
 
+  // Blocks this pool currently owns, in ascending id order. Used to build cache snapshots.
+  std::vector<std::shared_ptr<Block>> OwnedBlocks() const;
+
  private:
   std::vector<std::shared_ptr<Block>> AllocateBlocks(size_t num_slots, bool mark_slots_used);
+
+  // Validates that every listed block is owned by this pool and, when releasing, that its reference
+  // count can absorb the listed multiplicity. Returns the (block id, occurrences) pairs.
+  std::vector<std::pair<size_t, size_t>> ValidateOwnership(
+      const std::vector<std::shared_ptr<Block>>& blocks,
+      const char* operation,
+      bool require_references) const;
 
   const size_t block_size_;
   const size_t capacity_;

--- a/src/engine/block.h
+++ b/src/engine/block.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -24,6 +24,7 @@ class PagedCacheStepReservation final : public CacheStepReservation {
           entry.target_cache_slots,
           entry.newly_admitted,
           entry.whole_sequence_cache_slots,
+          entry.prefix_match.get(),
       });
       if (entry.newly_admitted) {
         newly_admitted_.push_back(entry.request);
@@ -240,6 +241,36 @@ std::vector<std::shared_ptr<Request>> PagedCacheManager::AllocatedRequests() con
 std::unique_ptr<CacheStepReservation> PagedCacheManager::ReserveStep(const StepPlan& plan) {
   return std::make_unique<PagedCacheStepReservation>(
       *key_value_cache_, cache_allocated_requests_, plan);
+}
+
+std::shared_ptr<const PrefixCacheMatch> PagedCacheManager::MatchPrefix(const Request& request) {
+  if (!key_value_cache_->PrefixCachingEnabled()) {
+    return nullptr;
+  }
+
+  const auto tokens = request.SequenceTokensCpu();
+  if (tokens.size() < 2) {
+    return nullptr;
+  }
+
+  // A request must always compute at least its last token: that token's logits are what select the
+  // next one, so adopting the whole sequence would leave the step with nothing to sample from.
+  auto match = key_value_cache_->MatchPrefix(tokens, tokens.size() - 1);
+  if (match.Empty()) {
+    return nullptr;
+  }
+  return std::make_shared<const PrefixCacheMatch>(std::move(match));
+}
+
+void PagedCacheManager::SealCommittedBlocks(const StepPlan& plan) {
+  if (!key_value_cache_->PrefixCachingEnabled()) {
+    return;
+  }
+
+  for (const auto& entry : plan.requests) {
+    key_value_cache_->SealCommittedBlocks(entry.request_id,
+                                          entry.request->SequenceTokensCpu());
+  }
 }
 
 }  // namespace Generators

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -3,7 +3,10 @@
 
 #include "cache_manager.h"
 
+#include <memory>
 #include <optional>
+#include <utility>
+#include <vector>
 
 namespace Generators {
 

--- a/src/engine/cache_manager.h
+++ b/src/engine/cache_manager.h
@@ -71,6 +71,17 @@ struct CacheManager {
     throw std::logic_error("Cache manager does not support transactional reservation.");
   }
 
+  // Longest run of leading prompt tokens already resident in the cache, so a newly admitted request
+  // can adopt those blocks and only compute the remainder. Caches without content-addressed blocks
+  // return an empty match, and the caller then admits the request exactly as it does today.
+  virtual std::shared_ptr<const PrefixCacheMatch> MatchPrefix(const Request&) { return nullptr; }
+
+  // Gives every block that filled up during the committed step a content identity. Called once the
+  // step's reservation is committed.
+  virtual void SealCommittedBlocks(const StepPlan&) {}
+
+  virtual const PrefixCacheMetrics* PrefixMetrics() const { return nullptr; }
+
   virtual ~CacheManager() = default;
 
  protected:
@@ -130,6 +141,14 @@ struct PagedCacheManager : CacheManager {
   }
 
   std::unique_ptr<CacheStepReservation> ReserveStep(const StepPlan& plan) override;
+
+  std::shared_ptr<const PrefixCacheMatch> MatchPrefix(const Request& request) override;
+
+  void SealCommittedBlocks(const StepPlan& plan) override;
+
+  const PrefixCacheMetrics* PrefixMetrics() const override {
+    return &key_value_cache_->PrefixMetrics();
+  }
 
  private:
   std::shared_ptr<GeneratorParams> params_;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -19,6 +19,31 @@ std::string AddExceptionCause(std::string message, std::exception_ptr error) {
   return message;
 }
 
+// Undoes any prefix adoption the step plan staged unless the step reached its commit boundary.
+// Every request rollback it performs is itself noexcept, so it is safe to run while unwinding.
+class PrefixAdoptionGuard {
+ public:
+  explicit PrefixAdoptionGuard(StepPlan* plan) : plan_{plan} {}
+  PrefixAdoptionGuard(const PrefixAdoptionGuard&) = delete;
+  PrefixAdoptionGuard& operator=(const PrefixAdoptionGuard&) = delete;
+  ~PrefixAdoptionGuard() { Rollback(); }
+
+  void Rollback() noexcept {
+    if (!plan_) {
+      return;
+    }
+    for (const auto& entry : plan_->requests) {
+      entry.request->RollbackPrefixAdoption();
+    }
+    plan_ = nullptr;
+  }
+
+  void Committed() noexcept { plan_ = nullptr; }
+
+ private:
+  StepPlan* plan_{};
+};
+
 }  // namespace
 
 Engine::Engine(std::shared_ptr<Model> model)
@@ -101,6 +126,10 @@ std::shared_ptr<Request> Engine::StepDynamic() {
     // Nothing becomes externally visible until the final commit succeeds.
     step_plan_.transaction_id = next_transaction_id_++;
     auto planning_result = scheduler_->PlanStep(step_plan_);
+    // Planning stages any prefix adoption as the last thing it does, so guarding it from here means
+    // no path out of this scope -- a rollback, a reservation failure, or an exception from any
+    // collaborator -- can leave a request claiming progress the released reservation never gave it.
+    PrefixAdoptionGuard adoption_guard{&step_plan_};
     if (planning_result.capacity_deferred) {
       ++transaction_metrics_.capacity_deferrals;
     }
@@ -164,6 +193,10 @@ std::shared_ptr<Request> Engine::StepDynamic() {
         }
         request_transaction_active = false;
       }
+      // A prefix adoption moves a request's processed cursor while the step is in flight, before
+      // any block table commits. Undo it here so a retried step re-matches from scratch instead of
+      // starting from a prefix the released reservation never gave it.
+      adoption_guard.Rollback();
       try {
         reservation->Release();
       } catch (...) {
@@ -276,6 +309,10 @@ std::shared_ptr<Request> Engine::StepDynamic() {
         step_plan_.requests[i].request->CommitStep(
             step_plan_.requests[i], step_results_[i]);
       }
+      // Content-address the blocks that filled up in this step only after the request bookkeeping
+      // is committed, so the host token mirror covers exactly the slots the cache now holds.
+      cache_manager_->SealCommittedBlocks(step_plan_);
+      adoption_guard.Committed();
     } catch (...) {
       MarkUnhealthyAndThrow(
           StepOutcomeKind::ExecutionContractFailure,

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -3,6 +3,10 @@
 
 #include "engine.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+
 namespace Generators {
 
 namespace {

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -118,6 +118,16 @@ struct Engine : std::enable_shared_from_this<Engine>,
    */
   bool HasPendingRequests() const;
 
+  /**
+   * @brief Transaction counters for this Engine's dynamic steps.
+   */
+  const EngineTransactionMetrics& TransactionMetrics() const { return transaction_metrics_; }
+
+  /**
+   * @brief Prefix-cache counters, or null when the cache does not content-address its blocks.
+   */
+  const PrefixCacheMetrics* PrefixCacheStats() const { return cache_manager_->PrefixMetrics(); }
+
  private:
   std::shared_ptr<Request> DrainReadyRequest();
   std::shared_ptr<Request> StepDynamic();

--- a/src/engine/engine_invariants.cpp
+++ b/src/engine/engine_invariants.cpp
@@ -36,22 +36,39 @@ std::vector<InvariantViolation> ValidateCacheInvariants(const PagedCacheSnapshot
     violations.push_back(InvariantViolation{std::move(message)});
   };
 
-  // Total accounting: every block is free, transaction-reserved, or committed to one Request.
-  const size_t allocated = cache.AllocatedBlocks();
-  const size_t transaction_reserved = cache.TransactionReservedBlocks();
+  // Total accounting: every physical block is either free or owned by at least one holder, and the
+  // block listing enumerates exactly the owned ones. Requests can share a block, so the sum of
+  // per-Request table lengths is no longer the physical block count.
+  std::unordered_map<size_t, const CachedBlockSnapshot*> owned_blocks;
+  for (const auto& block : cache.blocks) {
+    if (block.block_id >= cache.total_blocks) {
+      add("Cache owns out-of-range block id " + std::to_string(block.block_id) + " (total_blocks " +
+          std::to_string(cache.total_blocks) + ").");
+      continue;
+    }
+    if (!owned_blocks.emplace(block.block_id, &block).second) {
+      add("Cache lists block id " + std::to_string(block.block_id) + " more than once.");
+    }
+    if (block.ref_count == 0) {
+      add("Cache owns block id " + std::to_string(block.block_id) + " with no references.");
+    }
+  }
+
   if (cache.free_blocks > cache.total_blocks) {
     add("free_blocks (" + std::to_string(cache.free_blocks) + ") exceeds total_blocks (" +
         std::to_string(cache.total_blocks) + ").");
   }
-  if (cache.free_blocks + transaction_reserved + allocated != cache.total_blocks) {
-    add("free (" + std::to_string(cache.free_blocks) + ") + transaction_reserved (" +
-        std::to_string(transaction_reserved) + ") + allocated (" +
-        std::to_string(allocated) + ") != total_blocks (" +
+  if (cache.free_blocks + owned_blocks.size() != cache.total_blocks) {
+    add("free (" + std::to_string(cache.free_blocks) + ") + owned (" +
+        std::to_string(owned_blocks.size()) + ") != total_blocks (" +
         std::to_string(cache.total_blocks) + ").");
   }
 
-  // Single ownership: a physical block id appears in at most one Request's table.
-  std::unordered_map<size_t, const void*> owner_of_block;
+  // Reference accounting: a block's count has to equal the number of holders that actually list it,
+  // so neither a shared adoption nor a rolled back transaction can leak or drop a reference.
+  std::unordered_map<size_t, size_t> holders;
+  const auto count_holder = [&holders](size_t block_id) { ++holders[block_id]; };
+
   std::unordered_set<const void*> seen_requests;
   size_t max_blocks_per_request = 0;
 
@@ -59,16 +76,18 @@ std::vector<InvariantViolation> ValidateCacheInvariants(const PagedCacheSnapshot
     max_blocks_per_request = std::max(max_blocks_per_request, request.block_ids.size());
 
     // Each Request appears in the block-table listing at most once. A repeated row would let the
-    // same Request re-list a physical block without tripping the single-ownership check below.
+    // same Request re-list a physical block without tripping the checks below.
     if (!seen_requests.insert(request.request_id).second) {
       add("Request " + PtrId(request.request_id) + " appears in more than one block table.");
     }
 
     std::unordered_set<size_t> seen_within_request;
     for (const size_t block_id : request.block_ids) {
-      if (block_id >= cache.total_blocks) {
-        add("Request " + PtrId(request.request_id) + " owns out-of-range block id " +
-            std::to_string(block_id) + " (total_blocks " + std::to_string(cache.total_blocks) + ").");
+      const auto owned = owned_blocks.find(block_id);
+      if (owned == owned_blocks.end()) {
+        add("Request " + PtrId(request.request_id) + " owns block id " + std::to_string(block_id) +
+            " that the cache does not list as allocated.");
+        continue;
       }
 
       if (!seen_within_request.insert(block_id).second) {
@@ -76,10 +95,11 @@ std::vector<InvariantViolation> ValidateCacheInvariants(const PagedCacheSnapshot
             " more than once.");
       }
 
-      const auto [it, inserted] = owner_of_block.emplace(block_id, request.request_id);
-      if (!inserted && it->second != request.request_id) {
-        add("Block id " + std::to_string(block_id) + " is owned by more than one Request (" +
-            PtrId(it->second) + " and " + PtrId(request.request_id) + ").");
+      count_holder(block_id);
+      // Only a full block is ever safe to share: it is never written again, so no owner can
+      // diverge from another.
+      if (owned->second->ref_count > 1 && !owned->second->full) {
+        add("Block id " + std::to_string(block_id) + " is shared while it is only partially filled.");
       }
     }
 
@@ -101,15 +121,57 @@ std::vector<InvariantViolation> ValidateCacheInvariants(const PagedCacheSnapshot
 
   std::unordered_set<size_t> reserved_blocks;
   for (const size_t block_id : cache.transaction_reserved_block_ids) {
-    if (block_id >= cache.total_blocks) {
-      add("Transaction reserves out-of-range block id " + std::to_string(block_id) + ".");
+    if (owned_blocks.find(block_id) == owned_blocks.end()) {
+      add("Transaction reserves block id " + std::to_string(block_id) +
+          " that the cache does not list as allocated.");
+      continue;
     }
     if (!reserved_blocks.insert(block_id).second) {
       add("Transaction reserves block id " + std::to_string(block_id) + " more than once.");
     }
-    if (owner_of_block.find(block_id) != owner_of_block.end()) {
+    count_holder(block_id);
+    // A freshly reserved block is exclusively the transaction's until it commits.
+    if (owned_blocks[block_id]->ref_count != 1) {
       add("Transaction-reserved block id " + std::to_string(block_id) +
-          " is also committed to a Request.");
+          " is also held by another owner.");
+    }
+  }
+
+  // An adopted block is deliberately shared with the Request that already owns it, so unlike a
+  // reserved block it is expected to appear in a committed table as well.
+  for (const size_t block_id : cache.transaction_adopted_block_ids) {
+    const auto owned = owned_blocks.find(block_id);
+    if (owned == owned_blocks.end()) {
+      add("Transaction adopts block id " + std::to_string(block_id) +
+          " that the cache does not list as allocated.");
+      continue;
+    }
+    count_holder(block_id);
+    if (!owned->second->full) {
+      add("Transaction adopts block id " + std::to_string(block_id) + " that is not full.");
+    }
+    if (!owned->second->indexed) {
+      add("Transaction adopts block id " + std::to_string(block_id) +
+          " that the prefix cache does not index.");
+    }
+  }
+
+  for (const auto& block : cache.blocks) {
+    if (block.indexed) {
+      if (!block.full) {
+        add("Prefix cache indexes block id " + std::to_string(block.block_id) +
+            " that is not full.");
+      }
+      count_holder(block.block_id);
+    }
+  }
+
+  for (const auto& [block_id, block] : owned_blocks) {
+    const auto holder = holders.find(block_id);
+    const size_t holder_count = holder == holders.end() ? 0 : holder->second;
+    if (holder_count != block->ref_count) {
+      add("Block id " + std::to_string(block_id) + " has " + std::to_string(block->ref_count) +
+          " reference(s) but " + std::to_string(holder_count) + " owner(s).");
     }
   }
 
@@ -139,6 +201,15 @@ std::vector<InvariantViolation> ValidateCacheInvariants(const PagedCacheSnapshot
         add("Transaction-reserved block id " + std::to_string(block_id) +
             " is assigned to more than one Request delta.");
       }
+    }
+    // The adopted prefix has to line up with the slots the admission starts from, so the request
+    // never skips a token whose keys and values are not genuinely resident.
+    if (cache.block_size != 0 &&
+        reservation.adopted_block_ids.size() * cache.block_size != reservation.committed_slots &&
+        !reservation.adopted_block_ids.empty()) {
+      add("Request " + PtrId(reservation.request_id) + " adopts " +
+          std::to_string(reservation.adopted_block_ids.size()) +
+          " block(s) but starts from " + std::to_string(reservation.committed_slots) + " slot(s).");
     }
   }
   if (blocks_assigned_to_delta != reserved_blocks) {

--- a/src/engine/engine_invariants.h
+++ b/src/engine/engine_invariants.h
@@ -59,10 +59,10 @@ struct RequestReservationSnapshot {
 // Immutable view of one physical block the cache currently owns.
 struct CachedBlockSnapshot {
   size_t block_id{};
-  size_t ref_count{};   // Owners holding the block: request tables, the transaction, the index.
+  size_t ref_count{};  // Owners holding the block: request tables, the transaction, the index.
   size_t used_slots{};
   bool full{};
-  bool indexed{};       // The prefix cache holds one of the references and can give it back.
+  bool indexed{};  // The prefix cache holds one of the references and can give it back.
 };
 
 // Immutable view of the paged cache's block accounting. Produced by PagedKeyValueCache::Snapshot().

--- a/src/engine/engine_invariants.h
+++ b/src/engine/engine_invariants.h
@@ -53,6 +53,16 @@ struct RequestReservationSnapshot {
   size_t target_slots{};
   size_t tail_slots_to_consume{};
   std::vector<size_t> reserved_block_ids;
+  std::vector<size_t> adopted_block_ids;  // Resident prefix blocks this admission points at.
+};
+
+// Immutable view of one physical block the cache currently owns.
+struct CachedBlockSnapshot {
+  size_t block_id{};
+  size_t ref_count{};   // Owners holding the block: request tables, the transaction, the index.
+  size_t used_slots{};
+  bool full{};
+  bool indexed{};       // The prefix cache holds one of the references and can give it back.
 };
 
 // Immutable view of the paged cache's block accounting. Produced by PagedKeyValueCache::Snapshot().
@@ -63,9 +73,13 @@ struct PagedCacheSnapshot {
   size_t block_table_columns{};  // Padded block-table width the model sees, or 0 when unused.
   std::vector<RequestBlockSnapshot> requests;
   std::vector<size_t> transaction_reserved_block_ids;
+  std::vector<size_t> transaction_adopted_block_ids;
   std::vector<RequestReservationSnapshot> reservations;
+  std::vector<CachedBlockSnapshot> blocks;  // Every block the pool currently owns.
 
-  // Blocks currently owned by some Request (sum of per-Request block counts).
+  // Blocks currently owned by some Request (sum of per-Request block counts). A block several
+  // Requests share is counted once per Request, so this is a table-entry count rather than a
+  // physical block count.
   size_t AllocatedBlocks() const;
   size_t TransactionReservedBlocks() const {
     return transaction_reserved_block_ids.size();

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace Generators {
@@ -24,7 +25,8 @@ PagedCacheBlockTable* FindTable(std::vector<PagedCacheBlockTable>& tables, const
 PagedCacheReservation::PagedCacheReservation(
     BlockPool& block_pool,
     std::vector<PagedCacheBlockTable>& committed_tables,
-    std::span<const PagedCacheReservationRequest> requests)
+    std::span<const PagedCacheReservationRequest> requests,
+    BlockReclaimer* reclaimer)
     : block_pool_{&block_pool},
       committed_tables_{&committed_tables} {
   deltas_.reserve(requests.size());
@@ -47,8 +49,37 @@ PagedCacheReservation::PagedCacheReservation(
       throw std::runtime_error("Paged cache reservation request membership does not match the committed cache.");
     }
 
-    const size_t committed_slots = committed_table ? committed_table->committed_slots : 0;
-    const size_t committed_blocks = committed_table ? committed_table->blocks.size() : 0;
+    const PrefixCacheMatch* match = request.prefix_match;
+    if (match && match->Empty()) {
+      match = nullptr;
+    }
+    if (match && !request.newly_admitted) {
+      throw std::runtime_error("Only a newly admitted request can adopt a cached prefix.");
+    }
+
+    size_t adopted_block_offset = adopted_blocks_.size();
+    size_t adopted_block_count = 0;
+    if (match) {
+      // Only a full block is ever safe to share: it is never written again, so no owner can diverge
+      // from another. Reject anything else loudly rather than letting one request write into
+      // another request's key-value data.
+      for (const auto& block : match->blocks) {
+        if (!block || !block->IsFull()) {
+          throw std::runtime_error("A cached prefix can only adopt full blocks.");
+        }
+      }
+      if (match->token_count != match->blocks.size() * block_pool.BlockSize()) {
+        throw std::runtime_error("A cached prefix must cover whole blocks.");
+      }
+      if (match->token_count > request.target_slots) {
+        throw std::runtime_error("A cached prefix cannot exceed the request's target slots.");
+      }
+      adopted_block_count = match->blocks.size();
+    }
+
+    const size_t committed_slots = committed_table ? committed_table->committed_slots
+                                                   : (match ? match->token_count : 0);
+    const size_t committed_blocks = committed_table ? committed_table->blocks.size() : adopted_block_count;
     if (request.target_slots < committed_slots) {
       throw std::runtime_error("Paged cache reservation cannot reduce committed slots.");
     }
@@ -70,6 +101,8 @@ PagedCacheReservation::PagedCacheReservation(
         std::min(growth, tail_capacity),
         reserved_block_count,
         new_blocks,
+        adopted_block_offset,
+        adopted_block_count,
         request.newly_admitted,
     });
     reserved_block_count += new_blocks;
@@ -79,16 +112,42 @@ PagedCacheReservation::PagedCacheReservation(
     } else {
       PagedCacheBlockTable table;
       table.request_id = request.request_id;
-      table.blocks.reserve(new_blocks);
+      table.blocks.reserve(adopted_block_count + new_blocks);
+      if (match) {
+        // The adopted blocks are already sealed, so the table starts with them committed and only
+        // the tokens after them still have to be computed.
+        table.blocks = match->blocks;
+        table.committed_slots = match->token_count;
+        table.sealed_blocks = adopted_block_count;
+        table.sealed_identity = match->blocks.back()->IdentityPtr();
+        adopted_blocks_.insert(adopted_blocks_.end(), match->blocks.begin(), match->blocks.end());
+      }
       new_tables_.push_back(std::move(table));
     }
   }
 
-  if (reserved_block_count > block_pool.AvailableBlocks()) {
-    throw std::runtime_error("Not enough free blocks for the complete paged cache reservation.");
+  // Take the adopted references before reclaiming, so a retained block this reservation is about to
+  // adopt is no longer a candidate for eviction.
+  if (!adopted_blocks_.empty()) {
+    block_pool.AddRef(adopted_blocks_);
   }
 
-  reserved_blocks_ = block_pool.ReserveBlocks(reserved_block_count * block_pool.BlockSize());
+  try {
+    if (reclaimer && reserved_block_count > block_pool.AvailableBlocks()) {
+      reclaimer->Reclaim(reserved_block_count - block_pool.AvailableBlocks());
+    }
+    if (reserved_block_count > block_pool.AvailableBlocks()) {
+      throw std::runtime_error("Not enough free blocks for the complete paged cache reservation.");
+    }
+    reserved_blocks_ = block_pool.ReserveBlocks(reserved_block_count * block_pool.BlockSize());
+  } catch (...) {
+    // Nothing is reserved yet, so undoing the adopted references leaves the pool exactly as it was.
+    for (const auto& block : adopted_blocks_) {
+      block_pool.Release(block);
+    }
+    adopted_blocks_.clear();
+    throw;
+  }
   state_ = PagedCacheReservationState::Reserved;
 }
 
@@ -96,6 +155,7 @@ PagedCacheReservation::PagedCacheReservation(PagedCacheReservation&& other) noex
     : block_pool_{std::exchange(other.block_pool_, nullptr)},
       committed_tables_{std::exchange(other.committed_tables_, nullptr)},
       reserved_blocks_{std::move(other.reserved_blocks_)},
+      adopted_blocks_{std::move(other.adopted_blocks_)},
       deltas_{std::move(other.deltas_)},
       new_tables_{std::move(other.new_tables_)},
       state_{std::exchange(other.state_, PagedCacheReservationState::Released)} {}
@@ -110,7 +170,7 @@ size_t PagedCacheReservation::RequiredBlockTableColumns() const {
   size_t columns = 0;
   for (const auto& delta : deltas_) {
     const auto* table = FindCommittedTable(delta.request_id);
-    const size_t committed_blocks = table ? table->blocks.size() : 0;
+    const size_t committed_blocks = table ? table->blocks.size() : delta.adopted_block_count;
     columns = std::max(columns, committed_blocks + delta.reserved_block_count);
   }
   return columns;
@@ -140,6 +200,13 @@ void PagedCacheReservation::FillBlockTable(std::span<const void* const> request_
     if (table) {
       for (const auto& block : table->blocks) {
         output[row * columns + column++] = static_cast<int32_t>(block->Id());
+      }
+    } else {
+      // A newly admitted request's adopted prefix blocks come first: the model reads its cached
+      // tokens out of them at absolute positions [0, adopted blocks * block size).
+      for (size_t i = 0; i < delta.adopted_block_count; ++i) {
+        output[row * columns + column++] =
+            static_cast<int32_t>(adopted_blocks_[delta.adopted_block_offset + i]->Id());
       }
     }
     for (size_t i = 0; i < delta.reserved_block_count; ++i) {
@@ -171,6 +238,8 @@ void PagedCacheReservation::Commit() {
   }
 
   reserved_blocks_.clear();
+  // The adopted references now belong to the committed block tables.
+  adopted_blocks_.clear();
   new_tables_.clear();
   state_ = PagedCacheReservationState::Committed;
 }
@@ -183,8 +252,18 @@ void PagedCacheReservation::Release() {
     throw std::logic_error("Cannot release a committed paged cache reservation.");
   }
 
-  block_pool_->Free(reserved_blocks_);
+  // Release one block at a time. The single-block path allocates nothing, so a rollback -- which
+  // may already be running because the process is out of memory -- cannot fail here, and it also
+  // handles the same shared prefix block appearing once per request that adopted it.
+  for (const auto& block : reserved_blocks_) {
+    block_pool_->Release(block);
+  }
   reserved_blocks_.clear();
+  // A rolled back step must not leave a reference on a shared prefix block behind.
+  for (const auto& block : adopted_blocks_) {
+    block_pool_->Release(block);
+  }
+  adopted_blocks_.clear();
   new_tables_.clear();
   state_ = PagedCacheReservationState::Released;
 }
@@ -210,6 +289,15 @@ void PagedCacheReservation::AdvanceCommittedSlots(PagedCacheBlockTable& table, s
   size_t block_index = table.committed_slots / block_pool_->BlockSize();
   while (remaining > 0) {
     auto& block = table.blocks.at(block_index++);
+    // Sharing is restricted to full blocks, and a full block is never written again, so this never
+    // fires under the prefix cache's own policy. It is the backstop that makes that policy an
+    // enforced invariant instead of an assumption: a writer must take a private copy of a block
+    // another owner still references (PagedKeyValueCache::MakeTailBlockExclusive) rather than
+    // diverge into that owner's key-value data.
+    if (block->IsShared()) {
+      throw std::runtime_error("Cannot write into paged cache block " + std::to_string(block->Id()) +
+                               " while another owner still references it.");
+    }
     const size_t slots = std::min(remaining, block->EmptySlots());
     block->AddSlots(slots);
     remaining -= slots;

--- a/src/engine/paged_cache_reservation.h
+++ b/src/engine/paged_cache_reservation.h
@@ -10,6 +10,7 @@
 
 #include "../span.h"
 #include "block.h"
+#include "prefix_cache.h"
 
 namespace Generators {
 
@@ -17,6 +18,18 @@ struct PagedCacheBlockTable {
   const void* request_id{};
   size_t committed_slots{};
   std::vector<std::shared_ptr<Block>> blocks;
+  // Leading blocks that already carry a content identity, so a later step only has to seal the
+  // blocks that filled up since. Adopted prefix blocks arrive already sealed.
+  size_t sealed_blocks{};
+  // Identity the next block to seal chains from. Null while nothing is sealed.
+  std::shared_ptr<const BlockIdentity> sealed_identity;
+};
+
+// Reclaims capacity a reservation needs from owners that can give it back on demand, which is what
+// lets retained prefix blocks count as available without ever starving a live request.
+struct BlockReclaimer {
+  virtual size_t Reclaim(size_t blocks_needed) = 0;
+  virtual ~BlockReclaimer() = default;
 };
 
 struct PagedCacheReservationRequest {
@@ -26,6 +39,10 @@ struct PagedCacheReservationRequest {
   // Slots the reservation has to own blocks for, which is the whole sequence rather than this
   // step's target when a prefill is chunked. Clamped up to target_slots when left unset.
   size_t reserved_slots{};
+  // Resident blocks a newly admitted request adopts for the leading tokens of its prompt. The
+  // reservation takes a reference on each so a rolled back step cannot leak one, and seeds the
+  // request's block table with them on commit. Null for every other request.
+  const PrefixCacheMatch* prefix_match{};
 };
 
 struct PagedCacheReservationDelta {
@@ -35,6 +52,8 @@ struct PagedCacheReservationDelta {
   size_t tail_slots_to_consume{};
   size_t reserved_block_offset{};
   size_t reserved_block_count{};
+  size_t adopted_block_offset{};
+  size_t adopted_block_count{};
   bool newly_admitted{};
 };
 
@@ -49,7 +68,8 @@ class PagedCacheReservation {
   // Requests omitted from the reservation keep their committed tables unchanged.
   PagedCacheReservation(BlockPool& block_pool,
                         std::vector<PagedCacheBlockTable>& committed_tables,
-                        std::span<const PagedCacheReservationRequest> requests);
+                        std::span<const PagedCacheReservationRequest> requests,
+                        BlockReclaimer* reclaimer = nullptr);
   PagedCacheReservation(PagedCacheReservation&& other) noexcept;
   PagedCacheReservation& operator=(PagedCacheReservation&&) = delete;
   PagedCacheReservation(const PagedCacheReservation&) = delete;
@@ -60,6 +80,10 @@ class PagedCacheReservation {
   size_t ReservedBlockCount() const { return reserved_blocks_.size(); }
   const std::vector<std::shared_ptr<Block>>& ReservedBlocks() const {
     return reserved_blocks_;
+  }
+  size_t AdoptedBlockCount() const { return adopted_blocks_.size(); }
+  const std::vector<std::shared_ptr<Block>>& AdoptedBlocks() const {
+    return adopted_blocks_;
   }
   size_t RequiredBlockTableColumns() const;
   const std::vector<PagedCacheReservationDelta>& Deltas() const { return deltas_; }
@@ -78,6 +102,7 @@ class PagedCacheReservation {
   BlockPool* block_pool_{};
   std::vector<PagedCacheBlockTable>* committed_tables_{};
   std::vector<std::shared_ptr<Block>> reserved_blocks_;
+  std::vector<std::shared_ptr<Block>> adopted_blocks_;
   std::vector<PagedCacheReservationDelta> deltas_;
   std::vector<PagedCacheBlockTable> new_tables_;
   PagedCacheReservationState state_{PagedCacheReservationState::Released};

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -3,7 +3,12 @@
 
 #include "cache_manager.h"
 
+#include <algorithm>
+#include <memory>
 #include <numeric>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include "sequence_positions.h"
 

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -53,7 +53,56 @@ size_t RequiredSlots(const std::shared_ptr<Request>& request) {
   return static_cast<size_t>(request->CurrentSequenceLength());
 }
 
+PrefixCacheOptions ComposePrefixCacheOptions(const Config::Engine::DynamicBatching& config,
+                                             size_t num_blocks) {
+  PrefixCacheOptions options;
+  options.enabled = config.prefix_caching;
+  options.min_match_blocks = std::max<size_t>(config.prefix_cache_min_blocks, 1);
+  if (config.prefix_cache_max_blocks.has_value()) {
+    options.max_blocks = std::min(*config.prefix_cache_max_blocks, num_blocks);
+  } else {
+    const float fraction = std::clamp(config.prefix_cache_pool_fraction, 0.0f, 1.0f);
+    options.max_blocks = static_cast<size_t>(static_cast<float>(num_blocks) * fraction);
+  }
+  return options;
+}
+
 }  // namespace
+
+bool MakeTailBlockExclusive(PagedCacheBlockTable& table,
+                            size_t target_slots,
+                            BlockPool& pool,
+                            BlockCopier& copier) {
+  if (target_slots <= table.committed_slots || pool.BlockSize() == 0) {
+    return false;
+  }
+
+  const size_t block_index = table.committed_slots / pool.BlockSize();
+  if (block_index >= table.blocks.size()) {
+    return false;
+  }
+
+  auto& block = table.blocks[block_index];
+  if (!block->IsShared()) {
+    return false;
+  }
+
+  auto replacement = pool.ReserveBlocks(pool.BlockSize());
+  if (replacement.size() != 1) {
+    throw std::runtime_error("Copy-on-write needs exactly one replacement block.");
+  }
+  copier.CopyBlock(block->Id(), replacement.front()->Id());
+  replacement.front()->AddSlots(block->Size());
+
+  auto shared = block;
+  table.blocks[block_index] = replacement.front();
+  if (table.sealed_blocks > block_index) {
+    throw std::logic_error(
+        "Copy-on-write reached a block the prefix cache already sealed, which is never written.");
+  }
+  pool.Free({shared});
+  return true;
+}
 
 PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
     : model_(model) {
@@ -74,6 +123,13 @@ PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
     });
   }
   block_pool_ = std::make_unique<BlockPool>(model->config_->engine.dynamic_batching->block_size, num_blocks);
+  prefix_cache_ = std::make_unique<PrefixCache>(
+      *block_pool_,
+      ComposePrefixCacheOptions(*model->config_->engine.dynamic_batching, num_blocks));
+  block_bytes_per_layer_ = model->config_->engine.dynamic_batching->block_size *
+                           model->config_->model.decoder.num_key_value_heads *
+                           model->config_->model.decoder.head_size *
+                           Ort::SizeOf(dtype);
 
   max_batch_size_ = model->config_->engine.dynamic_batching->max_batch_size;
   graph_capture_ = IsGraphCaptureEnabled(model->config_->model.decoder.session_options);
@@ -173,6 +229,9 @@ void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
 void PagedKeyValueCache::Remove(std::shared_ptr<Request> request) {
   for (auto request_it = block_tables_.begin(); request_it != block_tables_.end(); ++request_it) {
     if (request_it->request_id == request.get()) {
+      // Blocks the prefix cache indexed keep its reference and stay resident, so the next turn of
+      // this conversation can adopt them. Everything else, including the partially filled tail
+      // block, goes straight back to the pool.
       block_pool_->Free(request_it->blocks);
       block_tables_.erase(request_it);
       return;
@@ -180,8 +239,116 @@ void PagedKeyValueCache::Remove(std::shared_ptr<Request> request) {
   }
 }
 
+PagedKeyValueCache::~PagedKeyValueCache() {
+  // Release the block tables before the prefix cache and the pool unwind, so every reference is
+  // accounted for regardless of whether the engine drained its requests first. The single-block
+  // release allocates nothing, so teardown cannot fail on a failed allocation.
+  for (auto& table : block_tables_) {
+    for (const auto& block : table.blocks) {
+      block_pool_->Release(block);
+    }
+  }
+  block_tables_.clear();
+}
+
+PrefixCacheMatch PagedKeyValueCache::MatchPrefix(std::span<const int32_t> tokens,
+                                                 size_t max_adoptable_tokens) {
+  return prefix_cache_->Match(tokens, max_adoptable_tokens);
+}
+
+bool PagedKeyValueCache::PrefixCachingEnabled() const {
+  return prefix_cache_->Enabled();
+}
+
+const PrefixCacheMetrics& PagedKeyValueCache::PrefixMetrics() const {
+  return prefix_cache_->Metrics();
+}
+
+void PagedKeyValueCache::SealCommittedBlocks(const void* request_id,
+                                             std::span<const int32_t> tokens) {
+  if (!prefix_cache_->Enabled()) {
+    return;
+  }
+
+  const auto table_it = std::find_if(block_tables_.begin(), block_tables_.end(),
+                                     [request_id](const PagedCacheBlockTable& table) {
+                                       return table.request_id == request_id;
+                                     });
+  if (table_it == block_tables_.end()) {
+    return;
+  }
+
+  const size_t block_size = block_pool_->BlockSize();
+  const size_t full_blocks = table_it->committed_slots / block_size;
+  if (full_blocks <= table_it->sealed_blocks) {
+    return;
+  }
+  if (tokens.size() < full_blocks * block_size) {
+    throw std::runtime_error(
+        "The request's token mirror is shorter than the slots the paged cache committed for it.");
+  }
+
+  auto parent = table_it->sealed_identity;
+  for (size_t index = table_it->sealed_blocks; index < full_blocks; ++index) {
+    auto chained = prefix_cache_->Register(table_it->blocks[index],
+                                           tokens.subspan(index * block_size, block_size),
+                                           parent);
+    if (!chained) {
+      // Nothing after an unreachable identity can be reached either, so the chain stops here and
+      // the remaining blocks stay private to this request.
+      break;
+    }
+    parent = std::move(chained);
+    table_it->sealed_blocks = index + 1;
+    table_it->sealed_identity = parent;
+  }
+}
+
 PagedCacheReservation PagedKeyValueCache::Reserve(std::span<const PagedCacheReservationRequest> requests) {
-  return PagedCacheReservation{*block_pool_, block_tables_, requests};
+  // A step only ever writes into a request's tail block, and sharing is restricted to full blocks
+  // that are never written again, so this normally finds nothing to do. When a tail block is shared
+  // anyway the writer takes a private copy of it here, before any reservation state exists, rather
+  // than diverging into the other owner's key-value data.
+  if (prefix_cache_->Enabled()) {
+    LayerBlockCopier copier{*this};
+    for (const auto& request : requests) {
+      if (request.newly_admitted) {
+        continue;
+      }
+      const auto table_it = std::find_if(block_tables_.begin(), block_tables_.end(),
+                                         [&request](const PagedCacheBlockTable& value) {
+                                           return value.request_id == request.request_id;
+                                         });
+      if (table_it == block_tables_.end()) {
+        continue;
+      }
+      MakeTailBlockExclusive(*table_it, request.target_slots, *block_pool_, copier);
+    }
+  }
+
+  RetainedBlockReclaimer reclaimer{*prefix_cache_};
+  return PagedCacheReservation{*block_pool_, block_tables_, requests, &reclaimer};
+}
+
+void PagedKeyValueCache::LayerBlockCopier::CopyBlock(size_t source_block_id,
+                                                     size_t destination_block_id) {
+  const size_t block_bytes = cache_.block_bytes_per_layer_;
+  if (block_bytes == 0) {
+    throw std::runtime_error("The paged cache cannot copy a block of unknown size.");
+  }
+
+  const auto copy = [&](OrtValue& tensor) {
+    auto* data = tensor.GetTensorMutableRawData();
+    const size_t total_bytes = cache_.block_pool_->Capacity() * block_bytes;
+    auto buffer = cache_.model_->p_device_kvcache_->WrapMemoryBase(data, total_bytes);
+    buffer->CopyFrom(destination_block_id * block_bytes, *buffer, source_block_id * block_bytes,
+                     block_bytes);
+  };
+
+  for (auto& layer : cache_.cache_) {
+    copy(*layer.key_cache);
+    copy(*layer.value_cache);
+  }
 }
 
 StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
@@ -197,7 +364,10 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
     throw std::runtime_error("Step plan request limit exceeds the configured batch size.");
   }
 
-  const size_t available_blocks = block_pool_->AvailableBlocks();
+  // Retained prefix blocks are always reclaimable, so they count as capacity a step can take. The
+  // reservation reclaims exactly what it needs, in least-recently-used order.
+  const size_t available_blocks =
+      block_pool_->AvailableBlocks() + prefix_cache_->ReclaimableBlocks();
   size_t planned_blocks = 0;
   size_t selected_requests = 0;
   size_t selected_new_requests = 0;
@@ -208,26 +378,51 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
   struct CacheGrowth {
     size_t proposed_blocks{};
     size_t new_blocks{};
+    // Retained prefix blocks this admission would adopt that no other selected request has already
+    // been charged for. They are counted as available above, but adopting them takes them out of
+    // the reclaimable pool, so they have to be charged to this step as well or the reservation
+    // could be planned to reclaim capacity it has just claimed.
+    std::vector<size_t> claimed_retained_blocks;
   };
+  // Retained blocks already charged to this step, so several requests adopting the same prefix pay
+  // for it once instead of being deferred for capacity that is not actually needed twice.
+  std::vector<size_t> charged_retained_blocks;
   // Blocks the request has to own for this step. A chunked prefill is planned one chunk at a time,
   // but the blocks are taken for the whole sequence: admitting a prompt on the strength of its
   // first chunk and then losing the rest of the pool to another request would stall it part way
   // through, holding the blocks it already took. PagedCacheReservation reserves the same blocks.
+  // Blocks adopted from the prefix cache already exist, so they widen the request's block table
+  // without drawing on the free pool.
   const auto calculate_growth = [&](const RequestStepPlan& entry,
                                     const PagedCacheBlockTable* table) {
-    const size_t committed_slots = table ? table->committed_slots : 0;
+    const size_t adopted_blocks =
+        entry.prefix_match ? entry.prefix_match->blocks.size() : 0;
+    const size_t committed_slots =
+        table ? table->committed_slots : (entry.prefix_match ? entry.prefix_match->token_count : 0);
     if (entry.target_cache_slots < committed_slots) {
       throw std::runtime_error("Step plan target precedes the committed cache boundary.");
     }
 
+    std::vector<size_t> claimed_retained_blocks;
+    if (entry.prefix_match) {
+      for (const auto& block : entry.prefix_match->blocks) {
+        if (block->RefCount() == 1 &&
+            std::find(charged_retained_blocks.begin(), charged_retained_blocks.end(),
+                      block->Id()) == charged_retained_blocks.end()) {
+          claimed_retained_blocks.push_back(block->Id());
+        }
+      }
+    }
+
     const size_t reserved_slots =
         std::max(entry.whole_sequence_cache_slots, entry.target_cache_slots);
-    const size_t committed_blocks = table ? table->blocks.size() : 0;
+    const size_t committed_blocks = table ? table->blocks.size() : adopted_blocks;
     const size_t committed_capacity = committed_blocks * block_pool_->BlockSize();
     const size_t additional_slots =
         reserved_slots > committed_capacity ? reserved_slots - committed_capacity : 0;
     const size_t new_blocks = block_pool_->BlocksNeeded(additional_slots);
-    return CacheGrowth{committed_blocks + new_blocks, new_blocks};
+    return CacheGrowth{committed_blocks + new_blocks, new_blocks,
+                       std::move(claimed_retained_blocks)};
   };
   const auto permanently_unserviceable = [&](const CacheGrowth& growth) {
     return growth.proposed_blocks > block_pool_->Capacity() ||
@@ -235,10 +430,13 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
             growth.proposed_blocks > max_block_table_columns_);
   };
   const auto select = [&](size_t request_index,
-                          const CacheGrowth& growth) {
+                          CacheGrowth& growth) {
     // Compact selected entries in place. Requests skipped for temporary capacity pressure remain
     // pending with their committed block tables untouched and can be reconsidered next Step().
-    planned_blocks += growth.new_blocks;
+    planned_blocks += growth.new_blocks + growth.claimed_retained_blocks.size();
+    charged_retained_blocks.insert(charged_retained_blocks.end(),
+                                   growth.claimed_retained_blocks.begin(),
+                                   growth.claimed_retained_blocks.end());
     max_blocks_per_request =
         std::max(max_blocks_per_request, growth.proposed_blocks);
     if (selected_requests != request_index) {
@@ -272,7 +470,7 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
       throw std::runtime_error("Step plan resident membership does not match the committed cache.");
     }
 
-    const auto growth = calculate_growth(candidate, table);
+    auto growth = calculate_growth(candidate, table);
     if (permanently_unserviceable(growth)) {
       if (!unserviceable_request_id) {
         unserviceable_request_id = candidate.request_id;
@@ -280,10 +478,15 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
       continue;
     }
 
+    // Charging the retained blocks an adoption claims alongside the blocks it still has to take
+    // makes adoption capacity-neutral: every adopted block removes one from `new_blocks` and adds
+    // one back here, so a step is never admitted on capacity the reservation then cannot reclaim,
+    // and a prefix hit never makes a request harder to admit than recomputing it would.
     if (selected_requests >= scheduled_request_limit ||
         (candidate.newly_admitted &&
          committed_request_count + selected_new_requests >= max_batch_size_) ||
-        planned_blocks + growth.new_blocks > available_blocks) {
+        planned_blocks + growth.new_blocks + growth.claimed_retained_blocks.size() >
+            available_blocks) {
       capacity_deferred = true;
       continue;
     }
@@ -345,6 +548,15 @@ PagedCacheSnapshot PagedKeyValueCache::Snapshot() const {
   snapshot.total_blocks = block_pool_->Capacity();
   snapshot.free_blocks = block_pool_->AvailableBlocks();
   snapshot.block_table_columns = block_table_columns_;
+  for (const auto& block : block_pool_->OwnedBlocks()) {
+    snapshot.blocks.push_back(CachedBlockSnapshot{
+        block->Id(),
+        block->RefCount(),
+        block->Size(),
+        block->IsFull(),
+        block->HasIdentity(),
+    });
+  }
   snapshot.requests.reserve(block_tables_.size());
   for (const auto& block_table : block_tables_) {
     RequestBlockSnapshot request_snapshot;
@@ -368,6 +580,11 @@ PagedCacheSnapshot PagedKeyValueCache::Snapshot(
   for (const auto& block : reservation.ReservedBlocks()) {
     snapshot.transaction_reserved_block_ids.push_back(block->Id());
   }
+  snapshot.transaction_adopted_block_ids.reserve(
+      reservation.AdoptedBlocks().size());
+  for (const auto& block : reservation.AdoptedBlocks()) {
+    snapshot.transaction_adopted_block_ids.push_back(block->Id());
+  }
   snapshot.reservations.reserve(reservation.Deltas().size());
   for (const auto& delta : reservation.Deltas()) {
     RequestReservationSnapshot request_reservation;
@@ -380,6 +597,11 @@ PagedCacheSnapshot PagedKeyValueCache::Snapshot(
     for (size_t i = 0; i < delta.reserved_block_count; ++i) {
       request_reservation.reserved_block_ids.push_back(
           reservation.ReservedBlocks()[delta.reserved_block_offset + i]->Id());
+    }
+    request_reservation.adopted_block_ids.reserve(delta.adopted_block_count);
+    for (size_t i = 0; i < delta.adopted_block_count; ++i) {
+      request_reservation.adopted_block_ids.push_back(
+          reservation.AdoptedBlocks()[delta.adopted_block_offset + i]->Id());
     }
     snapshot.reservations.push_back(std::move(request_reservation));
   }

--- a/src/engine/paged_key_value_cache.h
+++ b/src/engine/paged_key_value_cache.h
@@ -204,8 +204,8 @@ struct PagedKeyValueCache {
   //   M = block_size per block
 
   std::shared_ptr<Model> model_;
-  std::vector<LayerCache> cache_;                   // Pair of key and value caches for all layers
-  std::unique_ptr<BlockPool> block_pool_;           // Allocator for blocks
+  std::vector<LayerCache> cache_;          // Pair of key and value caches for all layers
+  std::unique_ptr<BlockPool> block_pool_;  // Allocator for blocks
   // Declared after the pool so it releases its retained references before the pool goes away.
   std::unique_ptr<PrefixCache> prefix_cache_;       // Content-addressed index over filled blocks
   std::vector<PagedCacheBlockTable> block_tables_;  // Block table for all requests in the cache

--- a/src/engine/paged_key_value_cache.h
+++ b/src/engine/paged_key_value_cache.h
@@ -10,10 +10,38 @@
 #include "block.h"
 #include "engine_invariants.h"
 #include "paged_cache_reservation.h"
+#include "prefix_cache.h"
 #include "request.h"
 #include "step_plan.h"
 
 namespace Generators {
+
+// Copies the key and value data of one physical block onto another. Implemented by the paged cache
+// over its per-layer tensors; separated so the divergence policy below can be exercised without a
+// device.
+struct BlockCopier {
+  virtual void CopyBlock(size_t source_block_id, size_t destination_block_id) = 0;
+  virtual ~BlockCopier() = default;
+};
+
+/**
+ * @brief Gives `table` a private copy of the block the next step is about to write into, when that
+ *        block is still referenced by another owner.
+ * @param table The request's committed block table.
+ * @param target_slots Slots the table will hold once the pending step commits.
+ * @param pool The pool the private replacement block is taken from.
+ * @param copier Moves the shared block's key-value data into the replacement.
+ * @return True when a private copy was made.
+ *
+ * Only full blocks are ever shared, and a full block is never written again, so under the prefix
+ * cache's own policy this finds nothing to do. It exists so that a partially filled block that is
+ * shared anyway diverges by copy instead of corrupting the other owner's key-value data, which is
+ * what makes "shared blocks are immutable" an enforced property rather than an assumption.
+ */
+bool MakeTailBlockExclusive(PagedCacheBlockTable& table,
+                            size_t target_slots,
+                            BlockPool& pool,
+                            BlockCopier& copier);
 
 /*
  * PagedKeyValueCache manages a paged key-value cache for models that use the PagedAttention operator.
@@ -28,6 +56,7 @@ namespace Generators {
 struct PagedKeyValueCache {
  public:
   PagedKeyValueCache(std::shared_ptr<Model> model);
+  ~PagedKeyValueCache();
 
   bool CanAdd(std::shared_ptr<Request> request) const;
 
@@ -43,6 +72,29 @@ struct PagedKeyValueCache {
 
   // Selects the active and pending requests whose immediate cache growth fits this step.
   StepPlanningResult PlanStepResources(StepPlan& plan) const;
+
+  /**
+   * @brief Longest run of leading prompt tokens already resident in the cache, or an empty match.
+   * @param tokens The request's whole sequence.
+   * @param max_adoptable_tokens Tokens the caller may skip; always at least one less than the
+   *        sequence length so the request still computes a token and produces logits.
+   *
+   * The returned blocks are the physical blocks the request will point at. Nothing is committed
+   * here: the reservation takes the references, so a step that never runs adopts nothing.
+   */
+  PrefixCacheMatch MatchPrefix(std::span<const int32_t> tokens, size_t max_adoptable_tokens);
+
+  /**
+   * @brief Gives every block that filled up during the committed step a content identity, so later
+   *        prompts sharing the same prefix can adopt it.
+   *
+   * Called once the step's reservation is committed, at which point the host token mirror of each
+   * request covers exactly the slots the cache holds for it.
+   */
+  void SealCommittedBlocks(const void* request_id, std::span<const int32_t> tokens);
+
+  bool PrefixCachingEnabled() const;
+  const PrefixCacheMetrics& PrefixMetrics() const;
 
   // Returns the K, V cache.
   std::vector<std::pair<OrtValue*, OrtValue*>> Cache();
@@ -106,7 +158,27 @@ struct PagedKeyValueCache {
     std::string value_cache_output_name;
   };
 
+  // Copies a block's key and value data across every layer, used only by MakeTailBlockExclusive.
+  class LayerBlockCopier final : public BlockCopier {
+   public:
+    explicit LayerBlockCopier(PagedKeyValueCache& cache) : cache_{cache} {}
+    void CopyBlock(size_t source_block_id, size_t destination_block_id) override;
+
+   private:
+    PagedKeyValueCache& cache_;
+  };
+
   void BindCache(State& state);
+
+  // Reclaims retained prefix blocks so the pool can satisfy a reservation.
+  class RetainedBlockReclaimer final : public BlockReclaimer {
+   public:
+    explicit RetainedBlockReclaimer(PrefixCache& prefix_cache) : prefix_cache_{prefix_cache} {}
+    size_t Reclaim(size_t blocks_needed) override { return prefix_cache_.Reclaim(blocks_needed); }
+
+   private:
+    PrefixCache& prefix_cache_;
+  };
 
   //   The key and the value cache is represented as an array of blocks. Each block contains
   //   a number of slots equal to the block size. Each slot contains num_kv_heads * head_size
@@ -134,8 +206,11 @@ struct PagedKeyValueCache {
   std::shared_ptr<Model> model_;
   std::vector<LayerCache> cache_;                   // Pair of key and value caches for all layers
   std::unique_ptr<BlockPool> block_pool_;           // Allocator for blocks
+  // Declared after the pool so it releases its retained references before the pool goes away.
+  std::unique_ptr<PrefixCache> prefix_cache_;       // Content-addressed index over filled blocks
   std::vector<PagedCacheBlockTable> block_tables_;  // Block table for all requests in the cache
   std::unique_ptr<OrtValue> block_tables_value_;    // Block tables for all requests in the cache
+  size_t block_bytes_per_layer_{};                  // Bytes one block occupies in one layer's cache
 
   // Graph capture needs the block table at a device address that never moves and at a shape that
   // repeats across steps, so it gets a dedicated persistent tensor instead of the per-step CPU one.

--- a/src/engine/prefix_cache.cpp
+++ b/src/engine/prefix_cache.cpp
@@ -1,0 +1,257 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "prefix_cache.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+namespace Generators {
+
+namespace {
+
+// FNV-1a. The identity only has to be well distributed and reproducible within one process; every
+// hit is verified against the stored tokens, so the hash never decides correctness on its own.
+constexpr uint64_t kFnvOffsetBasis = 1469598103934665603ULL;
+constexpr uint64_t kFnvPrime = 1099511628211ULL;
+
+uint64_t HashBytes(uint64_t hash, const void* data, size_t size) {
+  const auto* bytes = static_cast<const unsigned char*>(data);
+  for (size_t i = 0; i < size; ++i) {
+    hash ^= static_cast<uint64_t>(bytes[i]);
+    hash *= kFnvPrime;
+  }
+  return hash;
+}
+
+}  // namespace
+
+uint64_t PrefixCache::RootHash() {
+  return kFnvOffsetBasis;
+}
+
+uint64_t PrefixCache::ChainHash(uint64_t parent_hash, std::span<const int32_t> tokens) {
+  uint64_t hash = HashBytes(kFnvOffsetBasis, &parent_hash, sizeof(parent_hash));
+  const uint64_t token_count = tokens.size();
+  hash = HashBytes(hash, &token_count, sizeof(token_count));
+  for (const int32_t token : tokens) {
+    hash = HashBytes(hash, &token, sizeof(token));
+  }
+  return hash;
+}
+
+PrefixCache::PrefixCache(BlockPool& block_pool, PrefixCacheOptions options)
+    : block_pool_{block_pool}, options_{options} {}
+
+PrefixCache::~PrefixCache() {
+  // Hand every retained block back so the pool's accounting is balanced when the cache outlives its
+  // requests. Blocks a request still holds simply lose the cache's reference. The single-block
+  // release allocates nothing, so teardown cannot fail on a failed allocation.
+  for (auto& [hash, entry] : entries_) {
+    entry.block->ClearIdentity();
+    block_pool_.Release(entry.block);
+  }
+  entries_.clear();
+  recency_.clear();
+}
+
+PrefixCacheMatch PrefixCache::Match(std::span<const int32_t> tokens,
+                                    size_t max_adoptable_tokens) {
+  PrefixCacheMatch match;
+  if (!Enabled()) {
+    return match;
+  }
+
+  const size_t block_size = block_pool_.BlockSize();
+  if (block_size == 0) {
+    return match;
+  }
+
+  const size_t adoptable = std::min(max_adoptable_tokens, tokens.size());
+  ++metrics_.lookups;
+  metrics_.queried_tokens += adoptable;
+
+  uint64_t parent_hash = RootHash();
+  std::shared_ptr<const BlockIdentity> parent;
+  std::vector<std::unordered_map<uint64_t, Entry>::iterator> hits;
+  for (size_t offset = 0; offset + block_size <= adoptable; offset += block_size) {
+    const auto chunk = tokens.subspan(offset, block_size);
+    const uint64_t hash = Hash(parent_hash, chunk);
+    const auto it = entries_.find(hash);
+    if (it == entries_.end()) {
+      break;
+    }
+
+    // A hash match is not a match. The block's exact tokens are compared, and its parent is
+    // compared as the identity object it was computed behind rather than as a hash of it, so a
+    // collision anywhere in the chain costs a missed hit and can never splice a block onto a prefix
+    // it was not computed behind.
+    const auto& identity = *it->second.identity;
+    if (identity.parent != parent ||
+        identity.tokens.size() != chunk.size() ||
+        !std::equal(identity.tokens.begin(), identity.tokens.end(), chunk.begin())) {
+      ++metrics_.hash_collisions;
+      break;
+    }
+    if (!it->second.block->IsFull()) {
+      break;
+    }
+
+    hits.push_back(it);
+    parent = it->second.identity;
+    parent_hash = hash;
+  }
+
+  if (hits.size() < options_.min_match_blocks) {
+    return match;
+  }
+
+  match.blocks.reserve(hits.size());
+  for (const auto& it : hits) {
+    match.blocks.push_back(it->second.block);
+  }
+  // Refresh the run head first, so each block lands immediately before the one it chains from and
+  // the head of the chain ends up the most recently used. Evicting the head would orphan every
+  // block behind it -- their identities chain from it, so no lookup can reach them again -- while
+  // evicting the tail just shortens the prefix that stays reusable.
+  for (const auto& it : hits) {
+    Reorder(it->second, it->second.identity->parent);
+  }
+  match.token_count = hits.size() * block_size;
+
+  ++metrics_.hits;
+  metrics_.matched_tokens += match.token_count;
+  return match;
+}
+
+std::shared_ptr<const BlockIdentity> PrefixCache::Register(
+    const std::shared_ptr<Block>& block,
+    std::span<const int32_t> tokens,
+    const std::shared_ptr<const BlockIdentity>& parent) {
+  if (!Enabled()) {
+    return nullptr;
+  }
+  if (!block) {
+    throw std::runtime_error("Cannot index a null block in the prefix cache.");
+  }
+  if (!block->IsFull() || tokens.size() != block->Capacity()) {
+    throw std::runtime_error("Only a full block whose tokens cover every slot can be indexed.");
+  }
+  if (block->HasIdentity()) {
+    // Already indexed, which is the normal case for an adopted block being re-walked.
+    return block->IdentityPtr();
+  }
+  if (!block_pool_.Owns(block)) {
+    throw std::runtime_error("Cannot index a block the pool does not own.");
+  }
+
+  const uint64_t hash = Hash(parent ? parent->hash : RootHash(), tokens);
+  const auto existing = entries_.find(hash);
+  if (existing != entries_.end()) {
+    const auto& identity = *existing->second.identity;
+    if (identity.parent != parent ||
+        identity.tokens.size() != tokens.size() ||
+        !std::equal(identity.tokens.begin(), identity.tokens.end(), tokens.begin())) {
+      // A different block already holds this identity. Nothing after it can be reached either, so
+      // the caller stops here rather than indexing entries no lookup can ever verify.
+      ++metrics_.hash_collisions;
+      return nullptr;
+    }
+    // Two sequences computed the same prefix before either was indexed. The first physical copy
+    // serves every lookup, so this one stays private; the chain still continues through it because
+    // the indexed copy holds exactly the same tokens behind the same parent.
+    ++metrics_.duplicate_registrations;
+    Reorder(existing->second, parent);
+    return existing->second.identity;
+  }
+
+  if (entries_.size() >= options_.max_blocks && Reclaim(1) == 0) {
+    // The budget is full and every indexed block is still in use. Leaving this block unindexed is
+    // the safe outcome: it stays private and is freed with its request.
+    ++metrics_.retention_refusals;
+    return nullptr;
+  }
+
+  auto identity = std::make_shared<BlockIdentity>();
+  identity->hash = hash;
+  identity->parent = parent;
+  identity->tokens.assign(tokens.begin(), tokens.end());
+
+  // Everything that can fail happens first. Order the entry just behind its parent, so a chain is
+  // always evicted from its tail: the head is what every longer match starts from, and losing it
+  // would orphan everything chained behind it.
+  const auto parent_entry = parent ? entries_.find(parent->hash) : entries_.end();
+  const auto position = parent_entry == entries_.end() ? recency_.end() : parent_entry->second.recency;
+  const auto recency = recency_.insert(position, hash);
+  try {
+    entries_.emplace(hash, Entry{block, identity, recency});
+  } catch (...) {
+    recency_.erase(recency);
+    throw;
+  }
+
+  // The index owns a reference of its own, which is what keeps the block alive once its request
+  // releases it. Neither step allocates, so the entry above cannot end up without its reference.
+  block_pool_.AddRef(block);
+  block->SetIdentity(identity);
+  ++metrics_.registered_blocks;
+  return identity;
+}
+
+size_t PrefixCache::Reclaim(size_t blocks_needed) {
+  size_t reclaimed = 0;
+  auto recency_it = recency_.begin();
+  while (reclaimed < blocks_needed && recency_it != recency_.end()) {
+    const auto entry_it = entries_.find(*recency_it);
+    if (entry_it == entries_.end()) {
+      throw std::logic_error("Prefix cache recency order references an unknown identity.");
+    }
+    // A block a request still holds is not the cache's to give back.
+    if (entry_it->second.block->RefCount() > 1) {
+      ++recency_it;
+      continue;
+    }
+    ++recency_it;
+    Evict(entry_it);
+    ++reclaimed;
+    ++metrics_.evictions;
+  }
+  return reclaimed;
+}
+
+size_t PrefixCache::ReclaimableBlocks() const {
+  size_t reclaimable = 0;
+  for (const auto& [hash, entry] : entries_) {
+    if (entry.block->RefCount() == 1) {
+      ++reclaimable;
+    }
+  }
+  return reclaimable;
+}
+
+void PrefixCache::Reorder(Entry& entry, const std::shared_ptr<const BlockIdentity>& parent) {
+  // Every entry sits immediately before the entry it chains from, so the head of a chain is always
+  // the most recently used of its run and eviction takes the tail first.
+  if (!parent) {
+    recency_.splice(recency_.end(), recency_, entry.recency);
+    return;
+  }
+  const auto parent_entry = entries_.find(parent->hash);
+  if (parent_entry == entries_.end()) {
+    // No lookup can reach this entry any more, so it is the first thing worth reclaiming.
+    recency_.splice(recency_.begin(), recency_, entry.recency);
+    return;
+  }
+  recency_.splice(parent_entry->second.recency, recency_, entry.recency);
+}
+
+void PrefixCache::Evict(std::unordered_map<uint64_t, Entry>::iterator it) {
+  auto block = it->second.block;
+  recency_.erase(it->second.recency);
+  entries_.erase(it);
+  block->ClearIdentity();
+  block_pool_.Release(block);
+}
+
+}  // namespace Generators

--- a/src/engine/prefix_cache.cpp
+++ b/src/engine/prefix_cache.cpp
@@ -4,8 +4,10 @@
 #include "prefix_cache.h"
 
 #include <algorithm>
+#include <memory>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 namespace Generators {
 

--- a/src/engine/prefix_cache.h
+++ b/src/engine/prefix_cache.h
@@ -60,15 +60,15 @@ struct PrefixCacheMatch {
 };
 
 struct PrefixCacheMetrics {
-  uint64_t lookups{};                 // Prompts offered to the index.
-  uint64_t hits{};                    // Prompts that adopted at least one block.
-  uint64_t queried_tokens{};          // Prompt tokens eligible for adoption across all lookups.
-  uint64_t matched_tokens{};          // Prompt tokens actually adopted (prefill work skipped).
-  uint64_t registered_blocks{};       // Blocks given a content identity.
+  uint64_t lookups{};                  // Prompts offered to the index.
+  uint64_t hits{};                     // Prompts that adopted at least one block.
+  uint64_t queried_tokens{};           // Prompt tokens eligible for adoption across all lookups.
+  uint64_t matched_tokens{};           // Prompt tokens actually adopted (prefill work skipped).
+  uint64_t registered_blocks{};        // Blocks given a content identity.
   uint64_t duplicate_registrations{};  // Blocks whose content was already indexed elsewhere.
-  uint64_t hash_collisions{};         // Distinct contents that hashed to an indexed identity.
-  uint64_t evictions{};               // Indexed blocks dropped to make room.
-  uint64_t retention_refusals{};      // Registrations skipped because nothing was evictable.
+  uint64_t hash_collisions{};          // Distinct contents that hashed to an indexed identity.
+  uint64_t evictions{};                // Indexed blocks dropped to make room.
+  uint64_t retention_refusals{};       // Registrations skipped because nothing was evictable.
 };
 
 /**

--- a/src/engine/prefix_cache.h
+++ b/src/engine/prefix_cache.h
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include "../span.h"
+#include "block.h"
+
+/**
+ * @file prefix_cache.h
+ * @brief Content-addressed index of filled paged-cache blocks, so a prompt that repeats a prefix
+ *        another sequence already computed can adopt those blocks instead of recomputing them.
+ *
+ * Serving and agent traffic resends large identical prefixes every turn -- system prompts, tool
+ * schemas, retrieved context, and the conversation so far. Each filled block gets an identity that
+ * chains the identity of the block before it, so a block only matches when the whole preceding
+ * token sequence matches too. A hash match is never trusted on its own: the stored tokens and the
+ * parent identity are compared before a block is handed out, so a collision costs a missed hit
+ * rather than a wrong answer.
+ *
+ * Only full blocks are indexed. A full block is never written again, which is what makes it safe
+ * for several requests to point at the same physical block; a request's partially filled tail block
+ * stays private to it. Blocks stay indexed after their request finishes (retention) so the next
+ * turn of the same conversation can hit them, bounded by a block budget and reclaimable on demand
+ * so retention can never starve a live request.
+ */
+
+namespace Generators {
+
+struct PrefixCacheOptions {
+  bool enabled{};
+  // Upper bound on blocks the index may hold. Retention beyond this evicts the least recently used
+  // unreferenced entry. Zero disables the cache regardless of `enabled`.
+  size_t max_blocks{};
+  // A match shorter than this is not worth adopting: the saved prefill has to outweigh the extra
+  // block-table width and bookkeeping.
+  size_t min_match_blocks{1};
+  // Content hash used to address a block. Left null in production, where PrefixCache::ChainHash is
+  // used. Overridable so the collision-verification path -- distinct contents landing on the same
+  // identity -- can be exercised deterministically instead of hoping to find a real collision.
+  uint64_t (*hash)(uint64_t parent_hash, std::span<const int32_t> tokens){nullptr};
+};
+
+// A run of already-resident blocks covering the leading `token_count` tokens of a prompt. The
+// blocks are exactly the ones the adopting request will point at; `token_count` is always a whole
+// multiple of the block size.
+struct PrefixCacheMatch {
+  size_t token_count{};
+  std::vector<std::shared_ptr<Block>> blocks;
+
+  bool Empty() const { return blocks.empty(); }
+};
+
+struct PrefixCacheMetrics {
+  uint64_t lookups{};                 // Prompts offered to the index.
+  uint64_t hits{};                    // Prompts that adopted at least one block.
+  uint64_t queried_tokens{};          // Prompt tokens eligible for adoption across all lookups.
+  uint64_t matched_tokens{};          // Prompt tokens actually adopted (prefill work skipped).
+  uint64_t registered_blocks{};       // Blocks given a content identity.
+  uint64_t duplicate_registrations{};  // Blocks whose content was already indexed elsewhere.
+  uint64_t hash_collisions{};         // Distinct contents that hashed to an indexed identity.
+  uint64_t evictions{};               // Indexed blocks dropped to make room.
+  uint64_t retention_refusals{};      // Registrations skipped because nothing was evictable.
+};
+
+/**
+ * @class PrefixCache
+ * @brief Content-addressed index over a BlockPool's filled blocks with bounded LRU retention.
+ *
+ * The index holds one reference per indexed block, so an indexed block survives the request that
+ * produced it. `Reclaim` gives that capacity straight back to the pool under memory pressure, which
+ * is what keeps retention from ever starving a live request.
+ */
+class PrefixCache {
+ public:
+  PrefixCache(BlockPool& block_pool, PrefixCacheOptions options);
+  PrefixCache(const PrefixCache&) = delete;
+  PrefixCache& operator=(const PrefixCache&) = delete;
+  ~PrefixCache();
+
+  bool Enabled() const { return options_.enabled && options_.max_blocks != 0; }
+
+  const PrefixCacheOptions& Options() const { return options_; }
+
+  /**
+   * @brief Longest run of block-aligned leading tokens of `tokens` that is already resident.
+   * @param tokens The whole sequence the request wants computed.
+   * @param max_adoptable_tokens Upper bound on tokens the caller may skip. A request must always
+   *        compute at least its last token, so the caller passes one less than the sequence length.
+   *
+   * Marks every block it hands out as recently used, so adoption feeds the eviction order.
+   */
+  PrefixCacheMatch Match(std::span<const int32_t> tokens, size_t max_adoptable_tokens);
+
+  /**
+   * @brief Gives `block` a content identity and indexes it, taking a reference on it.
+   * @param block A full block whose slots hold exactly `tokens`.
+   * @param tokens The block-size-many tokens the block holds.
+   * @param parent The exact identity of the block that precedes it, or null for the first block.
+   * @return The identity the block after it chains from, or nothing when the chain has to stop.
+   *
+   * A block whose content is already indexed keeps no identity of its own and stays private: the
+   * first physical copy serves every lookup, so a lookup never has to choose between duplicates.
+   * The chain still continues through it, because the indexed copy holds the same tokens behind the
+   * same parent.
+   *
+   * Nothing is returned when the identity is already taken by a different block (a collision) or
+   * when the budget is full and nothing can be evicted. Neither this block nor anything after it is
+   * reachable then, so the caller stops sealing.
+   */
+  std::shared_ptr<const BlockIdentity> Register(const std::shared_ptr<Block>& block,
+                                                std::span<const int32_t> tokens,
+                                                const std::shared_ptr<const BlockIdentity>& parent);
+
+  /**
+   * @brief Identity hash a chain starts from, before any block has contributed to it.
+   */
+  static uint64_t RootHash();
+  static uint64_t ChainHash(uint64_t parent_hash, std::span<const int32_t> tokens);
+
+  // The hash this cache addresses blocks with, which is ChainHash unless overridden.
+  uint64_t Hash(uint64_t parent_hash, std::span<const int32_t> tokens) const {
+    return options_.hash ? options_.hash(parent_hash, tokens) : ChainHash(parent_hash, tokens);
+  }
+
+  /**
+   * @brief Returns indexed blocks that no request references back to the pool.
+   * @param blocks_needed How many blocks the caller needs.
+   * @return The number of blocks actually returned to the pool.
+   *
+   * Evicts in least-recently-used order and skips entries a request still holds, so reclaiming
+   * never takes a block out from under a live sequence.
+   */
+  size_t Reclaim(size_t blocks_needed);
+
+  // Indexed blocks no request currently references, which is the capacity Reclaim can hand back.
+  size_t ReclaimableBlocks() const;
+
+  size_t IndexedBlocks() const { return entries_.size(); }
+
+  const PrefixCacheMetrics& Metrics() const { return metrics_; }
+
+ private:
+  struct Entry {
+    std::shared_ptr<Block> block;
+    std::shared_ptr<const BlockIdentity> identity;
+    std::list<uint64_t>::iterator recency;
+  };
+
+  // Keeps `entry` ordered immediately before the entry it chains from, so a chain is always
+  // evicted from its tail rather than its head.
+  void Reorder(Entry& entry, const std::shared_ptr<const BlockIdentity>& parent);
+  void Evict(std::unordered_map<uint64_t, Entry>::iterator it);
+
+  BlockPool& block_pool_;
+  PrefixCacheOptions options_;
+  std::unordered_map<uint64_t, Entry> entries_;
+  // Front is the least recently used identity, back the most recently used.
+  std::list<uint64_t> recency_;
+  PrefixCacheMetrics metrics_;
+};
+
+}  // namespace Generators

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -176,6 +176,40 @@ std::span<const int32_t> Request::UnprocessedTokensCpu() const {
   return std::span<const int32_t>{tokens_host_}.subspan(begin, end - begin);
 }
 
+std::span<const int32_t> Request::SequenceTokensCpu() const {
+  return std::span<const int32_t>{tokens_host_};
+}
+
+void Request::StagePrefixAdoption(size_t adopted_slots) {
+  if (status_ != RequestStatus::Assigned) {
+    throw std::runtime_error("Only a request awaiting admission can adopt a cached prefix.");
+  }
+  if (prefix_adoption_staged_ || processed_sequence_length_ != 0) {
+    throw std::runtime_error("A request can only adopt a cached prefix before it processes a token.");
+  }
+  // The last token always has to go through the model: its logits are what select the next token.
+  if (adopted_slots == 0 ||
+      static_cast<int64_t>(adopted_slots) >= CurrentSequenceLength()) {
+    throw std::runtime_error("An adopted prefix must be shorter than the request's sequence.");
+  }
+  if (adopted_slots > tokens_host_.size()) {
+    throw std::runtime_error("An adopted prefix cannot exceed the request's token mirror.");
+  }
+
+  processed_sequence_length_ = static_cast<int64_t>(adopted_slots);
+  adopted_prefix_length_ = processed_sequence_length_;
+  prefix_adoption_staged_ = true;
+}
+
+void Request::RollbackPrefixAdoption() noexcept {
+  if (!prefix_adoption_staged_) {
+    return;
+  }
+  processed_sequence_length_ = 0;
+  adopted_prefix_length_ = 0;
+  prefix_adoption_staged_ = false;
+}
+
 bool Request::IsDone() const {
   return status_ == RequestStatus::Completed;
 }
@@ -271,6 +305,9 @@ void Request::CommitStep(const RequestStepPlan& plan,
     tokens_host_.push_back(result.token);
   }
   processed_sequence_length_ = static_cast<int64_t>(plan.target_cache_slots);
+  // The step committed, so the adopted prefix is now part of the request's committed progress and
+  // no longer something a rollback can undo.
+  prefix_adoption_staged_ = false;
   status_ = result.done ? RequestStatus::Completed : RequestStatus::InProgress;
 }
 

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -96,6 +96,37 @@ struct Request : std::enable_shared_from_this<Request>,
   std::span<const int32_t> UnprocessedTokensCpu() const;
 
   /**
+   * @brief Returns the whole host-side mirror of this request's sequence.
+   * @return Span of the prompt plus every committed generated token, valid until the next call that
+   *         appends to the sequence.
+   *
+   * The paged cache reads it to content-address the blocks it has committed for the request and to
+   * find a prompt whose prefix another sequence already computed.
+   */
+  std::span<const int32_t> SequenceTokensCpu() const;
+
+  /**
+   * @brief Moves the processed cursor to the end of a prefix whose keys and values are already in
+   *        the cache, so this request's prefill only computes the remainder.
+   * @param adopted_slots Tokens the cache holds for this request's leading sequence.
+   *
+   * Staged, not committed: the step that adopts the prefix has not run yet, so a rolled back step
+   * calls RollbackPrefixAdoption() and leaves the request exactly as it was. Only a request that
+   * has not processed anything yet can adopt a prefix.
+   */
+  void StagePrefixAdoption(size_t adopted_slots);
+
+  /**
+   * @brief Undoes a staged prefix adoption, returning the request to its pre-step cursor.
+   */
+  void RollbackPrefixAdoption() noexcept;
+
+  /**
+   * @brief Tokens this request skipped by adopting a cached prefix, for reporting.
+   */
+  int64_t AdoptedPrefixLength() const { return adopted_prefix_length_; }
+
+  /**
    * @brief Checks if there are any unseen tokens in the request.
    * @return True if there are unseen tokens, false otherwise.
    */
@@ -279,6 +310,10 @@ struct Request : std::enable_shared_from_this<Request>,
   // request is still prefilling while processed_sequence_length_ has not caught up with it.
   int64_t prompt_sequence_length_{};
   size_t scheduled_token_count_{};
+  // Set while a step that adopts a cached prefix is in flight, so a rollback can restore the cursor
+  // this request had before the step was planned. Kept after commit for reporting.
+  int64_t adopted_prefix_length_{};
+  bool prefix_adoption_staged_{};
   std::shared_ptr<GeneratorParams> params_;
   std::unique_ptr<Search> search_;
   std::unique_ptr<BatchedSamplerState> batched_sampler_state_;

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -162,16 +162,31 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
   };
   std::vector<Candidate> candidates;
 
-  const auto add_candidate = [&candidates](const std::shared_ptr<Request>& request,
-                                           bool newly_admitted) {
+  const auto add_candidate = [&](const std::shared_ptr<Request>& request,
+                                 bool newly_admitted) {
     const auto snapshot = request->Snapshot();
     const RequestStatus expected_status =
         newly_admitted ? RequestStatus::Assigned : RequestStatus::InProgress;
     if (snapshot.status != expected_status) {
       throw std::runtime_error("Request status is invalid for dynamic step planning.");
     }
+
+    // A request being admitted can start from a prefix another sequence already computed. Nothing
+    // is mutated here: the match only reaches the request once cache planning has selected it.
+    std::shared_ptr<const PrefixCacheMatch> prefix_match;
+    if (newly_admitted) {
+      // A request that reaches planning as a new admission owns no committed block table, so any
+      // cursor left staged by a step that never committed is stale by definition. Clearing it keeps
+      // planning idempotent however the previous attempt unwound.
+      request->RollbackPrefixAdoption();
+      prefix_match = cache_manager_->MatchPrefix(*request);
+    }
+    const size_t processed_sequence_length =
+        prefix_match ? prefix_match->token_count
+                     : static_cast<size_t>(snapshot.processed_sequence_length);
+
     const auto remaining_token_count =
-        snapshot.current_sequence_length - snapshot.processed_sequence_length;
+        snapshot.current_sequence_length - static_cast<int64_t>(processed_sequence_length);
     if (remaining_token_count <= 0) {
       throw std::runtime_error("Cannot plan a request with no unprocessed tokens.");
     }
@@ -181,10 +196,10 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     candidate.entry.request_id = request.get();
     candidate.entry.sequence_length_before = snapshot.current_sequence_length;
     candidate.entry.unprocessed_token_count = 1;
-    candidate.entry.target_cache_slots = RequiredSlots(
-        static_cast<size_t>(snapshot.processed_sequence_length), 1);
+    candidate.entry.target_cache_slots = RequiredSlots(processed_sequence_length, 1);
     candidate.entry.whole_sequence_cache_slots =
         SlotsForWholeSequence(snapshot.current_sequence_length);
+    candidate.entry.prefix_match = std::move(prefix_match);
     candidate.entry.is_prefill = snapshot.is_prefill;
     candidate.entry.newly_admitted = newly_admitted;
     candidate.budget = DecodeFirstBudgetCandidate{
@@ -192,8 +207,7 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
         static_cast<size_t>(remaining_token_count),
         request->SearchOptions().chunk_size,
     };
-    candidate.processed_sequence_length =
-        static_cast<size_t>(snapshot.processed_sequence_length);
+    candidate.processed_sequence_length = processed_sequence_length;
     candidates.push_back(std::move(candidate));
   };
 
@@ -258,8 +272,14 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     if (candidate == candidates.end())
       throw std::logic_error("Cache planning selected an unknown request.");
     entry.unprocessed_token_count = token_counts[i];
+    // Cache planning can drop a prefix match when adopting it would not fit, so the request's
+    // starting point is read back from the plan rather than from what planning was offered.
+    const size_t processed_sequence_length =
+        entry.newly_admitted
+            ? (entry.prefix_match ? entry.prefix_match->token_count : 0)
+            : candidate->processed_sequence_length;
     entry.target_cache_slots = RequiredSlots(
-        candidate->processed_sequence_length,
+        processed_sequence_length,
         entry.unprocessed_token_count);
     entry.packed_token_offset = packed_token_offset;
     entry.logits_row_index =
@@ -268,6 +288,25 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     plan.token_count += entry.unprocessed_token_count;
     plan.graph_capture_eligible &=
         !entry.is_prefill && entry.unprocessed_token_count == 1;
+  }
+
+  // Moving a request's processed cursor is the last thing planning does, so nothing after it can
+  // throw and leave a request claiming progress it was never given. Only the requests cache
+  // planning actually selected move: a request deferred for capacity is left exactly as it was and
+  // reconsidered, prefix match included, next step.
+  size_t staged = 0;
+  try {
+    for (; staged < plan.requests.size(); ++staged) {
+      const auto& entry = plan.requests[staged];
+      if (entry.prefix_match && !entry.prefix_match->Empty()) {
+        entry.request->StagePrefixAdoption(entry.prefix_match->token_count);
+      }
+    }
+  } catch (...) {
+    for (size_t i = 0; i < plan.requests.size(); ++i) {
+      plan.requests[i].request->RollbackPrefixAdoption();
+    }
+    throw;
   }
   return result;
 }

--- a/src/engine/step_plan.h
+++ b/src/engine/step_plan.h
@@ -14,6 +14,7 @@
 namespace Generators {
 
 struct Request;
+struct PrefixCacheMatch;
 
 using StepTransactionId = uint64_t;
 
@@ -56,6 +57,10 @@ struct RequestStepPlan {
   size_t logits_row_index{};            // Last packed row; its logits produce this request's next token.
   size_t target_cache_slots{};          // Committed KV slots required after the model run succeeds.
   size_t whole_sequence_cache_slots{};  // KV slots the whole sequence needs; admitted and reserved on this.
+  // Resident blocks this request adopts for the leading tokens of its prompt, so chunked prefill
+  // only computes the uncached remainder. Set at admission and consumed by the cache reservation;
+  // null when nothing matched or when prefix caching is off.
+  std::shared_ptr<const PrefixCacheMatch> prefix_match;
   bool is_prefill{};
   bool newly_admitted{};
 };

--- a/test/engine/engine_invariants_tests.cpp
+++ b/test/engine/engine_invariants_tests.cpp
@@ -7,6 +7,7 @@
 // violations are (and are not) reported.
 
 #include <algorithm>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -27,6 +28,47 @@ const void* const kRequestB = &kRequestStorageB;
 
 constexpr size_t kBlockSize = 4;
 
+// Rebuilds the physical block listing PagedKeyValueCache::Snapshot() produces, deriving each
+// block's reference count from the owners that list it and its fill level from the owning request's
+// used-slot count. Hand-built snapshots stay internally consistent this way, so a test that wants a
+// specific violation can break exactly one thing afterwards.
+void RebuildBlockListing(PagedCacheSnapshot& cache,
+                         const std::vector<size_t>& indexed_blocks = {}) {
+  std::map<size_t, CachedBlockSnapshot> blocks;
+  const auto hold = [&blocks](size_t block_id) -> CachedBlockSnapshot& {
+    auto& block = blocks[block_id];
+    block.block_id = block_id;
+    ++block.ref_count;
+    return block;
+  };
+
+  for (const auto& request : cache.requests) {
+    for (size_t index = 0; index < request.block_ids.size(); ++index) {
+      auto& block = hold(request.block_ids[index]);
+      const size_t filled_through = (index + 1) * cache.block_size;
+      block.used_slots = std::min(cache.block_size,
+                                  request.used_slots > index * cache.block_size
+                                      ? request.used_slots - index * cache.block_size
+                                      : 0);
+      block.full = request.used_slots >= filled_through;
+    }
+  }
+  for (const size_t block_id : cache.transaction_reserved_block_ids) {
+    hold(block_id);
+  }
+  for (const size_t block_id : cache.transaction_adopted_block_ids) {
+    hold(block_id);
+  }
+  for (const size_t block_id : indexed_blocks) {
+    hold(block_id).indexed = true;
+  }
+
+  cache.blocks.clear();
+  for (const auto& [block_id, block] : blocks) {
+    cache.blocks.push_back(block);
+  }
+}
+
 // A consistent two-request cache: A owns blocks {0,1} (full + one used slot), B owns block {2}
 // (fully used); one block free. Helpers below mutate copies to violate a single invariant at a time.
 PagedCacheSnapshot MakeValidCache() {
@@ -39,6 +81,7 @@ PagedCacheSnapshot MakeValidCache() {
       RequestBlockSnapshot{kRequestA, {0, 1}, /*used=*/kBlockSize + 1, /*empty=*/kBlockSize - 1},
       RequestBlockSnapshot{kRequestB, {2}, /*used=*/kBlockSize, /*empty=*/0},
   };
+  RebuildBlockListing(cache);
   return cache;
 }
 
@@ -82,6 +125,7 @@ TEST(InvariantValidatorTest, ValidTransactionReservationBalancesAccounting) {
           /*reserved_block_ids=*/{3},
       },
   };
+  RebuildBlockListing(cache);
 
   EXPECT_TRUE(ValidateCacheInvariants(cache).empty());
   EXPECT_EQ(cache.free_blocks + cache.TransactionReservedBlocks() +
@@ -98,6 +142,7 @@ TEST(InvariantValidatorTest, InitialAdmissionReservationValidatesWithoutCommitte
   cache.reservations = {
       RequestReservationSnapshot{kRequestA, 0, 1, 0, {0}},
   };
+  RebuildBlockListing(cache);
 
   EXPECT_TRUE(ValidateCacheInvariants(cache).empty());
 }
@@ -108,6 +153,7 @@ TEST(InvariantValidatorTest, InitialAdmissionRequiresEveryReservedBlockInADelta)
   cache.total_blocks = 1;
   cache.free_blocks = 0;
   cache.transaction_reserved_block_ids = {0};
+  RebuildBlockListing(cache);
 
   const auto violations = ValidateCacheInvariants(cache);
 
@@ -126,6 +172,7 @@ TEST(InvariantValidatorTest, InitialAdmissionRejectsUnreservedDeltaBlock) {
   cache.reservations = {
       RequestReservationSnapshot{kRequestA, 0, 1, 0, {1}},
   };
+  RebuildBlockListing(cache);
 
   const auto violations = ValidateCacheInvariants(cache);
 
@@ -151,6 +198,7 @@ TEST(InvariantValidatorTest, ReservedBlockCannotAlsoBeCommitted) {
   cache.reservations = {
       RequestReservationSnapshot{kRequestB, 4, 5, 0, {2}},
   };
+  RebuildBlockListing(cache);
 
   EXPECT_FALSE(ValidateCacheInvariants(cache).empty());
 }
@@ -159,6 +207,7 @@ TEST(InvariantValidatorTest, EveryReservedBlockNeedsOneRequestDelta) {
   auto cache = MakeValidCache();
   cache.free_blocks = 0;
   cache.transaction_reserved_block_ids = {3};
+  RebuildBlockListing(cache);
 
   const auto violations = ValidateCacheInvariants(cache);
   ASSERT_EQ(violations.size(), 1u);
@@ -184,6 +233,7 @@ TEST(InvariantValidatorTest, OutOfRangeBlockIdReported) {
   cache.requests[1].block_ids = {9};  // id 9 >= total_blocks (4)
   // Keep accounting otherwise sound so the out-of-range id is the reported problem.
   cache.free_blocks = 1;
+  RebuildBlockListing(cache);
   const auto violations = ValidateCacheInvariants(cache);
   ASSERT_FALSE(violations.empty());
 }
@@ -191,25 +241,88 @@ TEST(InvariantValidatorTest, OutOfRangeBlockIdReported) {
 TEST(InvariantValidatorTest, DuplicateBlockWithinRequestReported) {
   auto cache = MakeValidCache();
   cache.requests[0].block_ids = {0, 0};  // same block listed twice within request A
+  RebuildBlockListing(cache);
   EXPECT_FALSE(ValidateCacheInvariants(cache).empty());
 }
 
-TEST(InvariantValidatorTest, BlockOwnedByTwoRequestsReported) {
-  auto cache = MakeValidCache();
-  cache.requests[1].block_ids = {1};  // block 1 already owned by request A
-  cache.free_blocks = 2;              // keep total accounting consistent (A:2 + B:1 - shared)
+// Two requests pointing at the same full block is the whole point of prefix caching: a full block
+// is never written again, so neither owner can diverge from the other.
+TEST(InvariantValidatorTest, FullBlockSharedByTwoRequestsIsValid) {
+  PagedCacheSnapshot cache;
+  cache.block_size = kBlockSize;
+  cache.total_blocks = 4;
+  cache.free_blocks = 1;
+  cache.block_table_columns = 2;
+  cache.requests = {
+      RequestBlockSnapshot{kRequestA, {0, 1}, /*used=*/kBlockSize + 1, /*empty=*/kBlockSize - 1},
+      RequestBlockSnapshot{kRequestB, {0, 2}, /*used=*/kBlockSize + 2, /*empty=*/kBlockSize - 2},
+  };
+  RebuildBlockListing(cache, /*indexed_blocks=*/{0});
+
+  EXPECT_TRUE(ValidateCacheInvariants(cache).empty());
+}
+
+// A partially filled block is still being written, so sharing it would let one request's tokens
+// land in another request's key-value data.
+TEST(InvariantValidatorTest, PartiallyFilledBlockSharedByTwoRequestsReported) {
+  PagedCacheSnapshot cache;
+  cache.block_size = kBlockSize;
+  cache.total_blocks = 2;
+  cache.free_blocks = 1;
+  cache.block_table_columns = 1;
+  cache.requests = {
+      RequestBlockSnapshot{kRequestA, {0}, /*used=*/1, /*empty=*/kBlockSize - 1},
+      RequestBlockSnapshot{kRequestB, {0}, /*used=*/1, /*empty=*/kBlockSize - 1},
+  };
+  RebuildBlockListing(cache);
+
   const auto violations = ValidateCacheInvariants(cache);
-  bool found_shared = false;
-  for (const auto& v : violations) {
-    if (v.message.find("more than one Request") != std::string::npos) found_shared = true;
-  }
-  EXPECT_TRUE(found_shared);
+  EXPECT_NE(std::find_if(violations.begin(), violations.end(),
+                         [](const InvariantViolation& violation) {
+                           return violation.message.find("only partially filled") != std::string::npos;
+                         }),
+            violations.end());
+}
+
+// A reference the block still holds but no owner claims is a leak: exactly what a rolled back
+// adoption would produce if it forgot to release the prefix blocks it took.
+TEST(InvariantValidatorTest, LeakedBlockReferenceReported) {
+  auto cache = MakeValidCache();
+  cache.blocks[0].ref_count += 1;
+
+  const auto violations = ValidateCacheInvariants(cache);
+  EXPECT_NE(std::find_if(violations.begin(), violations.end(),
+                         [](const InvariantViolation& violation) {
+                           return violation.message.find("owner(s)") != std::string::npos;
+                         }),
+            violations.end());
+}
+
+// An adoption has to line up exactly with the slots the admission starts from, so the request never
+// skips a token whose keys and values are not genuinely resident.
+TEST(InvariantValidatorTest, AdoptedPrefixMustCoverTheCommittedSlots) {
+  auto cache = MakeValidCache();
+  cache.transaction_adopted_block_ids = {0};
+  cache.reservations = {
+      RequestReservationSnapshot{kRequestB, /*committed_slots=*/kBlockSize + 1,
+                                 /*target_slots=*/kBlockSize + 2, 0, {}, {0}},
+  };
+  RebuildBlockListing(cache, /*indexed_blocks=*/{0});
+  cache.free_blocks = 1;
+
+  const auto violations = ValidateCacheInvariants(cache);
+  EXPECT_NE(std::find_if(violations.begin(), violations.end(),
+                         [](const InvariantViolation& violation) {
+                           return violation.message.find("but starts from") != std::string::npos;
+                         }),
+            violations.end());
 }
 
 TEST(InvariantValidatorTest, DuplicateRequestBlockTableReported) {
   auto cache = MakeValidCache();
   // Request A appears twice in the block-table listing (a malformed/duplicated row).
   cache.requests.push_back(cache.requests[0]);
+  RebuildBlockListing(cache);
   const auto violations = ValidateCacheInvariants(cache);
   bool found_duplicate_row = false;
   for (const auto& v : violations) {

--- a/test/engine/engine_invariants_tests.cpp
+++ b/test/engine/engine_invariants_tests.cpp
@@ -305,7 +305,10 @@ TEST(InvariantValidatorTest, AdoptedPrefixMustCoverTheCommittedSlots) {
   cache.transaction_adopted_block_ids = {0};
   cache.reservations = {
       RequestReservationSnapshot{kRequestB, /*committed_slots=*/kBlockSize + 1,
-                                 /*target_slots=*/kBlockSize + 2, 0, {}, {0}},
+                                 /*target_slots=*/kBlockSize + 2,
+                                 0,
+                                 {},
+                                 {0}},
   };
   RebuildBlockListing(cache, /*indexed_blocks=*/{0});
   cache.free_blocks = 1;

--- a/test/engine/engine_test_doubles.h
+++ b/test/engine/engine_test_doubles.h
@@ -354,5 +354,126 @@ inline DoublesEngine MakeDoublesEngine(std::shared_ptr<Model> model, size_t capa
   return DoublesEngine{std::move(engine), cache_observer, executor_observer, std::move(trace)};
 }
 
+// A DecoderIO whose logits depend on the whole sequence each request holds, so a request served
+// from a warm cache and the same request served cold can be compared token for token. Every
+// request's row peaks at a token derived from its complete sequence, which is exactly the input the
+// model would see; adopting a prefix must not change it.
+struct SequenceDependentDecoderIO : DecoderIO {
+  SequenceDependentDecoderIO(std::shared_ptr<Model> model, ScheduledRequests& scheduled_requests,
+                             std::shared_ptr<CacheManager> cache_manager)
+      : DecoderIO(model, scheduled_requests, cache_manager),
+        vocab_size_{static_cast<int64_t>(model->config_->model.vocab_size)} {
+    const int64_t batch_size = static_cast<int64_t>(scheduled_requests.size());
+    logits_ = std::make_unique<Tensor>(model->p_device_inputs_, Ort::TypeToTensorType<float>);
+    const std::array<int64_t, 2> shape{batch_size, vocab_size_};
+    logits_->CreateTensor(shape);
+    auto device_span = logits_->GetDeviceSpan<float>();
+    auto cpu_span = device_span.CpuSpan();
+    std::fill(cpu_span.begin(), cpu_span.end(), 0.0f);
+    int64_t row = 0;
+    for (const auto& request : scheduled_requests) {
+      cpu_span[row * vocab_size_ + NextToken(*request)] = 100.0f;
+      ++row;
+    }
+    device_span.CopyCpuToDevice();
+  }
+
+  // Deterministic function of the sequence so far. Steers clear of token 0 and 1 (pad and
+  // end-of-stream for the engine test model) so a run ends on its length limit instead.
+  int32_t NextToken(const Request& request) const {
+    uint64_t accumulator = 1469598103934665603ULL;
+    for (const int32_t token : request.SequenceTokensCpu()) {
+      accumulator ^= static_cast<uint64_t>(static_cast<uint32_t>(token));
+      accumulator *= 1099511628211ULL;
+    }
+    const int64_t usable = vocab_size_ - 2;
+    return static_cast<int32_t>(2 + static_cast<int64_t>(accumulator % static_cast<uint64_t>(usable)));
+  }
+
+  std::vector<DeviceSpan<float>> ProcessLogits() override {
+    std::vector<DeviceSpan<float>> rows;
+    auto all = logits_->GetDeviceSpan<float>();
+    for (size_t i = 0; i < scheduled_requests_.size(); ++i) {
+      rows.push_back(all.subspan(i * vocab_size_, vocab_size_));
+    }
+    return rows;
+  }
+
+ private:
+  int64_t vocab_size_;
+};
+
+// A ModelExecutor that runs no model but records the packed token counts each step asked for, which
+// is the prefill work a prefix adoption is meant to remove.
+struct TokenCountingModelExecutor : ModelExecutor {
+  TokenCountingModelExecutor(std::shared_ptr<Model> model, std::shared_ptr<CacheManager> cache_manager)
+      : model_{std::move(model)}, cache_manager_{std::move(cache_manager)} {}
+
+  void Decode(ScheduledRequests& scheduled_requests, ExecutionContext& context) override {
+    ++decode_calls;
+    if (context.plan) {
+      decoded_token_counts.push_back(context.plan->token_count);
+      std::vector<size_t> adopted;
+      adopted.reserve(context.plan->requests.size());
+      for (const auto& entry : context.plan->requests) {
+        adopted.push_back(entry.prefix_match ? entry.prefix_match->token_count : 0);
+        adopted_tokens += entry.prefix_match ? entry.prefix_match->token_count : 0;
+        if (entry.is_prefill) {
+          prefill_tokens += entry.unprocessed_token_count;
+        } else {
+          decode_tokens += entry.unprocessed_token_count;
+        }
+      }
+      decoded_adopted_tokens.push_back(std::move(adopted));
+    }
+    const auto failure = std::exchange(next_failure_, ScriptedExecutionFailure::None);
+    if (failure == ScriptedExecutionFailure::RetryableBeforeExecution) {
+      throw ModelExecutionError{ExecutionFailureKind::RetryableAbort,
+                                "Injected retryable execution failure."};
+    }
+    scheduled_requests.AddDecoderState(
+        std::make_unique<SequenceDependentDecoderIO>(model_, scheduled_requests, cache_manager_));
+  }
+
+  void SetNextFailure(ScriptedExecutionFailure failure) { next_failure_ = failure; }
+
+  size_t TotalDecodedTokens() const {
+    size_t total = 0;
+    for (const size_t count : decoded_token_counts) total += count;
+    return total;
+  }
+
+  int decode_calls{0};
+  size_t prefill_tokens{0};  // Prompt tokens actually pushed through the model.
+  size_t decode_tokens{0};
+  size_t adopted_tokens{0};  // Prompt tokens skipped because their keys and values were resident.
+  std::vector<size_t> decoded_token_counts;
+  std::vector<std::vector<size_t>> decoded_adopted_tokens;
+
+ private:
+  std::shared_ptr<Model> model_;
+  std::shared_ptr<CacheManager> cache_manager_;
+  ScriptedExecutionFailure next_failure_{ScriptedExecutionFailure::None};
+};
+
+// An Engine wired to the real paged cache manager and the real dynamic scheduler, with only model
+// execution replaced. This is the production admission, reservation, prefix-cache, and commit path.
+struct PagedEngine {
+  std::shared_ptr<Engine> engine;
+  std::shared_ptr<CacheManager> cache;
+  TokenCountingModelExecutor* executor;
+};
+
+inline PagedEngine MakePagedEngine(std::shared_ptr<Model> model) {
+  std::shared_ptr<CacheManager> cache = std::make_shared<PagedCacheManager>(model);
+  auto scheduler = Scheduler::Create(model, cache);
+  auto executor = std::make_unique<TokenCountingModelExecutor>(model, cache);
+  TokenCountingModelExecutor* executor_observer = executor.get();
+
+  EngineDependencies dependencies{cache, std::move(scheduler), std::move(executor)};
+  auto engine = std::make_shared<Engine>(std::move(model), std::move(dependencies));
+  return PagedEngine{std::move(engine), std::move(cache), executor_observer};
+}
+
 }  // namespace test
 }  // namespace Generators

--- a/test/engine/prefix_cache_benchmark_tests.cpp
+++ b/test/engine/prefix_cache_benchmark_tests.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// A deterministic microbenchmark for prefix-aware paged key-value caching.
+//
+// It drives the production admission, planning, reservation, commit, retention, and eviction path
+// -- the real PagedCacheManager, the real dynamic scheduler, and the real Engine transaction --
+// over a repeated-prefix workload shaped like multi-turn agent traffic: a long shared prefix
+// (system prompt, tool schemas, file context) followed by a short varying suffix.
+//
+// Model execution is replaced by a double, so the wall-clock figures here are Engine host overhead
+// and NOT end-to-end latency: no model runs and no attention is computed. The token counts, block
+// residency, and cache-hit figures are exact and hardware-independent, and they are what determines
+// the prefill work a real deployment saves.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <numeric>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine/engine_invariants.h"
+#include "engine_test_doubles.h"
+#include "engine_test_helpers.h"
+
+namespace Generators {
+namespace test {
+namespace {
+
+constexpr size_t kBenchBlockSize = 16;
+constexpr size_t kBenchNumBlocks = 512;
+constexpr size_t kSharedPrefixTokens = 512;  // System prompt + tool schemas + file context.
+constexpr size_t kSuffixTokens = 15;         // The turn's own question.
+constexpr int kGeneratedTokens = 8;
+constexpr size_t kSequentialTurns = 32;
+constexpr size_t kConcurrentRequests = 8;
+
+struct BenchmarkReport {
+  double ttft_p50_us{};
+  double ttft_p95_us{};
+  size_t prefill_tokens{};
+  size_t adopted_tokens{};
+  size_t decode_tokens{};
+  size_t peak_blocks{};
+  size_t requests{};
+  double concurrent_wall_us{};
+  uint64_t lookups{};
+  uint64_t hits{};
+  uint64_t evictions{};
+  uint64_t retention_refusals{};
+  uint64_t duplicate_registrations{};
+  uint64_t hash_collisions{};
+  std::vector<int32_t> first_turn_output;
+};
+
+double Percentile(std::vector<double> samples, double fraction) {
+  if (samples.empty()) return 0.0;
+  std::sort(samples.begin(), samples.end());
+  const size_t index = std::min(samples.size() - 1,
+                                static_cast<size_t>(fraction * static_cast<double>(samples.size())));
+  return samples[index];
+}
+
+class PrefixCacheBenchmark : public ::testing::Test {
+ protected:
+  std::shared_ptr<Model> MakeModel(bool prefix_caching, size_t num_blocks) {
+    auto model = LoadDummyDecoderModel();
+    Config::Engine::DynamicBatching dynamic_batching;
+    dynamic_batching.block_size = kBenchBlockSize;
+    dynamic_batching.num_blocks = num_blocks;
+    dynamic_batching.max_batch_size = kConcurrentRequests;
+    dynamic_batching.max_scheduled_tokens = 4096;
+    dynamic_batching.prefix_caching = prefix_caching;
+    dynamic_batching.prefix_cache_pool_fraction = 0.5f;
+    model->config_->engine.dynamic_batching = dynamic_batching;
+    model->config_->model.context_length = 4096;
+    return model;
+  }
+
+  // Long shared prefix, short varying suffix: the shape multi-turn agent traffic has.
+  static std::vector<int32_t> MakeTurnPrompt(size_t turn) {
+    std::vector<int32_t> prompt;
+    prompt.reserve(kSharedPrefixTokens + kSuffixTokens);
+    for (size_t i = 0; i < kSharedPrefixTokens; ++i) {
+      prompt.push_back(static_cast<int32_t>(2 + (i % 29)));
+    }
+    for (size_t i = 0; i < kSuffixTokens; ++i) {
+      prompt.push_back(static_cast<int32_t>(2 + ((turn * 7 + i * 3) % 29)));
+    }
+    return prompt;
+  }
+
+  BenchmarkReport Run(bool prefix_caching, size_t num_blocks = kBenchNumBlocks) {
+    auto model = MakeModel(prefix_caching, num_blocks);
+    auto paged = MakePagedEngine(model);
+    BenchmarkReport report;
+    std::vector<double> ttft_samples;
+
+    const auto observe_peak = [&]() {
+      const auto snapshot = paged.cache->Snapshot();
+      report.peak_blocks = std::max(report.peak_blocks,
+                                    snapshot.total_blocks - snapshot.free_blocks);
+    };
+
+    // Phase 1: a sequential conversation, one turn at a time.
+    for (size_t turn = 0; turn < kSequentialTurns; ++turn) {
+      const auto prompt = MakeTurnPrompt(turn);
+      auto params = MakeGreedyParams(*model);
+      params->search.max_length = static_cast<int>(prompt.size()) + kGeneratedTokens;
+      auto request = std::make_shared<Request>(params);
+      request->AddTokens(prompt);
+
+      const auto admitted_at = std::chrono::steady_clock::now();
+      paged.engine->AddRequest(request);
+      bool first_token_seen = false;
+      std::vector<int32_t> generated;
+      while (paged.engine->HasPendingRequests()) {
+        auto ready = paged.engine->Step();
+        if (!ready) break;
+        if (!first_token_seen && ready.get() == request.get() && ready->HasUnseenTokens()) {
+          const auto now = std::chrono::steady_clock::now();
+          ttft_samples.push_back(
+              std::chrono::duration<double, std::micro>(now - admitted_at).count());
+          first_token_seen = true;
+        }
+        while (ready->HasUnseenTokens()) generated.push_back(ready->UnseenToken());
+        observe_peak();
+      }
+      if (turn == 0) report.first_turn_output = generated;
+      paged.engine->RemoveRequest(request);
+      ++report.requests;
+    }
+
+    // Phase 2: the same shared prefix under concurrency.
+    std::vector<std::shared_ptr<Request>> concurrent;
+    for (size_t i = 0; i < kConcurrentRequests; ++i) {
+      const auto prompt = MakeTurnPrompt(kSequentialTurns + i);
+      auto params = MakeGreedyParams(*model);
+      params->search.max_length = static_cast<int>(prompt.size()) + kGeneratedTokens;
+      auto request = std::make_shared<Request>(params);
+      request->AddTokens(prompt);
+      concurrent.push_back(std::move(request));
+    }
+
+    const auto concurrent_start = std::chrono::steady_clock::now();
+    for (const auto& request : concurrent) {
+      paged.engine->AddRequest(request);
+    }
+    while (paged.engine->HasPendingRequests()) {
+      auto ready = paged.engine->Step();
+      if (!ready) break;
+      while (ready->HasUnseenTokens()) ready->UnseenToken();
+      observe_peak();
+    }
+    report.concurrent_wall_us =
+        std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - concurrent_start)
+            .count();
+    for (const auto& request : concurrent) {
+      paged.engine->RemoveRequest(request);
+    }
+    report.requests += concurrent.size();
+
+    report.ttft_p50_us = Percentile(ttft_samples, 0.50);
+    report.ttft_p95_us = Percentile(ttft_samples, 0.95);
+    report.prefill_tokens = paged.executor->prefill_tokens;
+    report.decode_tokens = paged.executor->decode_tokens;
+    report.adopted_tokens = paged.executor->adopted_tokens;
+    if (const auto* metrics = paged.engine->PrefixCacheStats()) {
+      report.lookups = metrics->lookups;
+      report.hits = metrics->hits;
+      report.evictions = metrics->evictions;
+      report.retention_refusals = metrics->retention_refusals;
+      report.duplicate_registrations = metrics->duplicate_registrations;
+      report.hash_collisions = metrics->hash_collisions;
+    }
+    EXPECT_TRUE(ValidateCacheInvariants(paged.cache->Snapshot()).empty());
+    return report;
+  }
+};
+
+TEST_F(PrefixCacheBenchmark, RepeatedPrefixWorkloadColdVersusWarm) {
+  const auto cold = Run(/*prefix_caching=*/false);
+  const auto warm = Run(/*prefix_caching=*/true);
+
+  const double hit_rate =
+      warm.lookups == 0 ? 0.0 : 100.0 * static_cast<double>(warm.hits) / static_cast<double>(warm.lookups);
+  const size_t offered_prompt_tokens = warm.prefill_tokens + warm.adopted_tokens;
+  const double skipped_share =
+      offered_prompt_tokens == 0
+          ? 0.0
+          : 100.0 * static_cast<double>(warm.adopted_tokens) / static_cast<double>(offered_prompt_tokens);
+  const size_t block_bytes =
+      kBenchBlockSize * 2 /*kv*/ * 2 /*heads*/ * 4 /*head size*/ * 4 /*fp32*/;
+
+  std::printf(
+      "\n"
+      "prefix cache microbenchmark (engine host path only; model execution is stubbed)\n"
+      "  workload            : %zu shared-prefix tokens + %zu varying tokens, %d generated,\n"
+      "                        %zu sequential turns then %zu concurrent requests\n"
+      "  geometry            : block_size=%zu, num_blocks=%zu, max_batch_size=%zu\n"
+      "  ---------------------------------------------  cold  ----  warm  ----\n"
+      "  prompt tokens computed                      %8zu      %8zu\n"
+      "  prompt tokens skipped (adopted)             %8zu      %8zu\n"
+      "  decode tokens                               %8zu      %8zu\n"
+      "  peak KV blocks in use                       %8zu      %8zu\n"
+      "  peak KV bytes (all layers)                  %8zu      %8zu\n"
+      "  admission->first token p50 (us, host only)  %8.1f      %8.1f\n"
+      "  admission->first token p95 (us, host only)  %8.1f      %8.1f\n"
+      "  concurrent phase wall (us, host only)       %8.1f      %8.1f\n"
+      "  prefix lookups / hits                       %8llu/%llu   %8llu/%llu\n"
+      "  prefix cache hit rate                                      %7.1f%%\n"
+      "  prompt tokens skipped                                      %7.1f%%\n"
+      "  evictions / retention refusals                             %llu / %llu\n"
+      "  duplicate registrations / hash collisions                  %llu / %llu\n\n",
+      kSharedPrefixTokens, kSuffixTokens, kGeneratedTokens, kSequentialTurns, kConcurrentRequests,
+      kBenchBlockSize, kBenchNumBlocks, kConcurrentRequests,
+      cold.prefill_tokens, warm.prefill_tokens,
+      cold.adopted_tokens, warm.adopted_tokens,
+      cold.decode_tokens, warm.decode_tokens,
+      cold.peak_blocks, warm.peak_blocks,
+      cold.peak_blocks * block_bytes, warm.peak_blocks * block_bytes,
+      cold.ttft_p50_us, warm.ttft_p50_us,
+      cold.ttft_p95_us, warm.ttft_p95_us,
+      cold.concurrent_wall_us, warm.concurrent_wall_us,
+      static_cast<unsigned long long>(cold.lookups), static_cast<unsigned long long>(cold.hits),
+      static_cast<unsigned long long>(warm.lookups), static_cast<unsigned long long>(warm.hits),
+      hit_rate, skipped_share,
+      static_cast<unsigned long long>(warm.evictions),
+      static_cast<unsigned long long>(warm.retention_refusals),
+      static_cast<unsigned long long>(warm.duplicate_registrations),
+      static_cast<unsigned long long>(warm.hash_collisions));
+
+  // The workload has to actually exercise the feature, and it has to keep the same answers.
+  EXPECT_EQ(cold.adopted_tokens, 0u);
+  EXPECT_GT(warm.adopted_tokens, 0u);
+  EXPECT_LT(warm.prefill_tokens, cold.prefill_tokens);
+  EXPECT_EQ(warm.decode_tokens, cold.decode_tokens);
+  EXPECT_EQ(warm.first_turn_output, cold.first_turn_output);
+  EXPECT_EQ(warm.hash_collisions, 0u);
+}
+
+// The same workload on a pool barely large enough to hold one concurrent batch, so retention has to
+// give capacity back and the eviction policy is actually exercised.
+TEST_F(PrefixCacheBenchmark, RepeatedPrefixWorkloadUnderMemoryPressure) {
+  constexpr size_t kTightBlocks = 96;  // Eight concurrent 527-token sequences need 264 uncached.
+  const auto warm = Run(/*prefix_caching=*/true, kTightBlocks);
+
+  const double hit_rate =
+      warm.lookups == 0 ? 0.0 : 100.0 * static_cast<double>(warm.hits) / static_cast<double>(warm.lookups);
+  const size_t offered_prompt_tokens = warm.prefill_tokens + warm.adopted_tokens;
+  const double skipped_share =
+      offered_prompt_tokens == 0
+          ? 0.0
+          : 100.0 * static_cast<double>(warm.adopted_tokens) / static_cast<double>(offered_prompt_tokens);
+
+  std::printf(
+      "\n"
+      "prefix cache microbenchmark under memory pressure (num_blocks=%zu)\n"
+      "  prompt tokens computed / skipped            %zu / %zu (%.1f%% skipped)\n"
+      "  prefix lookups / hits                       %llu / %llu (%.1f%%)\n"
+      "  peak KV blocks in use                       %zu of %zu\n"
+      "  evictions / retention refusals              %llu / %llu\n"
+      "  admission->first token p50/p95 (us, host)   %.1f / %.1f\n\n",
+      kTightBlocks, warm.prefill_tokens, warm.adopted_tokens, skipped_share,
+      static_cast<unsigned long long>(warm.lookups), static_cast<unsigned long long>(warm.hits),
+      hit_rate, warm.peak_blocks, kTightBlocks,
+      static_cast<unsigned long long>(warm.evictions),
+      static_cast<unsigned long long>(warm.retention_refusals),
+      warm.ttft_p50_us, warm.ttft_p95_us);
+
+  // Every request still completed, so retention gave capacity back rather than starving anyone.
+  EXPECT_EQ(warm.requests, kSequentialTurns + kConcurrentRequests);
+  EXPECT_LE(warm.peak_blocks, kTightBlocks);
+  EXPECT_EQ(warm.hash_collisions, 0u);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace Generators

--- a/test/engine/prefix_cache_benchmark_tests.cpp
+++ b/test/engine/prefix_cache_benchmark_tests.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
+#include <memory>
 #include <numeric>
 #include <vector>
 

--- a/test/engine/prefix_cache_tests.cpp
+++ b/test/engine/prefix_cache_tests.cpp
@@ -1,0 +1,518 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Unit tests for the content-addressed block index, the reference counting that makes block sharing
+// safe, and the copy-on-write guard that keeps a shared block from being written. These exercise the
+// production policy types directly and need no model, device, or engine.
+
+#include <array>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine/block.h"
+#include "engine/paged_key_value_cache.h"
+#include "engine/prefix_cache.h"
+
+namespace Generators {
+namespace test {
+namespace {
+
+constexpr size_t kBlockSize = 4;
+
+PrefixCacheOptions MakeOptions(size_t max_blocks, size_t min_match_blocks = 1) {
+  PrefixCacheOptions options;
+  options.enabled = true;
+  options.max_blocks = max_blocks;
+  options.min_match_blocks = min_match_blocks;
+  return options;
+}
+
+// Takes one full block from the pool, marks every slot used, and indexes it behind `parent`.
+std::shared_ptr<Block> SealBlock(BlockPool& pool, PrefixCache& cache,
+                                 std::span<const int32_t> tokens,
+                                 std::shared_ptr<const BlockIdentity>& parent) {
+  auto blocks = pool.AllocateBlocks(kBlockSize);
+  EXPECT_EQ(blocks.size(), 1u);
+  auto chained = cache.Register(blocks.front(), tokens, parent);
+  if (chained) {
+    parent = std::move(chained);
+  }
+  return blocks.front();
+}
+
+// A BlockCopier double that records the copies the divergence policy asks for.
+struct RecordingBlockCopier final : BlockCopier {
+  void CopyBlock(size_t source_block_id, size_t destination_block_id) override {
+    copies.emplace_back(source_block_id, destination_block_id);
+  }
+  std::vector<std::pair<size_t, size_t>> copies;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Reference counting
+// ---------------------------------------------------------------------------------------------
+
+TEST(BlockReferenceCountingTest, BlockReturnsToThePoolOnlyWhenTheLastOwnerReleasesIt) {
+  BlockPool pool{kBlockSize, 2};
+  auto blocks = pool.AllocateBlocks(kBlockSize);
+  ASSERT_EQ(blocks.size(), 1u);
+  EXPECT_EQ(blocks.front()->RefCount(), 1u);
+  EXPECT_EQ(pool.AvailableBlocks(), 1u);
+
+  pool.AddRef(blocks);
+  EXPECT_EQ(blocks.front()->RefCount(), 2u);
+  EXPECT_TRUE(blocks.front()->IsShared());
+
+  pool.Free(blocks);
+  EXPECT_EQ(blocks.front()->RefCount(), 1u);
+  EXPECT_EQ(pool.AvailableBlocks(), 1u);
+
+  pool.Free(blocks);
+  EXPECT_EQ(pool.AvailableBlocks(), 2u);
+}
+
+// One reservation admitting two requests that adopt the same prefix holds two references to the
+// same block and releases both together.
+TEST(BlockReferenceCountingTest, ABlockCanBeReleasedOncePerReferenceInOneCall) {
+  BlockPool pool{kBlockSize, 1};
+  auto blocks = pool.AllocateBlocks(kBlockSize);
+  pool.AddRef(blocks);
+  ASSERT_EQ(blocks.front()->RefCount(), 2u);
+
+  const std::vector<std::shared_ptr<Block>> twice{blocks.front(), blocks.front()};
+  pool.Free(twice);
+
+  EXPECT_EQ(pool.AvailableBlocks(), 1u);
+}
+
+TEST(BlockReferenceCountingTest, ReleasingMoreReferencesThanAreHeldIsRejectedWithoutMutating) {
+  BlockPool pool{kBlockSize, 1};
+  auto blocks = pool.AllocateBlocks(kBlockSize);
+  const std::vector<std::shared_ptr<Block>> twice{blocks.front(), blocks.front()};
+
+  EXPECT_THROW(pool.Free(twice), std::runtime_error);
+  EXPECT_EQ(blocks.front()->RefCount(), 1u);
+  EXPECT_EQ(pool.AvailableBlocks(), 0u);
+}
+
+TEST(BlockReferenceCountingTest, AddingAReferenceToAForeignBlockIsRejected) {
+  BlockPool pool{kBlockSize, 1};
+  BlockPool other{kBlockSize, 1};
+  auto foreign = other.AllocateBlocks(kBlockSize);
+
+  EXPECT_THROW(pool.AddRef(foreign), std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Content addressing
+// ---------------------------------------------------------------------------------------------
+
+TEST(PrefixCacheTest, ExactPrefixMatchAdoptsEveryFullBlock) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 9> prompt{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::shared_ptr<const BlockIdentity> parent;
+  SealBlock(pool, cache, std::span<const int32_t>{prompt}.subspan(0, kBlockSize), parent);
+  SealBlock(pool, cache, std::span<const int32_t>{prompt}.subspan(kBlockSize, kBlockSize), parent);
+
+  const auto match = cache.Match(prompt, prompt.size() - 1);
+
+  EXPECT_EQ(match.blocks.size(), 2u);
+  EXPECT_EQ(match.token_count, 2 * kBlockSize);
+  EXPECT_EQ(cache.Metrics().hits, 1u);
+  EXPECT_EQ(cache.Metrics().matched_tokens, 2 * kBlockSize);
+}
+
+TEST(PrefixCacheTest, PartialPrefixMatchStopsAtTheFirstDivergingBlock) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 9> indexed{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::shared_ptr<const BlockIdentity> parent;
+  SealBlock(pool, cache, std::span<const int32_t>{indexed}.subspan(0, kBlockSize), parent);
+  SealBlock(pool, cache, std::span<const int32_t>{indexed}.subspan(kBlockSize, kBlockSize), parent);
+
+  // Same first block, different second block.
+  const std::array<int32_t, 9> probe{1, 2, 3, 4, 50, 60, 70, 80, 90};
+  const auto match = cache.Match(probe, probe.size() - 1);
+
+  EXPECT_EQ(match.blocks.size(), 1u);
+  EXPECT_EQ(match.token_count, kBlockSize);
+}
+
+TEST(PrefixCacheTest, ADifferentPromptMatchesNothing) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 4> indexed{1, 2, 3, 4};
+  std::shared_ptr<const BlockIdentity> parent;
+  SealBlock(pool, cache, indexed, parent);
+
+  const std::array<int32_t, 5> probe{9, 9, 9, 9, 9};
+  EXPECT_TRUE(cache.Match(probe, probe.size() - 1).Empty());
+  EXPECT_EQ(cache.Metrics().hits, 0u);
+}
+
+// The last token always has to go through the model, so a prompt that is exactly one indexed block
+// long adopts nothing.
+TEST(PrefixCacheTest, TheFinalTokenIsNeverAdopted) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 4> prompt{1, 2, 3, 4};
+  std::shared_ptr<const BlockIdentity> parent;
+  SealBlock(pool, cache, prompt, parent);
+
+  EXPECT_TRUE(cache.Match(prompt, prompt.size() - 1).Empty());
+}
+
+// The identity chains the block before it, so identical tokens at a different offset do not match.
+TEST(PrefixCacheTest, TheSameBlockContentAtADifferentOffsetDoesNotMatch) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 8> indexed{1, 2, 3, 4, 5, 6, 7, 8};
+  std::shared_ptr<const BlockIdentity> parent;
+  SealBlock(pool, cache, std::span<const int32_t>{indexed}.subspan(0, kBlockSize), parent);
+  SealBlock(pool, cache, std::span<const int32_t>{indexed}.subspan(kBlockSize, kBlockSize), parent);
+
+  // Starts with the tokens of the second indexed block, which sat behind a different prefix.
+  const std::array<int32_t, 5> probe{5, 6, 7, 8, 9};
+  EXPECT_TRUE(cache.Match(probe, probe.size() - 1).Empty());
+}
+
+// A hash match is never treated as proof of a match. The hash is overridden so distinct blocks
+// deterministically land on the same identity.
+TEST(PrefixCacheTest, CollidingContentIsRejectedRatherThanServed) {
+  BlockPool pool{kBlockSize, 8};
+  auto options = MakeOptions(8);
+  options.hash = [](uint64_t, std::span<const int32_t>) { return uint64_t{7}; };
+  PrefixCache cache{pool, options};
+
+  const std::array<int32_t, 4> indexed{1, 2, 3, 4};
+  std::shared_ptr<const BlockIdentity> parent;
+  SealBlock(pool, cache, indexed, parent);
+  ASSERT_EQ(cache.IndexedBlocks(), 1u);
+
+  // Different content, same identity: indexing it must not displace the first block.
+  const std::array<int32_t, 4> colliding{5, 6, 7, 8};
+  std::shared_ptr<const BlockIdentity> colliding_parent;
+  auto collided = SealBlock(pool, cache, colliding, colliding_parent);
+  EXPECT_FALSE(collided->HasIdentity());
+  EXPECT_EQ(cache.IndexedBlocks(), 1u);
+  EXPECT_EQ(cache.Metrics().hash_collisions, 1u);
+
+  // And a lookup for the colliding content finds the identity but rejects the tokens.
+  const std::array<int32_t, 5> probe{5, 6, 7, 8, 9};
+  EXPECT_TRUE(cache.Match(probe, probe.size() - 1).Empty());
+  EXPECT_EQ(cache.Metrics().hash_collisions, 2u);
+
+  // The original content still matches, so the collision cost a miss and nothing else.
+  const std::array<int32_t, 5> original{1, 2, 3, 4, 9};
+  EXPECT_EQ(cache.Match(original, original.size() - 1).blocks.size(), 1u);
+}
+
+// The dangerous collision is not on a block's own tokens but on its ancestry: a block whose parent
+// was evicted must never be spliced onto a different prefix that happens to hash the same. The
+// block's parent is compared as the identity it was computed behind, not as a hash of it, so this
+// cannot happen even when every hash collides.
+TEST(PrefixCacheTest, ABlockIsNeverSplicedOntoAPrefixItWasNotComputedBehind) {
+  BlockPool pool{kBlockSize, 8};
+  auto options = MakeOptions(8);
+  options.hash = [](uint64_t parent_hash, std::span<const int32_t> tokens) {
+    // Every first block collides with every other first block, and every second block collides with
+    // every other second block, so only the lineage check can tell them apart.
+    return parent_hash == PrefixCache::RootHash() ? uint64_t{1} : uint64_t{2};
+  };
+  PrefixCache cache{pool, options};
+
+  const std::array<int32_t, 8> original{1, 2, 3, 4, 5, 6, 7, 8};
+  std::shared_ptr<const BlockIdentity> parent;
+  auto head = SealBlock(pool, cache, std::span<const int32_t>{original}.subspan(0, kBlockSize), parent);
+  SealBlock(pool, cache, std::span<const int32_t>{original}.subspan(kBlockSize, kBlockSize), parent);
+  ASSERT_EQ(cache.IndexedBlocks(), 2u);
+
+  // The head is evicted, but the block behind it stays indexed under the colliding identity.
+  pool.Free({head});
+  ASSERT_EQ(cache.Reclaim(1), 1u);
+  ASSERT_EQ(cache.IndexedBlocks(), 1u);
+
+  // A different first block now takes the head's identity, and its follower is the original's.
+  const std::array<int32_t, 8> impostor{9, 9, 9, 9, 5, 6, 7, 8};
+  std::shared_ptr<const BlockIdentity> impostor_parent;
+  SealBlock(pool, cache, std::span<const int32_t>{impostor}.subspan(0, kBlockSize), impostor_parent);
+
+  const std::array<int32_t, 9> probe{9, 9, 9, 9, 5, 6, 7, 8, 1};
+  const auto match = cache.Match(probe, probe.size() - 1);
+
+  // The impostor's own block matches, but the block computed behind a different prefix does not.
+  EXPECT_EQ(match.token_count, kBlockSize);
+}
+
+TEST(PrefixCacheTest, DuplicateContentKeepsTheFirstPhysicalBlock) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 4> tokens{1, 2, 3, 4};
+  std::shared_ptr<const BlockIdentity> first_parent;
+  auto first = SealBlock(pool, cache, tokens, first_parent);
+  std::shared_ptr<const BlockIdentity> second_parent;
+  auto second = SealBlock(pool, cache, tokens, second_parent);
+
+  EXPECT_TRUE(first->HasIdentity());
+  EXPECT_FALSE(second->HasIdentity());
+  EXPECT_EQ(cache.IndexedBlocks(), 1u);
+  EXPECT_EQ(cache.Metrics().duplicate_registrations, 1u);
+
+  const std::array<int32_t, 5> probe{1, 2, 3, 4, 9};
+  const auto match = cache.Match(probe, probe.size() - 1);
+  ASSERT_EQ(match.blocks.size(), 1u);
+  EXPECT_EQ(match.blocks.front()->Id(), first->Id());
+}
+
+TEST(PrefixCacheTest, AMatchShorterThanTheMinimumIsNotWorthAdopting) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8, /*min_match_blocks=*/2)};
+
+  const std::array<int32_t, 4> tokens{1, 2, 3, 4};
+  std::shared_ptr<const BlockIdentity> parent;
+  SealBlock(pool, cache, tokens, parent);
+
+  const std::array<int32_t, 6> probe{1, 2, 3, 4, 9, 9};
+  EXPECT_TRUE(cache.Match(probe, probe.size() - 1).Empty());
+}
+
+TEST(PrefixCacheTest, ADisabledCacheIndexesAndMatchesNothing) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCacheOptions options;
+  options.enabled = false;
+  options.max_blocks = 8;
+  PrefixCache cache{pool, options};
+
+  const std::array<int32_t, 4> tokens{1, 2, 3, 4};
+  std::shared_ptr<const BlockIdentity> parent;
+  auto block = SealBlock(pool, cache, tokens, parent);
+
+  EXPECT_FALSE(block->HasIdentity());
+  EXPECT_EQ(cache.IndexedBlocks(), 0u);
+  const std::array<int32_t, 5> probe{1, 2, 3, 4, 9};
+  EXPECT_TRUE(cache.Match(probe, probe.size() - 1).Empty());
+}
+
+// ---------------------------------------------------------------------------------------------
+// Retention and eviction
+// ---------------------------------------------------------------------------------------------
+
+// A block its request has released survives on the index's own reference, which is what lets the
+// next turn of the same conversation adopt it.
+TEST(PrefixCacheTest, AnIndexedBlockOutlivesTheRequestThatProducedIt) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 4> tokens{1, 2, 3, 4};
+  std::shared_ptr<const BlockIdentity> parent;
+  auto block = SealBlock(pool, cache, tokens, parent);
+  ASSERT_EQ(block->RefCount(), 2u);
+
+  pool.Free({block});  // The request finished.
+
+  EXPECT_EQ(block->RefCount(), 1u);
+  EXPECT_EQ(pool.AvailableBlocks(), 7u);
+  EXPECT_EQ(cache.ReclaimableBlocks(), 1u);
+  const std::array<int32_t, 5> probe{1, 2, 3, 4, 9};
+  EXPECT_EQ(cache.Match(probe, probe.size() - 1).blocks.size(), 1u);
+}
+
+TEST(PrefixCacheTest, ReclaimReturnsRetainedBlocksInLeastRecentlyUsedOrder) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 4> older{1, 2, 3, 4};
+  const std::array<int32_t, 4> newer{5, 6, 7, 8};
+  std::shared_ptr<const BlockIdentity> older_parent;
+  auto older_block = SealBlock(pool, cache, older, older_parent);
+  std::shared_ptr<const BlockIdentity> newer_parent;
+  auto newer_block = SealBlock(pool, cache, newer, newer_parent);
+  pool.Free({older_block});
+  pool.Free({newer_block});
+  ASSERT_EQ(cache.ReclaimableBlocks(), 2u);
+
+  EXPECT_EQ(cache.Reclaim(1), 1u);
+
+  // The older entry went first, so the newer one still matches.
+  const std::array<int32_t, 5> newer_probe{5, 6, 7, 8, 9};
+  EXPECT_EQ(cache.Match(newer_probe, newer_probe.size() - 1).blocks.size(), 1u);
+  const std::array<int32_t, 5> older_probe{1, 2, 3, 4, 9};
+  EXPECT_TRUE(cache.Match(older_probe, older_probe.size() - 1).Empty());
+  EXPECT_EQ(cache.Metrics().evictions, 1u);
+}
+
+// Evicting the head of a chain would orphan everything behind it, because their identities chain
+// from it and no lookup can reach them again. Eviction has to take the tail first.
+TEST(PrefixCacheTest, EvictionTakesTheTailOfAChainBeforeItsHead) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 8> chain{1, 2, 3, 4, 5, 6, 7, 8};
+  std::shared_ptr<const BlockIdentity> parent;
+  auto head = SealBlock(pool, cache, std::span<const int32_t>{chain}.subspan(0, kBlockSize), parent);
+  auto tail = SealBlock(pool, cache, std::span<const int32_t>{chain}.subspan(kBlockSize, kBlockSize),
+                        parent);
+  pool.Free({head});
+  pool.Free({tail});
+
+  EXPECT_EQ(cache.Reclaim(1), 1u);
+
+  // The head survives, so the shorter prefix is still reusable.
+  const std::array<int32_t, 9> probe{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  const auto match = cache.Match(probe, probe.size() - 1);
+  ASSERT_EQ(match.blocks.size(), 1u);
+  EXPECT_EQ(match.blocks.front()->Id(), head->Id());
+}
+
+// A hit refreshes the whole run, and it has to keep the head newer than the tail so the next
+// eviction still takes the tail.
+TEST(PrefixCacheTest, AHitKeepsTheHeadOfTheChainNewerThanItsTail) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 8> chain{1, 2, 3, 4, 5, 6, 7, 8};
+  std::shared_ptr<const BlockIdentity> parent;
+  auto head = SealBlock(pool, cache, std::span<const int32_t>{chain}.subspan(0, kBlockSize), parent);
+  auto tail = SealBlock(pool, cache, std::span<const int32_t>{chain}.subspan(kBlockSize, kBlockSize),
+                        parent);
+  pool.Free({head});
+  pool.Free({tail});
+
+  const std::array<int32_t, 9> probe{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  ASSERT_EQ(cache.Match(probe, probe.size() - 1).blocks.size(), 2u);
+
+  EXPECT_EQ(cache.Reclaim(1), 1u);
+  const auto match = cache.Match(probe, probe.size() - 1);
+  ASSERT_EQ(match.blocks.size(), 1u);
+  EXPECT_EQ(match.blocks.front()->Id(), head->Id());
+}
+
+// Retention must never starve a live request: a block a request still holds is not the cache's to
+// give back.
+TEST(PrefixCacheTest, ReclaimSkipsBlocksARequestStillHolds) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(8)};
+
+  const std::array<int32_t, 4> held{1, 2, 3, 4};
+  const std::array<int32_t, 4> retained{5, 6, 7, 8};
+  std::shared_ptr<const BlockIdentity> held_parent;
+  auto held_block = SealBlock(pool, cache, held, held_parent);
+  std::shared_ptr<const BlockIdentity> retained_parent;
+  auto retained_block = SealBlock(pool, cache, retained, retained_parent);
+  pool.Free({retained_block});
+
+  EXPECT_EQ(cache.ReclaimableBlocks(), 1u);
+  EXPECT_EQ(cache.Reclaim(2), 1u);
+  EXPECT_EQ(held_block->RefCount(), 2u);
+  EXPECT_TRUE(held_block->HasIdentity());
+}
+
+TEST(PrefixCacheTest, RetentionStaysWithinItsBlockBudget) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(/*max_blocks=*/2)};
+
+  std::vector<std::shared_ptr<Block>> blocks;
+  for (int32_t i = 0; i < 3; ++i) {
+    const std::array<int32_t, 4> tokens{i, i, i, i};
+    std::shared_ptr<const BlockIdentity> parent;
+    auto block = SealBlock(pool, cache, tokens, parent);
+    pool.Free({block});  // Each request finishes immediately.
+    blocks.push_back(block);
+  }
+
+  EXPECT_EQ(cache.IndexedBlocks(), 2u);
+  EXPECT_EQ(cache.Metrics().evictions, 1u);
+}
+
+TEST(PrefixCacheTest, AFullBudgetOfLiveBlocksRefusesRetentionRatherThanEvicting) {
+  BlockPool pool{kBlockSize, 8};
+  PrefixCache cache{pool, MakeOptions(/*max_blocks=*/1)};
+
+  const std::array<int32_t, 4> live{1, 2, 3, 4};
+  std::shared_ptr<const BlockIdentity> live_parent;
+  auto live_block = SealBlock(pool, cache, live, live_parent);
+
+  const std::array<int32_t, 4> refused{5, 6, 7, 8};
+  std::shared_ptr<const BlockIdentity> refused_parent;
+  auto refused_block = SealBlock(pool, cache, refused, refused_parent);
+
+  EXPECT_TRUE(live_block->HasIdentity());
+  EXPECT_FALSE(refused_block->HasIdentity());
+  EXPECT_EQ(cache.Metrics().retention_refusals, 1u);
+  EXPECT_EQ(cache.IndexedBlocks(), 1u);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Copy-on-write divergence
+// ---------------------------------------------------------------------------------------------
+
+// Two owners sharing a block that is still being written must not both write into it. The writer
+// takes a private copy of the block's key-value data and diverges into that instead.
+TEST(CopyOnWriteTest, AWriterDivergesFromASharedTailBlockByCopyingIt) {
+  BlockPool pool{kBlockSize, 4};
+  auto blocks = pool.AllocateBlocks(1);  // One slot used, so the block is still being written.
+  ASSERT_EQ(blocks.size(), 1u);
+  pool.AddRef(blocks);  // A second owner references the same partially filled block.
+
+  PagedCacheBlockTable table;
+  table.request_id = &table;
+  table.committed_slots = 1;
+  table.blocks = blocks;
+
+  RecordingBlockCopier copier;
+  const bool copied = MakeTailBlockExclusive(table, /*target_slots=*/2, pool, copier);
+
+  ASSERT_TRUE(copied);
+  ASSERT_EQ(copier.copies.size(), 1u);
+  EXPECT_EQ(copier.copies.front().first, blocks.front()->Id());
+  EXPECT_EQ(copier.copies.front().second, table.blocks.front()->Id());
+  EXPECT_NE(table.blocks.front()->Id(), blocks.front()->Id());
+  // The private copy carries the same tokens so far, and neither owner is shared any more.
+  EXPECT_EQ(table.blocks.front()->Size(), 1u);
+  EXPECT_FALSE(table.blocks.front()->IsShared());
+  EXPECT_EQ(blocks.front()->RefCount(), 1u);
+}
+
+TEST(CopyOnWriteTest, AnExclusiveTailBlockIsWrittenInPlace) {
+  BlockPool pool{kBlockSize, 4};
+  auto blocks = pool.AllocateBlocks(1);
+
+  PagedCacheBlockTable table;
+  table.request_id = &table;
+  table.committed_slots = 1;
+  table.blocks = blocks;
+
+  RecordingBlockCopier copier;
+  EXPECT_FALSE(MakeTailBlockExclusive(table, /*target_slots=*/2, pool, copier));
+  EXPECT_TRUE(copier.copies.empty());
+  EXPECT_EQ(table.blocks.front()->Id(), blocks.front()->Id());
+}
+
+// A step that writes nothing has nothing to diverge from, so a shared block stays shared.
+TEST(CopyOnWriteTest, AStepThatWritesNothingLeavesASharedBlockAlone) {
+  BlockPool pool{kBlockSize, 4};
+  auto blocks = pool.AllocateBlocks(kBlockSize);
+  pool.AddRef(blocks);
+
+  PagedCacheBlockTable table;
+  table.request_id = &table;
+  table.committed_slots = kBlockSize;
+  table.blocks = blocks;
+
+  RecordingBlockCopier copier;
+  EXPECT_FALSE(MakeTailBlockExclusive(table, /*target_slots=*/kBlockSize, pool, copier));
+  EXPECT_TRUE(blocks.front()->IsShared());
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace Generators

--- a/test/engine/prefix_cache_tests.cpp
+++ b/test/engine/prefix_cache_tests.cpp
@@ -7,6 +7,9 @@
 
 #include <array>
 #include <memory>
+#include <span>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/test/engine/prefix_caching_engine_tests.cpp
+++ b/test/engine/prefix_caching_engine_tests.cpp
@@ -1,0 +1,434 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// End-to-end tests for prefix-aware paged key-value caching. These drive the production admission,
+// planning, reservation, commit, and retention path -- the real PagedCacheManager, the real dynamic
+// scheduler, and the real Engine transaction -- with only model execution replaced by a double, so
+// they run deterministically without a GPU or a real model.
+
+#include <array>
+#include <numeric>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine/engine_invariants.h"
+#include "engine/paged_key_value_cache.h"
+#include "engine_test_doubles.h"
+#include "engine_test_helpers.h"
+
+namespace Generators {
+namespace test {
+namespace {
+
+constexpr size_t kBlockSize = 4;
+
+class PrefixCachingEngineTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    model_ = LoadDummyDecoderModel();
+    Config::Engine::DynamicBatching dynamic_batching;
+    dynamic_batching.block_size = kBlockSize;
+    dynamic_batching.num_blocks = 32;
+    dynamic_batching.max_batch_size = 4;
+    dynamic_batching.max_scheduled_tokens = 64;
+    dynamic_batching.prefix_caching = true;
+    dynamic_batching.prefix_cache_max_blocks = 16;
+    model_->config_->engine.dynamic_batching = dynamic_batching;
+  }
+
+  Config::Engine::DynamicBatching& Batching() {
+    return *model_->config_->engine.dynamic_batching;
+  }
+
+  // A prompt whose leading tokens repeat between turns, which is the shape agent traffic has: a
+  // long shared system prompt and tool schema followed by a short varying suffix.
+  static std::vector<int32_t> MakePrompt(size_t shared_tokens, int32_t suffix) {
+    std::vector<int32_t> prompt(shared_tokens);
+    std::iota(prompt.begin(), prompt.end(), 2);
+    prompt.push_back(suffix);
+    return prompt;
+  }
+
+  // Runs one request to completion, releases it the way an application would, and returns the
+  // tokens the engine generated for it.
+  std::vector<int32_t> RunToCompletion(PagedEngine& paged,
+                                       const std::vector<int32_t>& prompt,
+                                       int max_length) {
+    auto params = MakeGreedyParams(*model_);
+    params->search.max_length = max_length;
+    auto request = std::make_shared<Request>(params);
+    request->AddTokens(prompt);
+    paged.engine->AddRequest(request);
+
+    std::vector<int32_t> generated;
+    while (paged.engine->HasPendingRequests()) {
+      auto ready = paged.engine->Step();
+      if (!ready) break;
+      while (ready->HasUnseenTokens()) {
+        generated.push_back(ready->UnseenToken());
+      }
+    }
+    EXPECT_EQ(request->status_, RequestStatus::Completed);
+    paged.engine->RemoveRequest(request);
+    return generated;
+  }
+
+  std::shared_ptr<Model> model_;
+};
+
+// The decisive correctness property: a request served with a warm cache produces exactly the tokens
+// it produces cold, while computing strictly less prefill.
+TEST_F(PrefixCachingEngineTest, WarmCacheProducesTokenForTokenIdenticalOutput) {
+  const auto prompt = MakePrompt(11, /*suffix=*/29);
+
+  auto cold_engine = MakePagedEngine(model_);
+  const auto cold = RunToCompletion(cold_engine, prompt, /*max_length=*/16);
+  const size_t cold_tokens = cold_engine.executor->TotalDecodedTokens();
+
+  auto warm_engine = MakePagedEngine(model_);
+  RunToCompletion(warm_engine, prompt, /*max_length=*/16);  // Warms the index.
+  const size_t warm_up_tokens = warm_engine.executor->TotalDecodedTokens();
+  const auto warm = RunToCompletion(warm_engine, prompt, /*max_length=*/16);
+  const size_t warm_tokens = warm_engine.executor->TotalDecodedTokens() - warm_up_tokens;
+
+  EXPECT_FALSE(cold.empty());
+  EXPECT_EQ(warm, cold);
+  EXPECT_LT(warm_tokens, cold_tokens);
+
+  const auto* metrics = warm_engine.engine->PrefixCacheStats();
+  ASSERT_NE(metrics, nullptr);
+  EXPECT_EQ(metrics->hits, 1u);
+  // Prompt is 12 tokens and the last one always runs, so 11 are adoptable: two whole blocks.
+  EXPECT_EQ(metrics->matched_tokens, 2 * kBlockSize);
+  EXPECT_EQ(cold_tokens - warm_tokens, 2 * kBlockSize);
+}
+
+// The prefix a second request adopts is the one the first request is still holding, so sharing
+// works between live requests and not only across turns.
+TEST_F(PrefixCachingEngineTest, ConcurrentRequestsShareTheSamePrefixBlocks) {
+  auto paged = MakePagedEngine(model_);
+  const auto prompt = MakePrompt(11, /*suffix=*/29);
+
+  auto params = MakeGreedyParams(*model_);
+  params->search.max_length = 32;
+  auto first = std::make_shared<Request>(params);
+  first->AddTokens(prompt);
+  paged.engine->AddRequest(first);
+  paged.engine->Step();  // Prefill and seal the first request's blocks.
+
+  auto second = std::make_shared<Request>(MakeGreedyParams(*model_));
+  second->AddTokens(prompt);
+  paged.engine->AddRequest(second);
+  paged.engine->Step();
+
+  // The whole uncached remainder of the prompt runs in one step, so the cursor lands on the end of
+  // the prompt with the first eight tokens never recomputed.
+  EXPECT_EQ(second->ProcessedSequenceLength(), static_cast<int64_t>(prompt.size()));
+  EXPECT_EQ(second->AdoptedPrefixLength(), static_cast<int64_t>(2 * kBlockSize));
+
+  const auto snapshot = paged.cache->Snapshot();
+  EXPECT_TRUE(ValidateCacheInvariants(snapshot).empty());
+  size_t shared_blocks = 0;
+  for (const auto& block : snapshot.blocks) {
+    if (block.ref_count > 2) ++shared_blocks;  // Both requests plus the index.
+  }
+  EXPECT_EQ(shared_blocks, 2u);
+}
+
+// A prompt that shares nothing pays exactly what it paid before the feature existed.
+TEST_F(PrefixCachingEngineTest, AnUnrelatedPromptAdoptsNothing) {
+  auto paged = MakePagedEngine(model_);
+
+  RunToCompletion(paged, MakePrompt(11, /*suffix=*/29), /*max_length=*/16);
+  const size_t after_first = paged.executor->TotalDecodedTokens();
+
+  std::vector<int32_t> unrelated(12, 0);
+  std::iota(unrelated.begin(), unrelated.end(), 17);
+  RunToCompletion(paged, unrelated, /*max_length=*/16);
+
+  const auto* metrics = paged.engine->PrefixCacheStats();
+  ASSERT_NE(metrics, nullptr);
+  EXPECT_EQ(metrics->hits, 0u);
+  EXPECT_EQ(metrics->matched_tokens, 0u);
+  EXPECT_EQ(paged.executor->TotalDecodedTokens() - after_first, after_first);
+}
+
+// A finished request's blocks stay indexed, so the next turn of the same conversation hits them
+// even though nothing holds them any more.
+TEST_F(PrefixCachingEngineTest, RetainedBlocksAreReusedByALaterRequest) {
+  auto paged = MakePagedEngine(model_);
+  const auto prompt = MakePrompt(11, /*suffix=*/29);
+
+  RunToCompletion(paged, prompt, /*max_length=*/16);
+
+  // Nothing holds the blocks now, but they are still indexed and still resident.
+  const auto snapshot = paged.cache->Snapshot();
+  EXPECT_TRUE(snapshot.requests.empty());
+  size_t retained = 0;
+  for (const auto& block : snapshot.blocks) {
+    if (block.indexed && block.ref_count == 1) ++retained;
+  }
+  EXPECT_GE(retained, 2u);
+
+  const size_t before = paged.executor->TotalDecodedTokens();
+  RunToCompletion(paged, prompt, /*max_length=*/16);
+  EXPECT_EQ(before - (paged.executor->TotalDecodedTokens() - before), 2 * kBlockSize);
+}
+
+// The processed cursor after an adoption has to land exactly on the adopted block boundary: one
+// token too far and the request would skip a token whose keys and values were never computed.
+TEST_F(PrefixCachingEngineTest, AdoptionLeavesTheProcessedCursorOnTheBlockBoundary) {
+  auto paged = MakePagedEngine(model_);
+  const auto prompt = MakePrompt(11, /*suffix=*/29);
+  RunToCompletion(paged, prompt, /*max_length=*/16);
+
+  auto warm = std::make_shared<Request>(MakeGreedyParams(*model_));
+  warm->AddTokens(prompt);
+  paged.engine->AddRequest(warm);
+  EXPECT_EQ(warm->ProcessedSequenceLength(), 0);
+
+  paged.engine->Step();
+
+  // Adopted 8 tokens, computed the remaining 4, and sampled one more.
+  EXPECT_EQ(warm->AdoptedPrefixLength(), static_cast<int64_t>(2 * kBlockSize));
+  EXPECT_EQ(warm->ProcessedSequenceLength(), static_cast<int64_t>(prompt.size()));
+  ASSERT_FALSE(paged.executor->decoded_token_counts.empty());
+  EXPECT_EQ(paged.executor->decoded_token_counts.back(), prompt.size() - 2 * kBlockSize);
+}
+
+// A step that rolls back must leave the request exactly where it was, including the cursor the
+// adoption moved and the references the reservation took on the shared blocks.
+TEST_F(PrefixCachingEngineTest, RolledBackAdoptionRestoresTheCursorAndReleasesEveryReference) {
+  auto paged = MakePagedEngine(model_);
+  const auto prompt = MakePrompt(11, /*suffix=*/29);
+  RunToCompletion(paged, prompt, /*max_length=*/16);
+
+  const auto before = paged.cache->Snapshot();
+
+  auto warm = std::make_shared<Request>(MakeGreedyParams(*model_));
+  warm->AddTokens(prompt);
+  paged.engine->AddRequest(warm);
+  paged.executor->SetNextFailure(ScriptedExecutionFailure::RetryableBeforeExecution);
+
+  EXPECT_THROW(paged.engine->Step(), EngineStepError);
+
+  EXPECT_EQ(warm->ProcessedSequenceLength(), 0);
+  EXPECT_EQ(warm->AdoptedPrefixLength(), 0);
+  const auto after = paged.cache->Snapshot();
+  EXPECT_TRUE(ValidateCacheInvariants(after).empty());
+  EXPECT_EQ(after.free_blocks, before.free_blocks);
+  ASSERT_EQ(after.blocks.size(), before.blocks.size());
+  for (size_t i = 0; i < after.blocks.size(); ++i) {
+    EXPECT_EQ(after.blocks[i].block_id, before.blocks[i].block_id);
+    EXPECT_EQ(after.blocks[i].ref_count, before.blocks[i].ref_count);
+  }
+
+  // The retry adopts the prefix cleanly, so the rollback lost nothing but the step.
+  paged.engine->Step();
+  EXPECT_EQ(warm->AdoptedPrefixLength(), static_cast<int64_t>(2 * kBlockSize));
+}
+
+// Retention is bounded and always reclaimable: a live request under memory pressure takes the
+// blocks back rather than being deferred forever.
+TEST_F(PrefixCachingEngineTest, RetainedBlocksAreReclaimedForALiveRequestUnderPressure) {
+  Batching().num_blocks = 6;
+  Batching().prefix_cache_max_blocks = 6;
+  auto paged = MakePagedEngine(model_);
+
+  RunToCompletion(paged, MakePrompt(7, /*suffix=*/29), /*max_length=*/12);
+  const auto retained = paged.cache->Snapshot();
+  size_t retained_blocks = 0;
+  for (const auto& block : retained.blocks) {
+    if (block.indexed && block.ref_count == 1) ++retained_blocks;
+  }
+  ASSERT_GT(retained_blocks, 0u);
+
+  // A prompt sharing nothing now needs the whole pool, so retention has to give way.
+  std::vector<int32_t> unrelated(20, 0);
+  std::iota(unrelated.begin(), unrelated.end(), 11);
+  RunToCompletion(paged, unrelated, /*max_length=*/24);
+
+  const auto* metrics = paged.engine->PrefixCacheStats();
+  ASSERT_NE(metrics, nullptr);
+  EXPECT_GT(metrics->evictions, 0u);
+  EXPECT_TRUE(ValidateCacheInvariants(paged.cache->Snapshot()).empty());
+}
+
+// The engine's default configuration must behave exactly as it did before the feature existed.
+TEST_F(PrefixCachingEngineTest, DefaultConfigurationDoesNotCacheAnyPrefix) {
+  Batching().prefix_caching = Config::Engine::DynamicBatching{}.prefix_caching;
+  ASSERT_FALSE(Batching().prefix_caching);
+  auto paged = MakePagedEngine(model_);
+  const auto prompt = MakePrompt(11, /*suffix=*/29);
+
+  const auto first = RunToCompletion(paged, prompt, /*max_length=*/16);
+  const size_t first_tokens = paged.executor->TotalDecodedTokens();
+  const auto second = RunToCompletion(paged, prompt, /*max_length=*/16);
+  const size_t second_tokens = paged.executor->TotalDecodedTokens() - first_tokens;
+
+  EXPECT_EQ(second, first);
+  EXPECT_EQ(second_tokens, first_tokens);
+  const auto* metrics = paged.engine->PrefixCacheStats();
+  ASSERT_NE(metrics, nullptr);
+  EXPECT_EQ(metrics->lookups, 0u);
+  EXPECT_EQ(metrics->registered_blocks, 0u);
+}
+
+// Static batching keeps a single contiguous cache with no content-addressed blocks, so it reports
+// no prefix cache rather than pretending a hit occurred.
+TEST_F(PrefixCachingEngineTest, StaticBatchingReportsNoPrefixCache) {
+  model_->config_->engine.dynamic_batching.reset();
+  model_->config_->engine.static_batching = Config::Engine::StaticBatching{};
+  auto cache = CacheManager::Create(model_);
+
+  EXPECT_FALSE(cache->SupportsDynamicBatching());
+  EXPECT_EQ(cache->PrefixMetrics(), nullptr);
+  auto request = MintRequest(*model_, std::array<int32_t, 2>{2, 3});
+  EXPECT_EQ(cache->MatchPrefix(*request), nullptr);
+}
+
+// Beam search keeps several live sequences behind one request, which the engine does not model, so
+// it is rejected up front rather than silently sharing a prefix between beams.
+TEST_F(PrefixCachingEngineTest, BeamSearchIsRejectedRatherThanSharingAPrefix) {
+  auto params = MakeGreedyParams(*model_);
+  params->search.num_beams = 2;
+  EXPECT_THROW(
+      {
+        auto rejected = std::make_shared<Request>(params);
+        static_cast<void>(rejected);
+      },
+      std::runtime_error);
+}
+
+// The block table the model sees after an adoption has to name the adopted blocks first, and the
+// step has to write at absolute positions that continue exactly where they end.
+TEST_F(PrefixCachingEngineTest, AdoptedBlocksLeadTheBlockTableAndPositionsContinueFromThem) {
+  PagedKeyValueCache cache{model_};
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/2, EosToken(*model_)).engine;
+
+  const std::array<int32_t, 8> tokens{2, 3, 4, 5, 6, 7, 8, 9};
+  auto first = MintAssignedRequest(engine, *model_, tokens);
+  const std::array reserve_first{
+      PagedCacheReservationRequest{first.get(), tokens.size(), true, tokens.size()},
+  };
+  auto first_reservation = cache.Reserve(reserve_first);
+  first_reservation.Commit();
+  cache.SealCommittedBlocks(first.get(), tokens);
+
+  // A second prompt sharing the first seven tokens can adopt one whole block.
+  const std::array<int32_t, 8> warm_tokens{2, 3, 4, 5, 6, 7, 8, 99};
+  auto second = MintAssignedRequest(engine, *model_, warm_tokens);
+  const auto match = cache.MatchPrefix(warm_tokens, warm_tokens.size() - 1);
+  ASSERT_EQ(match.token_count, kBlockSize);
+  ASSERT_EQ(match.blocks.size(), 1u);
+  const int32_t adopted_block_id = static_cast<int32_t>(match.blocks.front()->Id());
+
+  const std::array reserve_second{
+      PagedCacheReservationRequest{second.get(), warm_tokens.size(), true, warm_tokens.size(), &match},
+  };
+  auto second_reservation = cache.Reserve(reserve_second);
+
+  // The adopted block leads the row, so the step writes token j at absolute position 4 + j, which
+  // lands in the block that follows it.
+  const std::array<const void*, 1> ids{second.get()};
+  std::vector<int32_t> row(2, -1);
+  second_reservation.FillBlockTable(ids, 2, row);
+  EXPECT_EQ(row[0], adopted_block_id);
+  EXPECT_NE(row[1], adopted_block_id);
+  EXPECT_NE(row[1], -1);
+
+  EXPECT_TRUE(ValidateCacheInvariants(cache.Snapshot(second_reservation)).empty());
+  second_reservation.Commit();
+
+  const auto snapshot = cache.Snapshot();
+  EXPECT_TRUE(ValidateCacheInvariants(snapshot).empty());
+  ASSERT_EQ(snapshot.requests.size(), 2u);
+  EXPECT_EQ(snapshot.requests[1].used_slots, warm_tokens.size());
+
+  cache.Remove(first);
+  cache.Remove(second);
+}
+
+// Adoption is capacity-neutral: the retained blocks a match claims stop being reclaimable, so they
+// are charged to the step alongside the blocks it still has to take. This admission starts with an
+// empty free pool and every block retained, and it has to reclaim exactly the shortfall.
+TEST_F(PrefixCachingEngineTest, AdmissionWithNoFreeBlocksReclaimsExactlyWhatItNeeds) {
+  Batching().num_blocks = 3;
+  PagedKeyValueCache cache{model_};
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/2, EosToken(*model_)).engine;
+
+  const std::array<int32_t, 12> tokens{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+  auto first = MintAssignedRequest(engine, *model_, tokens);
+  const std::array reserve_first{
+      PagedCacheReservationRequest{first.get(), tokens.size(), true, tokens.size()},
+  };
+  auto first_reservation = cache.Reserve(reserve_first);
+  first_reservation.Commit();
+  cache.SealCommittedBlocks(first.get(), tokens);
+  cache.Remove(first);
+
+  const auto retained = cache.Snapshot();
+  EXPECT_EQ(retained.free_blocks, 0u);
+  EXPECT_EQ(retained.blocks.size(), 3u);
+
+  auto second = MintAssignedRequest(engine, *model_, tokens);
+  const auto match = cache.MatchPrefix(tokens, tokens.size() - 1);
+  ASSERT_EQ(match.blocks.size(), 2u);
+
+  StepPlan plan;
+  RequestStepPlan entry;
+  entry.request = second;
+  entry.request_id = second.get();
+  entry.target_cache_slots = match.token_count + 1;
+  entry.whole_sequence_cache_slots = tokens.size();
+  entry.newly_admitted = true;
+  entry.prefix_match = std::make_shared<const PrefixCacheMatch>(match);
+  plan.requests.push_back(std::move(entry));
+
+  const auto result = cache.PlanStepResources(plan);
+  ASSERT_TRUE(result.executable);
+  ASSERT_EQ(plan.requests.size(), 1u);
+
+  const std::array reserve_second{
+      PagedCacheReservationRequest{second.get(), match.token_count + 1, true, tokens.size(), &match},
+  };
+  auto second_reservation = cache.Reserve(reserve_second);
+  EXPECT_EQ(second_reservation.ReservedBlockCount(), 1u);
+  second_reservation.Commit();
+
+  const auto snapshot = cache.Snapshot();
+  EXPECT_TRUE(ValidateCacheInvariants(snapshot).empty());
+  ASSERT_EQ(snapshot.requests.size(), 1u);
+  EXPECT_EQ(snapshot.requests[0].block_ids.size(), 3u);
+
+  cache.Remove(second);
+}
+
+// A cached prefix is only ever made of full blocks, because a partially filled block is still being
+// written and sharing it would let one request's tokens land in another's key-value data.
+TEST_F(PrefixCachingEngineTest, APartiallyFilledBlockIsNeverOfferedAsAPrefix) {
+  PagedKeyValueCache cache{model_};
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/2, EosToken(*model_)).engine;
+
+  // Six tokens fill one block and leave two slots of the next one used.
+  const std::array<int32_t, 6> tokens{2, 3, 4, 5, 6, 7};
+  auto request = MintAssignedRequest(engine, *model_, tokens);
+  const std::array reserve{
+      PagedCacheReservationRequest{request.get(), tokens.size(), true, tokens.size()},
+  };
+  auto reservation = cache.Reserve(reserve);
+  reservation.Commit();
+  cache.SealCommittedBlocks(request.get(), tokens);
+
+  // Only the first four tokens are adoptable; the half-written second block is not offered.
+  const std::array<int32_t, 7> probe{2, 3, 4, 5, 6, 7, 8};
+  const auto match = cache.MatchPrefix(probe, probe.size() - 1);
+  EXPECT_EQ(match.token_count, kBlockSize);
+
+  cache.Remove(request);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace Generators

--- a/test/engine/prefix_caching_engine_tests.cpp
+++ b/test/engine/prefix_caching_engine_tests.cpp
@@ -7,6 +7,7 @@
 // they run deterministically without a GPU or a real model.
 
 #include <array>
+#include <memory>
 #include <numeric>
 #include <vector>
 


### PR DESCRIPTION
> **No model ran in these measurements.** There is no GPU in the environment this was built and measured in (CPU-only build, `USE_CUDA=OFF`). Token counts, block residency, and hit rates below are exact and hardware-independent, because they are counts rather than timings. **End-to-end TTFT and throughput in seconds are not measured**, and the microsecond figures are Engine host overhead only — noise at this scale. Nothing is extrapolated.

> **Off by default** (`engine.dynamic_batching.prefix_caching = false`). Merged behavior is byte-identical to today.

Based on current `main` (`f6a871db`). Not stacked on anything.

### Description

Serving and agent workloads resend large identical prefixes on every turn: system prompts, tool schemas, repository and RAG context, and prior conversation. Today every one of those turns re-prefills from scratch, because `BlockPool` allocates and frees blocks with no notion of content identity.

This makes the engine detect that a new request's prompt shares a prefix with KV blocks that are already resident — or retained from a request that has finished — and adopt those blocks instead of recomputing them.

**Content-addressed blocks.** A filled block gets an identity that chains the identity of the block before it, so a block only matches when the entire preceding token sequence matches. A hash match is never treated as proof of a match: exact tokens are compared, **and the parent is compared as the identity object it was computed behind, rather than as a hash of it**.

That second point is the subtle one. Verifying only a parent *hash* leaves a real hole: if an ancestor is evicted and its hash is later reused by different content, a follower block can be spliced onto a prefix it was never computed behind — silently serving KV from the wrong context. An adversarial review pass caught this. It is fixed, and regression-tested by **`PrefixCacheTest.ABlockIsNeverSplicedOntoAPrefixItWasNotComputedBehind`**, which overrides the hash so that every first block collides with every other first block and every second block collides with every other second block — only the lineage check can tell them apart.

**Reference-counted sharing.** Several requests, the in-flight reservation, and the index can each hold a reference to one block; it returns to the pool only at zero references. The all-or-nothing reservation contract from #2365 holds — adopted references are released on rollback.

**Copy-on-write.** Only full blocks are shared, because a full block is never written again; the partial tail block stays private to its owner. `MakeTailBlockExclusive()` performs a real per-layer KV copy and table swap, and the reservation throws rather than write into a shared block, so "shared blocks are immutable" is enforced rather than assumed. This path is unreachable under the merged policy and is tested directly.

**Admission-time adoption.** Matching is read-only at admission, so a deferred request is left untouched; the cursor is staged only for selected requests, and only as the last thing planning does. It reuses the existing `processed_sequence_length_` / `UnprocessedTokens()` machinery, so the `past_sequence_lengths` guard added in #2354 validates every step — which matters, because that off-by-one is precisely the failure mode prefix adoption could otherwise reintroduce.

**Retention and LRU eviction.** Retention is bounded and always reclaimable under pressure. Planning charges a request for the retained blocks its adoption claims, which makes **adoption capacity-neutral** — that property is what makes the memory-pressure result below a designed outcome rather than a lucky one. Eviction takes a chain's **tail** first, so a head is never orphaned.

**Invariants** now validate per-block reference accounting (references must equal owners), full-blocks-only sharing, and adopted-prefix / committed-slot alignment.

### Measured results

Windows x64, MSVC (VS 18), Release, ORT 1.26, model `test/models/engine/dummy-decoder`. The benchmark drives the real `PagedCacheManager`, the real dynamic scheduler, and the real `Engine` transaction, stubbing only model execution.

Workload: 512-token shared prefix + 15 varying tokens + 8 generated, 32 sequential turns followed by 8 concurrent.

**A — `num_blocks=512`, `block_size=16`, `max_batch_size=8`**

| | cold | warm |
|---|---:|---:|
| prompt tokens computed | 21080 | **1112** |
| prompt tokens skipped | 0 | **19968** |
| decode tokens | 280 | 280 |
| peak KV blocks | 272 | **77** |
| admission -> first token p50 / p95 (µs, host only) | 36.4 / 55.3 | 44.1 / 59.7 |
| concurrent phase wall (µs, host only) | 1356.6 | 912.6 |

Hit rate **97.5%** (39/40 — the first turn is necessarily cold). **94.7%** of prompt tokens skipped. Peak KV residency **−71.7%**. Evictions 0, retention refusals 0, duplicate registrations 11, hash collisions 0.

**B — `num_blocks=96` (memory pressure)**

94.7% of prompt tokens skipped, 97.5% hit rate, peak 56/96 blocks, **24 evictions, 0 retention refusals**, and all 40 requests completed. Retention gave capacity back under pressure rather than starving anyone — which is the capacity-neutral adoption property doing its job.

### Why default-off

Warm-versus-cold output is bit-identical in the deterministic harness, but that cannot be qualified on CUDA or DML, where reused KV is compared against KV that a different batch composition would recompute with a different reduction order. It also changes KV block lifetime. Flipping the default is a one-line change once real-model qualification exists.

| Key (under `engine.dynamic_batching`) | Default | Meaning |
| --- | --- | --- |
| `prefix_caching` | `false` | Reuse resident blocks whose token prefix matches a new prompt. |
| `prefix_cache_pool_fraction` | `0.5` | Share of the block pool the index may retain. |
| `prefix_cache_max_blocks` | unset | Absolute ceiling on indexed blocks; overrides the fraction. |
| `prefix_cache_min_blocks` | `1` | Shortest match worth adopting, in blocks. |

### Relationship to #2418

#2418 (recompute preemption) reimplements `Remove()` on top of a new `CacheManager::ReclaimRequestCache`. That is the same release path this PR's reference-counted block release hooks into. The two are related by design rather than colliding accidentally, and **whichever merges second will need a rebase**.

### Tests

171 engine tests pass; 167 broader `unit_tests` pass with 22 skipped for absent models.

New: `prefix_cache_tests.cpp`, `prefix_caching_engine_tests.cpp`, `prefix_cache_benchmark_tests.cpp`; the invariant tests are rewritten.

Coverage: exact / partial / no hit; hash-collision safety; ancestor-collision splicing (**`ABlockIsNeverSplicedOntoAPrefixItWasNotComputedBehind`**); copy-on-write divergence; reference-count lifetime under transactional rollback; eviction under pressure; retained-block reuse across sequential requests; cursor continuity after adoption; default-config compatibility; and explicit rejection for static batching and beam search.

The decisive test is `WarmCacheProducesTokenForTokenIdenticalOutput`: warm output is token-for-token identical to cold, with strictly less prefill performed.

### Could not verify / residual risk

1. **No real-model or GPU qualification.** This is the main reason the feature is default-off.
2. `LayerBlockCopier` uses offset `DeviceBuffer::CopyFrom`, which is fine on CPU/CUDA/DML, but WebGPU and AMDGPU support only zero-offset copies. Reachable only from the copy-on-write path that the merged policy never takes, and it fails loudly rather than silently.
3. `PagedCacheReservation::Release()` can still throw from a destructor on allocation failure. The paths added here are non-allocating and `Release()` was converted to a non-allocating loop, but the destructor-calls-`Release()` shape is pre-existing and was not restructured.
4. **Ring / windowed pools (#2357, #2358) are not integrated.** They are documented as ineligible for sharing, since ring blocks are overwritten in place, but there is no test against that unmerged layout.
5. Real multi-threaded server concurrency and production block sizes (256+) are unmeasured.

`docs/paged_attention_engine.md` is updated in the same change.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

