### PR TITLE
Add decoder state manifest contract for hybrid model support

### DIFF
--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -85,6 +85,21 @@ to 2048. Both limits are positive and independent.
 
 Without dynamic batching, the engine uses the older static batching path. Static batching allocates and advances a batch as a unit. It does not use the transaction flow described below.
 
+## Decoder state manifest
+
+`model.decoder.state_groups` can describe decoder-owned state without identifying a model family. The supported group kinds are `paged_kv` and `fixed`. Each group has logical layer IDs and typed input/output binding templates. Paged KV groups have key and value bindings; fixed groups have one state binding. Binding templates contain one `%d` placeholder for the logical layer ID. A layer may own both paged and fixed state, and multiple fixed groups may cover the same layer when it owns more than one independent state tensor. Layers omitted from a group do not own that kind of state.
+
+The group kind defines the state transition:
+
+- Paged KV grows by appending token slots and commits by advancing logical occupancy.
+- Fixed convolution and recurrent state replace one request-indexed state value and require a staged output to be published at commit.
+
+Configuration loading rejects unknown kinds or layouts, missing or incompatible bindings, malformed templates, duplicate IDs or logical layers, and conflicting resolved bindings. Overlay application validates a complete copy and publishes it only on success. When `state_groups` is absent, the typed configuration retains the legacy dense paged-KV behavior over `0..num_hidden_layers-1` using the existing decoder key/value templates; it does not insert a synthetic group into the parsed configuration.
+
+When an explicit manifest is present, model loading expands every binding and verifies that its decoder input and output exist with compatible dtype and shape. Paged bindings must also have compatible rank-four geometry throughout their group.
+
+This manifest does not change Engine execution on this branch. The current dynamic path still owns only dense sequential paged KV and does not bind fixed state. Dynamic Engine construction fails with a clear compatibility error for other state or layout contracts. Later Engine changes must consume the manifest before sparse or fixed state is supported.
+
 ## Request lifecycle
 
 A `Request` is one sequence. Engine requests currently require:

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -3,6 +3,7 @@
 // Modifications Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Portions of this file consist of AI generated content.
 #include "generators.h"
+#include "models/model_state_manifest.h"
 #include "models/model_type.h"
 #include "runtime_settings.h"
 #include "json.h"
@@ -13,6 +14,7 @@
 #include <limits>
 #include <cmath>
 #include <stdexcept>
+#include <utility>
 
 namespace Generators {
 
@@ -497,6 +499,111 @@ struct SharedInitializers_Element : JSON::Element {
   std::unique_ptr<SharedInitializer_Element> element_;
 };
 
+using DecoderStateGroup = Config::Model::Decoder::StateGroup;
+using DecoderStateGroupKind = Config::Model::Decoder::StateGroupKind;
+
+struct StateBinding_Element : JSON::Element {
+  explicit StateBinding_Element(Config::Model::Decoder::StateBinding& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "input") {
+      v_.input = JSON::Get<std::string_view>(value);
+    } else if (name == "output") {
+      v_.output = JSON::Get<std::string_view>(value);
+    } else {
+      throw JSON::unknown_value_error{};
+    }
+  }
+
+ private:
+  Config::Model::Decoder::StateBinding& v_;
+};
+
+struct StateBindings_Element : JSON::Element {
+  explicit StateBindings_Element(DecoderStateGroup& v) : v_{v} {}
+
+  Element& OnObject(std::string_view name) override {
+    std::optional<Config::Model::Decoder::StateBinding>* binding{};
+    std::unique_ptr<StateBinding_Element>* element{};
+    if (name == "key") {
+      binding = &v_.key;
+      element = &key_;
+    } else if (name == "value") {
+      binding = &v_.value;
+      element = &value_;
+    } else if (name == "state") {
+      binding = &v_.state;
+      element = &state_;
+    } else {
+      throw JSON::unknown_value_error{};
+    }
+
+    if (binding->has_value()) {
+      throw std::runtime_error("Duplicate decoder state binding semantic '" + std::string{name} + "'");
+    }
+    binding->emplace();
+    *element = std::make_unique<StateBinding_Element>(binding->value());
+    return **element;
+  }
+
+ private:
+  DecoderStateGroup& v_;
+  std::unique_ptr<StateBinding_Element> key_;
+  std::unique_ptr<StateBinding_Element> value_;
+  std::unique_ptr<StateBinding_Element> state_;
+};
+
+struct StateGroup_Element : JSON::Element {
+  explicit StateGroup_Element(DecoderStateGroup& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name != "kind") {
+      throw JSON::unknown_value_error{};
+    }
+    const auto kind = JSON::Get<std::string_view>(value);
+    if (kind == "paged_kv") {
+      v_.kind = DecoderStateGroupKind::PagedKeyValue;
+    } else if (kind == "fixed") {
+      v_.kind = DecoderStateGroupKind::Fixed;
+    } else {
+      throw std::runtime_error("Unsupported decoder state group kind '" + std::string{kind} + "'");
+    }
+  }
+
+  Element& OnObject(std::string_view name) override {
+    if (name == "bindings") {
+      return bindings_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
+  Element& OnArray(std::string_view name) override {
+    if (name == "layer_ids") {
+      return layer_ids_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
+ private:
+  DecoderStateGroup& v_;
+  IntArray_Element layer_ids_{v_.layer_ids};
+  StateBindings_Element bindings_{v_};
+};
+
+struct StateGroups_Element : JSON::Element {
+  explicit StateGroups_Element(std::vector<DecoderStateGroup>& v) : v_{v} {}
+
+  Element& OnObject(std::string_view /*name*/) override {
+    auto& group = v_.emplace_back();
+    current_ = std::make_unique<StateGroup_Element>(group);
+    return *current_;
+  }
+
+ private:
+  std::vector<DecoderStateGroup>& v_;
+  std::unique_ptr<StateGroup_Element> current_;
+};
+
 struct StringStringMap_Element : JSON::Element {
   explicit StringStringMap_Element(std::unordered_map<std::string, std::string>& v) : v_{v} {}
 
@@ -738,6 +845,11 @@ struct Decoder_Element : JSON::Element {
     if (name == "shared_initializers") {
       return shared_initializers_;
     }
+    if (name == "state_groups") {
+      v_.state_groups.emplace();
+      state_groups_ = std::make_unique<StateGroups_Element>(*v_.state_groups);
+      return *state_groups_;
+    }
     throw JSON::unknown_value_error{};
   }
 
@@ -752,6 +864,7 @@ struct Decoder_Element : JSON::Element {
   std::unique_ptr<PipelineModelObject_Element> pipeline_object_;  // object-style pipeline support
   std::unique_ptr<StringArray_Element> layer_types_;
   SharedInitializers_Element shared_initializers_{v_.shared_initializers};
+  std::unique_ptr<StateGroups_Element> state_groups_;
 };
 
 struct MtpInputs_Element : JSON::Element {
@@ -1995,9 +2108,12 @@ void ParseConfig(const fs::path& filename, std::string_view json_overlay, Config
 }
 
 void OverlayConfig(Config& config, std::string_view json) {
-  Root_Element root{config};
+  Config candidate{config};
+  Root_Element root{candidate};
   RootObject_Element element{root};
   JSON::Parse(element, json);
+  ModelStateManifest::ValidateConfig(candidate.model.decoder);
+  std::swap(config, candidate);
 }
 
 fs::path Config::ResolvePath(std::string_view value) const {
@@ -2094,6 +2210,7 @@ void ValidateModelPaths(const Config& config) {
 
 Config::Config(const fs::path& path, std::string_view json_overlay) : config_path{path} {
   ParseConfig(path / "genai_config.json", json_overlay, *this);
+  ModelStateManifest::ValidateConfig(model.decoder);
 
   if (model.context_length == 0 && !ModelType::IsRNNT(model.type)) {
     throw std::runtime_error("model context_length is 0 or was not set. It must be greater than 0");

--- a/src/config.h
+++ b/src/config.h
@@ -376,6 +376,28 @@ struct Config {
       };
       std::optional<SlidingWindow> sliding_window;
 
+      enum class StateGroupKind {
+        Invalid,
+        PagedKeyValue,
+        Fixed,
+      };
+
+      struct StateBinding {
+        std::string input;
+        std::string output;
+      };
+
+      struct StateGroup {
+        StateGroupKind kind{StateGroupKind::Invalid};
+        std::vector<int> layer_ids;
+        std::optional<StateBinding> key;
+        std::optional<StateBinding> value;
+        std::optional<StateBinding> state;
+      };
+
+      // Absence preserves the legacy dense, sequential paged-KV contract.
+      std::optional<std::vector<StateGroup>> state_groups;
+
       struct Inputs {
         std::string input_ids{Defaults::InputIdsName};
         std::string embeddings{Defaults::InputsEmbedsName};

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -67,6 +67,7 @@ class PagedCacheStepReservation final : public CacheStepReservation {
 
 std::unique_ptr<CacheManager> CacheManager::Create(std::shared_ptr<Model> model) {
   if (model->config_->engine.dynamic_batching) {
+    ModelStateManifest::ValidateDynamicEngineCompatibility(model->config_->model.decoder);
     return std::make_unique<PagedCacheManager>(model);
   }
 

--- a/src/models/decoder_only_pipeline.cpp
+++ b/src/models/decoder_only_pipeline.cpp
@@ -18,6 +18,9 @@ DecoderOnlyPipelineModel::DecoderOnlyPipelineModel(std::unique_ptr<Config> confi
   for (auto& session : sessions_) {
     session_info_.Add(*session);
   }
+  if (config_->model.decoder.state_groups) {
+    ModelStateManifest{config_->model.decoder}.ValidateSession(session_info_);
+  }
 }
 
 std::unique_ptr<State> DecoderOnlyPipelineModel::CreateState(DeviceSpan<int32_t> sequence_lengths,

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1030,6 +1030,7 @@ OrtSessionOptions* Model::GetSessionOptions(const std::string& model_id) const {
 }
 
 std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::string& model_filename, OrtSessionOptions* session_options) {
+  std::unique_ptr<OrtSession> session;
   if (auto model_data_it = config_->model_data_spans_.find(model_filename);
       model_data_it != config_->model_data_spans_.end()) {
     // If model data was provided, load the model from memory
@@ -1045,11 +1046,20 @@ std::unique_ptr<OrtSession> Model::CreateSession(OrtEnv& ort_env, const std::str
       session_options->AddConfigEntry(kOrtSessionOptionsModelExternalInitializersFileFolderPath,
                                       external_initializers_path.string().c_str());
     }
-    return OrtSession::Create(ort_env, model_data_it->second.data(), model_data_it->second.size(), session_options);
+    session = OrtSession::Create(ort_env, model_data_it->second.data(), model_data_it->second.size(), session_options);
+  } else {
+    session = OrtSession::Create(ort_env, (config_->config_path / fs::path(model_filename)).c_str(), session_options);
   }
 
-  // Otherwise, load the model from the file system
-  return OrtSession::Create(ort_env, (config_->config_path / fs::path(model_filename)).c_str(), session_options);
+  if (config_->model.decoder.state_groups &&
+      config_->model.decoder.pipeline.empty() &&
+      model_filename == config_->model.decoder.filename) {
+    SessionInfo decoder_session_info;
+    decoder_session_info.Add(*session);
+    ModelStateManifest{config_->model.decoder}.ValidateSession(decoder_session_info);
+  }
+
+  return session;
 }
 
 std::shared_ptr<Tokenizer> Model::CreateTokenizer() const {

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -4,6 +4,7 @@
 // Modifications Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Portions of this file consist of AI generated content.
 #pragma once
+#include "model_state_manifest.h"
 #include "model_type.h"
 #include "ortx_tokenizer.h"
 #include "../generators.h"
@@ -177,21 +178,21 @@ struct MultiModalProcessor : std::enable_shared_from_this<MultiModalProcessor>, 
   std::unordered_map<std::string, std::function<std::shared_ptr<Processor>(Config&, const SessionInfo&)>> processor_factory_;
 };
 
-struct SessionInfo {
+struct SessionInfo : ModelStateMetadata {
   SessionInfo() = default;
 
   void Add(OrtSession& session);
 
-  bool HasInput(const std::string& name) const;
-  bool HasOutput(const std::string& name) const;
+  bool HasInput(const std::string& name) const override;
+  bool HasOutput(const std::string& name) const override;
 
-  ONNXTensorElementDataType GetInputDataType(const std::string& name) const;
-  ONNXTensorElementDataType GetOutputDataType(const std::string& name) const;
+  ONNXTensorElementDataType GetInputDataType(const std::string& name) const override;
+  ONNXTensorElementDataType GetOutputDataType(const std::string& name) const override;
 
   std::vector<std::string> GetInputNames() const;
 
-  std::vector<int64_t> GetInputShape(const std::string& name) const;
-  std::vector<int64_t> GetOutputShape(const std::string& name) const;
+  std::vector<int64_t> GetInputShape(const std::string& name) const override;
+  std::vector<int64_t> GetOutputShape(const std::string& name) const override;
 
   std::vector<const char*> GetInputSymbolicShape(const std::string& name) const;
   std::vector<const char*> GetOutputSymbolicShape(const std::string& name) const;

--- a/src/models/model_state_manifest.cpp
+++ b/src/models/model_state_manifest.cpp
@@ -1,0 +1,292 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "model_state_manifest.h"
+
+#include <optional>
+#include <set>
+#include <sstream>
+#include <utility>
+
+namespace Generators {
+namespace {
+
+using Decoder = Config::Model::Decoder;
+using StateBinding = Decoder::StateBinding;
+using StateGroup = Decoder::StateGroup;
+using StateGroupKind = Decoder::StateGroupKind;
+
+std::string_view StateGroupKindName(StateGroupKind kind) {
+  switch (kind) {
+    case StateGroupKind::PagedKeyValue:
+      return "paged_kv";
+    case StateGroupKind::Fixed:
+      return "fixed";
+    case StateGroupKind::Invalid:
+      return "invalid";
+  }
+  return "invalid";
+}
+
+std::string StateGroupLabel(size_t index, StateGroupKind kind) {
+  return "model.decoder.state_groups[" + std::to_string(index) + "] (" +
+         std::string{StateGroupKindName(kind)} + ")";
+}
+
+void ValidateBindingTemplate(std::string_view group_label,
+                             std::string_view semantic,
+                             std::string_view direction,
+                             const std::string& value) {
+  if (value.empty()) {
+    throw std::runtime_error(
+        std::string{group_label} + " binding '" +
+        std::string{semantic} + "' is missing its " + std::string{direction} + " template");
+  }
+
+  const auto placeholder = value.find('%');
+  if (placeholder == std::string::npos ||
+      placeholder + 1 >= value.size() ||
+      value[placeholder + 1] != 'd' ||
+      value.find('%', placeholder + 2) != std::string::npos) {
+    throw std::runtime_error(
+        std::string{group_label} + " binding '" +
+        std::string{semantic} + "' has malformed " + std::string{direction} +
+        " template '" + value + "'; expected exactly one %d");
+  }
+}
+
+std::string ExpandBinding(const std::string& value, int layer_id) {
+  std::string result{value};
+  result.replace(result.find("%d"), 2, std::to_string(layer_id));
+  return result;
+}
+
+bool ShapesCompatible(const std::vector<int64_t>& left,
+                      const std::vector<int64_t>& right) {
+  if (left.size() != right.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < left.size(); ++i) {
+    if (left[i] >= 0 && right[i] >= 0 && left[i] != right[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string ShapeString(const std::vector<int64_t>& shape) {
+  std::ostringstream output;
+  output << '[';
+  for (size_t i = 0; i < shape.size(); ++i) {
+    if (i != 0) {
+      output << ", ";
+    }
+    output << shape[i];
+  }
+  output << ']';
+  return output.str();
+}
+
+struct TensorMetadata {
+  ONNXTensorElementDataType data_type;
+  std::vector<int64_t> shape;
+  std::string name;
+};
+
+void ValidateCompatiblePair(std::string_view group_label,
+                            std::string_view semantic,
+                            const TensorMetadata& input,
+                            const TensorMetadata& output) {
+  if (input.data_type != output.data_type) {
+    throw std::runtime_error(
+        std::string{group_label} + " binding '" + std::string{semantic} +
+        "' has incompatible dtypes for input '" + input.name + "' and output '" +
+        output.name + "'");
+  }
+  if (!ShapesCompatible(input.shape, output.shape)) {
+    throw std::runtime_error(
+        std::string{group_label} + " binding '" + std::string{semantic} +
+        "' has incompatible shapes for input '" + input.name + "' " +
+        ShapeString(input.shape) + " and output '" + output.name + "' " +
+        ShapeString(output.shape));
+  }
+}
+
+void ValidatePagedGeometry(std::string_view group_label,
+                           const TensorMetadata& tensor,
+                           std::optional<TensorMetadata>& reference) {
+  if (tensor.shape.size() != 4) {
+    throw std::runtime_error(
+        std::string{group_label} + " paged binding '" + tensor.name +
+        "' must have rank 4, got " + std::to_string(tensor.shape.size()));
+  }
+  if (!reference) {
+    reference = tensor;
+    return;
+  }
+  if (tensor.data_type != reference->data_type ||
+      !ShapesCompatible(tensor.shape, reference->shape)) {
+    throw std::runtime_error(
+        std::string{group_label} + " has incompatible paged geometry between '" +
+        reference->name + "' " + ShapeString(reference->shape) +
+        " and '" + tensor.name + "' " + ShapeString(tensor.shape));
+  }
+}
+
+}  // namespace
+
+ModelStateManifest::ModelStateManifest(const Decoder& decoder)
+    : state_groups_{decoder.state_groups.value_or(std::vector<StateGroup>{})} {
+  ValidateConfig(decoder);
+}
+
+void ModelStateManifest::ValidateConfig(const Decoder& decoder) {
+  if (!decoder.state_groups) {
+    return;
+  }
+  if (decoder.state_groups->empty()) {
+    throw std::runtime_error("model.decoder.state_groups must not be empty");
+  }
+
+  std::set<int> paged_layers;
+  std::set<std::string> expanded_bindings;
+
+  for (size_t group_index = 0; group_index < decoder.state_groups->size(); ++group_index) {
+    const auto& group = (*decoder.state_groups)[group_index];
+    const auto group_label = StateGroupLabel(group_index, group.kind);
+    if (group.kind == StateGroupKind::Invalid) {
+      throw std::runtime_error(group_label + " is missing kind");
+    }
+    if (group.layer_ids.empty()) {
+      throw std::runtime_error(group_label + " must contain at least one layer_id");
+    }
+
+    if (group.kind == StateGroupKind::PagedKeyValue) {
+      if (!group.key || !group.value || group.state) {
+        throw std::runtime_error(group_label + " requires exactly key and value bindings");
+      }
+    } else if (!group.state || group.key || group.value) {
+      throw std::runtime_error(group_label + " requires exactly one state binding");
+    }
+
+    std::set<int> layer_ids;
+    for (const int layer_id : group.layer_ids) {
+      if (layer_id < 0 || layer_id >= decoder.num_hidden_layers) {
+        throw std::runtime_error(
+            group_label + " has layer_id " +
+            std::to_string(layer_id) + " outside [0, num_hidden_layers)");
+      }
+      if (!layer_ids.insert(layer_id).second) {
+        throw std::runtime_error(
+            group_label + " contains duplicate layer_id " +
+            std::to_string(layer_id));
+      }
+      if (group.kind == StateGroupKind::PagedKeyValue &&
+          !paged_layers.insert(layer_id).second) {
+        throw std::runtime_error(
+            group_label + " overlaps another paged_kv group at layer_id " +
+            std::to_string(layer_id));
+      }
+    }
+
+    const auto validate_binding = [&](std::string_view semantic, const StateBinding& binding) {
+      ValidateBindingTemplate(group_label, semantic, "input", binding.input);
+      ValidateBindingTemplate(group_label, semantic, "output", binding.output);
+      for (const int layer_id : group.layer_ids) {
+        for (const auto& name : {
+                 ExpandBinding(binding.input, layer_id),
+                 ExpandBinding(binding.output, layer_id)}) {
+          if (!expanded_bindings.insert(name).second) {
+            throw std::runtime_error(
+                group_label + " resolves more than one binding to '" + name + "'");
+          }
+        }
+      }
+    };
+
+    if (group.key) {
+      validate_binding("key", *group.key);
+    }
+    if (group.value) {
+      validate_binding("value", *group.value);
+    }
+    if (group.state) {
+      validate_binding("state", *group.state);
+    }
+  }
+}
+
+void ModelStateManifest::ValidateSession(const ModelStateMetadata& metadata) const {
+  for (size_t group_index = 0; group_index < state_groups_.size(); ++group_index) {
+    const auto& group = state_groups_[group_index];
+    const auto group_label = StateGroupLabel(group_index, group.kind);
+    std::optional<TensorMetadata> paged_reference;
+    const auto validate_binding = [&](std::string_view semantic, const StateBinding& binding) {
+      for (const int layer_id : group.layer_ids) {
+        const auto input_name = ExpandBinding(binding.input, layer_id);
+        const auto output_name = ExpandBinding(binding.output, layer_id);
+        if (!metadata.HasInput(input_name)) {
+          throw std::runtime_error(
+              group_label + " binding '" + std::string{semantic} +
+              "' input was not found: " + input_name);
+        }
+        if (!metadata.HasOutput(output_name)) {
+          throw std::runtime_error(
+              group_label + " binding '" + std::string{semantic} +
+              "' output was not found: " + output_name);
+        }
+
+        TensorMetadata input{
+            metadata.GetInputDataType(input_name),
+            metadata.GetInputShape(input_name),
+            input_name};
+        TensorMetadata output{
+            metadata.GetOutputDataType(output_name),
+            metadata.GetOutputShape(output_name),
+            output_name};
+        ValidateCompatiblePair(group_label, semantic, input, output);
+
+        if (group.kind == StateGroupKind::PagedKeyValue) {
+          ValidatePagedGeometry(group_label, input, paged_reference);
+          ValidatePagedGeometry(group_label, output, paged_reference);
+        }
+      }
+    };
+
+    if (group.key) {
+      validate_binding("key", *group.key);
+    }
+    if (group.value) {
+      validate_binding("value", *group.value);
+    }
+    if (group.state) {
+      validate_binding("state", *group.state);
+    }
+  }
+}
+
+void ModelStateManifest::ValidateDynamicEngineCompatibility(const Decoder& decoder) {
+  ValidateConfig(decoder);
+
+  if (!decoder.state_groups) {
+    return;
+  }
+
+  if (decoder.state_groups->size() != 1 ||
+      decoder.state_groups->front().kind != StateGroupKind::PagedKeyValue ||
+      decoder.state_groups->front().layer_ids.size() != static_cast<size_t>(decoder.num_hidden_layers)) {
+    throw std::runtime_error(
+        "Dynamic batching currently supports only one dense paged_kv state group covering every decoder layer");
+  }
+
+  const auto& paged_kv = decoder.state_groups->front();
+  if (paged_kv.key->input != decoder.inputs.past_key_names ||
+      paged_kv.key->output != decoder.outputs.present_key_names ||
+      paged_kv.value->input != decoder.inputs.past_value_names ||
+      paged_kv.value->output != decoder.outputs.present_value_names) {
+    throw std::runtime_error(
+        "Dynamic batching currently requires paged_kv bindings to match the decoder's legacy key/value names");
+  }
+}
+
+}  // namespace Generators

--- a/src/models/model_state_manifest.h
+++ b/src/models/model_state_manifest.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "../config.h"
+
+#include "onnxruntime_c_api.h"
+
+namespace Generators {
+
+struct ModelStateMetadata {
+  virtual ~ModelStateMetadata() = default;
+
+  virtual bool HasInput(const std::string& name) const = 0;
+  virtual bool HasOutput(const std::string& name) const = 0;
+  virtual ONNXTensorElementDataType GetInputDataType(const std::string& name) const = 0;
+  virtual ONNXTensorElementDataType GetOutputDataType(const std::string& name) const = 0;
+  virtual std::vector<int64_t> GetInputShape(const std::string& name) const = 0;
+  virtual std::vector<int64_t> GetOutputShape(const std::string& name) const = 0;
+};
+
+class ModelStateManifest {
+ public:
+  explicit ModelStateManifest(const Config::Model::Decoder& decoder);
+
+  static void ValidateConfig(const Config::Model::Decoder& decoder);
+  static void ValidateDynamicEngineCompatibility(const Config::Model::Decoder& decoder);
+  void ValidateSession(const ModelStateMetadata& metadata) const;
+
+ private:
+  std::vector<Config::Model::Decoder::StateGroup> state_groups_;
+};
+
+}  // namespace Generators

--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -283,6 +283,8 @@ This scenario is for when you want to build a model that uses the `PagedAttentio
 
 Paged attention supports CUDA with `fp16` or `bf16` precision and cannot be combined with `exclude_embeds` or `exclude_lm_head`. `paged_block_size` defaults to `256` and must be a positive multiple of `256`; for models with short and long rotary caches, it must evenly divide `original_max_position_embeddings`. `gpu_utilization_factor` defaults to `0.6` and must be greater than `0` and at most `1`. `max_batch_size` defaults to `100` and must be a positive integer no greater than `256`.
 
+Paged builds can describe non-legacy decoder state in `model.decoder.state_groups`. The Qwen hybrid builder emits exact logical layer IDs and binding templates for sparse paged KV and fixed state. Legacy models whose every decoder layer uses paged KV omit the manifest and preserve the existing implicit contract. Manifest metadata describes the graph contract; Engine support for a state kind still depends on the runtime implementation.
+
 ```bash
 # From wheel:
 python -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o path_to_output_folder -p fp16 -e cuda -c cache_dir_to_store_temp_files --extra_options use_paged_attention=true prune_lm_head=true

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1056,6 +1056,10 @@ class Model:
                 },
             }
 
+        state_groups = self.make_decoder_state_groups(inputs, outputs)
+        if state_groups:
+            genai_config["model"]["decoder"]["state_groups"] = state_groups
+
         self.update_genai_config(genai_config)
 
         print(f"Saving GenAI config in {out_dir}")
@@ -1067,6 +1071,25 @@ class Model:
         Override in subclasses to modify genai_config before it is written to disk.
         """
         pass
+
+    def make_decoder_state_groups(self, inputs, outputs):
+        return []
+
+    def make_paged_key_value_state_group(self, layer_ids, inputs, outputs):
+        return {
+            "kind": "paged_kv",
+            "layer_ids": list(layer_ids),
+            "bindings": {
+                "key": {
+                    "input": inputs["past_key_names"],
+                    "output": outputs["present_key_names"],
+                },
+                "value": {
+                    "input": inputs["past_value_names"],
+                    "output": outputs["present_value_names"],
+                },
+            },
+        }
 
     def make_key_value_cache_names(self, layer_id):
         """

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -972,6 +972,38 @@ class Qwen35TextModel(Model):
     def _get_model_type(self, config):
         return "Qwen3_5_textForCausalLM" if self.is_text_only else "Qwen3_5ForConditionalGeneration"
 
+    @staticmethod
+    def _resolve_layer_types(config, num_layers):
+        text_config = getattr(config, "text_config", config)
+        configured_layer_types = getattr(config, "layer_types", None)
+        if configured_layer_types is None:
+            configured_layer_types = getattr(text_config, "layer_types", None)
+
+        if configured_layer_types is not None:
+            if len(configured_layer_types) < num_layers:
+                raise ValueError(
+                    f"Qwen3.5 layer_types has {len(configured_layer_types)} entries, "
+                    f"but {num_layers} layers were requested"
+                )
+            layer_types = list(configured_layer_types[:num_layers])
+        else:
+            interval = getattr(config, "full_attention_interval", None)
+            if interval is None:
+                interval = getattr(text_config, "full_attention_interval", None)
+            if interval is not None:
+                layer_types = [
+                    "full_attention" if (i + 1) % interval == 0 else "linear_attention"
+                    for i in range(num_layers)
+                ]
+            else:
+                layer_types = ["full_attention"] * num_layers
+
+        supported_layer_types = {"full_attention", "linear_attention"}
+        unknown_layer_types = sorted(set(layer_types) - supported_layer_types)
+        if unknown_layer_types:
+            raise ValueError(f"Unsupported Qwen3.5 layer_types: {unknown_layer_types}")
+        return layer_types
+
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
         # Qwen3.5 is a VL model. The decoder takes inputs_embeds.
         # When exclude_embeds is explicitly set to False, build as a standalone LLM.
@@ -1003,15 +1035,7 @@ class Qwen35TextModel(Model):
         # Mirror base class logic: prefer extra_options["num_hidden_layers"] when present.
         text_config = getattr(config, "text_config", config)
         num_layers = extra_options.get("num_hidden_layers", getattr(text_config, "num_hidden_layers", 0))
-        if hasattr(config, "layer_types") and config.layer_types is not None:
-            self.layer_types = list(config.layer_types)
-        elif hasattr(config, "full_attention_interval") and config.full_attention_interval is not None:
-            interval = config.full_attention_interval
-            self.layer_types = [
-                "full_attention" if (i + 1) % interval == 0 else "linear_attention" for i in range(num_layers)
-            ]
-        else:
-            self.layer_types = ["full_attention"] * num_layers
+        self.layer_types = self._resolve_layer_types(config, num_layers)
 
         # ModelOpt's FP8 KV-cache metadata maps to the generic fp8_per_tensor path in builder.py.
         # Without a calibration file, preserve the checkpoint's shared unit-scale convention.
@@ -2193,6 +2217,41 @@ class Qwen35TextModel(Model):
         gated_output = f"{gated_name}/output_0"
 
         return gated_output
+
+    def make_decoder_state_groups(self, inputs, outputs):
+        if not self.use_paged_attention:
+            return []
+
+        full_attention_layers = [
+            i for i, layer_type in enumerate(self.layer_types) if layer_type == "full_attention"
+        ]
+        linear_attention_layers = [
+            i for i, layer_type in enumerate(self.layer_types) if layer_type == "linear_attention"
+        ]
+        if not linear_attention_layers:
+            return []
+
+        state_groups = []
+
+        if full_attention_layers:
+            state_groups.append(self.make_paged_key_value_state_group(full_attention_layers, inputs, outputs))
+
+        if linear_attention_layers:
+            for state_name in ("conv_state", "recurrent_state"):
+                state_groups.append(
+                    {
+                        "kind": "fixed",
+                        "layer_ids": linear_attention_layers,
+                        "bindings": {
+                            "state": {
+                                "input": f"past_key_values.%d.{state_name}",
+                                "output": f"present.%d.{state_name}",
+                            }
+                        },
+                    }
+                )
+
+        return state_groups
 
     def make_genai_config(self, model_name_or_path, extra_kwargs, out_dir):
         """Generate genai_config.json for the decoder (text-only) model.

--- a/test/engine/dynamic_batching_config_tests.cpp
+++ b/test/engine/dynamic_batching_config_tests.cpp
@@ -19,6 +19,30 @@ Config LoadDynamicConfig(std::string_view dynamic_batching) {
       overlay};
 }
 
+Config LoadDecoderConfig(std::string_view decoder) {
+  const std::string overlay =
+      R"({ "model": { "decoder": )" +
+      std::string{decoder} + " } }";
+  return Config{
+      fs::path{std::string{MODEL_PATH "engine/dummy-decoder"}},
+      overlay};
+}
+
+std::string CaptureStateGroupError(std::string_view decoder) {
+  try {
+    (void)LoadDecoderConfig(decoder);
+  } catch (const std::runtime_error& error) {
+    return error.what();
+  }
+  return {};
+}
+
+void ExpectStateGroupError(std::string_view decoder, std::string_view expected) {
+  const auto message = CaptureStateGroupError(decoder);
+  ASSERT_FALSE(message.empty());
+  EXPECT_NE(message.find(expected), std::string::npos) << message;
+}
+
 TEST(DynamicBatchingConfigTest, ScheduledTokenBudgetDefaultsTo2048) {
   const auto config = LoadDynamicConfig(R"({ "max_batch_size": 4 })");
 
@@ -48,6 +72,189 @@ INSTANTIATE_TEST_SUITE_P(
     InvalidValues,
     InvalidScheduledTokenBudgetTest,
     ::testing::Values("0", "-1", "1.5", "4000000000"));
+
+TEST(DecoderStateGroupsConfigTest, PreservesLegacyManifestAbsence) {
+  const auto config = LoadDynamicConfig(R"({ "max_batch_size": 4 })");
+
+  EXPECT_FALSE(config.model.decoder.state_groups.has_value());
+}
+
+TEST(DecoderStateGroupsConfigTest, ParsesSparseHybridManifest) {
+  const auto config = LoadDecoderConfig(R"({
+    "num_hidden_layers": 4,
+    "state_groups": [
+      {
+        "kind": "paged_kv",
+        "layer_ids": [3],
+        "bindings": {
+          "key": {"input": "past_key_values.%d.key", "output": "present.%d.key"},
+          "value": {"input": "past_key_values.%d.value", "output": "present.%d.value"}
+        }
+      },
+      {
+        "kind": "fixed",
+        "layer_ids": [0, 1, 2],
+        "bindings": {
+          "state": {"input": "past_key_values.%d.conv_state", "output": "present.%d.conv_state"}
+        }
+      },
+      {
+        "kind": "fixed",
+        "layer_ids": [0, 1, 2],
+        "bindings": {
+          "state": {"input": "past_key_values.%d.recurrent_state", "output": "present.%d.recurrent_state"}
+        }
+      }
+    ]
+  })");
+
+  ASSERT_TRUE(config.model.decoder.state_groups);
+  const auto& state_groups = *config.model.decoder.state_groups;
+  ASSERT_EQ(state_groups.size(), 3u);
+  EXPECT_EQ(state_groups[0].kind, Config::Model::Decoder::StateGroupKind::PagedKeyValue);
+  EXPECT_EQ(state_groups[0].layer_ids, std::vector<int>({3}));
+  EXPECT_EQ(state_groups[1].kind, Config::Model::Decoder::StateGroupKind::Fixed);
+  EXPECT_EQ(state_groups[1].layer_ids, std::vector<int>({0, 1, 2}));
+  EXPECT_EQ(state_groups[2].kind, Config::Model::Decoder::StateGroupKind::Fixed);
+  EXPECT_EQ(state_groups[2].layer_ids, std::vector<int>({0, 1, 2}));
+}
+
+TEST(DecoderStateGroupsConfigTest, OverlayValidationIsTransactional) {
+  auto config = LoadDecoderConfig(R"({
+    "num_hidden_layers": 1,
+    "state_groups": [{
+      "kind": "fixed",
+      "layer_ids": [0],
+      "bindings": {
+        "state": {"input": "past_conv.%d", "output": "present_conv.%d"}
+      }
+    }]
+  })");
+
+  EXPECT_THROW(
+      OverlayConfig(config, R"({
+        "model": {"decoder": {
+          "state_groups": [{
+            "kind": "fixed",
+            "layer_ids": [1],
+            "bindings": {
+              "state": {"input": "past.%d", "output": "present.%d"}
+            }
+          }]
+        }}
+      })"),
+      std::runtime_error);
+
+  ASSERT_TRUE(config.model.decoder.state_groups);
+  ASSERT_EQ(config.model.decoder.state_groups->size(), 1u);
+  EXPECT_EQ(config.model.decoder.state_groups->front().kind, Config::Model::Decoder::StateGroupKind::Fixed);
+  EXPECT_EQ(config.model.decoder.state_groups->front().layer_ids, std::vector<int>({0}));
+}
+
+TEST(DecoderStateGroupsConfigTest, RejectsMissingOrUnknownKind) {
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [{
+        "layer_ids": [0],
+        "bindings": {"state": {"input": "past.%d", "output": "present.%d"}}
+      }]})",
+      "is missing kind");
+
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [{
+        "kind": "unknown", "layer_ids": [0],
+        "bindings": {"state": {"input": "past.%d", "output": "present.%d"}}
+      }]})",
+      "Unsupported decoder state group kind 'unknown'");
+}
+
+TEST(DecoderStateGroupsConfigTest, AllowsIndependentFixedGroupsOnTheSameLayer) {
+  EXPECT_NO_THROW(LoadDecoderConfig(
+      R"({"num_hidden_layers": 1, "state_groups": [
+        {"kind": "fixed", "layer_ids": [0],
+         "bindings": {"state": {"input": "past_conv.%d", "output": "present_conv.%d"}}},
+        {"kind": "fixed", "layer_ids": [0],
+         "bindings": {"state": {"input": "past_recurrent.%d", "output": "present_recurrent.%d"}}}
+      ]})"));
+}
+
+TEST(DecoderStateGroupsConfigTest, RejectsMissingOrIncompatibleBindings) {
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [{
+        "kind": "paged_kv", "layer_ids": [0],
+        "bindings": {"key": {"input": "past.%d.key", "output": "present.%d.key"}}
+      }]})",
+      "requires exactly key and value bindings");
+
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [{
+        "kind": "fixed", "layer_ids": [0],
+        "bindings": {
+          "key": {"input": "past.%d.key", "output": "present.%d.key"},
+          "state": {"input": "past.%d.state", "output": "present.%d.state"}
+        }
+      }]})",
+      "requires exactly one state binding");
+}
+
+TEST(DecoderStateGroupsConfigTest, RejectsMalformedBindingTemplates) {
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [{
+        "kind": "fixed", "layer_ids": [0],
+        "bindings": {"state": {"input": "past.recurrent", "output": "present.%d.recurrent"}}
+      }]})",
+      "expected exactly one %d");
+
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [{
+        "kind": "fixed", "layer_ids": [0],
+        "bindings": {"state": {"input": "past.%d.recurrent"}}
+      }]})",
+      "missing its output template");
+}
+
+TEST(DecoderStateGroupsConfigTest, RejectsDuplicateOrOutOfRangeLayerIds) {
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 2, "state_groups": [{
+        "kind": "fixed", "layer_ids": [0, 0],
+        "bindings": {"state": {"input": "past.%d.recurrent", "output": "present.%d.recurrent"}}
+      }]})",
+      "duplicate layer_id 0");
+
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 2, "state_groups": [{
+        "kind": "fixed", "layer_ids": [2],
+        "bindings": {"state": {"input": "past.%d.recurrent", "output": "present.%d.recurrent"}}
+      }]})",
+      "outside [0, num_hidden_layers)");
+}
+
+TEST(DecoderStateGroupsConfigTest, RejectsPagedLayerOverlap) {
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [
+        {"kind": "paged_kv", "layer_ids": [0],
+         "bindings": {
+           "key": {"input": "past_a.%d.key", "output": "present_a.%d.key"},
+           "value": {"input": "past_a.%d.value", "output": "present_a.%d.value"}
+         }},
+        {"kind": "paged_kv", "layer_ids": [0],
+         "bindings": {
+           "key": {"input": "past_b.%d.key", "output": "present_b.%d.key"},
+           "value": {"input": "past_b.%d.value", "output": "present_b.%d.value"}
+         }}
+      ]})",
+      "overlaps another paged_kv group at layer_id 0");
+}
+
+TEST(DecoderStateGroupsConfigTest, RejectsDuplicateExpandedBindings) {
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [
+        {"kind": "fixed", "layer_ids": [0],
+         "bindings": {"state": {"input": "past.%d", "output": "present_conv.%d"}}},
+        {"kind": "fixed", "layer_ids": [0],
+         "bindings": {"state": {"input": "past.%d", "output": "present_recurrent.%d"}}}
+      ]})",
+      "resolves more than one binding to 'past.0'");
+}
 
 }  // namespace
 }  // namespace Generators::test

--- a/test/engine/model_state_manifest_tests.cpp
+++ b/test/engine/model_state_manifest_tests.cpp
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "engine_test_helpers.h"
+#include "models/model_state_manifest.h"
+
+namespace Generators::test {
+namespace {
+
+struct TensorMetadata {
+  ONNXTensorElementDataType data_type;
+  std::vector<int64_t> shape;
+};
+
+class FakeModelStateMetadata final : public ModelStateMetadata {
+ public:
+  void AddInput(std::string name,
+                ONNXTensorElementDataType data_type,
+                std::vector<int64_t> shape) {
+    inputs_.insert_or_assign(
+        std::move(name),
+        TensorMetadata{data_type, std::move(shape)});
+  }
+
+  void AddOutput(std::string name,
+                 ONNXTensorElementDataType data_type,
+                 std::vector<int64_t> shape) {
+    outputs_.insert_or_assign(
+        std::move(name),
+        TensorMetadata{data_type, std::move(shape)});
+  }
+
+  bool HasInput(const std::string& name) const override {
+    return inputs_.contains(name);
+  }
+
+  bool HasOutput(const std::string& name) const override {
+    return outputs_.contains(name);
+  }
+
+  ONNXTensorElementDataType GetInputDataType(const std::string& name) const override {
+    return inputs_.at(name).data_type;
+  }
+
+  ONNXTensorElementDataType GetOutputDataType(const std::string& name) const override {
+    return outputs_.at(name).data_type;
+  }
+
+  std::vector<int64_t> GetInputShape(const std::string& name) const override {
+    return inputs_.at(name).shape;
+  }
+
+  std::vector<int64_t> GetOutputShape(const std::string& name) const override {
+    return outputs_.at(name).shape;
+  }
+
+ private:
+  std::unordered_map<std::string, TensorMetadata> inputs_;
+  std::unordered_map<std::string, TensorMetadata> outputs_;
+};
+
+Config::Model::Decoder MakeSparseDecoder() {
+  using Decoder = Config::Model::Decoder;
+
+  Decoder decoder;
+  decoder.num_hidden_layers = 4;
+  decoder.state_groups = std::vector<Decoder::StateGroup>{
+      Decoder::StateGroup{
+          Decoder::StateGroupKind::PagedKeyValue,
+          {1, 3},
+          Decoder::StateBinding{"past.%d.key", "present.%d.key"},
+          Decoder::StateBinding{"past.%d.value", "present.%d.value"},
+          std::nullopt},
+      Decoder::StateGroup{
+          Decoder::StateGroupKind::Fixed,
+          {0, 2},
+          std::nullopt,
+          std::nullopt,
+          Decoder::StateBinding{"past.%d.conv", "present.%d.conv"}}};
+  return decoder;
+}
+
+FakeModelStateMetadata MakeValidMetadata() {
+  FakeModelStateMetadata metadata;
+  for (const int layer_id : {1, 3}) {
+    for (const auto* semantic : {"key", "value"}) {
+      metadata.AddInput(
+          "past." + std::to_string(layer_id) + "." + semantic,
+          ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+          {-1, 256, 4, 128});
+      metadata.AddOutput(
+          "present." + std::to_string(layer_id) + "." + semantic,
+          ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+          {-1, 256, 4, 128});
+    }
+  }
+  for (const int layer_id : {0, 2}) {
+    metadata.AddInput(
+        "past." + std::to_string(layer_id) + ".conv",
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+        {-1, 8192, 3});
+    metadata.AddOutput(
+        "present." + std::to_string(layer_id) + ".conv",
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+        {-1, 8192, 3});
+  }
+  return metadata;
+}
+
+std::string CaptureValidationError(const ModelStateManifest& manifest,
+                                   const ModelStateMetadata& metadata) {
+  try {
+    manifest.ValidateSession(metadata);
+  } catch (const std::runtime_error& error) {
+    return error.what();
+  }
+  return {};
+}
+
+TEST(ModelStateManifestTest, ValidatesEveryExpandedBinding) {
+  const ModelStateManifest manifest{MakeSparseDecoder()};
+  const auto metadata = MakeValidMetadata();
+
+  EXPECT_NO_THROW(manifest.ValidateSession(metadata));
+}
+
+TEST(ModelStateManifestTest, RejectsMissingBinding) {
+  const ModelStateManifest manifest{MakeSparseDecoder()};
+  const FakeModelStateMetadata metadata;
+
+  const auto message = CaptureValidationError(manifest, metadata);
+  EXPECT_NE(message.find("input was not found: past.1.key"), std::string::npos) << message;
+}
+
+TEST(ModelStateManifestTest, RejectsInputOutputDtypeMismatch) {
+  const ModelStateManifest manifest{MakeSparseDecoder()};
+  auto metadata = MakeValidMetadata();
+  metadata.AddOutput(
+      "present.1.key",
+      ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
+      {-1, 256, 4, 128});
+
+  const auto message = CaptureValidationError(manifest, metadata);
+  EXPECT_NE(message.find("incompatible dtypes"), std::string::npos) << message;
+}
+
+TEST(ModelStateManifestTest, RejectsInputOutputShapeMismatch) {
+  const ModelStateManifest manifest{MakeSparseDecoder()};
+  auto metadata = MakeValidMetadata();
+  metadata.AddOutput(
+      "present.1.key",
+      ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+      {-1, 256, 4, 64});
+
+  const auto message = CaptureValidationError(manifest, metadata);
+  EXPECT_NE(message.find("incompatible shapes"), std::string::npos) << message;
+}
+
+TEST(ModelStateManifestTest, AllowsDynamicDimensions) {
+  const ModelStateManifest manifest{MakeSparseDecoder()};
+  auto metadata = MakeValidMetadata();
+  metadata.AddInput(
+      "past.1.key",
+      ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+      {-1, -1, 4, 128});
+  metadata.AddOutput(
+      "present.1.key",
+      ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+      {-1, -1, 4, 128});
+
+  EXPECT_NO_THROW(manifest.ValidateSession(metadata));
+}
+
+TEST(ModelStateManifestTest, RejectsIncompatiblePagedGeometry) {
+  const ModelStateManifest manifest{MakeSparseDecoder()};
+  auto metadata = MakeValidMetadata();
+  metadata.AddInput(
+      "past.1.value",
+      ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+      {-1, 256, 4, 64});
+  metadata.AddOutput(
+      "present.1.value",
+      ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+      {-1, 256, 4, 64});
+
+  const auto message = CaptureValidationError(manifest, metadata);
+  EXPECT_NE(message.find("incompatible paged geometry"), std::string::npos) << message;
+}
+
+TEST(ModelStateManifestTest, DecoderModelLoadValidatesExplicitBindings) {
+  const auto model_path = fs::path{std::string{MODEL_PATH "engine/dummy-decoder"}};
+  const auto invalid_overlay = R"({
+    "model": {"decoder": {"state_groups": [{
+      "kind": "paged_kv",
+      "layer_ids": [0],
+      "bindings": {
+        "key": {"input": "past_key_values.%d.key", "output": "missing.%d.key"},
+        "value": {"input": "past_key_values.%d.value", "output": "present.%d.value"}
+      }
+    }]}}
+  })";
+  auto invalid_config = std::make_unique<Config>(model_path, invalid_overlay);
+  EXPECT_THROW(CreateModel(GetOrtEnv(), std::move(invalid_config)), std::runtime_error);
+}
+
+TEST(ModelStateManifestTest, DecoderModelLoadsWithValidExplicitBindings) {
+  const auto model_path = fs::path{std::string{MODEL_PATH "engine/dummy-decoder"}};
+  const auto valid_overlay = R"({
+    "model": {"decoder": {"state_groups": [{
+      "kind": "paged_kv",
+      "layer_ids": [0],
+      "bindings": {
+        "key": {"input": "past_key_values.%d.key", "output": "present.%d.key"},
+        "value": {"input": "past_key_values.%d.value", "output": "present.%d.value"}
+      }
+    }]}}
+  })";
+  auto valid_config = std::make_unique<Config>(model_path, valid_overlay);
+  EXPECT_NO_THROW(CreateModel(GetOrtEnv(), std::move(valid_config)));
+}
+
+TEST(ModelStateManifestTest, RejectsSparsePagedDynamicEngineContract) {
+  auto decoder = MakeSparseDecoder();
+  try {
+    ModelStateManifest::ValidateDynamicEngineCompatibility(decoder);
+    FAIL() << "Expected the sparse state contract to be rejected";
+  } catch (const std::runtime_error& error) {
+    EXPECT_NE(std::string{error.what()}.find("dense paged_kv"), std::string::npos) << error.what();
+  }
+}
+
+TEST(ModelStateManifestTest, RejectsDynamicEngineBindingsThatDifferFromLegacyNames) {
+  using Decoder = Config::Model::Decoder;
+  Decoder decoder;
+  decoder.num_hidden_layers = 1;
+  decoder.state_groups = std::vector<Decoder::StateGroup>{
+      Decoder::StateGroup{
+          Decoder::StateGroupKind::PagedKeyValue,
+          {0},
+          Decoder::StateBinding{"custom.%d.key", "present.%d.key"},
+          Decoder::StateBinding{"custom.%d.value", "present.%d.value"},
+          std::nullopt}};
+
+  EXPECT_THROW(
+      ModelStateManifest::ValidateDynamicEngineCompatibility(decoder),
+      std::runtime_error);
+}
+
+TEST(ModelStateManifestTest, AcceptsLegacyDynamicEngineContract) {
+  Config::Model::Decoder decoder;
+  decoder.num_hidden_layers = 4;
+
+  EXPECT_NO_THROW(ModelStateManifest::ValidateDynamicEngineCompatibility(decoder));
+}
+
+}  // namespace
+}  // namespace Generators::test

--- a/test/python/builder/test_decoder_state_groups.py
+++ b/test/python/builder/test_decoder_state_groups.py
@@ -1,0 +1,166 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+BUILDERS_DIR = Path(__file__).parents[3] / "src" / "python" / "py" / "models" / "builders"
+sys.path.insert(0, str(BUILDERS_DIR.parents[1]))
+
+
+def _load_builder_module(module_name):
+    spec = importlib.util.spec_from_file_location(f"models.builders.{module_name}", BUILDERS_DIR / f"{module_name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f"models.builders.{module_name}"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("models", types.ModuleType("models"))
+builders_package = sys.modules.setdefault("models.builders", types.ModuleType("models.builders"))
+builders_package.__path__ = [str(BUILDERS_DIR)]
+
+base_module = _load_builder_module("base")
+qwen_module = _load_builder_module("qwen")
+Model = base_module.Model
+Qwen35TextModel = qwen_module.Qwen35TextModel
+
+
+class _NoGenerationConfig:
+    @staticmethod
+    def from_pretrained(*args, **kwargs):
+        raise FileNotFoundError("no generation_config.json")
+
+
+def _make_config_model(model_type, layer_types=None, use_paged_attention=True):
+    model = model_type.__new__(model_type)
+    model.hf_token = None
+    model.hf_remote = False
+    model.ep = "cuda"
+    model.ep_attrs = {"cuda": {}}
+    model.extra_options = {}
+    model.use_paged_attention = use_paged_attention
+    model.past_present_share_buffer = False
+    model.context_length = 262144
+    model.filename = "model.onnx"
+    model.head_size = 256
+    model.hidden_size = 5120
+    model.num_attn_heads = 24
+    model.num_kv_heads = 4
+    model.num_layers = 64
+    model.model_type = "Qwen3_5_textForCausalLM"
+    model.vocab_size = 248320
+    model.window_size = None
+    model.eps_with_windowed_kv_cache = {"cuda"}
+    model.attention_attrs = {"paged_block_size": 256}
+    model.input_names = {
+        "input_ids": "input_ids",
+        "block_table": "block_table",
+        "cumulative_sequence_lengths": "cumulative_sequence_lengths",
+        "past_sequence_lengths": "past_sequence_lengths",
+        "attention_metadata": "attention_metadata",
+        "past_key_values.key": "past_key_values.%d.key",
+        "past_key_values.value": "past_key_values.%d.value",
+    }
+    model.output_names = {
+        "logits": "logits",
+        "present.key": "present.%d.key",
+        "present.value": "present.%d.value",
+    }
+    if layer_types is not None:
+        model.layer_types = layer_types
+    return model
+
+
+def _write_config(monkeypatch, tmp_path, model):
+    hf_config = SimpleNamespace(eos_token_id=[248044], bos_token_id=248045, pad_token_id=248044)
+    monkeypatch.setattr(base_module, "AutoConfig", SimpleNamespace(from_pretrained=lambda *a, **k: hf_config))
+    monkeypatch.setattr(base_module, "GenerationConfig", _NoGenerationConfig)
+    make_config = Model.make_genai_config.__get__(model)
+    make_config("model_name_or_path", {}, str(tmp_path))
+    return json.loads((tmp_path / "genai_config.json").read_text())
+
+
+def test_common_paged_builder_preserves_legacy_manifest_absence(monkeypatch, tmp_path):
+    config = _write_config(monkeypatch, tmp_path, _make_config_model(Model))
+
+    assert "state_groups" not in config["model"]["decoder"]
+
+
+def test_common_nonpaged_builder_preserves_manifest_absence(monkeypatch, tmp_path):
+    config = _write_config(
+        monkeypatch,
+        tmp_path,
+        _make_config_model(Model, use_paged_attention=False),
+    )
+
+    assert "state_groups" not in config["model"]["decoder"]
+
+
+def test_qwen_all_attention_builder_preserves_legacy_manifest_absence(monkeypatch, tmp_path):
+    config = _write_config(
+        monkeypatch,
+        tmp_path,
+        _make_config_model(Qwen35TextModel, layer_types=["full_attention"] * 64),
+    )
+
+    assert "state_groups" not in config["model"]["decoder"]
+
+
+def test_qwen38_official_geometry_emits_exact_sparse_groups(monkeypatch, tmp_path):
+    layer_types = ["full_attention" if (layer_id + 1) % 4 == 0 else "linear_attention" for layer_id in range(64)]
+    config = _write_config(
+        monkeypatch,
+        tmp_path,
+        _make_config_model(Qwen35TextModel, layer_types=layer_types),
+    )
+
+    groups = config["model"]["decoder"]["state_groups"]
+    assert [group["kind"] for group in groups] == [
+        "paged_kv",
+        "fixed",
+        "fixed",
+    ]
+    assert groups[0]["layer_ids"] == list(range(3, 64, 4))
+    assert groups[1]["layer_ids"] == [i for i in range(64) if (i + 1) % 4 != 0]
+    assert groups[2]["layer_ids"] == groups[1]["layer_ids"]
+    assert groups[1]["bindings"]["state"] == {
+        "input": "past_key_values.%d.conv_state",
+        "output": "present.%d.conv_state",
+    }
+    assert groups[2]["bindings"]["state"] == {
+        "input": "past_key_values.%d.recurrent_state",
+        "output": "present.%d.recurrent_state",
+    }
+
+
+def test_qwen38_layer_types_support_reduced_official_fixture():
+    official_layer_types = [
+        "full_attention" if (layer_id + 1) % 4 == 0 else "linear_attention" for layer_id in range(64)
+    ]
+    config = SimpleNamespace(text_config=SimpleNamespace(layer_types=official_layer_types))
+
+    assert Qwen35TextModel._resolve_layer_types(config, 4) == [
+        "linear_attention",
+        "linear_attention",
+        "linear_attention",
+        "full_attention",
+    ]
+
+
+def test_qwen38_layer_types_reject_invalid_configurations():
+    short_config = SimpleNamespace(text_config=SimpleNamespace(layer_types=["linear_attention"]))
+    with pytest.raises(ValueError, match="1 entries"):
+        Qwen35TextModel._resolve_layer_types(short_config, 2)
+
+    unknown_config = SimpleNamespace(text_config=SimpleNamespace(layer_types=["unknown"]))
+    with pytest.raises(ValueError, match="Unsupported"):
+        Qwen35TextModel._resolve_layer_types(unknown_config, 1)


### PR DESCRIPTION
## Summary

Introduce an optional, model-described decoder state manifest that defines which logical layers own paged key/value state or fixed-size state, and maps that state to ONNX graph inputs and outputs.

The continuous-batching Engine currently assumes every decoder layer owns the same growing K/V cache. That assumption does not hold for hybrid decoders that combine attention layers with recurrent or convolutional layers. This PR establishes the configuration and validation contract needed to support those models without adding sparse or fixed-state execution to the Engine yet.

## Configuration contract

`model.decoder.state_groups` is an optional list of state groups. Each group contains:

- `kind`: `paged_kv` or `fixed`
- `layer_ids`: logical decoder layer IDs that own the state
- binding templates containing exactly one `%d`, expanded with the logical layer ID
- `key` and `value` bindings for `paged_kv`, or one `state` binding for `fixed`

Example:

```json
{
  "model": {
    "decoder": {
      "state_groups": [
        {
          "kind": "paged_kv",
          "layer_ids": [3, 7],
          "bindings": {
            "key": {
              "input": "past_key_values.%d.key",
              "output": "present.%d.key"
            },
            "value": {
              "input": "past_key_values.%d.value",
              "output": "present.%d.value"
            }
          }
        },
        {
          "kind": "fixed",
          "layer_ids": [0, 1, 2],
          "bindings": {
            "state": {
              "input": "past_state.%d",
              "output": "present_state.%d"
            }
          }
        }
      ]
    }
  }
}
```

A layer may own both paged and fixed state. Multiple fixed groups may cover the same layer when their expanded tensor bindings are distinct. Layers omitted from a group do not own that kind of state.

## Compatibility and Engine behavior

This change is backward compatible:

- `state_groups` remains absent for existing model configurations and builders.
- Absence preserves the current dense, sequential, all-layer paged-KV contract.
- Existing paged and non-paged models therefore retain their current configuration and runtime behavior.

The current dynamic Engine does not consume sparse paged or fixed state yet. It explicitly fails closed when a manifest describes a contract other than the legacy all-layer paged-KV layout. An explicit legacy-equivalent manifest is accepted only when its bindings exactly match the names used by the existing Engine.

This prevents a hybrid model from loading with a manifest that the current cache manager would silently interpret as dense K/V state. Sparse paged-cache allocation and fixed-state management can build on this contract in subsequent PRs.

## Builder changes

The common builder exposes hooks for emitting decoder state groups but preserves manifest absence by default.

The hybrid Qwen builder resolves layer types from either the root model configuration or nested `text_config`, including reduced-layer exports. It emits:

- one sparse `paged_kv` group for full-attention layers;
- independent `fixed` groups for convolutional and recurrent state.

All-attention exports continue to omit the manifest and use the legacy contract.