### PR TITLE
adds 5th percentile stats for decode baseline

### DIFF
--- a/benchmark/engine/scenarios/decode_baseline.cpp
+++ b/benchmark/engine/scenarios/decode_baseline.cpp
@@ -240,6 +240,7 @@ ScenarioExecutionOutput DecodeBaselineScenario::Execute(const ScenarioConfig& co
 
   output.ttft_p50_ms = Percentile(ttft_values, 50.0);
   output.ttft_p95_ms = Percentile(ttft_values, 95.0);
+  output.ttft_p5_ms = Percentile(ttft_values, 5.0);
   output.inter_token_latency_p50_ms = Percentile(inter_token_latency_values, 50.0);
   output.inter_token_latency_p95_ms = Percentile(inter_token_latency_values, 95.0);
 

--- a/benchmark/engine/scenarios/scenario_base.cpp
+++ b/benchmark/engine/scenarios/scenario_base.cpp
@@ -77,7 +77,7 @@ nlohmann::json ScenarioBase::Run(const ScenarioConfig& config, const BenchmarkCo
     }
     result["core_metrics"] = {
         {"summary",
-         {{"ttft_ms", {{"p50", output.ttft_p50_ms}, {"p95", output.ttft_p95_ms}}},
+         {{"ttft_ms", {{"p5", output.ttft_p5_ms}, {"p50", output.ttft_p50_ms}, {"p95", output.ttft_p95_ms}}},
           {"inter_token_latency_ms", {{"p50", output.inter_token_latency_p50_ms}, {"p95", output.inter_token_latency_p95_ms}}},
           {"peak_device_memory_mb", output.peak_device_memory_mb},
           {"steady_state_device_memory_mb", output.steady_state_device_memory_mb}}},

--- a/benchmark/engine/scenarios/utils.h
+++ b/benchmark/engine/scenarios/utils.h
@@ -51,6 +51,7 @@ struct RequestMetrics {
 
 struct ScenarioExecutionOutput {
   std::vector<RequestMetrics> requests;
+  double ttft_p5_ms{0.0};
   double ttft_p50_ms{0.0};
   double ttft_p95_ms{0.0};
   double inter_token_latency_p50_ms{0.0};


### PR DESCRIPTION
ttft is better if its a lower number so we should report p5 in addition to p50/p95