### PR TITLE
Add kv_cache_block_size search option for KV cache buffer sizing

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1436,6 +1436,13 @@ struct Search_Element : JSON::Element {
       } else {
         v_.chunk_size = std::nullopt;
       }
+    } else if (name == "kv_cache_block_size") {
+      double block_value = JSON::Get<double>(value);
+      if (block_value > 0) {
+        v_.kv_cache_block_size = static_cast<size_t>(block_value);
+      } else {
+        v_.kv_cache_block_size = std::nullopt;
+      }
     } else if (name == "do_sample") {
       v_.do_sample = JSON::Get<bool>(value);
     } else if (name == "past_present_share_buffer") {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1437,7 +1437,7 @@ struct Search_Element : JSON::Element {
         v_.chunk_size = std::nullopt;
       }
     } else if (name == "kv_cache_block_size") {
-      double block_value = JSON::Get<double>(value);
+      const int block_value = SafeDoubleToInt(JSON::Get<double>(value), name);
       if (block_value > 0) {
         v_.kv_cache_block_size = static_cast<size_t>(block_value);
       } else {

--- a/src/config.h
+++ b/src/config.h
@@ -505,6 +505,7 @@ struct Config {
     bool past_present_share_buffer{};  // The past/present kv tensors are shared and allocated once to max_length (cuda only)
     int random_seed{-1};               // -1 = Seed with random device, otherwise use value to seed RNG
     std::optional<size_t> chunk_size;  // Chunk size for prefill chunking during context processing. If present, chunking is enabled with the chunk size > 0.
+    std::optional<size_t> kv_cache_block_size;  // If set (>0) and past_present_share_buffer is enabled, the pre-allocated KV cache sequence length is rounded up to a multiple of this value.
     float blank_penalty{};             // Penalty applied to blank token logits in CTC/RNNT decoding. Default 0 means no penalty.
   } search;
 

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -472,6 +472,8 @@ double GeneratorParams::GetSearchNumber(std::string_view name) const {
     return static_cast<double>(search.batch_size);
   } else if (name == "chunk_size") {
     return static_cast<double>(search.chunk_size.value_or(0));
+  } else if (name == "kv_cache_block_size") {
+    return static_cast<double>(search.kv_cache_block_size.value_or(0));
   } else if (name == "diversity_penalty") {
     return search.diversity_penalty;
   } else if (name == "length_penalty") {

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -493,6 +493,47 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
     }
   }
 
+  // kv_cache_block_size: round the pre-allocated KV cache sequence length up to
+  // a multiple of the block size. Only meaningful with a shared past/present
+  // buffer, where the sequence dimension is fixed at allocation time.
+  // Local (sliding-window) attention layers are left untouched: their cache is
+  // capped to the window size and does not grow, so block-alignment does not apply.
+  // No-op for fixed-KV-shape models: their sequence dim is dictated by the model
+  // graph, so rounding it would desync the cache from the graph's fixed shape.
+  if (past_present_share_buffer_ && fixed_kv_seq_len <= 0 &&
+      state_.params_->search.kv_cache_block_size.has_value()) {
+    const int64_t block_size = static_cast<int64_t>(state_.params_->search.kv_cache_block_size.value());
+    if (block_size > 0) {
+      const auto round_up_to_block = [block_size](int64_t seq_len) {
+        return ((seq_len + block_size - 1) / block_size) * block_size;
+      };
+
+      // Mark which cache slots correspond to local (sliding-window) attention
+      // layers so they can be skipped (0 = global/full attention, 1 = local).
+      std::vector<std::uint8_t> is_local_attention(layer_shapes_.size(), 0);
+      const auto& sliding_window = model_.config_->model.decoder.sliding_window;
+      if (!layer_shapes_.empty() && sliding_window.has_value() && !sliding_window->layers.empty()) {
+        std::unordered_map<int, int> model_layer_to_cache_slot;
+        for (int slot = 0; slot < layer_count_; ++slot) {
+          int model_idx = kv_layer_indices_.empty() ? slot : kv_layer_indices_[slot];
+          model_layer_to_cache_slot[model_idx] = slot;
+        }
+        for (int model_layer_idx : sliding_window->layers) {
+          auto it = model_layer_to_cache_slot.find(model_layer_idx);
+          if (it != model_layer_to_cache_slot.end())
+            is_local_attention[it->second] = 1;
+        }
+      }
+
+      shape_[2] = round_up_to_block(shape_[2]);
+      for (size_t layer_idx = 0; layer_idx < layer_shapes_.size(); ++layer_idx) {
+        if (is_local_attention[layer_idx])
+          continue;
+        layer_shapes_[layer_idx][2] = round_up_to_block(layer_shapes_[layer_idx][2]);
+      }
+    }
+  }
+
   try {
     // Allocate KV cache tensors - 2 per layer (key and value)
     // For per-layer shapes: alternates between key and value for each layer

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -497,10 +497,16 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
   // a multiple of the block size. Only meaningful with a shared past/present
   // buffer, where the sequence dimension is fixed at allocation time.
   // Local (sliding-window) attention layers are left untouched: their cache is
-  // capped to the window size and does not grow, so block-alignment does not apply.
+  // capped to the window and does not grow, so block-alignment does not apply.
   // No-op for fixed-KV-shape models: their sequence dim is dictated by the model
   // graph, so rounding it would desync the cache from the graph's fixed shape.
-  if (past_present_share_buffer_ && fixed_kv_seq_len <= 0 &&
+  const auto& sliding_window = model_.config_->model.decoder.sliding_window;
+  // We took the windowed path above iff a windowed cache was computed and there is
+  // no beam search. When it is uniform (empty layers list) *every* layer is a
+  // sliding-window layer, so the whole cache is local and must not be rounded.
+  const bool windowed_cache = windowed_cache_size > 0 && state_.params_->search.num_beams == 1;
+  const bool uniform_local_cache = windowed_cache && sliding_window->layers.empty();
+  if (past_present_share_buffer_ && fixed_kv_seq_len <= 0 && !uniform_local_cache &&
       state_.params_->search.kv_cache_block_size.has_value()) {
     const int64_t block_size = static_cast<int64_t>(state_.params_->search.kv_cache_block_size.value());
     if (block_size > 0) {
@@ -510,9 +516,10 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
 
       // Mark which cache slots correspond to local (sliding-window) attention
       // layers so they can be skipped (0 = global/full attention, 1 = local).
+      // Only the alternating windowed path gives some layers a smaller cache;
+      // otherwise no layer is local and the whole cache is rounded.
       std::vector<std::uint8_t> is_local_attention(layer_shapes_.size(), 0);
-      const auto& sliding_window = model_.config_->model.decoder.sliding_window;
-      if (!layer_shapes_.empty() && sliding_window.has_value() && !sliding_window->layers.empty()) {
+      if (windowed_cache && !layer_shapes_.empty() && !sliding_window->layers.empty()) {
         std::unordered_map<int, int> model_layer_to_cache_slot;
         for (int slot = 0; slot < layer_count_; ++slot) {
           int model_idx = kv_layer_indices_.empty() ? slot : kv_layer_indices_[slot];

--- a/src/models/kv_cache.cpp
+++ b/src/models/kv_cache.cpp
@@ -5,6 +5,7 @@
 #include "../generators.h"
 #include "model.h"
 #include "kv_cache.h"
+#include "kv_cache_block_size.h"
 #include "windowed_kv_cache.h"
 #include "../config_utils.h"
 #include "../openvino/interface.h"
@@ -493,52 +494,22 @@ DefaultKeyValueCache::DefaultKeyValueCache(State& state)
     }
   }
 
-  // kv_cache_block_size: round the pre-allocated KV cache sequence length up to
-  // a multiple of the block size. Only meaningful with a shared past/present
-  // buffer, where the sequence dimension is fixed at allocation time.
-  // Local (sliding-window) attention layers are left untouched: their cache is
-  // capped to the window and does not grow, so block-alignment does not apply.
-  // No-op for fixed-KV-shape models: their sequence dim is dictated by the model
-  // graph, so rounding it would desync the cache from the graph's fixed shape.
+  // kv_cache_block_size: round the pre-allocated KV cache sequence length up to a
+  // multiple of the block size (see kv_cache_block_size.h). Skipped for
+  // fixed-KV-shape models and for uniform sliding-window caches (every layer is
+  // local); on the alternating windowed path only the local layers are spared.
   const auto& sliding_window = model_.config_->model.decoder.sliding_window;
-  // We took the windowed path above iff a windowed cache was computed and there is
-  // no beam search. When it is uniform (empty layers list) *every* layer is a
-  // sliding-window layer, so the whole cache is local and must not be rounded.
   const bool windowed_cache = windowed_cache_size > 0 && state_.params_->search.num_beams == 1;
-  const bool uniform_local_cache = windowed_cache && sliding_window->layers.empty();
-  if (past_present_share_buffer_ && fixed_kv_seq_len <= 0 && !uniform_local_cache &&
-      state_.params_->search.kv_cache_block_size.has_value()) {
+  const bool sliding_window_layers_empty = !sliding_window.has_value() || sliding_window->layers.empty();
+  if (ShouldRoundKvCacheToBlock(past_present_share_buffer_, fixed_kv_seq_len, windowed_cache,
+                                sliding_window_layers_empty, state_.params_->search.kv_cache_block_size)) {
     const int64_t block_size = static_cast<int64_t>(state_.params_->search.kv_cache_block_size.value());
-    if (block_size > 0) {
-      const auto round_up_to_block = [block_size](int64_t seq_len) {
-        return ((seq_len + block_size - 1) / block_size) * block_size;
-      };
-
-      // Mark which cache slots correspond to local (sliding-window) attention
-      // layers so they can be skipped (0 = global/full attention, 1 = local).
-      // Only the alternating windowed path gives some layers a smaller cache;
-      // otherwise no layer is local and the whole cache is rounded.
-      std::vector<std::uint8_t> is_local_attention(layer_shapes_.size(), 0);
-      if (windowed_cache && !layer_shapes_.empty() && !sliding_window->layers.empty()) {
-        std::unordered_map<int, int> model_layer_to_cache_slot;
-        for (int slot = 0; slot < layer_count_; ++slot) {
-          int model_idx = kv_layer_indices_.empty() ? slot : kv_layer_indices_[slot];
-          model_layer_to_cache_slot[model_idx] = slot;
-        }
-        for (int model_layer_idx : sliding_window->layers) {
-          auto it = model_layer_to_cache_slot.find(model_layer_idx);
-          if (it != model_layer_to_cache_slot.end())
-            is_local_attention[it->second] = 1;
-        }
-      }
-
-      shape_[2] = round_up_to_block(shape_[2]);
-      for (size_t layer_idx = 0; layer_idx < layer_shapes_.size(); ++layer_idx) {
-        if (is_local_attention[layer_idx])
-          continue;
-        layer_shapes_[layer_idx][2] = round_up_to_block(layer_shapes_[layer_idx][2]);
-      }
-    }
+    // Only the alternating windowed path gives some layers a smaller (local) cache.
+    const std::vector<int> local_layers =
+        (windowed_cache && !sliding_window_layers_empty) ? sliding_window->layers : std::vector<int>{};
+    const std::vector<std::uint8_t> is_local_attention =
+        ComputeLocalAttentionSlots(layer_count_, kv_layer_indices_, local_layers);
+    ApplyKvCacheBlockSize(block_size, is_local_attention, shape_, layer_shapes_);
   }
 
   try {

--- a/src/models/kv_cache_block_size.h
+++ b/src/models/kv_cache_block_size.h
@@ -18,7 +18,9 @@
 namespace Generators {
 
 // Round seq_len up to the nearest multiple of block_size. block_size <= 0 means
-// "not configured" and leaves seq_len unchanged.
+// "not configured" and leaves seq_len unchanged. block_size is bounded to int32 at
+// the config boundary (SafeDoubleToInt) and seq_len is an int-sized cache dimension,
+// so the int64 arithmetic cannot overflow.
 inline int64_t RoundUpToKvCacheBlock(int64_t seq_len, int64_t block_size) {
   if (block_size <= 0)
     return seq_len;

--- a/src/models/kv_cache_block_size.h
+++ b/src/models/kv_cache_block_size.h
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Pure helpers for the kv_cache_block_size search option: decide whether the
+// pre-allocated KV cache sequence length should be rounded up to a multiple of a
+// block size, and apply that rounding while leaving local (sliding-window) layers
+// untouched. Kept header-only and free of any model/session state so the sizing
+// behavior can be unit tested directly (see test/kv_cache_block_size_test.cpp).
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace Generators {
+
+// Round seq_len up to the nearest multiple of block_size. block_size <= 0 means
+// "not configured" and leaves seq_len unchanged.
+inline int64_t RoundUpToKvCacheBlock(int64_t seq_len, int64_t block_size) {
+  if (block_size <= 0)
+    return seq_len;
+  return ((seq_len + block_size - 1) / block_size) * block_size;
+}
+
+// Whether the KV cache sequence length should be block-rounded at all.
+// Rounding only makes sense for a shared past/present buffer whose sequence
+// dimension is fixed at allocation time, and is suppressed when:
+//   * the model has a fixed KV shape dictated by its graph (fixed_kv_seq_len > 0), or
+//   * the cache is a uniform sliding-window cache -- windowed with no explicit
+//     per-layer list -- in which case every layer is local and must not grow.
+inline bool ShouldRoundKvCacheToBlock(bool past_present_share_buffer,
+                                      int64_t fixed_kv_seq_len,
+                                      bool windowed_cache,
+                                      bool sliding_window_layers_empty,
+                                      const std::optional<size_t>& block_size) {
+  if (!past_present_share_buffer || fixed_kv_seq_len > 0)
+    return false;
+  const bool uniform_local_cache = windowed_cache && sliding_window_layers_empty;
+  if (uniform_local_cache)
+    return false;
+  return block_size.has_value() && static_cast<int64_t>(block_size.value()) > 0;
+}
+
+// Build a per-cache-slot flag marking local (sliding-window) attention layers
+// (0 = global/full attention, 1 = local). sliding_window_layers holds model-layer
+// indices; kv_layer_indices maps cache slot -> model layer for sparse KV layouts
+// (empty means slot i == model layer i). Returns an all-zero vector of length
+// layer_count when there are no sliding-window layers.
+inline std::vector<std::uint8_t> ComputeLocalAttentionSlots(
+    int layer_count,
+    const std::vector<int>& kv_layer_indices,
+    const std::vector<int>& sliding_window_layers) {
+  std::vector<std::uint8_t> is_local_attention(layer_count > 0 ? static_cast<size_t>(layer_count) : 0, 0);
+  if (layer_count <= 0 || sliding_window_layers.empty())
+    return is_local_attention;
+
+  std::unordered_map<int, int> model_layer_to_cache_slot;
+  for (int slot = 0; slot < layer_count; ++slot) {
+    int model_idx = kv_layer_indices.empty() ? slot : kv_layer_indices[slot];
+    model_layer_to_cache_slot[model_idx] = slot;
+  }
+  for (int model_layer_idx : sliding_window_layers) {
+    auto it = model_layer_to_cache_slot.find(model_layer_idx);
+    if (it != model_layer_to_cache_slot.end())
+      is_local_attention[static_cast<size_t>(it->second)] = 1;
+  }
+  return is_local_attention;
+}
+
+// Round the sequence dimension (index 2) of the shared uniform shape and every
+// per-layer shape up to a multiple of block_size, skipping local attention slots.
+// No-op when block_size <= 0. layer_shapes may be empty (uniform cache), in which
+// case only the shared shape is adjusted.
+inline void ApplyKvCacheBlockSize(int64_t block_size,
+                                  const std::vector<std::uint8_t>& is_local_attention,
+                                  std::array<int64_t, 4>& shape,
+                                  std::vector<std::array<int64_t, 4>>& layer_shapes) {
+  if (block_size <= 0)
+    return;
+  shape[2] = RoundUpToKvCacheBlock(shape[2], block_size);
+  for (size_t layer_idx = 0; layer_idx < layer_shapes.size(); ++layer_idx) {
+    if (layer_idx < is_local_attention.size() && is_local_attention[layer_idx])
+      continue;
+    layer_shapes[layer_idx][2] = RoundUpToKvCacheBlock(layer_shapes[layer_idx][2], block_size);
+  }
+}
+
+}  // namespace Generators

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -224,6 +224,7 @@ struct PyGeneratorParams {
     pybind11::dict d;
     d["batch_size"] = params_->GetSearchNumber("batch_size");
     d["chunk_size"] = params_->GetSearchNumber("chunk_size");
+    d["kv_cache_block_size"] = params_->GetSearchNumber("kv_cache_block_size");
     d["diversity_penalty"] = params_->GetSearchNumber("diversity_penalty");
     d["do_sample"] = params_->GetSearchBool("do_sample");
     d["early_stopping"] = params_->GetSearchBool("early_stopping");

--- a/test/kv_cache_block_size_test.cpp
+++ b/test/kv_cache_block_size_test.cpp
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for the kv_cache_block_size sizing helpers (models/kv_cache_block_size.h):
+// when block rounding applies, how sliding-window (local) layers are identified,
+// and how the rounding is applied to the shared and per-layer cache shapes.
+//
+// These mirror the decisions DefaultKeyValueCache makes in its constructor, but on
+// the pure helpers so the rounding behavior -- and the uniform vs. alternating
+// sliding-window cases -- can be checked without a model or ONNX session.
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "models/kv_cache_block_size.h"
+
+namespace Generators::test {
+namespace {
+
+using Shape = std::array<int64_t, 4>;
+
+// [batch, kv_heads, seq_len, head_size]; only index 2 (seq_len) is rounded.
+Shape MakeShape(int64_t seq_len) { return Shape{1, 2, seq_len, 16}; }
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// RoundUpToKvCacheBlock
+// ---------------------------------------------------------------------------
+
+TEST(KvCacheBlockSizeTest, RoundUpLeavesValueWhenNotConfigured) {
+  // block_size <= 0 means "not configured": the length is returned unchanged.
+  EXPECT_EQ(RoundUpToKvCacheBlock(1000, 0), 1000);
+  EXPECT_EQ(RoundUpToKvCacheBlock(1000, -8), 1000);
+}
+
+TEST(KvCacheBlockSizeTest, RoundUpAlreadyAlignedIsUnchanged) {
+  EXPECT_EQ(RoundUpToKvCacheBlock(512, 256), 512);
+  EXPECT_EQ(RoundUpToKvCacheBlock(256, 256), 256);
+}
+
+TEST(KvCacheBlockSizeTest, RoundUpRoundsToNextMultiple) {
+  EXPECT_EQ(RoundUpToKvCacheBlock(1, 256), 256);
+  EXPECT_EQ(RoundUpToKvCacheBlock(257, 256), 512);
+  EXPECT_EQ(RoundUpToKvCacheBlock(8192, 384), 8448);  // gpt-oss-20b style window rounding
+}
+
+// ---------------------------------------------------------------------------
+// ShouldRoundKvCacheToBlock: the default (no option) case vs. the enabled cases.
+// ---------------------------------------------------------------------------
+
+TEST(KvCacheBlockSizeTest, DefaultCaseDoesNotRound) {
+  // No search option set -> the default sizing path, no rounding.
+  EXPECT_FALSE(ShouldRoundKvCacheToBlock(/*share_buffer=*/true, /*fixed_kv_seq_len=*/0,
+                                         /*windowed=*/false, /*layers_empty=*/true,
+                                         /*block_size=*/std::nullopt));
+  // A zero block size is parsed as "not configured".
+  EXPECT_FALSE(ShouldRoundKvCacheToBlock(true, 0, false, true, std::optional<size_t>{0}));
+}
+
+TEST(KvCacheBlockSizeTest, EnabledOnlyWithSharedBuffer) {
+  EXPECT_TRUE(ShouldRoundKvCacheToBlock(true, 0, false, true, std::optional<size_t>{256}));
+  // Without a shared past/present buffer the sequence dim is not fixed at
+  // allocation time, so the option does not apply.
+  EXPECT_FALSE(ShouldRoundKvCacheToBlock(false, 0, false, true, std::optional<size_t>{256}));
+}
+
+TEST(KvCacheBlockSizeTest, FixedShapeModelDoesNotRound) {
+  // A fixed KV shape comes from the model graph and must not be resized.
+  EXPECT_FALSE(ShouldRoundKvCacheToBlock(true, /*fixed_kv_seq_len=*/2048, false, true,
+                                         std::optional<size_t>{256}));
+}
+
+TEST(KvCacheBlockSizeTest, UniformSlidingWindowCacheDoesNotRound) {
+  // Windowed cache with an empty layers list => every layer is a sliding-window
+  // (local) layer, so the whole cache is local and must not be grown.
+  EXPECT_FALSE(ShouldRoundKvCacheToBlock(true, 0, /*windowed=*/true, /*layers_empty=*/true,
+                                         std::optional<size_t>{256}));
+}
+
+TEST(KvCacheBlockSizeTest, AlternatingSlidingWindowCacheRounds) {
+  // Windowed cache with an explicit layers list has global layers to round.
+  EXPECT_TRUE(ShouldRoundKvCacheToBlock(true, 0, /*windowed=*/true, /*layers_empty=*/false,
+                                        std::optional<size_t>{256}));
+}
+
+// ---------------------------------------------------------------------------
+// ComputeLocalAttentionSlots
+// ---------------------------------------------------------------------------
+
+TEST(KvCacheBlockSizeTest, NoSlidingWindowLayersMeansNoLocalSlots) {
+  const auto is_local = ComputeLocalAttentionSlots(/*layer_count=*/4, /*kv_layer_indices=*/{}, /*layers=*/{});
+  EXPECT_EQ(is_local, (std::vector<std::uint8_t>{0, 0, 0, 0}));
+}
+
+TEST(KvCacheBlockSizeTest, AlternatingLayersMarkListedSlotsLocal) {
+  // Layers 0 and 2 are sliding-window; slot index == model layer index here.
+  const auto is_local = ComputeLocalAttentionSlots(4, {}, {0, 2});
+  EXPECT_EQ(is_local, (std::vector<std::uint8_t>{1, 0, 1, 0}));
+}
+
+TEST(KvCacheBlockSizeTest, SparseKvLayoutMapsModelLayerToCacheSlot) {
+  // Sparse KV layout: cache slot i holds model layer kv_layer_indices[i].
+  // Model layer 5 is sliding-window and lives in cache slot 1.
+  const std::vector<int> kv_layer_indices{3, 5, 7};
+  const auto is_local = ComputeLocalAttentionSlots(3, kv_layer_indices, {5});
+  EXPECT_EQ(is_local, (std::vector<std::uint8_t>{0, 1, 0}));
+}
+
+// ---------------------------------------------------------------------------
+// ApplyKvCacheBlockSize: uniform vs. alternating rounding on real shapes.
+// ---------------------------------------------------------------------------
+
+TEST(KvCacheBlockSizeTest, ApplyRoundsSharedShapeWhenNoPerLayerShapes) {
+  Shape shape = MakeShape(1000);
+  std::vector<Shape> layer_shapes;  // uniform cache: no per-layer shapes
+  ApplyKvCacheBlockSize(256, /*is_local=*/{}, shape, layer_shapes);
+  EXPECT_EQ(shape[2], 1024);
+}
+
+TEST(KvCacheBlockSizeTest, ApplyRoundsEveryLayerWhenNoneLocal) {
+  Shape shape = MakeShape(1000);
+  std::vector<Shape> layer_shapes{MakeShape(1000), MakeShape(1000)};
+  const std::vector<std::uint8_t> is_local{0, 0};
+  ApplyKvCacheBlockSize(256, is_local, shape, layer_shapes);
+  EXPECT_EQ(shape[2], 1024);
+  EXPECT_EQ(layer_shapes[0][2], 1024);
+  EXPECT_EQ(layer_shapes[1][2], 1024);
+}
+
+TEST(KvCacheBlockSizeTest, ApplySkipsLocalLayersOnAlternatingPath) {
+  // Global layers sit at max_length (1000); local layers at a smaller window (300).
+  Shape shape = MakeShape(1000);
+  std::vector<Shape> layer_shapes{MakeShape(300), MakeShape(1000), MakeShape(300), MakeShape(1000)};
+  const std::vector<std::uint8_t> is_local{1, 0, 1, 0};
+  ApplyKvCacheBlockSize(256, is_local, shape, layer_shapes);
+
+  EXPECT_EQ(shape[2], 1024);            // shared/global bound rounded
+  EXPECT_EQ(layer_shapes[0][2], 300);   // local: untouched
+  EXPECT_EQ(layer_shapes[1][2], 1024);  // global: rounded
+  EXPECT_EQ(layer_shapes[2][2], 300);   // local: untouched
+  EXPECT_EQ(layer_shapes[3][2], 1024);  // global: rounded
+}
+
+TEST(KvCacheBlockSizeTest, ApplyIsNoOpWhenBlockSizeNotConfigured) {
+  Shape shape = MakeShape(1000);
+  std::vector<Shape> layer_shapes{MakeShape(1000)};
+  ApplyKvCacheBlockSize(0, {0}, shape, layer_shapes);
+  EXPECT_EQ(shape[2], 1000);
+  EXPECT_EQ(layer_shapes[0][2], 1000);
+}
+
+}  // namespace Generators::test


### PR DESCRIPTION
## Summary

Add a new `kv_cache_block_size` search option that rounds the pre-allocated KV cache sequence length up to a multiple of a configurable block size, so shared past/present buffers can be allocated in fixed-size blocks.

## Motivation

Some execution providers and cache-management schemes want the KV cache sequence dimension to be a multiple of a fixed block/page size rather than an arbitrary `max_length`. Today there is no way to request that from the search options — the pre-allocated sequence length is taken verbatim. 

This option lets a caller opt into block-aligned buffer sizing without any device-specific plumbing, since it applies to any shared past/present buffer.

## Implementation

New `std::optional<size_t> kv_cache_block_size` search option, wired through the same paths as the existing `chunk_size` option:

- **`config.h`** — new field in `Config::search`.
- **`config.cpp`** — JSON parsing (`>0` → value, else `std::nullopt`).
- **`generators.cpp`** — `GetSearchNumber("kv_cache_block_size")`.
- **`python.cpp`** — exposed in the Python search-options dict.
- **`kv_cache.cpp`** — `DefaultKeyValueCache` rounds the sequence dim (`shape_[2]` and per-layer `layer_shapes_[i][2]`) up to the nearest multiple of the block size after the sliding-window / share-buffer sizing runs.

Behavior and guards:

- **Only applies with `past_present_share_buffer`**, where the sequence dimension is fixed at allocation time.
- **Local (sliding-window) attention layers are skipped** — their cache is capped to the window size and does not grow, so block-alignment does not apply. Local layers are identified via `sliding_window->layers`, mapped through `kv_layer_indices_` to the correct cache slots.
- **No-op for fixed-KV-shape models** (`fixed_kv_seq_len > 0`): their sequence dim is dictated by the model graph and must not be resized.
- When the option is unset (or `0`), behavior is unchanged.

## Testing

- Builds cleanly on Windows/Release (DLL, Python wheel/`.pyd`, and test binaries); verified the `kv_cache_block_size` option string is present in the built `onnxruntime-genai.dll` and `.pyd`.
- No behavior change when the option is unset.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>