### PR TITLE
Split paged cache reservation commit into validate and publish phases

### DIFF
--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -586,6 +586,22 @@ A request's `PagedCacheBlockTable` owns these blocks. The table records:
 
 Every physical block must be in exactly one of these states. The invariant helpers under `engine_invariants.*` validate total accounting, single ownership, valid block identifiers, reservation accounting, and consistency between request progress and cache progress.
 
+Paged-cache publication exposes a validate/publish split for the composite transaction introduced
+by the next Engine integration step. The current Engine continues to use the `Commit()` convenience
+wrapper.
+`ValidateCommit()` is repeatable and mutates nothing; it verifies request ownership, token
+boundaries, exact ordered full-cache and resident window-ring block mappings, block occupancy,
+block-pool identity ownership, unique committed request tables, empty reserved blocks,
+reserved-span accounting, and preallocated vector capacity.
+`CommitValidated()` then publishes the already-validated block handles and advances committed
+slots without allocating or touching the device. `Commit()` remains the single-reservation
+convenience wrapper that calls both phases.
+
+A future composite transaction must validate every participating state reservation before
+publishing any of them. Changing cache ownership, slot occupancy, block identity, or vector
+headroom after validation invalidates the publish preconditions and is a fatal
+transaction-contract error.
+
 ## Sliding-window paged layers
 
 The runtime can store selected sliding-window layers in a fixed ring instead of growing their KV

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -608,8 +608,10 @@ publishing any of them. Changing cache ownership, slot occupancy, block identity
 headroom after validation invalidates the publish preconditions and is a fatal
 transaction-contract error. A transaction must aggregate all paged-cache changes that share a
 block pool into one `PagedCacheReservation`. This is a caller-enforced precondition: pool
-generations reject overlapping reservations that allocate or free blocks, but a reservation whose
-growth fits existing preallocated capacity does not mutate the pool.
+generations reject overlapping reservations that allocate, free, or advance block occupancy.
+`Block` identity and occupancy cannot be assigned through exposed handles; only the pool, cache,
+and reservation mutation paths can advance occupancy, and each records the change in the pool
+generation.
 
 ## Sliding-window paged layers
 

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -590,17 +590,22 @@ Paged-cache publication exposes a validate/publish split for the composite trans
 by the next Engine integration step. The current Engine continues to use the `Commit()` convenience
 wrapper.
 `ValidateCommit()` is repeatable and mutates nothing; it verifies request ownership, token
-boundaries, exact ordered full-cache and resident window-ring block mappings, block occupancy,
-block-pool identity ownership, unique committed request tables, empty reserved blocks,
-reserved-span accounting, and preallocated vector capacity.
-`CommitValidated()` then publishes the already-validated block handles and advances committed
-slots without allocating or touching the device. `Commit()` remains the single-reservation
-convenience wrapper that calls both phases.
+boundaries and scalar table/pool mutation generations, unique committed request tables, empty
+reserved blocks, reserved-span accounting, touched-block mappings and occupancy, resident window
+rings, and preallocated vector capacity. Generations make this check independent of
+already-committed context blocks; its work is proportional to resident request tables, scheduled
+requests, current growth, and the fixed window ring. `CommitValidated()` allocation-free preflights
+every delta and its captured growth mapping again before publishing the already-validated block
+handles and advancing committed slots. `Commit()` remains the single-reservation convenience
+wrapper that calls both phases.
 
 A future composite transaction must validate every participating state reservation before
 publishing any of them. Changing cache ownership, slot occupancy, block identity, or vector
 headroom after validation invalidates the publish preconditions and is a fatal
-transaction-contract error.
+transaction-contract error. A transaction must aggregate all paged-cache changes that share a
+block pool into one `PagedCacheReservation`. This is a caller-enforced precondition: pool
+generations reject overlapping reservations that allocate or free blocks, but a reservation whose
+growth fits existing preallocated capacity does not mutate the pool.
 
 ## Sliding-window paged layers
 

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -592,12 +592,16 @@ wrapper.
 `ValidateCommit()` is repeatable and mutates nothing; it verifies request ownership, token
 boundaries and scalar table/pool mutation generations, unique committed request tables, empty
 reserved blocks, reserved-span accounting, touched-block mappings and occupancy, resident window
-rings, and preallocated vector capacity. Generations make this check independent of
-already-committed context blocks; its work is proportional to resident request tables, scheduled
-requests, current growth, and the fixed window ring. `CommitValidated()` allocation-free preflights
-every delta and its captured growth mapping again before publishing the already-validated block
-handles and advancing committed slots. `Commit()` remains the single-reservation convenience
-wrapper that calls both phases.
+rings, and preallocated vector capacity. It also snapshots every committed resident table in order,
+including requests omitted from the step, and requires its request identity, generation, block
+mapping storage, committed-token boundary, and full/window mapping sizes to remain unchanged
+through publication. Table replacement advances the destination generation even when vector
+storage is reused. These
+checks are independent of already-committed context blocks; their work is proportional to resident
+request tables, scheduled requests, current growth, and the fixed window ring.
+`CommitValidated()` allocation-free preflights every resident snapshot, delta, and captured growth
+mapping again before publishing the already-validated block handles and advancing committed slots.
+`Commit()` remains the single-reservation convenience wrapper that calls both phases.
 
 A future composite transaction must validate every participating state reservation before
 publishing any of them. Changing cache ownership, slot occupancy, block identity, or vector

--- a/src/engine/block.cpp
+++ b/src/engine/block.cpp
@@ -54,29 +54,31 @@ BlockPool::BlockPool(size_t block_size, size_t num_blocks)
     : block_size_(block_size), capacity_(num_blocks) {}
 
 std::vector<std::shared_ptr<Block>> BlockPool::AllocateBlocks(size_t num_slots, bool mark_slots_used) {
-  const auto allocate_block = [this](size_t slots) {
-    for (size_t i = 0; i < Capacity(); ++i) {
-      if (blocks_[i] == nullptr) {
-        blocks_[i] = std::make_shared<Block>(i, slots, block_size_);
-        return blocks_[i];
-      }
-    }
-    return std::shared_ptr<Block>();
-  };
-
-  if (BlocksNeeded(num_slots) > AvailableBlocks()) {
-    throw std::runtime_error("Requested number of blocks " + std::to_string(BlocksNeeded(num_slots)) +
+  const size_t blocks_needed = BlocksNeeded(num_slots);
+  if (blocks_needed > AvailableBlocks()) {
+    throw std::runtime_error("Requested number of blocks " + std::to_string(blocks_needed) +
                              " for number of slots " + std::to_string(num_slots) +
                              " exceeds available blocks " + std::to_string(AvailableBlocks()) + ".");
   }
 
   std::vector<std::shared_ptr<Block>> allocated_blocks;
-  for (size_t i = 0; i < num_slots; i += block_size_) {
-    auto block = allocate_block(mark_slots_used ? std::min(block_size_, num_slots - i) : 0);
-    if (!block) {
-      throw std::runtime_error("Failed to allocate a block.");
+  allocated_blocks.reserve(blocks_needed);
+  for (size_t id = 0; id < Capacity() && allocated_blocks.size() < blocks_needed; ++id) {
+    if (blocks_[id] == nullptr) {
+      const size_t allocated_slots = allocated_blocks.size() * block_size_;
+      const size_t slots =
+          mark_slots_used ? std::min(block_size_, num_slots - allocated_slots) : 0;
+      allocated_blocks.push_back(std::make_shared<Block>(id, slots, block_size_));
     }
-    allocated_blocks.push_back(block);
+  }
+
+  // Publish only after every allocation succeeds. Until this loop, an exception leaves the pool
+  // unchanged and the local handles clean themselves up.
+  for (const auto& block : allocated_blocks) {
+    blocks_[block->Id()] = block;
+  }
+  if (!allocated_blocks.empty()) {
+    ++mutation_generation_;
   }
   return allocated_blocks;
 }
@@ -124,6 +126,19 @@ void BlockPool::Free(const std::vector<std::shared_ptr<Block>>& blocks) {
 
   for (const auto& block : blocks) {
     blocks_[block->Id()].reset();
+  }
+  if (!blocks.empty()) {
+    ++mutation_generation_;
+  }
+}
+
+void BlockPool::RollbackReservedBlocks(
+    const std::vector<std::shared_ptr<Block>>& blocks) noexcept {
+  for (const auto& block : blocks) {
+    blocks_[block->Id()].reset();
+  }
+  if (!blocks.empty()) {
+    ++mutation_generation_;
   }
 }
 

--- a/src/engine/block.cpp
+++ b/src/engine/block.cpp
@@ -143,6 +143,10 @@ size_t BlockPool::BlockSize() const {
   return block_size_;
 }
 
+bool BlockPool::Owns(const std::shared_ptr<Block>& block) const {
+  return block && block->Id() < Capacity() && blocks_[block->Id()] == block;
+}
+
 size_t BlockPool::BlocksNeeded(size_t num_slots) {
   return (num_slots + block_size_ - 1) / block_size_;
 }

--- a/src/engine/block.cpp
+++ b/src/engine/block.cpp
@@ -163,7 +163,7 @@ bool BlockPool::Owns(const std::shared_ptr<Block>& block) const {
 }
 
 size_t BlockPool::BlocksNeeded(size_t num_slots) {
-  return (num_slots + block_size_ - 1) / block_size_;
+  return num_slots / block_size_ + (num_slots % block_size_ != 0);
 }
 
 }  // namespace Generators

--- a/src/engine/block.h
+++ b/src/engine/block.h
@@ -13,7 +13,6 @@ class PagedCacheBlockTable;
 class PagedCacheReservation;
 struct PagedKeyValueCache;
 struct BlockPool;
-struct BlockTestAccess;
 
 /*
  * Block represents a contiguous set of slots in the paged key-value cache.
@@ -22,6 +21,10 @@ struct BlockTestAccess;
  */
 struct Block {
   Block(size_t id, size_t slots, size_t block_size);
+  Block(const Block&) = default;
+  Block(Block&&) = default;
+  Block& operator=(const Block&) = delete;
+  Block& operator=(Block&&) = delete;
 
   size_t Id() const;
 
@@ -40,8 +43,6 @@ struct Block {
   friend class PagedCacheReservation;
   friend struct PagedKeyValueCache;
   friend struct BlockPool;
-  friend struct BlockTestAccess;
-
   void AddSlot();
   void AddSlots(size_t slots);
 
@@ -83,9 +84,11 @@ struct BlockPool {
 
  private:
   friend class PagedCacheReservation;
+  friend struct PagedKeyValueCache;
 
   std::vector<std::shared_ptr<Block>> AllocateBlocks(size_t num_slots, bool mark_slots_used);
   void RollbackReservedBlocks(const std::vector<std::shared_ptr<Block>>& blocks) noexcept;
+  void RecordOccupancyMutation() noexcept { ++mutation_generation_; }
 
   const size_t block_size_;
   const size_t capacity_;

--- a/src/engine/block.h
+++ b/src/engine/block.h
@@ -3,10 +3,17 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 
 namespace Generators {
+
+class PagedCacheBlockTable;
+class PagedCacheReservation;
+struct PagedKeyValueCache;
+struct BlockPool;
+struct BlockTestAccess;
 
 /*
  * Block represents a contiguous set of slots in the paged key-value cache.
@@ -26,13 +33,18 @@ struct Block {
 
   size_t EmptySlots() const;
 
-  void AddSlot();
-
-  void AddSlots(size_t slots);
-
   std::vector<size_t> SlotIds() const;
 
  private:
+  friend class PagedCacheBlockTable;
+  friend class PagedCacheReservation;
+  friend struct PagedKeyValueCache;
+  friend struct BlockPool;
+  friend struct BlockTestAccess;
+
+  void AddSlot();
+  void AddSlots(size_t slots);
+
   size_t id_;
   size_t size_;
   size_t capacity_;
@@ -55,6 +67,7 @@ struct BlockPool {
   size_t BlockSize() const;
 
   bool Owns(const std::shared_ptr<Block>& block) const;
+  uint64_t MutationGeneration() const { return mutation_generation_; }
 
   // Allocates enough blocks to hold `num_slots` and marks those slots used.
   std::vector<std::shared_ptr<Block>> AllocateBlocks(size_t num_slots);
@@ -69,11 +82,15 @@ struct BlockPool {
   size_t BlocksNeeded(size_t num_slots);
 
  private:
+  friend class PagedCacheReservation;
+
   std::vector<std::shared_ptr<Block>> AllocateBlocks(size_t num_slots, bool mark_slots_used);
+  void RollbackReservedBlocks(const std::vector<std::shared_ptr<Block>>& blocks) noexcept;
 
   const size_t block_size_;
   const size_t capacity_;
   std::vector<std::shared_ptr<Block>> blocks_{capacity_};
+  uint64_t mutation_generation_{};
 };
 
 }  // namespace Generators

--- a/src/engine/block.h
+++ b/src/engine/block.h
@@ -54,6 +54,8 @@ struct BlockPool {
 
   size_t BlockSize() const;
 
+  bool Owns(const std::shared_ptr<Block>& block) const;
+
   // Allocates enough blocks to hold `num_slots` and marks those slots used.
   std::vector<std::shared_ptr<Block>> AllocateBlocks(size_t num_slots);
 

--- a/src/engine/engine_invariants.cpp
+++ b/src/engine/engine_invariants.cpp
@@ -124,11 +124,6 @@ std::vector<InvariantViolation> ValidateCacheInvariants(const PagedCacheSnapshot
       add("Request " + PtrId(reservation.request_id) +
           " transaction target precedes its committed slot boundary.");
     }
-    if (reservation.tail_slots_to_consume >
-        reservation.target_slots - reservation.committed_slots) {
-      add("Request " + PtrId(reservation.request_id) +
-          " transaction tail-slot growth exceeds total growth.");
-    }
     for (const size_t block_id : reservation.reserved_block_ids) {
       if (reserved_blocks.find(block_id) == reserved_blocks.end()) {
         add("Request " + PtrId(reservation.request_id) +

--- a/src/engine/engine_invariants.h
+++ b/src/engine/engine_invariants.h
@@ -51,7 +51,6 @@ struct RequestReservationSnapshot {
   const void* request_id{nullptr};
   size_t committed_slots{};
   size_t target_slots{};
-  size_t tail_slots_to_consume{};
   std::vector<size_t> reserved_block_ids;
 };
 

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -563,6 +563,7 @@ void PagedCacheReservation::CommitValidated() {
   }
 
   size_t new_table_index = 0;
+  bool occupancy_changed = false;
   for (const auto& delta : deltas_) {
     PagedCacheBlockTable* table = FindTable(*committed_tables_, delta.request_id);
     if (delta.newly_admitted) {
@@ -577,11 +578,15 @@ void PagedCacheReservation::CommitValidated() {
         table->window_blocks_.end(), window_first,
         window_first + static_cast<ptrdiff_t>(delta.reserved_window_block_count));
     AdvanceCommittedSlots(*table, delta.target_slots);
+    occupancy_changed |= delta.target_slots != delta.committed_slots;
     ++table->mutation_generation_;
 
     if (delta.newly_admitted) {
       committed_tables_->push_back(std::move(*table));
     }
+  }
+  if (occupancy_changed) {
+    block_pool_->RecordOccupancyMutation();
   }
 
   reserved_blocks_.clear();

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <limits>
 #include <stdexcept>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -156,8 +156,6 @@ PagedCacheReservation::PagedCacheReservation(
     const size_t additional_slots =
         reserved_slots > committed_capacity ? reserved_slots - committed_capacity : 0;
     const size_t new_blocks = block_pool.BlocksNeeded(additional_slots);
-    const size_t tail_capacity = committed_capacity - committed_slots;
-    const size_t growth = request.target_slots - committed_slots;
     const size_t first_advance_block = committed_slots / block_pool.BlockSize();
     const size_t past_last_advance_block =
         request.target_slots / block_pool.BlockSize() +
@@ -170,7 +168,6 @@ PagedCacheReservation::PagedCacheReservation(
         committed_slots,
         table_generation,
         request.target_slots,
-        std::min(growth, tail_capacity),
         reserved_block_count,
         new_blocks,
         reserved_window_block_count,

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -4,6 +4,7 @@
 #include "paged_cache_reservation.h"
 
 #include <algorithm>
+#include <limits>
 #include <stdexcept>
 #include <unordered_set>
 #include <utility>
@@ -34,7 +35,41 @@ void ValidateEmptyReservedBlocks(
   }
 }
 
+size_t CheckedBlockSlots(
+    size_t block_count,
+    size_t block_size,
+    std::string_view description) {
+  if (block_size != 0 &&
+      block_count > std::numeric_limits<size_t>::max() / block_size) {
+    throw std::overflow_error(
+        "Paged cache " + std::string{description} + " block capacity overflow.");
+  }
+  return block_count * block_size;
+}
+
 }  // namespace
+
+PagedCacheBlockTable& PagedCacheBlockTable::operator=(
+    const PagedCacheBlockTable& other) {
+  if (this != &other) {
+    PagedCacheBlockTable copy{other};
+    *this = std::move(copy);
+  }
+  return *this;
+}
+
+PagedCacheBlockTable& PagedCacheBlockTable::operator=(
+    PagedCacheBlockTable&& other) noexcept {
+  if (this != &other) {
+    const uint64_t next_generation = mutation_generation_ + 1;
+    request_id_ = other.request_id_;
+    committed_slots_ = other.committed_slots_;
+    blocks_ = std::move(other.blocks_);
+    window_blocks_ = std::move(other.window_blocks_);
+    mutation_generation_ = next_generation;
+  }
+  return *this;
+}
 
 void RemovePagedCacheBlockTable(
     BlockPool& block_pool,
@@ -124,7 +159,8 @@ PagedCacheReservation::PagedCacheReservation(
       }
     }
 
-    const size_t committed_capacity = committed_blocks * block_pool.BlockSize();
+    const size_t committed_capacity = CheckedBlockSlots(
+        committed_blocks, block_pool.BlockSize(), "committed");
     if (committed_slots > committed_capacity) {
       throw std::logic_error(
           "Paged cache committed boundary exceeds its block capacity.");
@@ -193,6 +229,7 @@ PagedCacheReservation::PagedCacheReservation(
     }
   }
 
+  resident_table_snapshots_.reserve(committed_tables.size());
   if (reserved_block_count > block_pool.AvailableBlocks()) {
     throw std::runtime_error("Not enough free blocks for the complete paged cache reservation.");
   }
@@ -201,11 +238,13 @@ PagedCacheReservation::PagedCacheReservation(
   }
 
   advance_blocks_.reserve(advance_block_count);
-  reserved_blocks_ = block_pool.ReserveBlocks(reserved_block_count * block_pool.BlockSize());
+  reserved_blocks_ = block_pool.ReserveBlocks(CheckedBlockSlots(
+      reserved_block_count, block_pool.BlockSize(), "reserved"));
   try {
     if (window_block_pool_) {
-      reserved_window_blocks_ = window_block_pool_->ReserveBlocks(
-          reserved_window_block_count * window_block_pool_->BlockSize());
+      reserved_window_blocks_ = window_block_pool_->ReserveBlocks(CheckedBlockSlots(
+          reserved_window_block_count, window_block_pool_->BlockSize(),
+          "reserved window"));
     }
   } catch (...) {
     block_pool.RollbackReservedBlocks(reserved_blocks_);
@@ -229,6 +268,17 @@ PagedCacheReservation::PagedCacheReservation(
                     .get());
     }
   }
+  for (const auto& table : committed_tables) {
+    resident_table_snapshots_.push_back(ResidentTableSnapshot{
+        table.request_id_,
+        table.committed_slots_,
+        table.mutation_generation_,
+        table.blocks_.data(),
+        table.blocks_.size(),
+        table.window_blocks_.data(),
+        table.window_blocks_.size(),
+    });
+  }
   state_ = PagedCacheReservationState::Reserved;
 }
 
@@ -242,6 +292,7 @@ PagedCacheReservation::PagedCacheReservation(PagedCacheReservation&& other) noex
       deltas_{std::move(other.deltas_)},
       new_tables_{std::move(other.new_tables_)},
       advance_blocks_{std::move(other.advance_blocks_)},
+      resident_table_snapshots_{std::move(other.resident_table_snapshots_)},
       block_pool_generation_{std::exchange(other.block_pool_generation_, 0)},
       window_block_pool_generation_{std::exchange(other.window_block_pool_generation_, 0)},
       state_{std::exchange(other.state_, PagedCacheReservationState::Released)} {}
@@ -342,6 +393,7 @@ void PagedCacheReservation::ValidateCommit() const {
     throw std::logic_error(
         "Paged cache block pool ownership changed after reservation.");
   }
+  ValidateResidentTablesUnchanged();
 
   // Re-derive everything CommitValidated depends on straight from the committed cache so that a
   // change to ownership, token boundaries, delta layout, or preallocated capacity between reserve
@@ -423,7 +475,9 @@ void PagedCacheReservation::ValidateCommit() const {
 
     const size_t committed_blocks = table ? table->blocks_.size() : 0;
     const size_t total_blocks = committed_blocks + delta.reserved_block_count;
-    if (delta.target_slots > total_blocks * block_pool_->BlockSize()) {
+    if (delta.target_slots >
+        CheckedBlockSlots(
+            total_blocks, block_pool_->BlockSize(), "target")) {
       throw std::logic_error(
           "Paged cache reservation cannot reach its target token boundary.");
     }
@@ -475,6 +529,7 @@ void PagedCacheReservation::CommitValidated() {
     throw std::logic_error(
         "Paged cache block pool ownership changed after validation.");
   }
+  ValidateResidentTablesUnchanged();
   size_t preflight_new_table_index = 0;
   size_t preflight_new_table_count = 0;
   for (const auto& delta : deltas_) {
@@ -569,6 +624,27 @@ const PagedCacheReservationDelta& PagedCacheReservation::FindDelta(const void* r
     throw std::runtime_error("Request is not part of the paged cache reservation.");
   }
   return *it;
+}
+
+void PagedCacheReservation::ValidateResidentTablesUnchanged() const {
+  if (committed_tables_->size() != resident_table_snapshots_.size()) {
+    throw std::logic_error(
+        "Paged cache committed table membership changed after reservation.");
+  }
+  for (size_t index = 0; index < resident_table_snapshots_.size(); ++index) {
+    const auto& table = (*committed_tables_)[index];
+    const auto& snapshot = resident_table_snapshots_[index];
+    if (table.request_id_ != snapshot.request_id ||
+        table.committed_slots_ != snapshot.committed_slots ||
+        table.mutation_generation_ != snapshot.mutation_generation ||
+        table.blocks_.data() != snapshot.blocks_data ||
+        table.blocks_.size() != snapshot.block_count ||
+        table.window_blocks_.data() != snapshot.window_blocks_data ||
+        table.window_blocks_.size() != snapshot.window_block_count) {
+      throw std::logic_error(
+          "Paged cache committed table mapping changed after reservation.");
+    }
+  }
 }
 
 void PagedCacheReservation::ValidateAdvancePreconditions(

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <unordered_set>
 #include <utility>
 
 #include "window_ring.h"
@@ -19,6 +20,72 @@ PagedCacheBlockTable* FindTable(std::vector<PagedCacheBlockTable>& tables, const
                                  return table.request_id == request_id;
                                });
   return it == tables.end() ? nullptr : &*it;
+}
+
+std::vector<std::weak_ptr<Block>> CaptureBlockHandles(
+    const std::vector<std::shared_ptr<Block>>& blocks,
+    const BlockPool& pool,
+    std::string_view description) {
+  std::vector<std::weak_ptr<Block>> handles;
+  handles.reserve(blocks.size());
+  for (const auto& block : blocks) {
+    if (!pool.Owns(block) || block->Capacity() != pool.BlockSize()) {
+      throw std::logic_error(
+          "Paged cache " + std::string{description} + " block mapping is invalid.");
+    }
+    handles.push_back(block);
+  }
+  return handles;
+}
+
+void ValidateBlockHandles(
+    const std::vector<std::shared_ptr<Block>>& blocks,
+    std::span<const std::weak_ptr<Block>> expected_handles,
+    const BlockPool& pool,
+    std::string_view description) {
+  if (blocks.size() != expected_handles.size()) {
+    throw std::logic_error(
+        "Paged cache " + std::string{description} + " block mapping changed after reservation.");
+  }
+  for (size_t index = 0; index < blocks.size(); ++index) {
+    if (!pool.Owns(blocks[index]) ||
+        blocks[index]->Capacity() != pool.BlockSize() ||
+        expected_handles[index].lock() != blocks[index]) {
+      throw std::logic_error(
+          "Paged cache " + std::string{description} + " block mapping changed after reservation.");
+    }
+  }
+}
+
+void ValidateCommittedBlockLayout(const PagedCacheBlockTable& table, size_t block_size) {
+  size_t remaining = table.committed_slots;
+  for (const auto& block : table.blocks) {
+    if (!block || block->Capacity() != block_size) {
+      throw std::logic_error("Paged cache committed block layout is invalid.");
+    }
+    const size_t expected_size = std::min(remaining, block_size);
+    if (block->Size() != expected_size) {
+      throw std::logic_error(
+          "Paged cache block occupancy does not match the committed token boundary.");
+    }
+    remaining -= expected_size;
+  }
+  if (remaining != 0) {
+    throw std::logic_error(
+        "Paged cache committed blocks cannot represent the committed token boundary.");
+  }
+}
+
+void ValidateEmptyReservedBlocks(
+    std::span<const std::shared_ptr<Block>> blocks,
+    size_t block_size,
+    std::string_view description) {
+  for (const auto& block : blocks) {
+    if (!block || block->Capacity() != block_size || block->Size() != 0) {
+      throw std::logic_error(
+          "Paged cache " + std::string{description} + " blocks are invalid.");
+    }
+  }
 }
 
 }  // namespace
@@ -80,6 +147,25 @@ PagedCacheReservation::PagedCacheReservation(
 
     const size_t committed_slots = committed_table ? committed_table->committed_slots : 0;
     const size_t committed_blocks = committed_table ? committed_table->blocks.size() : 0;
+    std::vector<std::weak_ptr<Block>> committed_blocks_snapshot;
+    std::vector<std::weak_ptr<Block>> committed_window_blocks_snapshot;
+    if (committed_table) {
+      ValidateCommittedBlockLayout(*committed_table, block_pool.BlockSize());
+      committed_blocks_snapshot = CaptureBlockHandles(
+          committed_table->blocks, block_pool, "committed");
+      if (window_block_pool_) {
+        if (committed_table->window_blocks.size() != window_ring_blocks_) {
+          throw std::logic_error(
+              "Paged cache committed window ring has an invalid size.");
+        }
+        committed_window_blocks_snapshot = CaptureBlockHandles(
+            committed_table->window_blocks, *window_block_pool_,
+            "committed window");
+      } else if (!committed_table->window_blocks.empty()) {
+        throw std::logic_error(
+            "Paged cache committed table has unexpected window blocks.");
+      }
+    }
     if (request.target_slots < committed_slots) {
       throw std::runtime_error("Paged cache reservation cannot reduce committed slots.");
     }
@@ -97,6 +183,8 @@ PagedCacheReservation::PagedCacheReservation(
     deltas_.push_back(PagedCacheReservationDelta{
         request.request_id,
         committed_slots,
+        std::move(committed_blocks_snapshot),
+        std::move(committed_window_blocks_snapshot),
         request.target_slots,
         std::min(growth, tail_capacity),
         reserved_block_count,
@@ -223,6 +311,159 @@ void PagedCacheReservation::FillWindowBlockTable(
 }
 
 void PagedCacheReservation::Commit() {
+  ValidateCommit();
+  CommitValidated();
+}
+
+void PagedCacheReservation::ValidateCommit() const {
+  if (state_ != PagedCacheReservationState::Reserved) {
+    throw std::logic_error("Paged cache reservation can only be committed once.");
+  }
+  if (!block_pool_ || !committed_tables_) {
+    throw std::logic_error("Paged cache reservation has no owning cache.");
+  }
+  if ((window_block_pool_ == nullptr) != (window_ring_blocks_ == 0)) {
+    throw std::logic_error("Paged cache window reservation configuration is inconsistent.");
+  }
+
+  // Re-derive everything CommitValidated depends on straight from the committed cache so that a
+  // change to ownership, token boundaries, delta layout, or preallocated capacity between reserve
+  // and commit is rejected here rather than during publication.
+  size_t new_table_count = 0;
+  size_t assigned_reserved_blocks = 0;
+  size_t assigned_reserved_window_blocks = 0;
+  std::unordered_set<const void*> committed_request_ids;
+  committed_request_ids.reserve(committed_tables_->size());
+  for (const auto& table : *committed_tables_) {
+    if (!table.request_id ||
+        !committed_request_ids.insert(table.request_id).second) {
+      throw std::logic_error(
+          "Paged cache committed tables contain an invalid or duplicate request.");
+    }
+  }
+  std::vector<const void*> request_ids;
+  request_ids.reserve(deltas_.size());
+  for (const auto& delta : deltas_) {
+    if (!delta.request_id ||
+        std::find(request_ids.begin(), request_ids.end(), delta.request_id) !=
+            request_ids.end()) {
+      throw std::logic_error(
+          "Paged cache reservation contains an invalid request delta.");
+    }
+    request_ids.push_back(delta.request_id);
+
+    const auto* table = FindCommittedTable(delta.request_id);
+    if (delta.newly_admitted == (table != nullptr)) {
+      throw std::logic_error("Paged cache ownership changed after reservation.");
+    }
+    if (table && table->committed_slots != delta.committed_slots) {
+      throw std::logic_error(
+          "Paged cache token boundary changed after reservation.");
+    }
+    if (table) {
+      ValidateCommittedBlockLayout(*table, block_pool_->BlockSize());
+      ValidateBlockHandles(
+          table->blocks, delta.committed_blocks, *block_pool_,
+          "committed");
+      if (window_block_pool_) {
+        ValidateBlockHandles(
+            table->window_blocks, delta.committed_window_blocks,
+            *window_block_pool_, "committed window");
+      } else if (!table->window_blocks.empty() ||
+                 !delta.committed_window_blocks.empty()) {
+        throw std::logic_error(
+            "Paged cache committed table has unexpected window blocks.");
+      }
+    }
+
+    // The delta must consume exactly its own contiguous slice of the reserved block and window
+    // block pools, in order, and never grow below the already-committed boundary.
+    if (delta.target_slots < delta.committed_slots ||
+        delta.reserved_block_offset != assigned_reserved_blocks ||
+        assigned_reserved_blocks > reserved_blocks_.size() ||
+        delta.reserved_block_count >
+            reserved_blocks_.size() - assigned_reserved_blocks ||
+        delta.reserved_window_block_offset != assigned_reserved_window_blocks ||
+        assigned_reserved_window_blocks > reserved_window_blocks_.size() ||
+        delta.reserved_window_block_count >
+            reserved_window_blocks_.size() - assigned_reserved_window_blocks) {
+      throw std::logic_error("Paged cache reservation delta is inconsistent.");
+    }
+
+    ValidateEmptyReservedBlocks(
+        std::span<const std::shared_ptr<Block>>{reserved_blocks_}.subspan(
+            assigned_reserved_blocks, delta.reserved_block_count),
+        block_pool_->BlockSize(), "reserved");
+    for (const auto& block :
+         std::span<const std::shared_ptr<Block>>{reserved_blocks_}.subspan(
+             assigned_reserved_blocks, delta.reserved_block_count)) {
+      if (!block_pool_->Owns(block)) {
+        throw std::logic_error(
+            "Paged cache reserved blocks are not owned by the block pool.");
+      }
+    }
+    if (window_block_pool_) {
+      const auto reserved_window_blocks =
+          std::span<const std::shared_ptr<Block>>{reserved_window_blocks_}.subspan(
+              assigned_reserved_window_blocks, delta.reserved_window_block_count);
+      ValidateEmptyReservedBlocks(
+          reserved_window_blocks,
+          window_block_pool_->BlockSize(), "reserved window");
+      for (const auto& block : reserved_window_blocks) {
+        if (!window_block_pool_->Owns(block)) {
+          throw std::logic_error(
+              "Paged cache reserved window blocks are not owned by the window block pool.");
+        }
+      }
+    }
+
+    const size_t committed_blocks = table ? table->blocks.size() : 0;
+    const size_t total_blocks = committed_blocks + delta.reserved_block_count;
+    if (delta.target_slots > total_blocks * block_pool_->BlockSize()) {
+      throw std::logic_error(
+          "Paged cache reservation cannot reach its target token boundary.");
+    }
+    // Existing tables must already have room for the appended blocks so CommitValidated's insert
+    // cannot reallocate. New tables preallocated their capacity at reservation time.
+    if (table && table->blocks.capacity() < total_blocks) {
+      throw std::logic_error(
+          "Paged cache reservation did not preallocate commit capacity.");
+    }
+
+    assigned_reserved_blocks += delta.reserved_block_count;
+    assigned_reserved_window_blocks += delta.reserved_window_block_count;
+    new_table_count += delta.newly_admitted ? 1 : 0;
+  }
+
+  if (assigned_reserved_blocks != reserved_blocks_.size() ||
+      assigned_reserved_window_blocks != reserved_window_blocks_.size() ||
+      new_table_count != new_tables_.size() ||
+      committed_tables_->capacity() <
+          committed_tables_->size() + new_table_count) {
+    throw std::logic_error(
+        "Paged cache reservation commit resources are inconsistent.");
+  }
+}
+
+// Publication path for a reservation that ValidateCommit has already accepted. It only moves
+// shared_ptr block handles and preallocated tables into the committed cache; ValidateCommit
+// guarantees the reserved-block/table spans indexed below and both insert capacities, so none of
+// the block/table moves reallocate or touch the device. (The AdvanceCommittedSlots slot walk relies
+// on the same UsedSlots == committed_slots invariant the whole reservation model maintains, which
+// ValidateCommit re-derives via the token-boundary and target-reachability checks.) The one caveat
+// is committed_tables_->push_back, whose headroom was reserved by the constructor and rechecked by
+// ValidateCommit. It is deliberately not marked noexcept: the std::vector insert/push_back and .at()
+// calls it relies on are not themselves noexcept-declared, so marking it noexcept would turn any
+// unexpected precondition violation into std::terminate instead of a catchable failure the Engine
+// can surface as unhealthy. Keeping it potentially-throwing is the safest honest signature while
+// still contributing no new fallible work of its own.
+void PagedCacheReservation::CommitValidated() {
+  // The one precondition re-checked here: publishing twice would walk cleared reserved-block spans
+  // with stale delta offsets, which is undefined behavior rather than a catchable error. This is a
+  // state-only comparison performed before any mutation, so it introduces no allocation or
+  // device work and never leaves a half-published reservation. It intentionally does NOT re-run the
+  // ownership, boundary, or capacity checks -- those belong to ValidateCommit and a composite
+  // transaction runs them for every reservation up front.
   if (state_ != PagedCacheReservationState::Reserved) {
     throw std::logic_error("Paged cache reservation can only be committed once.");
   }
@@ -230,8 +471,15 @@ void PagedCacheReservation::Commit() {
   size_t new_table_index = 0;
   for (const auto& delta : deltas_) {
     PagedCacheBlockTable* table = FindTable(*committed_tables_, delta.request_id);
-    if (!table) {
+    if (delta.newly_admitted) {
+      if (table) {
+        throw std::logic_error(
+            "Paged cache ownership changed after validation.");
+      }
       table = &new_tables_.at(new_table_index++);
+    } else if (!table) {
+      throw std::logic_error(
+          "Paged cache ownership changed after validation.");
     }
 
     const auto first = reserved_blocks_.begin() + static_cast<ptrdiff_t>(delta.reserved_block_offset);

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -17,63 +17,9 @@ namespace {
 PagedCacheBlockTable* FindTable(std::vector<PagedCacheBlockTable>& tables, const void* request_id) {
   const auto it = std::find_if(tables.begin(), tables.end(),
                                [request_id](const PagedCacheBlockTable& table) {
-                                 return table.request_id == request_id;
+                                 return table.RequestId() == request_id;
                                });
   return it == tables.end() ? nullptr : &*it;
-}
-
-std::vector<std::weak_ptr<Block>> CaptureBlockHandles(
-    const std::vector<std::shared_ptr<Block>>& blocks,
-    const BlockPool& pool,
-    std::string_view description) {
-  std::vector<std::weak_ptr<Block>> handles;
-  handles.reserve(blocks.size());
-  for (const auto& block : blocks) {
-    if (!pool.Owns(block) || block->Capacity() != pool.BlockSize()) {
-      throw std::logic_error(
-          "Paged cache " + std::string{description} + " block mapping is invalid.");
-    }
-    handles.push_back(block);
-  }
-  return handles;
-}
-
-void ValidateBlockHandles(
-    const std::vector<std::shared_ptr<Block>>& blocks,
-    std::span<const std::weak_ptr<Block>> expected_handles,
-    const BlockPool& pool,
-    std::string_view description) {
-  if (blocks.size() != expected_handles.size()) {
-    throw std::logic_error(
-        "Paged cache " + std::string{description} + " block mapping changed after reservation.");
-  }
-  for (size_t index = 0; index < blocks.size(); ++index) {
-    if (!pool.Owns(blocks[index]) ||
-        blocks[index]->Capacity() != pool.BlockSize() ||
-        expected_handles[index].lock() != blocks[index]) {
-      throw std::logic_error(
-          "Paged cache " + std::string{description} + " block mapping changed after reservation.");
-    }
-  }
-}
-
-void ValidateCommittedBlockLayout(const PagedCacheBlockTable& table, size_t block_size) {
-  size_t remaining = table.committed_slots;
-  for (const auto& block : table.blocks) {
-    if (!block || block->Capacity() != block_size) {
-      throw std::logic_error("Paged cache committed block layout is invalid.");
-    }
-    const size_t expected_size = std::min(remaining, block_size);
-    if (block->Size() != expected_size) {
-      throw std::logic_error(
-          "Paged cache block occupancy does not match the committed token boundary.");
-    }
-    remaining -= expected_size;
-  }
-  if (remaining != 0) {
-    throw std::logic_error(
-        "Paged cache committed blocks cannot represent the committed token boundary.");
-  }
 }
 
 void ValidateEmptyReservedBlocks(
@@ -98,15 +44,15 @@ void RemovePagedCacheBlockTable(
   const auto table = std::find_if(
       committed_tables.begin(), committed_tables.end(),
       [request_id](const PagedCacheBlockTable& candidate) {
-        return candidate.request_id == request_id;
+        return candidate.RequestId() == request_id;
       });
   if (table == committed_tables.end()) {
     return;
   }
 
-  block_pool.Free(table->blocks);
+  block_pool.Free(table->Blocks());
   if (window_block_pool) {
-    window_block_pool->Free(table->window_blocks);
+    window_block_pool->Free(table->WindowBlocks());
   }
   committed_tables.erase(table);
 }
@@ -130,6 +76,9 @@ PagedCacheReservation::PagedCacheReservation(
 
   size_t reserved_block_count = 0;
   size_t reserved_window_block_count = 0;
+  size_t advance_block_count = 0;
+  std::unordered_set<const Block*> touched_committed_blocks;
+  std::unordered_set<const Block*> resident_window_blocks;
   for (const auto& request : requests) {
     const bool duplicate_request =
         std::any_of(deltas_.begin(), deltas_.end(),
@@ -145,32 +94,62 @@ PagedCacheReservation::PagedCacheReservation(
       throw std::runtime_error("Paged cache reservation request membership does not match the committed cache.");
     }
 
-    const size_t committed_slots = committed_table ? committed_table->committed_slots : 0;
-    const size_t committed_blocks = committed_table ? committed_table->blocks.size() : 0;
-    std::vector<std::weak_ptr<Block>> committed_blocks_snapshot;
-    std::vector<std::weak_ptr<Block>> committed_window_blocks_snapshot;
-    if (committed_table) {
-      ValidateCommittedBlockLayout(*committed_table, block_pool.BlockSize());
-      committed_blocks_snapshot = CaptureBlockHandles(
-          committed_table->blocks, block_pool, "committed");
-      if (window_block_pool_) {
-        if (committed_table->window_blocks.size() != window_ring_blocks_) {
-          throw std::logic_error(
-              "Paged cache committed window ring has an invalid size.");
-        }
-        committed_window_blocks_snapshot = CaptureBlockHandles(
-            committed_table->window_blocks, *window_block_pool_,
-            "committed window");
-      } else if (!committed_table->window_blocks.empty()) {
-        throw std::logic_error(
-            "Paged cache committed table has unexpected window blocks.");
-      }
-    }
+    const size_t committed_slots = committed_table ? committed_table->committed_slots_ : 0;
+    const size_t committed_blocks = committed_table ? committed_table->blocks_.size() : 0;
+    const uint64_t table_generation =
+        committed_table ? committed_table->mutation_generation_ : 0;
     if (request.target_slots < committed_slots) {
       throw std::runtime_error("Paged cache reservation cannot reduce committed slots.");
     }
+    if (committed_table) {
+      if (window_block_pool_) {
+        if (committed_table->window_blocks_.size() != window_ring_blocks_) {
+          throw std::logic_error(
+              "Paged cache resident window ring has an invalid size.");
+        }
+        for (const auto& block : committed_table->window_blocks_) {
+          if (!window_block_pool_->Owns(block) ||
+              block->Capacity() != window_block_pool_->BlockSize()) {
+            throw std::logic_error(
+                "Paged cache resident window ring contains an invalid block.");
+          }
+          if (!resident_window_blocks.insert(block.get()).second) {
+            throw std::logic_error(
+                "Paged cache resident window rings cannot share a physical block.");
+          }
+        }
+      } else if (!committed_table->window_blocks_.empty()) {
+        throw std::logic_error(
+            "Paged cache without a window pool cannot own window blocks.");
+      }
+    }
 
     const size_t committed_capacity = committed_blocks * block_pool.BlockSize();
+    if (committed_slots > committed_capacity) {
+      throw std::logic_error(
+          "Paged cache committed boundary exceeds its block capacity.");
+    }
+    if (committed_table && request.target_slots > committed_slots) {
+      const size_t block_size = block_pool.BlockSize();
+      const size_t first_block = committed_slots / block_size;
+      const size_t end_block = std::min(
+          committed_blocks,
+          (request.target_slots + block_size - 1) / block_size);
+      for (size_t block_index = first_block; block_index < end_block; ++block_index) {
+        const auto& block = committed_table->blocks_[block_index];
+        const size_t expected_size =
+            block_index == first_block ? committed_slots % block_size : 0;
+        if (!block_pool.Owns(block) || block->Capacity() != block_size ||
+            block->Size() != expected_size) {
+          throw std::logic_error(
+              "Paged cache block occupancy is inconsistent with its committed boundary.");
+        }
+        if (!touched_committed_blocks.insert(block.get()).second) {
+          throw std::logic_error(
+              "Paged cache growth cannot share a physical block.");
+        }
+      }
+    }
     // Blocks are taken for the whole sequence so that a chunked prefill cannot lose the rest of its
     // capacity to another request between steps, but only target_slots is committed below.
     const size_t reserved_slots = std::max(request.reserved_slots, request.target_slots);
@@ -179,32 +158,40 @@ PagedCacheReservation::PagedCacheReservation(
     const size_t new_blocks = block_pool.BlocksNeeded(additional_slots);
     const size_t tail_capacity = committed_capacity - committed_slots;
     const size_t growth = request.target_slots - committed_slots;
+    const size_t first_advance_block = committed_slots / block_pool.BlockSize();
+    const size_t past_last_advance_block =
+        request.target_slots / block_pool.BlockSize() +
+        (request.target_slots % block_pool.BlockSize() != 0);
+    const size_t request_advance_blocks =
+        past_last_advance_block - first_advance_block;
 
     deltas_.push_back(PagedCacheReservationDelta{
         request.request_id,
         committed_slots,
-        std::move(committed_blocks_snapshot),
-        std::move(committed_window_blocks_snapshot),
+        table_generation,
         request.target_slots,
         std::min(growth, tail_capacity),
         reserved_block_count,
         new_blocks,
         reserved_window_block_count,
         request.newly_admitted ? window_ring_blocks_ : 0,
+        advance_block_count,
+        request_advance_blocks,
         request.newly_admitted,
     });
     reserved_block_count += new_blocks;
+    advance_block_count += request_advance_blocks;
     if (request.newly_admitted) {
       reserved_window_block_count += window_ring_blocks_;
     }
 
     if (committed_table) {
-      committed_table->blocks.reserve(committed_blocks + new_blocks);
+      committed_table->blocks_.reserve(committed_blocks + new_blocks);
     } else {
       PagedCacheBlockTable table;
-      table.request_id = request.request_id;
-      table.blocks.reserve(new_blocks);
-      table.window_blocks.reserve(window_ring_blocks_);
+      table.request_id_ = request.request_id;
+      table.blocks_.reserve(new_blocks);
+      table.window_blocks_.reserve(window_ring_blocks_);
       new_tables_.push_back(std::move(table));
     }
   }
@@ -216,10 +203,34 @@ PagedCacheReservation::PagedCacheReservation(
     throw std::runtime_error("Not enough free window blocks for the complete paged cache reservation.");
   }
 
+  advance_blocks_.reserve(advance_block_count);
   reserved_blocks_ = block_pool.ReserveBlocks(reserved_block_count * block_pool.BlockSize());
-  if (window_block_pool_) {
-    reserved_window_blocks_ = window_block_pool_->ReserveBlocks(
-        reserved_window_block_count * window_block_pool_->BlockSize());
+  try {
+    if (window_block_pool_) {
+      reserved_window_blocks_ = window_block_pool_->ReserveBlocks(
+          reserved_window_block_count * window_block_pool_->BlockSize());
+    }
+  } catch (...) {
+    block_pool.RollbackReservedBlocks(reserved_blocks_);
+    reserved_blocks_.clear();
+    throw;
+  }
+  block_pool_generation_ = block_pool_->MutationGeneration();
+  window_block_pool_generation_ =
+      window_block_pool_ ? window_block_pool_->MutationGeneration() : 0;
+  for (const auto& delta : deltas_) {
+    const auto* table = FindCommittedTable(delta.request_id);
+    const size_t committed_blocks = table ? table->blocks_.size() : 0;
+    const size_t first_block = delta.committed_slots / block_pool_->BlockSize();
+    for (size_t i = 0; i < delta.advance_block_count; ++i) {
+      const size_t block_index = first_block + i;
+      advance_blocks_.push_back(
+          block_index < committed_blocks
+              ? table->blocks_[block_index].get()
+              : reserved_blocks_[delta.reserved_block_offset +
+                                 block_index - committed_blocks]
+                    .get());
+    }
   }
   state_ = PagedCacheReservationState::Reserved;
 }
@@ -233,6 +244,9 @@ PagedCacheReservation::PagedCacheReservation(PagedCacheReservation&& other) noex
       reserved_window_blocks_{std::move(other.reserved_window_blocks_)},
       deltas_{std::move(other.deltas_)},
       new_tables_{std::move(other.new_tables_)},
+      advance_blocks_{std::move(other.advance_blocks_)},
+      block_pool_generation_{std::exchange(other.block_pool_generation_, 0)},
+      window_block_pool_generation_{std::exchange(other.window_block_pool_generation_, 0)},
       state_{std::exchange(other.state_, PagedCacheReservationState::Released)} {}
 
 PagedCacheReservation::~PagedCacheReservation() {
@@ -245,7 +259,7 @@ size_t PagedCacheReservation::RequiredBlockTableColumns() const {
   size_t columns = 0;
   for (const auto& delta : deltas_) {
     const auto* table = FindCommittedTable(delta.request_id);
-    const size_t committed_blocks = table ? table->blocks.size() : 0;
+    const size_t committed_blocks = table ? table->blocks_.size() : 0;
     columns = std::max(columns, committed_blocks + delta.reserved_block_count);
   }
   return columns;
@@ -273,7 +287,7 @@ void PagedCacheReservation::FillBlockTable(std::span<const void* const> request_
     const auto* table = FindCommittedTable(request_ids[row]);
     size_t column = 0;
     if (table) {
-      for (const auto& block : table->blocks) {
+      for (const auto& block : table->blocks_) {
         output[row * columns + column++] = static_cast<int32_t>(block->Id());
       }
     }
@@ -302,7 +316,7 @@ void PagedCacheReservation::FillWindowBlockTable(
     for (size_t column = 0; column < columns; ++column) {
       const size_t ring_column = WindowRingColumn(column, window_ring_blocks_);
       const auto& block = table
-                              ? table->window_blocks.at(ring_column)
+                              ? table->window_blocks_.at(ring_column)
                               : reserved_window_blocks_.at(
                                     delta.reserved_window_block_offset + ring_column);
       output[row * columns + column] = static_cast<int32_t>(block->Id());
@@ -325,6 +339,12 @@ void PagedCacheReservation::ValidateCommit() const {
   if ((window_block_pool_ == nullptr) != (window_ring_blocks_ == 0)) {
     throw std::logic_error("Paged cache window reservation configuration is inconsistent.");
   }
+  if (block_pool_->MutationGeneration() != block_pool_generation_ ||
+      (window_block_pool_ &&
+       window_block_pool_->MutationGeneration() != window_block_pool_generation_)) {
+    throw std::logic_error(
+        "Paged cache block pool ownership changed after reservation.");
+  }
 
   // Re-derive everything CommitValidated depends on straight from the committed cache so that a
   // change to ownership, token boundaries, delta layout, or preallocated capacity between reserve
@@ -335,8 +355,8 @@ void PagedCacheReservation::ValidateCommit() const {
   std::unordered_set<const void*> committed_request_ids;
   committed_request_ids.reserve(committed_tables_->size());
   for (const auto& table : *committed_tables_) {
-    if (!table.request_id ||
-        !committed_request_ids.insert(table.request_id).second) {
+    if (!table.request_id_ ||
+        !committed_request_ids.insert(table.request_id_).second) {
       throw std::logic_error(
           "Paged cache committed tables contain an invalid or duplicate request.");
     }
@@ -356,24 +376,11 @@ void PagedCacheReservation::ValidateCommit() const {
     if (delta.newly_admitted == (table != nullptr)) {
       throw std::logic_error("Paged cache ownership changed after reservation.");
     }
-    if (table && table->committed_slots != delta.committed_slots) {
+    if (table &&
+        (table->committed_slots_ != delta.committed_slots ||
+         table->mutation_generation_ != delta.table_generation)) {
       throw std::logic_error(
-          "Paged cache token boundary changed after reservation.");
-    }
-    if (table) {
-      ValidateCommittedBlockLayout(*table, block_pool_->BlockSize());
-      ValidateBlockHandles(
-          table->blocks, delta.committed_blocks, *block_pool_,
-          "committed");
-      if (window_block_pool_) {
-        ValidateBlockHandles(
-            table->window_blocks, delta.committed_window_blocks,
-            *window_block_pool_, "committed window");
-      } else if (!table->window_blocks.empty() ||
-                 !delta.committed_window_blocks.empty()) {
-        throw std::logic_error(
-            "Paged cache committed table has unexpected window blocks.");
-      }
+          "Paged cache committed state changed after reservation.");
     }
 
     // The delta must consume exactly its own contiguous slice of the reserved block and window
@@ -417,7 +424,7 @@ void PagedCacheReservation::ValidateCommit() const {
       }
     }
 
-    const size_t committed_blocks = table ? table->blocks.size() : 0;
+    const size_t committed_blocks = table ? table->blocks_.size() : 0;
     const size_t total_blocks = committed_blocks + delta.reserved_block_count;
     if (delta.target_slots > total_blocks * block_pool_->BlockSize()) {
       throw std::logic_error(
@@ -425,10 +432,13 @@ void PagedCacheReservation::ValidateCommit() const {
     }
     // Existing tables must already have room for the appended blocks so CommitValidated's insert
     // cannot reallocate. New tables preallocated their capacity at reservation time.
-    if (table && table->blocks.capacity() < total_blocks) {
+    if (table && table->blocks_.capacity() < total_blocks) {
       throw std::logic_error(
           "Paged cache reservation did not preallocate commit capacity.");
     }
+    const auto& target_table =
+        table ? *table : new_tables_.at(new_table_count);
+    ValidateAdvancePreconditions(delta, target_table);
 
     assigned_reserved_blocks += delta.reserved_block_count;
     assigned_reserved_window_blocks += delta.reserved_window_block_count;
@@ -447,49 +457,75 @@ void PagedCacheReservation::ValidateCommit() const {
 
 // Publication path for a reservation that ValidateCommit has already accepted. It only moves
 // shared_ptr block handles and preallocated tables into the committed cache; ValidateCommit
-// guarantees the reserved-block/table spans indexed below and both insert capacities, so none of
-// the block/table moves reallocate or touch the device. (The AdvanceCommittedSlots slot walk relies
-// on the same UsedSlots == committed_slots invariant the whole reservation model maintains, which
-// ValidateCommit re-derives via the token-boundary and target-reachability checks.) The one caveat
-// is committed_tables_->push_back, whose headroom was reserved by the constructor and rechecked by
-// ValidateCommit. It is deliberately not marked noexcept: the std::vector insert/push_back and .at()
-// calls it relies on are not themselves noexcept-declared, so marking it noexcept would turn any
-// unexpected precondition violation into std::terminate instead of a catchable failure the Engine
-// can surface as unhealthy. Keeping it potentially-throwing is the safest honest signature while
-// still contributing no new fallible work of its own.
+// guarantees the reserved-block/table spans indexed below, the occupancy of every block the current
+// growth touches, and both insert capacities, so none of the block/table moves reallocate or touch
+// the device. The one caveat is committed_tables_->push_back, whose headroom was reserved by the
+// constructor and rechecked by ValidateCommit. It is deliberately not marked noexcept: the
+// std::vector insert/push_back and .at() calls it relies on are not themselves noexcept-declared, so
+// marking it noexcept would turn any unexpected precondition violation into std::terminate instead
+// of a catchable failure the Engine can surface as unhealthy. Keeping it potentially-throwing is the
+// safest honest signature while still contributing no new fallible work of its own.
 void PagedCacheReservation::CommitValidated() {
-  // The one precondition re-checked here: publishing twice would walk cleared reserved-block spans
-  // with stale delta offsets, which is undefined behavior rather than a catchable error. This is a
-  // state-only comparison performed before any mutation, so it introduces no allocation or
-  // device work and never leaves a half-published reservation. It intentionally does NOT re-run the
-  // ownership, boundary, or capacity checks -- those belong to ValidateCommit and a composite
-  // transaction runs them for every reservation up front.
   if (state_ != PagedCacheReservationState::Reserved) {
     throw std::logic_error("Paged cache reservation can only be committed once.");
+  }
+
+  // Preflight every ownership/generation check before mutating the first table. A later mismatch
+  // must never surface after an earlier request has already published.
+  if (block_pool_->MutationGeneration() != block_pool_generation_ ||
+      (window_block_pool_ &&
+       window_block_pool_->MutationGeneration() != window_block_pool_generation_)) {
+    throw std::logic_error(
+        "Paged cache block pool ownership changed after validation.");
+  }
+  size_t preflight_new_table_index = 0;
+  size_t preflight_new_table_count = 0;
+  for (const auto& delta : deltas_) {
+    const auto* table = FindCommittedTable(delta.request_id);
+    if (delta.newly_admitted) {
+      if (table) {
+        throw std::logic_error(
+            "Paged cache ownership changed after validation.");
+      }
+    } else if (!table ||
+               table->mutation_generation_ != delta.table_generation ||
+               table->committed_slots_ != delta.committed_slots) {
+      throw std::logic_error(
+          "Paged cache committed state changed after validation.");
+    }
+    const auto& target_table =
+        table ? *table : new_tables_.at(preflight_new_table_index++);
+    if (table &&
+        table->blocks_.capacity() <
+            table->blocks_.size() + delta.reserved_block_count) {
+      throw std::logic_error(
+          "Paged cache reservation lost preallocated commit capacity after validation.");
+    }
+    preflight_new_table_count += delta.newly_admitted ? 1 : 0;
+    ValidateAdvancePreconditions(delta, target_table);
+  }
+  if (committed_tables_->capacity() <
+      committed_tables_->size() + preflight_new_table_count) {
+    throw std::logic_error(
+        "Paged cache reservation lost table capacity after validation.");
   }
 
   size_t new_table_index = 0;
   for (const auto& delta : deltas_) {
     PagedCacheBlockTable* table = FindTable(*committed_tables_, delta.request_id);
     if (delta.newly_admitted) {
-      if (table) {
-        throw std::logic_error(
-            "Paged cache ownership changed after validation.");
-      }
       table = &new_tables_.at(new_table_index++);
-    } else if (!table) {
-      throw std::logic_error(
-          "Paged cache ownership changed after validation.");
     }
 
     const auto first = reserved_blocks_.begin() + static_cast<ptrdiff_t>(delta.reserved_block_offset);
-    table->blocks.insert(table->blocks.end(), first, first + static_cast<ptrdiff_t>(delta.reserved_block_count));
+    table->blocks_.insert(table->blocks_.end(), first, first + static_cast<ptrdiff_t>(delta.reserved_block_count));
     const auto window_first = reserved_window_blocks_.begin() +
                               static_cast<ptrdiff_t>(delta.reserved_window_block_offset);
-    table->window_blocks.insert(
-        table->window_blocks.end(), window_first,
+    table->window_blocks_.insert(
+        table->window_blocks_.end(), window_first,
         window_first + static_cast<ptrdiff_t>(delta.reserved_window_block_count));
     AdvanceCommittedSlots(*table, delta.target_slots);
+    ++table->mutation_generation_;
 
     if (delta.newly_admitted) {
       committed_tables_->push_back(std::move(*table));
@@ -499,6 +535,7 @@ void PagedCacheReservation::CommitValidated() {
   reserved_blocks_.clear();
   reserved_window_blocks_.clear();
   new_tables_.clear();
+  advance_blocks_.clear();
   state_ = PagedCacheReservationState::Committed;
 }
 
@@ -517,6 +554,7 @@ void PagedCacheReservation::Release() {
   reserved_blocks_.clear();
   reserved_window_blocks_.clear();
   new_tables_.clear();
+  advance_blocks_.clear();
   state_ = PagedCacheReservationState::Released;
 }
 
@@ -536,16 +574,53 @@ const PagedCacheReservationDelta& PagedCacheReservation::FindDelta(const void* r
   return *it;
 }
 
-void PagedCacheReservation::AdvanceCommittedSlots(PagedCacheBlockTable& table, size_t target_slots) {
-  size_t remaining = target_slots - table.committed_slots;
-  size_t block_index = table.committed_slots / block_pool_->BlockSize();
+void PagedCacheReservation::ValidateAdvancePreconditions(
+    const PagedCacheReservationDelta& delta,
+    const PagedCacheBlockTable& table) const {
+  const size_t block_size = block_pool_->BlockSize();
+  size_t remaining = delta.target_slots - delta.committed_slots;
+  size_t block_index = delta.committed_slots / block_size;
+  const size_t first_block_index = block_index;
   while (remaining > 0) {
-    auto& block = table.blocks.at(block_index++);
+    const std::shared_ptr<Block>* block{};
+    if (block_index < table.blocks_.size()) {
+      block = &table.blocks_[block_index];
+    } else {
+      const size_t reserved_index = block_index - table.blocks_.size();
+      if (reserved_index >= delta.reserved_block_count) {
+        throw std::logic_error(
+            "Paged cache reservation cannot reach its target token boundary.");
+      }
+      block = &reserved_blocks_.at(delta.reserved_block_offset + reserved_index);
+    }
+
+    const size_t expected_size =
+        block_index == first_block_index ? delta.committed_slots % block_size : 0;
+    if (!*block || (*block)->Capacity() != block_size ||
+        (*block)->Size() != expected_size ||
+        block_index - first_block_index >= delta.advance_block_count ||
+        block->get() !=
+            advance_blocks_.at(delta.advance_block_offset +
+                               block_index - first_block_index)) {
+      throw std::logic_error(
+          "Paged cache block mapping or occupancy changed after reservation.");
+    }
+    const size_t slots = std::min(remaining, block_size - expected_size);
+    remaining -= slots;
+    ++block_index;
+  }
+}
+
+void PagedCacheReservation::AdvanceCommittedSlots(PagedCacheBlockTable& table, size_t target_slots) {
+  size_t remaining = target_slots - table.committed_slots_;
+  size_t block_index = table.committed_slots_ / block_pool_->BlockSize();
+  while (remaining > 0) {
+    auto& block = table.blocks_.at(block_index++);
     const size_t slots = std::min(remaining, block->EmptySlots());
     block->AddSlots(slots);
     remaining -= slots;
   }
-  table.committed_slots = target_slots;
+  table.committed_slots_ = target_slots;
 }
 
 }  // namespace Generators

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -47,6 +47,17 @@ size_t CheckedBlockSlots(
   return block_count * block_size;
 }
 
+size_t CheckedAdd(
+    size_t left,
+    size_t right,
+    std::string_view description) {
+  if (right > std::numeric_limits<size_t>::max() - left) {
+    throw std::overflow_error(
+        "Paged cache " + std::string{description} + " overflow.");
+  }
+  return left + right;
+}
+
 }  // namespace
 
 PagedCacheBlockTable& PagedCacheBlockTable::operator=(
@@ -107,7 +118,8 @@ PagedCacheReservation::PagedCacheReservation(
   }
   deltas_.reserve(requests.size());
   new_tables_.reserve(requests.size());
-  committed_tables.reserve(committed_tables.size() + requests.size());
+  committed_tables.reserve(CheckedAdd(
+      committed_tables.size(), requests.size(), "table capacity"));
 
   size_t reserved_block_count = 0;
   size_t reserved_window_block_count = 0;
@@ -169,8 +181,7 @@ PagedCacheReservation::PagedCacheReservation(
       const size_t block_size = block_pool.BlockSize();
       const size_t first_block = committed_slots / block_size;
       const size_t end_block = std::min(
-          committed_blocks,
-          (request.target_slots + block_size - 1) / block_size);
+          committed_blocks, block_pool.BlocksNeeded(request.target_slots));
       for (size_t block_index = first_block; block_index < end_block; ++block_index) {
         const auto& block = committed_table->blocks_[block_index];
         const size_t expected_size =
@@ -212,14 +223,20 @@ PagedCacheReservation::PagedCacheReservation(
         request_advance_blocks,
         request.newly_admitted,
     });
-    reserved_block_count += new_blocks;
-    advance_block_count += request_advance_blocks;
+    reserved_block_count = CheckedAdd(
+        reserved_block_count, new_blocks, "reserved block count");
+    advance_block_count = CheckedAdd(
+        advance_block_count, request_advance_blocks,
+        "advance block count");
     if (request.newly_admitted) {
-      reserved_window_block_count += window_ring_blocks_;
+      reserved_window_block_count = CheckedAdd(
+          reserved_window_block_count, window_ring_blocks_,
+          "reserved window block count");
     }
 
     if (committed_table) {
-      committed_table->blocks_.reserve(committed_blocks + new_blocks);
+      committed_table->blocks_.reserve(CheckedAdd(
+          committed_blocks, new_blocks, "committed block capacity"));
     } else {
       PagedCacheBlockTable table;
       table.request_id_ = request.request_id;
@@ -474,7 +491,9 @@ void PagedCacheReservation::ValidateCommit() const {
     }
 
     const size_t committed_blocks = table ? table->blocks_.size() : 0;
-    const size_t total_blocks = committed_blocks + delta.reserved_block_count;
+    const size_t total_blocks = CheckedAdd(
+        committed_blocks, delta.reserved_block_count,
+        "target block capacity");
     if (delta.target_slots >
         CheckedBlockSlots(
             total_blocks, block_pool_->BlockSize(), "target")) {
@@ -499,8 +518,8 @@ void PagedCacheReservation::ValidateCommit() const {
   if (assigned_reserved_blocks != reserved_blocks_.size() ||
       assigned_reserved_window_blocks != reserved_window_blocks_.size() ||
       new_table_count != new_tables_.size() ||
-      committed_tables_->capacity() <
-          committed_tables_->size() + new_table_count) {
+      new_table_count >
+          committed_tables_->capacity() - committed_tables_->size()) {
     throw std::logic_error(
         "Paged cache reservation commit resources are inconsistent.");
   }
@@ -548,16 +567,16 @@ void PagedCacheReservation::CommitValidated() {
     const auto& target_table =
         table ? *table : new_tables_.at(preflight_new_table_index++);
     if (table &&
-        table->blocks_.capacity() <
-            table->blocks_.size() + delta.reserved_block_count) {
+        delta.reserved_block_count >
+            table->blocks_.capacity() - table->blocks_.size()) {
       throw std::logic_error(
           "Paged cache reservation lost preallocated commit capacity after validation.");
     }
     preflight_new_table_count += delta.newly_admitted ? 1 : 0;
     ValidateAdvancePreconditions(delta, target_table);
   }
-  if (committed_tables_->capacity() <
-      committed_tables_->size() + preflight_new_table_count) {
+  if (preflight_new_table_count >
+      committed_tables_->capacity() - committed_tables_->size()) {
     throw std::logic_error(
         "Paged cache reservation lost table capacity after validation.");
   }

--- a/src/engine/paged_cache_reservation.h
+++ b/src/engine/paged_cache_reservation.h
@@ -97,7 +97,6 @@ struct PagedCacheReservationDelta {
   size_t committed_slots{};
   uint64_t table_generation{};
   size_t target_slots{};
-  size_t tail_slots_to_consume{};
   size_t reserved_block_offset{};
   size_t reserved_block_count{};
   size_t reserved_window_block_offset{};

--- a/src/engine/paged_cache_reservation.h
+++ b/src/engine/paged_cache_reservation.h
@@ -39,39 +39,6 @@ class PagedCacheBlockTable {
   const std::vector<std::shared_ptr<Block>>& WindowBlocks() const { return window_blocks_; }
   uint64_t MutationGeneration() const { return mutation_generation_; }
 
-  void SetCommittedSlots(size_t committed_slots) {
-    committed_slots_ = committed_slots;
-    ++mutation_generation_;
-  }
-  void SwapCommittedBlocks(size_t left, size_t right) {
-    auto& left_block = blocks_.at(left);
-    auto& right_block = blocks_.at(right);
-    std::swap(left_block, right_block);
-    ++mutation_generation_;
-  }
-  void ReplaceCommittedBlock(size_t index, std::shared_ptr<Block> block) {
-    blocks_.at(index) = std::move(block);
-    ++mutation_generation_;
-  }
-  void ReplaceCommittedBlocks(std::vector<std::shared_ptr<Block>> blocks) {
-    blocks_ = std::move(blocks);
-    ++mutation_generation_;
-  }
-  void ShrinkCommittedBlockCapacity() {
-    blocks_.shrink_to_fit();
-    ++mutation_generation_;
-  }
-  void SwapWindowBlocks(size_t left, size_t right) {
-    auto& left_block = window_blocks_.at(left);
-    auto& right_block = window_blocks_.at(right);
-    std::swap(left_block, right_block);
-    ++mutation_generation_;
-  }
-  void ReplaceWindowBlocks(std::vector<std::shared_ptr<Block>> blocks) {
-    window_blocks_ = std::move(blocks);
-    ++mutation_generation_;
-  }
-
  private:
   friend class PagedCacheReservation;
   friend struct PagedKeyValueCache;

--- a/src/engine/paged_cache_reservation.h
+++ b/src/engine/paged_cache_reservation.h
@@ -28,6 +28,10 @@ class PagedCacheBlockTable {
         committed_slots_{committed_slots},
         blocks_{std::move(blocks)},
         window_blocks_{std::move(window_blocks)} {}
+  PagedCacheBlockTable(const PagedCacheBlockTable&) = default;
+  PagedCacheBlockTable(PagedCacheBlockTable&&) noexcept = default;
+  PagedCacheBlockTable& operator=(const PagedCacheBlockTable& other);
+  PagedCacheBlockTable& operator=(PagedCacheBlockTable&& other) noexcept;
 
   const void* RequestId() const { return request_id_; }
   size_t CommittedSlots() const { return committed_slots_; }
@@ -164,8 +168,19 @@ class PagedCacheReservation {
   void Release();
 
  private:
+  struct ResidentTableSnapshot {
+    const void* request_id{};
+    size_t committed_slots{};
+    uint64_t mutation_generation{};
+    const std::shared_ptr<Block>* blocks_data{};
+    size_t block_count{};
+    const std::shared_ptr<Block>* window_blocks_data{};
+    size_t window_block_count{};
+  };
+
   const PagedCacheBlockTable* FindCommittedTable(const void* request_id) const;
   const PagedCacheReservationDelta& FindDelta(const void* request_id) const;
+  void ValidateResidentTablesUnchanged() const;
   void ValidateAdvancePreconditions(const PagedCacheReservationDelta& delta,
                                     const PagedCacheBlockTable& table) const;
   void AdvanceCommittedSlots(PagedCacheBlockTable& table, size_t target_slots);
@@ -179,6 +194,7 @@ class PagedCacheReservation {
   std::vector<PagedCacheReservationDelta> deltas_;
   std::vector<PagedCacheBlockTable> new_tables_;
   std::vector<const Block*> advance_blocks_;
+  std::vector<ResidentTableSnapshot> resident_table_snapshots_;
   uint64_t block_pool_generation_{};
   uint64_t window_block_pool_generation_{};
   PagedCacheReservationState state_{PagedCacheReservationState::Released};

--- a/src/engine/paged_cache_reservation.h
+++ b/src/engine/paged_cache_reservation.h
@@ -43,10 +43,6 @@ class PagedCacheBlockTable {
     committed_slots_ = committed_slots;
     ++mutation_generation_;
   }
-  void AddCommittedBlockSlot(size_t index) {
-    blocks_.at(index)->AddSlot();
-    ++mutation_generation_;
-  }
   void SwapCommittedBlocks(size_t left, size_t right) {
     auto& left_block = blocks_.at(left);
     auto& right_block = blocks_.at(right);

--- a/src/engine/paged_cache_reservation.h
+++ b/src/engine/paged_cache_reservation.h
@@ -32,6 +32,8 @@ struct PagedCacheReservationRequest {
 struct PagedCacheReservationDelta {
   const void* request_id{};
   size_t committed_slots{};
+  std::vector<std::weak_ptr<Block>> committed_blocks;
+  std::vector<std::weak_ptr<Block>> committed_window_blocks;
   size_t target_slots{};
   size_t tail_slots_to_consume{};
   size_t reserved_block_offset{};
@@ -83,6 +85,19 @@ class PagedCacheReservation {
   void FillWindowBlockTable(std::span<const void* const> request_ids,
                             size_t columns,
                             std::span<int32_t> output) const;
+  // Validates every precondition this reservation's own CommitValidated relies on, without
+  // mutating any state. For a reservation that still satisfies the publish contract it is the only
+  // part of committing that can throw; CommitValidated additionally throws if the reservation is no
+  // longer Reserved (double publish), so an orchestrator must still guard CommitValidated too.
+  void ValidateCommit() const;
+  // Publishes a reservation that ValidateCommit has already accepted. For a single reservation it
+  // moves preallocated blocks and tables into the committed cache and performs no fallible allocation
+  // or device work; its only guard is a state-only, allocation-free check that the reservation is
+  // still Reserved (it throws rather than publish twice, which would be undefined behavior). See the
+  // implementation for why it is intentionally not marked noexcept.
+  void CommitValidated();
+  // Convenience wrapper preserving the original single-call contract: ValidateCommit then
+  // CommitValidated.
   void Commit();
   void Release();
 

--- a/src/engine/paged_cache_reservation.h
+++ b/src/engine/paged_cache_reservation.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "../span.h"
@@ -13,11 +14,73 @@
 
 namespace Generators {
 
-struct PagedCacheBlockTable {
-  const void* request_id{};
-  size_t committed_slots{};
-  std::vector<std::shared_ptr<Block>> blocks;
-  std::vector<std::shared_ptr<Block>> window_blocks;
+struct PagedKeyValueCache;
+
+class PagedCacheBlockTable {
+ public:
+  PagedCacheBlockTable() = default;
+  explicit PagedCacheBlockTable(
+      const void* request_id,
+      size_t committed_slots,
+      std::vector<std::shared_ptr<Block>> blocks = {},
+      std::vector<std::shared_ptr<Block>> window_blocks = {})
+      : request_id_{request_id},
+        committed_slots_{committed_slots},
+        blocks_{std::move(blocks)},
+        window_blocks_{std::move(window_blocks)} {}
+
+  const void* RequestId() const { return request_id_; }
+  size_t CommittedSlots() const { return committed_slots_; }
+  const std::vector<std::shared_ptr<Block>>& Blocks() const { return blocks_; }
+  const std::vector<std::shared_ptr<Block>>& WindowBlocks() const { return window_blocks_; }
+  uint64_t MutationGeneration() const { return mutation_generation_; }
+
+  void SetCommittedSlots(size_t committed_slots) {
+    committed_slots_ = committed_slots;
+    ++mutation_generation_;
+  }
+  void AddCommittedBlockSlot(size_t index) {
+    blocks_.at(index)->AddSlot();
+    ++mutation_generation_;
+  }
+  void SwapCommittedBlocks(size_t left, size_t right) {
+    auto& left_block = blocks_.at(left);
+    auto& right_block = blocks_.at(right);
+    std::swap(left_block, right_block);
+    ++mutation_generation_;
+  }
+  void ReplaceCommittedBlock(size_t index, std::shared_ptr<Block> block) {
+    blocks_.at(index) = std::move(block);
+    ++mutation_generation_;
+  }
+  void ReplaceCommittedBlocks(std::vector<std::shared_ptr<Block>> blocks) {
+    blocks_ = std::move(blocks);
+    ++mutation_generation_;
+  }
+  void ShrinkCommittedBlockCapacity() {
+    blocks_.shrink_to_fit();
+    ++mutation_generation_;
+  }
+  void SwapWindowBlocks(size_t left, size_t right) {
+    auto& left_block = window_blocks_.at(left);
+    auto& right_block = window_blocks_.at(right);
+    std::swap(left_block, right_block);
+    ++mutation_generation_;
+  }
+  void ReplaceWindowBlocks(std::vector<std::shared_ptr<Block>> blocks) {
+    window_blocks_ = std::move(blocks);
+    ++mutation_generation_;
+  }
+
+ private:
+  friend class PagedCacheReservation;
+  friend struct PagedKeyValueCache;
+
+  const void* request_id_{};
+  size_t committed_slots_{};
+  std::vector<std::shared_ptr<Block>> blocks_;
+  std::vector<std::shared_ptr<Block>> window_blocks_;
+  uint64_t mutation_generation_{};
 };
 
 struct PagedCacheReservationRequest {
@@ -32,14 +95,15 @@ struct PagedCacheReservationRequest {
 struct PagedCacheReservationDelta {
   const void* request_id{};
   size_t committed_slots{};
-  std::vector<std::weak_ptr<Block>> committed_blocks;
-  std::vector<std::weak_ptr<Block>> committed_window_blocks;
+  uint64_t table_generation{};
   size_t target_slots{};
   size_t tail_slots_to_consume{};
   size_t reserved_block_offset{};
   size_t reserved_block_count{};
   size_t reserved_window_block_offset{};
   size_t reserved_window_block_count{};
+  size_t advance_block_offset{};
+  size_t advance_block_count{};
   bool newly_admitted{};
 };
 
@@ -87,13 +151,12 @@ class PagedCacheReservation {
                             std::span<int32_t> output) const;
   // Validates every precondition this reservation's own CommitValidated relies on, without
   // mutating any state. For a reservation that still satisfies the publish contract it is the only
-  // part of committing that can throw; CommitValidated additionally throws if the reservation is no
-  // longer Reserved (double publish), so an orchestrator must still guard CommitValidated too.
+  // part of committing expected to fail under the Engine's serialized transaction contract.
   void ValidateCommit() const;
   // Publishes a reservation that ValidateCommit has already accepted. For a single reservation it
-  // moves preallocated blocks and tables into the committed cache and performs no fallible allocation
-  // or device work; its only guard is a state-only, allocation-free check that the reservation is
-  // still Reserved (it throws rather than publish twice, which would be undefined behavior). See the
+  // moves preallocated blocks and tables into the committed cache and performs no fallible
+  // allocation or device work. Before mutation it preflights every delta again using only
+  // allocation-free state, ownership, generation, boundary, and occupancy checks. See the
   // implementation for why it is intentionally not marked noexcept.
   void CommitValidated();
   // Convenience wrapper preserving the original single-call contract: ValidateCommit then
@@ -104,6 +167,8 @@ class PagedCacheReservation {
  private:
   const PagedCacheBlockTable* FindCommittedTable(const void* request_id) const;
   const PagedCacheReservationDelta& FindDelta(const void* request_id) const;
+  void ValidateAdvancePreconditions(const PagedCacheReservationDelta& delta,
+                                    const PagedCacheBlockTable& table) const;
   void AdvanceCommittedSlots(PagedCacheBlockTable& table, size_t target_slots);
 
   BlockPool* block_pool_{};
@@ -114,6 +179,9 @@ class PagedCacheReservation {
   std::vector<std::shared_ptr<Block>> reserved_window_blocks_;
   std::vector<PagedCacheReservationDelta> deltas_;
   std::vector<PagedCacheBlockTable> new_tables_;
+  std::vector<const Block*> advance_blocks_;
+  uint64_t block_pool_generation_{};
+  uint64_t window_block_pool_generation_{};
   PagedCacheReservationState state_{PagedCacheReservationState::Released};
 };
 

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -336,8 +336,19 @@ void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
   if (required_slots <= used_slots) {
     return;
   }
-  size_t num_slots = required_slots - used_slots;
+  const size_t growth = required_slots - used_slots;
+  const size_t committed_capacity =
+      block_table_it->blocks_.size() * block_pool_->BlockSize();
+  const size_t tail_capacity = committed_capacity - used_slots;
+  const size_t new_slots = growth > tail_capacity ? growth - tail_capacity : 0;
+  const size_t new_block_count = block_pool_->BlocksNeeded(new_slots);
 
+  // Complete every fallible allocation before changing existing block occupancy.
+  block_table_it->blocks_.reserve(
+      block_table_it->blocks_.size() + new_block_count);
+  auto allocated_blocks = block_pool_->AllocateBlocks(new_slots);
+
+  size_t num_slots = growth - new_slots;
   size_t block_index = used_slots / block_pool_->BlockSize();
   while (num_slots > 0 && block_index < block_table_it->blocks_.size()) {
     auto& block = block_table_it->blocks_[block_index++];
@@ -345,14 +356,11 @@ void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
     block->AddSlots(slots);
     num_slots -= slots;
   }
-
-  if (num_slots > 0) {
-    auto allocated_blocks = block_pool_->AllocateBlocks(num_slots);
-    std::move(allocated_blocks.begin(), allocated_blocks.end(),
-              std::back_inserter(block_table_it->blocks_));
-  }
+  std::move(allocated_blocks.begin(), allocated_blocks.end(),
+            std::back_inserter(block_table_it->blocks_));
   block_table_it->committed_slots_ = required_slots;
   ++block_table_it->mutation_generation_;
+  block_pool_->RecordOccupancyMutation();
 }
 
 void PagedKeyValueCache::Remove(std::shared_ptr<Request> request) {

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -576,7 +576,6 @@ PagedCacheSnapshot PagedKeyValueCache::Snapshot(
     request_reservation.request_id = delta.request_id;
     request_reservation.committed_slots = delta.committed_slots;
     request_reservation.target_slots = delta.target_slots;
-    request_reservation.tail_slots_to_consume = delta.tail_slots_to_consume;
     request_reservation.reserved_block_ids.reserve(
         delta.reserved_block_count);
     for (size_t i = 0; i < delta.reserved_block_count; ++i) {

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -291,20 +291,20 @@ void PagedKeyValueCache::Add(std::shared_ptr<Request> request) {
 bool PagedKeyValueCache::CanAppendTokens(std::shared_ptr<Request> request) const {
   const auto block_table_it = std::find_if(block_tables_.begin(), block_tables_.end(),
                                            [&request](const PagedCacheBlockTable& block_table) {
-                                             return block_table.request_id == request.get();
+                                             return block_table.request_id_ == request.get();
                                            });
   if (block_table_it == block_tables_.end()) {
     throw std::runtime_error("Given request is not found in the cache.");
   }
 
   const size_t required_slots = RequiredSlots(request);
-  const size_t used_slots = block_table_it->committed_slots;
+  const size_t used_slots = block_table_it->committed_slots_;
   if (required_slots <= used_slots) {
     return true;
   }
 
   const size_t num_slots_available =
-      block_table_it->blocks.size() * block_pool_->BlockSize() - used_slots +
+      block_table_it->blocks_.size() * block_pool_->BlockSize() - used_slots +
       block_pool_->AvailableBlocks() * block_pool_->BlockSize();
 
   return num_slots_available >= required_slots - used_slots;
@@ -325,13 +325,13 @@ void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
 
   const auto block_table_it = std::find_if(block_tables_.begin(), block_tables_.end(),
                                            [&request](const PagedCacheBlockTable& block_table) {
-                                             return block_table.request_id == request.get();
+                                             return block_table.request_id_ == request.get();
                                            });
   assert(block_table_it != block_tables_.end());
 
   const size_t required_slots = RequiredSlots(request);
-  const size_t used_slots = block_table_it->committed_slots;
-  assert(UsedSlots(block_table_it->blocks) == used_slots);
+  const size_t used_slots = block_table_it->committed_slots_;
+  assert(UsedSlots(block_table_it->blocks_) == used_slots);
   assert(used_slots == static_cast<size_t>(request->ProcessedSequenceLength()));
   if (required_slots <= used_slots) {
     return;
@@ -339,8 +339,8 @@ void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
   size_t num_slots = required_slots - used_slots;
 
   size_t block_index = used_slots / block_pool_->BlockSize();
-  while (num_slots > 0 && block_index < block_table_it->blocks.size()) {
-    auto& block = block_table_it->blocks[block_index++];
+  while (num_slots > 0 && block_index < block_table_it->blocks_.size()) {
+    auto& block = block_table_it->blocks_[block_index++];
     const size_t slots = std::min(num_slots, block->EmptySlots());
     block->AddSlots(slots);
     num_slots -= slots;
@@ -349,9 +349,10 @@ void PagedKeyValueCache::AppendTokens(std::shared_ptr<Request> request) {
   if (num_slots > 0) {
     auto allocated_blocks = block_pool_->AllocateBlocks(num_slots);
     std::move(allocated_blocks.begin(), allocated_blocks.end(),
-              std::back_inserter(block_table_it->blocks));
+              std::back_inserter(block_table_it->blocks_));
   }
-  block_table_it->committed_slots = required_slots;
+  block_table_it->committed_slots_ = required_slots;
+  ++block_table_it->mutation_generation_;
 }
 
 void PagedKeyValueCache::Remove(std::shared_ptr<Request> request) {
@@ -397,14 +398,14 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
   // through, holding the blocks it already took. PagedCacheReservation reserves the same blocks.
   const auto calculate_growth = [&](const RequestStepPlan& entry,
                                     const PagedCacheBlockTable* table) {
-    const size_t committed_slots = table ? table->committed_slots : 0;
+    const size_t committed_slots = table ? table->committed_slots_ : 0;
     if (entry.target_cache_slots < committed_slots) {
       throw std::runtime_error("Step plan target precedes the committed cache boundary.");
     }
 
     const size_t reserved_slots =
         std::max(entry.whole_sequence_cache_slots, entry.target_cache_slots);
-    const size_t committed_blocks = table ? table->blocks.size() : 0;
+    const size_t committed_blocks = table ? table->blocks_.size() : 0;
     const size_t committed_capacity = committed_blocks * block_pool_->BlockSize();
     const size_t additional_slots =
         reserved_slots > committed_capacity ? reserved_slots - committed_capacity : 0;
@@ -432,7 +433,7 @@ StepPlanningResult PagedKeyValueCache::PlanStepResources(StepPlan& plan) const {
   const auto find_table = [this](const void* request_id) {
     const auto it = std::find_if(block_tables_.begin(), block_tables_.end(),
                                  [request_id](const PagedCacheBlockTable& table) {
-                                   return table.request_id == request_id;
+                                   return table.request_id_ == request_id;
                                  });
     return it == block_tables_.end() ? nullptr : &*it;
   };
@@ -529,9 +530,9 @@ PagedCacheSnapshot PagedKeyValueCache::Snapshot() const {
   snapshot.requests.reserve(block_tables_.size());
   for (const auto& block_table : block_tables_) {
     RequestBlockSnapshot request_snapshot;
-    request_snapshot.request_id = block_table.request_id;
-    request_snapshot.block_ids.reserve(block_table.blocks.size());
-    for (const auto& block : block_table.blocks) {
+    request_snapshot.request_id = block_table.request_id_;
+    request_snapshot.block_ids.reserve(block_table.blocks_.size());
+    for (const auto& block : block_table.blocks_) {
       request_snapshot.block_ids.push_back(block->Id());
       request_snapshot.used_slots += block->Size();
       request_snapshot.empty_slots += block->EmptySlots();
@@ -545,9 +546,9 @@ PagedCacheSnapshot PagedKeyValueCache::Snapshot() const {
     snapshot.window_blocks.requests.reserve(block_tables_.size());
     for (const auto& block_table : block_tables_) {
       RequestBlockSnapshot request_snapshot;
-      request_snapshot.request_id = block_table.request_id;
-      request_snapshot.block_ids.reserve(block_table.window_blocks.size());
-      for (const auto& block : block_table.window_blocks) {
+      request_snapshot.request_id = block_table.request_id_;
+      request_snapshot.block_ids.reserve(block_table.window_blocks_.size());
+      for (const auto& block : block_table.window_blocks_) {
         request_snapshot.block_ids.push_back(block->Id());
       }
       snapshot.window_blocks.requests.push_back(std::move(request_snapshot));
@@ -618,7 +619,7 @@ void PagedKeyValueCache::FillBlockTables(const std::vector<std::shared_ptr<Reque
   for (auto& block_table : block_tables_) {
     auto it = std::find_if(requests.begin(), requests.end(),
                            [&block_table](const std::shared_ptr<Request>& request) {
-                             return request.get() == block_table.request_id;
+                             return request.get() == block_table.request_id_;
                            });
     if (it == requests.end()) {
       throw std::runtime_error("Given request is not found in the cache. Please add it before requesting block tables.");
@@ -629,16 +630,16 @@ void PagedKeyValueCache::FillBlockTables(const std::vector<std::shared_ptr<Reque
       // Repeat the ring across every column. There is nothing to pad: whichever column the
       // operator reaches for, the ring block it names is the one holding that position.
       for (size_t j = 0; j < columns; ++j) {
-        const auto& block = block_table.window_blocks[WindowRingColumn(j, window_ring_blocks_)];
+        const auto& block = block_table.window_blocks_[WindowRingColumn(j, window_ring_blocks_)];
         data[index * columns + j] = static_cast<int32_t>(block->Id());
       }
       continue;
     }
 
-    for (size_t j = 0; j < block_table.blocks.size(); ++j) {
-      data[index * columns + j] = static_cast<int32_t>(block_table.blocks[j]->Id());
+    for (size_t j = 0; j < block_table.blocks_.size(); ++j) {
+      data[index * columns + j] = static_cast<int32_t>(block_table.blocks_[j]->Id());
     }
-    for (size_t j = block_table.blocks.size(); j < columns; ++j) {
+    for (size_t j = block_table.blocks_.size(); j < columns; ++j) {
       data[index * columns + j] = block_tables_pad_value;
     }
   }
@@ -649,9 +650,9 @@ std::pair<OrtValue*, const char*> PagedKeyValueCache::BlockTables(const std::vec
   for (auto& block_table : block_tables_) {
     if (std::find_if(requests.begin(), requests.end(),
                      [&block_table](const std::shared_ptr<Request>& request) {
-                       return request.get() == block_table.request_id;
+                       return request.get() == block_table.request_id_;
                      }) != requests.end()) {
-      max_blocks = std::max(max_blocks, block_table.blocks.size());
+      max_blocks = std::max(max_blocks, block_table.blocks_.size());
     } else {
       throw std::runtime_error("Given request is not found in the cache. Please add it before requesting block tables.");
     }

--- a/test/cpp/engine/block_pool_tests.cpp
+++ b/test/cpp/engine/block_pool_tests.cpp
@@ -8,6 +8,7 @@
 
 #include <limits>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -15,16 +16,6 @@
 #include "engine/block.h"
 
 namespace Generators {
-
-struct BlockTestAccess {
-  static void AddSlot(Block& block) {
-    block.AddSlot();
-  }
-
-  static void AddSlots(Block& block, size_t slots) {
-    block.AddSlots(slots);
-  }
-};
 
 namespace {
 
@@ -62,37 +53,11 @@ TEST(BlockTest, ConstructFull) {
             (std::vector<size_t>{kBlockSize, kBlockSize + 1, kBlockSize + 2, kBlockSize + 3}));
 }
 
-TEST(BlockTest, AddSlotProgression) {
-  Block block(/*id=*/0, /*slots=*/0, kBlockSize);
-  for (size_t expected = 1; expected <= kBlockSize; ++expected) {
-    BlockTestAccess::AddSlot(block);
-    EXPECT_EQ(block.Size(), expected);
-    EXPECT_EQ(block.EmptySlots(), kBlockSize - expected);
-    EXPECT_EQ(block.SlotIds().size(), expected);
-  }
-  EXPECT_TRUE(block.IsFull());
-}
-
-TEST(BlockTest, AddSlotOverflowRejected) {
-  Block block(/*id=*/0, /*slots=*/kBlockSize, kBlockSize);
-  ASSERT_TRUE(block.IsFull());
-  EXPECT_THROW(BlockTestAccess::AddSlot(block), std::runtime_error);
-  // The rejected AddSlot must not have mutated the block.
-  EXPECT_EQ(block.Size(), kBlockSize);
-}
-
-TEST(BlockTest, AddSlotsAdvancesInBulk) {
-  Block block(/*id=*/0, /*slots=*/1, kBlockSize);
-  BlockTestAccess::AddSlots(block, 3);
-  EXPECT_EQ(block.Size(), kBlockSize);
-  EXPECT_THROW(BlockTestAccess::AddSlots(block, 1), std::runtime_error);
-  EXPECT_EQ(block.Size(), kBlockSize);
-}
-
 TEST(BlockTest, IdentityAndSlotIdsAreStable) {
-  Block block(/*id=*/3, /*slots=*/0, kBlockSize);
-  BlockTestAccess::AddSlot(block);
-  BlockTestAccess::AddSlot(block);
+  static_assert(std::is_copy_constructible_v<Block>);
+  static_assert(!std::is_copy_assignable_v<Block>);
+  static_assert(!std::is_move_assignable_v<Block>);
+  Block block(/*id=*/3, /*slots=*/2, kBlockSize);
   EXPECT_EQ(block.Id(), 3u);
   EXPECT_EQ(block.SlotIds(), (std::vector<size_t>{3 * kBlockSize, 3 * kBlockSize + 1}));
 }
@@ -237,41 +202,6 @@ TEST(BlockPoolTest, RepeatedAllocateFreeCyclesPreserveTotals) {
     pool.Free(blocks);
     EXPECT_EQ(pool.AvailableBlocks(), kNumBlocks);
     EXPECT_EQ(pool.Capacity(), kNumBlocks);
-  }
-}
-
-// ---------------------------------------------------------------------------------------------
-// BlockPool: production reservation pattern
-// ---------------------------------------------------------------------------------------------
-
-// Mirrors how the cache reserves capacity ahead of time and then fills slots one token at a time:
-// reserve block_size + 1 slots, advance the returned blocks slot-by-slot, and verify the state
-// transitions converge on what an allocation of block_size + 1 slots would have produced.
-TEST(BlockPoolTest, ReserveThenAdvanceMatchesAllocation) {
-  BlockPool pool(kBlockSize, /*num_blocks=*/4);
-  auto reserved = pool.ReserveBlocks(kBlockSize + 1);
-  ASSERT_EQ(reserved.size(), 2u);
-
-  // Fill the first block one slot at a time.
-  for (size_t i = 0; i < kBlockSize; ++i) {
-    EXPECT_EQ(reserved[0]->Size(), i);
-    EXPECT_FALSE(reserved[0]->IsFull());
-    BlockTestAccess::AddSlot(*reserved[0]);
-  }
-  EXPECT_TRUE(reserved[0]->IsFull());
-
-  // Fill the single trailing slot of the second block.
-  EXPECT_EQ(reserved[1]->Size(), 0u);
-  BlockTestAccess::AddSlot(*reserved[1]);
-
-  // Compare against a direct allocation of the same slot count.
-  BlockPool allocated_pool(kBlockSize, /*num_blocks=*/4);
-  auto allocated = allocated_pool.AllocateBlocks(kBlockSize + 1);
-  ASSERT_EQ(allocated.size(), reserved.size());
-  for (size_t i = 0; i < reserved.size(); ++i) {
-    EXPECT_EQ(reserved[i]->Size(), allocated[i]->Size());
-    EXPECT_EQ(reserved[i]->IsFull(), allocated[i]->IsFull());
-    EXPECT_EQ(reserved[i]->EmptySlots(), allocated[i]->EmptySlots());
   }
 }
 

--- a/test/cpp/engine/block_pool_tests.cpp
+++ b/test/cpp/engine/block_pool_tests.cpp
@@ -6,6 +6,7 @@
 // GPU; they validate slot arithmetic, allocation/reservation semantics, capacity accounting, and
 // free-time ownership guards deterministically.
 
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -109,6 +110,12 @@ TEST(BlockPoolTest, BlocksNeededBoundaries) {
   EXPECT_EQ(pool.BlocksNeeded(kBlockSize), 1u);
   EXPECT_EQ(pool.BlocksNeeded(kBlockSize + 1), 2u);
   EXPECT_EQ(pool.BlocksNeeded(kNumBlocks * kBlockSize), kNumBlocks);
+  EXPECT_EQ(
+      pool.BlocksNeeded(std::numeric_limits<size_t>::max()),
+      std::numeric_limits<size_t>::max() / kBlockSize + 1);
+  EXPECT_THROW(
+      pool.AllocateBlocks(std::numeric_limits<size_t>::max()),
+      std::runtime_error);
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/test/cpp/engine/block_pool_tests.cpp
+++ b/test/cpp/engine/block_pool_tests.cpp
@@ -14,6 +14,17 @@
 #include "engine/block.h"
 
 namespace Generators {
+
+struct BlockTestAccess {
+  static void AddSlot(Block& block) {
+    block.AddSlot();
+  }
+
+  static void AddSlots(Block& block, size_t slots) {
+    block.AddSlots(slots);
+  }
+};
+
 namespace {
 
 constexpr size_t kBlockSize = 4;
@@ -53,7 +64,7 @@ TEST(BlockTest, ConstructFull) {
 TEST(BlockTest, AddSlotProgression) {
   Block block(/*id=*/0, /*slots=*/0, kBlockSize);
   for (size_t expected = 1; expected <= kBlockSize; ++expected) {
-    block.AddSlot();
+    BlockTestAccess::AddSlot(block);
     EXPECT_EQ(block.Size(), expected);
     EXPECT_EQ(block.EmptySlots(), kBlockSize - expected);
     EXPECT_EQ(block.SlotIds().size(), expected);
@@ -64,23 +75,23 @@ TEST(BlockTest, AddSlotProgression) {
 TEST(BlockTest, AddSlotOverflowRejected) {
   Block block(/*id=*/0, /*slots=*/kBlockSize, kBlockSize);
   ASSERT_TRUE(block.IsFull());
-  EXPECT_THROW(block.AddSlot(), std::runtime_error);
+  EXPECT_THROW(BlockTestAccess::AddSlot(block), std::runtime_error);
   // The rejected AddSlot must not have mutated the block.
   EXPECT_EQ(block.Size(), kBlockSize);
 }
 
 TEST(BlockTest, AddSlotsAdvancesInBulk) {
   Block block(/*id=*/0, /*slots=*/1, kBlockSize);
-  block.AddSlots(3);
+  BlockTestAccess::AddSlots(block, 3);
   EXPECT_EQ(block.Size(), kBlockSize);
-  EXPECT_THROW(block.AddSlots(1), std::runtime_error);
+  EXPECT_THROW(BlockTestAccess::AddSlots(block, 1), std::runtime_error);
   EXPECT_EQ(block.Size(), kBlockSize);
 }
 
 TEST(BlockTest, IdentityAndSlotIdsAreStable) {
   Block block(/*id=*/3, /*slots=*/0, kBlockSize);
-  block.AddSlot();
-  block.AddSlot();
+  BlockTestAccess::AddSlot(block);
+  BlockTestAccess::AddSlot(block);
   EXPECT_EQ(block.Id(), 3u);
   EXPECT_EQ(block.SlotIds(), (std::vector<size_t>{3 * kBlockSize, 3 * kBlockSize + 1}));
 }
@@ -238,13 +249,13 @@ TEST(BlockPoolTest, ReserveThenAdvanceMatchesAllocation) {
   for (size_t i = 0; i < kBlockSize; ++i) {
     EXPECT_EQ(reserved[0]->Size(), i);
     EXPECT_FALSE(reserved[0]->IsFull());
-    reserved[0]->AddSlot();
+    BlockTestAccess::AddSlot(*reserved[0]);
   }
   EXPECT_TRUE(reserved[0]->IsFull());
 
   // Fill the single trailing slot of the second block.
   EXPECT_EQ(reserved[1]->Size(), 0u);
-  reserved[1]->AddSlot();
+  BlockTestAccess::AddSlot(*reserved[1]);
 
   // Compare against a direct allocation of the same slot count.
   BlockPool allocated_pool(kBlockSize, /*num_blocks=*/4);

--- a/test/cpp/engine/engine_invariants_tests.cpp
+++ b/test/cpp/engine/engine_invariants_tests.cpp
@@ -130,7 +130,6 @@ TEST(InvariantValidatorTest, ValidTransactionReservationBalancesAccounting) {
           kRequestA,
           /*committed_slots=*/kBlockSize + 1,
           /*target_slots=*/2 * kBlockSize + 1,
-          /*tail_slots_to_consume=*/kBlockSize - 1,
           /*reserved_block_ids=*/{3},
       },
   };
@@ -148,7 +147,7 @@ TEST(InvariantValidatorTest, InitialAdmissionReservationValidatesWithoutCommitte
   cache.free_blocks = 0;
   cache.transaction_reserved_block_ids = {0};
   cache.reservations = {
-      RequestReservationSnapshot{kRequestA, 0, 1, 0, {0}},
+      RequestReservationSnapshot{kRequestA, 0, 1, {0}},
   };
 
   EXPECT_TRUE(ValidateCacheInvariants(cache).empty());
@@ -176,7 +175,7 @@ TEST(InvariantValidatorTest, InitialAdmissionRejectsUnreservedDeltaBlock) {
   cache.free_blocks = 1;
   cache.transaction_reserved_block_ids = {0};
   cache.reservations = {
-      RequestReservationSnapshot{kRequestA, 0, 1, 0, {1}},
+      RequestReservationSnapshot{kRequestA, 0, 1, {1}},
   };
 
   const auto violations = ValidateCacheInvariants(cache);
@@ -201,7 +200,7 @@ TEST(InvariantValidatorTest, ReservedBlockCannotAlsoBeCommitted) {
   cache.free_blocks = 0;
   cache.transaction_reserved_block_ids = {2};
   cache.reservations = {
-      RequestReservationSnapshot{kRequestB, 4, 5, 0, {2}},
+      RequestReservationSnapshot{kRequestB, 4, 5, {2}},
   };
 
   EXPECT_FALSE(ValidateCacheInvariants(cache).empty());

--- a/test/cpp/engine/paged_cache_reservation_tests.cpp
+++ b/test/cpp/engine/paged_cache_reservation_tests.cpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <limits>
+#include <type_traits>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -193,6 +194,59 @@ TEST(PagedCacheReservationTest, ChunkedPrefillHoldsWholePromptButCommitsOnlyTheC
   next.Commit();
   EXPECT_EQ(tables[0].CommittedSlots(), 6u);
   EXPECT_EQ(tables[0].Blocks().size(), 3u);
+}
+
+TEST(PagedCacheReservationTest, FutureReservedCapacityRemainsImmutableAfterValidation) {
+  BlockPool pool{kBlockSize, 2};
+  std::vector<PagedCacheBlockTable> tables;
+  const std::array requests{
+      PagedCacheReservationRequest{
+          kRequestA, /*target_slots=*/1, /*newly_admitted=*/true,
+          /*reserved_slots=*/2 * kBlockSize},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  ASSERT_EQ(reservation.ReservedBlocks().size(), 2u);
+  static_assert(!std::is_assignable_v<Block&, const Block&>);
+  const size_t future_block_id = reservation.ReservedBlocks()[1]->Id();
+
+  reservation.ValidateCommit();
+  reservation.CommitValidated();
+
+  ASSERT_EQ(tables.size(), 1u);
+  ASSERT_EQ(tables[0].Blocks().size(), 2u);
+  EXPECT_EQ(tables[0].Blocks()[1]->Id(), future_block_id);
+  EXPECT_EQ(tables[0].Blocks()[1]->Size(), 0u);
+  EXPECT_TRUE(pool.Owns(tables[0].Blocks()[1]));
+}
+
+TEST(PagedCacheReservationTest, AliasReservationInvalidatesOriginalPublication) {
+  BlockPool pool{kBlockSize, 2};
+  std::vector<PagedCacheBlockTable> tables;
+  const std::array requests{
+      PagedCacheReservationRequest{
+          kRequestA, /*target_slots=*/1, /*newly_admitted=*/true,
+          /*reserved_slots=*/2 * kBlockSize},
+  };
+  PagedCacheReservation original{pool, tables, requests};
+  original.ValidateCommit();
+
+  std::vector<std::shared_ptr<Block>> alias_blocks{
+      original.ReservedBlocks().begin(), original.ReservedBlocks().end()};
+  std::vector<PagedCacheBlockTable> alias_tables{
+      PagedCacheBlockTable{kRequestB, kBlockSize, std::move(alias_blocks)},
+  };
+  const std::array alias_requests{
+      PagedCacheReservationRequest{
+          kRequestB, /*target_slots=*/kBlockSize + 1,
+          /*newly_admitted=*/false,
+          /*reserved_slots=*/2 * kBlockSize},
+  };
+  PagedCacheReservation alias{pool, alias_tables, alias_requests};
+  alias.Commit();
+
+  EXPECT_THROW(original.CommitValidated(), std::logic_error);
+  EXPECT_TRUE(tables.empty());
+  EXPECT_EQ(original.State(), PagedCacheReservationState::Reserved);
 }
 
 TEST(PagedCacheReservationTest, ReleaseReturnsWindowRingBlocks) {
@@ -599,28 +653,6 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsTokenBoundaryChangeBeforePu
   // Validation did not further change the boundary or append the reserved block.
   EXPECT_EQ(tables[0].CommittedSlots(), 2u);
   EXPECT_EQ(tables[0].Blocks().size(), blocks_before);
-  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
-}
-
-TEST(PagedCacheReservationTest, ValidateCommitRejectsChangedCommittedBlockOccupancy) {
-  BlockPool pool{kBlockSize, 3};
-  std::vector<PagedCacheBlockTable> tables{
-      PagedCacheBlockTable{kRequestA, 3, pool.AllocateBlocks(3)},
-  };
-  const std::array requests{
-      PagedCacheReservationRequest{kRequestA, 5, false},
-  };
-  PagedCacheReservation reservation{pool, tables, requests};
-  const size_t available_before = pool.AvailableBlocks();
-
-  // The scalar boundary is unchanged, but the physical block now claims one extra committed slot.
-  tables[0].AddCommittedBlockSlot(0);
-
-  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_EQ(tables[0].CommittedSlots(), 3u);
-  ASSERT_EQ(tables[0].Blocks().size(), 1u);
-  EXPECT_EQ(tables[0].Blocks()[0]->Size(), 4u);
-  EXPECT_EQ(pool.AvailableBlocks(), available_before);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 

--- a/test/cpp/engine/paged_cache_reservation_tests.cpp
+++ b/test/cpp/engine/paged_cache_reservation_tests.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <array>
+#include <limits>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -54,6 +55,23 @@ TEST(PagedCacheReservationTest, AggregateRejectionDoesNotConsumeBlocks) {
   EXPECT_THROW((PagedCacheReservation{pool, tables, requests}), std::runtime_error);
   EXPECT_TRUE(tables.empty());
   EXPECT_EQ(pool.AvailableBlocks(), 1u);
+}
+
+TEST(PagedCacheReservationTest, ReservationRejectsBlockCapacityOverflow) {
+  constexpr size_t block_size =
+      std::numeric_limits<size_t>::max() / 2 + 1;
+  BlockPool pool{block_size, 2};
+  std::vector<PagedCacheBlockTable> tables;
+  const std::array requests{
+      PagedCacheReservationRequest{
+          kRequestA, std::numeric_limits<size_t>::max(), true},
+  };
+
+  EXPECT_THROW(
+      (PagedCacheReservation{pool, tables, requests}),
+      std::overflow_error);
+  EXPECT_TRUE(tables.empty());
+  EXPECT_EQ(pool.AvailableBlocks(), 2u);
 }
 
 TEST(PagedCacheReservationTest, CommitConsumesExistingTailWithoutNewBlock) {
@@ -373,7 +391,130 @@ TEST(PagedCacheReservationTest, CommitValidatedRejectsTailAliasingBeforePublicat
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
-TEST(PagedCacheReservationTest, CommitRejectsStableMalformedLaterTailBeforePublication) {
+TEST(PagedCacheReservationTest, CommitValidatedRejectsOmittedResidentMutationBeforePublication) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+      PagedCacheBlockTable{kRequestB, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  ASSERT_EQ(reservation.ReservedBlocks().size(), 1u);
+  reservation.ValidateCommit();
+
+  // B is omitted from this step, but it must not be allowed to claim A's reserved block without
+  // invalidating the publication preflight after the earlier validation succeeded.
+  tables[1].ReplaceCommittedBlock(0, reservation.ReservedBlocks()[0]);
+
+  EXPECT_THROW(reservation.CommitValidated(), std::logic_error);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
+  EXPECT_EQ(tables[0].Blocks().size(), 1u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsOmittedResidentMutation) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+      PagedCacheBlockTable{kRequestB, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+
+  tables[1].ReplaceCommittedBlock(0, reservation.ReservedBlocks()[0]);
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, OmittedResidentUnchangedAllowsMovedReservationCommit) {
+  BlockPool pool{kBlockSize, 3};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+      PagedCacheBlockTable{kRequestB, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  PagedCacheReservation moved{std::move(reservation)};
+
+  moved.Commit();
+
+  EXPECT_EQ(tables[0].CommittedSlots(), 5u);
+  EXPECT_EQ(tables[1].CommittedSlots(), 4u);
+  EXPECT_EQ(moved.State(), PagedCacheReservationState::Committed);
+}
+
+TEST(PagedCacheReservationTest, RejectsSameScalarResidentTableReplacement) {
+  BlockPool pool{kBlockSize, 3};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+      PagedCacheBlockTable{kRequestB, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  const size_t block_id = tables[1].Blocks()[0]->Id();
+
+  // Preserve request ID, vector sizes, block ID, capacity, and occupancy. Only the mapping storage
+  // and physical block identity change; move assignment also advances the destination generation.
+  tables[1] = PagedCacheBlockTable{
+      kRequestB, 4, {std::make_shared<Block>(block_id, kBlockSize, kBlockSize)}};
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, RejectsCopyAssignedOmittedResidentMapping) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+      PagedCacheBlockTable{kRequestB, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  PagedCacheBlockTable replacement{
+      kRequestB, 4, {reservation.ReservedBlocks()[0]}};
+
+  // Copy assignment may reuse the destination vector's storage. Its explicit generation advance
+  // must still invalidate the omitted resident snapshot.
+  tables[1] = replacement;
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, RejectsOmittedResidentBoundaryReplacement) {
+  BlockPool pool{kBlockSize, 2};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 0, {}},
+      PagedCacheBlockTable{kRequestB, 0, {}},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 1, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  reservation.ValidateCommit();
+
+  tables[1] = PagedCacheBlockTable{kRequestB, 1, {}};
+
+  EXPECT_THROW(reservation.CommitValidated(), std::logic_error);
+  EXPECT_EQ(tables[0].CommittedSlots(), 0u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ReservationRejectsStableMalformedLaterTail) {
   BlockPool pool{kBlockSize, 4};
   std::vector<PagedCacheBlockTable> tables{
       PagedCacheBlockTable{kRequestA, 3, pool.AllocateBlocks(3)},

--- a/test/cpp/engine/paged_cache_reservation_tests.cpp
+++ b/test/cpp/engine/paged_cache_reservation_tests.cpp
@@ -17,6 +17,18 @@ const char kRequestStorageB{};
 const void* const kRequestA = &kRequestStorageA;
 const void* const kRequestB = &kRequestStorageB;
 
+TEST(PagedCacheReservationTest, ExternalMutationOperationsAdvanceGeneration) {
+  PagedCacheBlockTable table{kRequestA, 0};
+
+  EXPECT_EQ(table.MutationGeneration(), 0u);
+  table.SetCommittedSlots(1);
+  EXPECT_EQ(table.MutationGeneration(), 1u);
+  table.ReplaceCommittedBlocks({});
+  EXPECT_EQ(table.MutationGeneration(), 2u);
+  table.ReplaceWindowBlocks({});
+  EXPECT_EQ(table.MutationGeneration(), 3u);
+}
+
 TEST(PagedCacheReservationTest, SumsPerRequestBlockCeilings) {
   BlockPool pool{kBlockSize, 4};
   std::vector<PagedCacheBlockTable> tables;
@@ -60,9 +72,9 @@ TEST(PagedCacheReservationTest, CommitConsumesExistingTailWithoutNewBlock) {
 
   reservation.Commit();
 
-  EXPECT_EQ(tables[0].committed_slots, 4u);
-  EXPECT_EQ(tables[0].blocks.size(), 1u);
-  EXPECT_TRUE(tables[0].blocks[0]->IsFull());
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
+  EXPECT_EQ(tables[0].Blocks().size(), 1u);
+  EXPECT_TRUE(tables[0].Blocks()[0]->IsFull());
 }
 
 TEST(PagedCacheReservationTest, ProposedBlockTableIncludesReservationsAndPadding) {
@@ -124,11 +136,11 @@ TEST(PagedCacheReservationTest, CommitPublishesNewOwnershipExactlyOnce) {
   reservation.Commit();
 
   ASSERT_EQ(tables.size(), 1u);
-  EXPECT_EQ(tables[0].request_id, kRequestA);
-  EXPECT_EQ(tables[0].committed_slots, 5u);
-  ASSERT_EQ(tables[0].blocks.size(), 2u);
-  EXPECT_EQ(tables[0].blocks[0]->Size(), kBlockSize);
-  EXPECT_EQ(tables[0].blocks[1]->Size(), 1u);
+  EXPECT_EQ(tables[0].RequestId(), kRequestA);
+  EXPECT_EQ(tables[0].CommittedSlots(), 5u);
+  ASSERT_EQ(tables[0].Blocks().size(), 2u);
+  EXPECT_EQ(tables[0].Blocks()[0]->Size(), kBlockSize);
+  EXPECT_EQ(tables[0].Blocks()[1]->Size(), 1u);
   EXPECT_THROW(reservation.Commit(), std::logic_error);
   EXPECT_THROW(reservation.Release(), std::logic_error);
 }
@@ -150,8 +162,8 @@ TEST(PagedCacheReservationTest, ChunkedPrefillHoldsWholePromptButCommitsOnlyTheC
   reservation.Commit();
 
   ASSERT_EQ(tables.size(), 1u);
-  EXPECT_EQ(tables[0].committed_slots, 2u);
-  EXPECT_EQ(tables[0].blocks.size(), 3u);
+  EXPECT_EQ(tables[0].CommittedSlots(), 2u);
+  EXPECT_EQ(tables[0].Blocks().size(), 3u);
 
   // The next chunk finds its capacity already owned and needs no new block.
   const std::array next_requests{
@@ -162,8 +174,8 @@ TEST(PagedCacheReservationTest, ChunkedPrefillHoldsWholePromptButCommitsOnlyTheC
   EXPECT_EQ(next.ReservedBlockCount(), 0u);
 
   next.Commit();
-  EXPECT_EQ(tables[0].committed_slots, 6u);
-  EXPECT_EQ(tables[0].blocks.size(), 3u);
+  EXPECT_EQ(tables[0].CommittedSlots(), 6u);
+  EXPECT_EQ(tables[0].Blocks().size(), 3u);
 }
 
 TEST(PagedCacheReservationTest, ReleaseReturnsWindowRingBlocks) {
@@ -203,10 +215,10 @@ TEST(PagedCacheReservationTest, RollbackReturnsBothPoolsForMixedExistingAndNewRe
   reservation.Release();
 
   ASSERT_EQ(tables.size(), 1u);
-  EXPECT_EQ(tables[0].request_id, kRequestA);
-  EXPECT_EQ(tables[0].committed_slots, 4u);
-  EXPECT_EQ(tables[0].blocks.size(), 1u);
-  EXPECT_EQ(tables[0].window_blocks.size(), 2u);
+  EXPECT_EQ(tables[0].RequestId(), kRequestA);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
+  EXPECT_EQ(tables[0].Blocks().size(), 1u);
+  EXPECT_EQ(tables[0].WindowBlocks().size(), 2u);
   EXPECT_EQ(pool.AvailableBlocks(), 2u);
   EXPECT_EQ(window_pool.AvailableBlocks(), 2u);
 }
@@ -221,7 +233,7 @@ TEST(PagedCacheReservationTest, CommittedWindowBlocksCanBeRemovedAndReused) {
   PagedCacheReservation first{pool, tables, request_a, &window_pool, 2};
   first.Commit();
   ASSERT_EQ(tables.size(), 1u);
-  const auto first_window_blocks = tables[0].window_blocks;
+  const auto first_window_blocks = tables[0].WindowBlocks();
 
   RemovePagedCacheBlockTable(pool, &window_pool, tables, kRequestA);
 
@@ -231,8 +243,8 @@ TEST(PagedCacheReservationTest, CommittedWindowBlocksCanBeRemovedAndReused) {
   PagedCacheReservation second{pool, tables, request_b, &window_pool, 2};
   second.Commit();
   ASSERT_EQ(tables.size(), 1u);
-  EXPECT_EQ(tables[0].window_blocks[0]->Id(), first_window_blocks[0]->Id());
-  EXPECT_EQ(tables[0].window_blocks[1]->Id(), first_window_blocks[1]->Id());
+  EXPECT_EQ(tables[0].WindowBlocks()[0]->Id(), first_window_blocks[0]->Id());
+  EXPECT_EQ(tables[0].WindowBlocks()[1]->Id(), first_window_blocks[1]->Id());
 }
 
 TEST(PagedCacheReservationTest, WindowTableUsesReservedRingBeforeCommit) {
@@ -251,9 +263,9 @@ TEST(PagedCacheReservationTest, WindowTableUsesReservedRingBeforeCommit) {
   EXPECT_EQ(window_table, (std::array<int32_t, 5>{0, 1, 0, 1, 0}));
   reservation.Commit();
   ASSERT_EQ(tables.size(), 1u);
-  ASSERT_EQ(tables[0].window_blocks.size(), 2u);
-  EXPECT_EQ(tables[0].window_blocks[0]->Id(), 0u);
-  EXPECT_EQ(tables[0].window_blocks[1]->Id(), 1u);
+  ASSERT_EQ(tables[0].WindowBlocks().size(), 2u);
+  EXPECT_EQ(tables[0].WindowBlocks()[0]->Id(), 0u);
+  EXPECT_EQ(tables[0].WindowBlocks()[1]->Id(), 1u);
 }
 
 // ValidateCommit must be a pure precondition check: it may not touch the committed cache, the
@@ -280,8 +292,8 @@ TEST(PagedCacheReservationTest, ValidateCommitDoesNotMutateAndIsRepeatable) {
   // The still-Reserved reservation commits normally afterwards.
   reservation.CommitValidated();
   ASSERT_EQ(tables.size(), 1u);
-  EXPECT_EQ(tables[0].committed_slots, 5u);
-  EXPECT_EQ(tables[0].blocks.size(), 2u);
+  EXPECT_EQ(tables[0].CommittedSlots(), 5u);
+  EXPECT_EQ(tables[0].Blocks().size(), 2u);
 }
 
 // CommitValidated publishes a reservation that ValidateCommit already accepted, producing exactly
@@ -301,12 +313,104 @@ TEST(PagedCacheReservationTest, CommitValidatedPublishesPreviouslyValidatedReser
 
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Committed);
   ASSERT_EQ(tables.size(), 1u);
-  EXPECT_EQ(tables[0].committed_slots, 5u);
-  ASSERT_EQ(tables[0].blocks.size(), 2u);
+  EXPECT_EQ(tables[0].CommittedSlots(), 5u);
+  ASSERT_EQ(tables[0].Blocks().size(), 2u);
   // Committing again is rejected exactly as the legacy single-call path is.
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_THROW(reservation.CommitValidated(), std::logic_error);
   EXPECT_THROW(reservation.Commit(), std::logic_error);
+}
+
+TEST(PagedCacheReservationTest, CommitValidatedPreflightsAllRequestsBeforePublication) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+      PagedCacheBlockTable{kRequestB, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+      PagedCacheReservationRequest{kRequestB, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  reservation.ValidateCommit();
+  const size_t available_before = pool.AvailableBlocks();
+
+  // Invalidate only the later request after validation. Publication must reject this before the
+  // first request consumes or appends any reserved state.
+  tables[1].SetCommittedSlots(3);
+
+  EXPECT_THROW(reservation.CommitValidated(), std::logic_error);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
+  EXPECT_EQ(tables[0].Blocks().size(), 1u);
+  EXPECT_EQ(tables[0].Blocks()[0]->Size(), 4u);
+  EXPECT_EQ(tables[1].CommittedSlots(), 3u);
+  EXPECT_EQ(tables[1].Blocks().size(), 1u);
+  EXPECT_EQ(pool.AvailableBlocks(), available_before);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, CommitValidatedRejectsTailAliasingBeforePublication) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 3, pool.AllocateBlocks(3)},
+      PagedCacheBlockTable{kRequestB, 3, pool.AllocateBlocks(3)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 4, false},
+      PagedCacheReservationRequest{kRequestB, 4, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  reservation.ValidateCommit();
+
+  // Mapping mutation cannot alias a later request's touched tail after validation and allow the
+  // first request to publish.
+  tables[1].ReplaceCommittedBlock(0, tables[0].Blocks()[0]);
+
+  EXPECT_THROW(reservation.CommitValidated(), std::logic_error);
+  EXPECT_EQ(tables[0].CommittedSlots(), 3u);
+  EXPECT_EQ(tables[0].Blocks()[0]->Size(), 3u);
+  EXPECT_EQ(tables[1].CommittedSlots(), 3u);
+  EXPECT_EQ(tables[1].Blocks()[0]->Size(), 3u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, CommitRejectsStableMalformedLaterTailBeforePublication) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 3, pool.AllocateBlocks(3)},
+      PagedCacheBlockTable{kRequestB, 3, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 4, false},
+      PagedCacheReservationRequest{kRequestB, 4, false},
+  };
+  // Request B's unchanged generation cannot make its full tail consistent with committed_slots=3.
+  EXPECT_THROW((PagedCacheReservation{pool, tables, requests}), std::logic_error);
+  EXPECT_EQ(tables[0].CommittedSlots(), 3u);
+  EXPECT_EQ(tables[0].Blocks()[0]->Size(), 3u);
+  EXPECT_EQ(tables[1].CommittedSlots(), 3u);
+  EXPECT_TRUE(tables[1].Blocks()[0]->IsFull());
+  EXPECT_EQ(pool.AvailableBlocks(), 2u);
+}
+
+TEST(PagedCacheReservationTest, ReservationRejectsSharedTouchedBlockBeforePublication) {
+  BlockPool pool{kBlockSize, 3};
+  auto shared_tail = pool.AllocateBlocks(3);
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 3, shared_tail},
+      PagedCacheBlockTable{kRequestB, 3, shared_tail},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 4, false},
+      PagedCacheReservationRequest{kRequestB, 4, false},
+  };
+
+  EXPECT_THROW((PagedCacheReservation{pool, tables, requests}), std::logic_error);
+  EXPECT_EQ(tables[0].CommittedSlots(), 3u);
+  EXPECT_EQ(tables[1].CommittedSlots(), 3u);
+  EXPECT_EQ(tables[0].Blocks()[0]->Size(), 3u);
+  EXPECT_EQ(tables[1].Blocks()[0]->Size(), 3u);
+  EXPECT_EQ(pool.AvailableBlocks(), 2u);
 }
 
 // If ownership changes between reserve and commit -- here a committed table for the request
@@ -322,14 +426,14 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsOwnershipChangeBeforePublic
 
   // Simulate another transaction admitting the same request id first.
   tables.push_back(PagedCacheBlockTable{kRequestA, 1, pool.AllocateBlocks(1)});
-  const size_t blocks_before = tables[0].blocks.size();
+  const size_t blocks_before = tables[0].Blocks().size();
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_THROW(reservation.Commit(), std::logic_error);
 
   // The pre-existing table was not extended and the reservation never published.
-  EXPECT_EQ(tables[0].blocks.size(), blocks_before);
-  EXPECT_EQ(tables[0].committed_slots, 1u);
+  EXPECT_EQ(tables[0].Blocks().size(), blocks_before);
+  EXPECT_EQ(tables[0].CommittedSlots(), 1u);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
@@ -347,14 +451,14 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsTokenBoundaryChangeBeforePu
 
   // Another transaction moved this request's committed boundary backward after the reservation
   // planned against committed_slots == 3.
-  tables[0].committed_slots = 2;
-  const size_t blocks_before = tables[0].blocks.size();
+  tables[0].SetCommittedSlots(2);
+  const size_t blocks_before = tables[0].Blocks().size();
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
 
   // Validation did not further change the boundary or append the reserved block.
-  EXPECT_EQ(tables[0].committed_slots, 2u);
-  EXPECT_EQ(tables[0].blocks.size(), blocks_before);
+  EXPECT_EQ(tables[0].CommittedSlots(), 2u);
+  EXPECT_EQ(tables[0].Blocks().size(), blocks_before);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
@@ -370,30 +474,12 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsChangedCommittedBlockOccupa
   const size_t available_before = pool.AvailableBlocks();
 
   // The scalar boundary is unchanged, but the physical block now claims one extra committed slot.
-  tables[0].blocks[0]->AddSlot();
+  tables[0].AddCommittedBlockSlot(0);
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_EQ(tables[0].committed_slots, 3u);
-  ASSERT_EQ(tables[0].blocks.size(), 1u);
-  EXPECT_EQ(tables[0].blocks[0]->Size(), 4u);
-  EXPECT_EQ(pool.AvailableBlocks(), available_before);
-  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
-}
-
-TEST(PagedCacheReservationTest, ValidateCommitRejectsNonemptyReservedBlock) {
-  BlockPool pool{kBlockSize, 2};
-  std::vector<PagedCacheBlockTable> tables;
-  const std::array requests{
-      PagedCacheReservationRequest{kRequestA, 1, true},
-  };
-  PagedCacheReservation reservation{pool, tables, requests};
-  ASSERT_EQ(reservation.ReservedBlocks().size(), 1u);
-  reservation.ReservedBlocks()[0]->AddSlot();
-  const size_t available_before = pool.AvailableBlocks();
-
-  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_TRUE(tables.empty());
-  EXPECT_EQ(reservation.ReservedBlocks()[0]->Size(), 1u);
+  EXPECT_EQ(tables[0].CommittedSlots(), 3u);
+  ASSERT_EQ(tables[0].Blocks().size(), 1u);
+  EXPECT_EQ(tables[0].Blocks()[0]->Size(), 4u);
   EXPECT_EQ(pool.AvailableBlocks(), available_before);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
@@ -407,16 +493,16 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsReorderedCommittedBlocks) {
       PagedCacheReservationRequest{kRequestA, 9, false},
   };
   PagedCacheReservation reservation{pool, tables, requests};
-  ASSERT_EQ(tables[0].blocks.size(), 2u);
-  const auto first_id = tables[0].blocks[0]->Id();
-  const auto second_id = tables[0].blocks[1]->Id();
+  ASSERT_EQ(tables[0].Blocks().size(), 2u);
+  const auto first_id = tables[0].Blocks()[0]->Id();
+  const auto second_id = tables[0].Blocks()[1]->Id();
 
-  std::swap(tables[0].blocks[0], tables[0].blocks[1]);
+  tables[0].SwapCommittedBlocks(0, 1);
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_EQ(tables[0].blocks[0]->Id(), second_id);
-  EXPECT_EQ(tables[0].blocks[1]->Id(), first_id);
-  EXPECT_EQ(tables[0].committed_slots, 8u);
+  EXPECT_EQ(tables[0].Blocks()[0]->Id(), second_id);
+  EXPECT_EQ(tables[0].Blocks()[1]->Id(), first_id);
+  EXPECT_EQ(tables[0].CommittedSlots(), 8u);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
@@ -429,13 +515,13 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsDuplicateCommittedBlocks) {
       PagedCacheReservationRequest{kRequestA, 9, false},
   };
   PagedCacheReservation reservation{pool, tables, requests};
-  ASSERT_EQ(tables[0].blocks.size(), 2u);
+  ASSERT_EQ(tables[0].Blocks().size(), 2u);
 
-  tables[0].blocks[1] = tables[0].blocks[0];
+  tables[0].ReplaceCommittedBlock(1, tables[0].Blocks()[0]);
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_EQ(tables[0].blocks[0], tables[0].blocks[1]);
-  EXPECT_EQ(tables[0].committed_slots, 8u);
+  EXPECT_EQ(tables[0].Blocks()[0], tables[0].Blocks()[1]);
+  EXPECT_EQ(tables[0].CommittedSlots(), 8u);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
@@ -448,16 +534,16 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsForeignSameIdCommittedBlock
       PagedCacheReservationRequest{kRequestA, 9, false},
   };
   PagedCacheReservation reservation{pool, tables, requests};
-  ASSERT_EQ(tables[0].blocks.size(), 2u);
-  const size_t second_id = tables[0].blocks[1]->Id();
+  ASSERT_EQ(tables[0].Blocks().size(), 2u);
+  const size_t second_id = tables[0].Blocks()[1]->Id();
 
-  tables[0].blocks[1] =
-      std::make_shared<Block>(second_id, kBlockSize, kBlockSize);
+  tables[0].ReplaceCommittedBlock(
+      1, std::make_shared<Block>(second_id, kBlockSize, kBlockSize));
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_EQ(tables[0].blocks[1]->Id(), second_id);
-  EXPECT_EQ(tables[0].blocks[1]->Size(), kBlockSize);
-  EXPECT_EQ(tables[0].committed_slots, 8u);
+  EXPECT_EQ(tables[0].Blocks()[1]->Id(), second_id);
+  EXPECT_EQ(tables[0].Blocks()[1]->Size(), kBlockSize);
+  EXPECT_EQ(tables[0].CommittedSlots(), 8u);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
@@ -470,17 +556,17 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsReallocatedSameIdCommittedB
       PagedCacheReservationRequest{kRequestA, 5, false},
   };
   PagedCacheReservation reservation{pool, tables, requests};
-  const size_t original_id = tables[0].blocks[0]->Id();
+  const size_t original_id = tables[0].Blocks()[0]->Id();
 
-  pool.Free(tables[0].blocks);
+  pool.Free(tables[0].Blocks());
   auto replacement = pool.AllocateBlocks(4);
   ASSERT_EQ(replacement.size(), 1u);
   ASSERT_EQ(replacement[0]->Id(), original_id);
-  tables[0].blocks = std::move(replacement);
+  tables[0].ReplaceCommittedBlocks(std::move(replacement));
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_EQ(tables[0].blocks[0]->Id(), original_id);
-  EXPECT_EQ(tables[0].committed_slots, 4u);
+  EXPECT_EQ(tables[0].Blocks()[0]->Id(), original_id);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
@@ -498,10 +584,10 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsDuplicateCommittedRequestTa
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   ASSERT_EQ(tables.size(), 2u);
-  EXPECT_EQ(tables[0].request_id, kRequestA);
-  EXPECT_EQ(tables[1].request_id, kRequestA);
-  EXPECT_EQ(tables[0].committed_slots, 4u);
-  EXPECT_EQ(tables[1].committed_slots, 4u);
+  EXPECT_EQ(tables[0].RequestId(), kRequestA);
+  EXPECT_EQ(tables[1].RequestId(), kRequestA);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
+  EXPECT_EQ(tables[1].CommittedSlots(), 4u);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
@@ -516,16 +602,16 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsReorderedResidentWindowRing
       PagedCacheReservationRequest{kRequestA, 5, false},
   };
   PagedCacheReservation reservation{pool, tables, requests, &window_pool, 2};
-  ASSERT_EQ(tables[0].window_blocks.size(), 2u);
-  const auto first_id = tables[0].window_blocks[0]->Id();
-  const auto second_id = tables[0].window_blocks[1]->Id();
+  ASSERT_EQ(tables[0].WindowBlocks().size(), 2u);
+  const auto first_id = tables[0].WindowBlocks()[0]->Id();
+  const auto second_id = tables[0].WindowBlocks()[1]->Id();
 
-  std::swap(tables[0].window_blocks[0], tables[0].window_blocks[1]);
+  tables[0].SwapWindowBlocks(0, 1);
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_EQ(tables[0].window_blocks[0]->Id(), second_id);
-  EXPECT_EQ(tables[0].window_blocks[1]->Id(), first_id);
-  EXPECT_EQ(tables[0].committed_slots, 4u);
+  EXPECT_EQ(tables[0].WindowBlocks()[0]->Id(), second_id);
+  EXPECT_EQ(tables[0].WindowBlocks()[1]->Id(), first_id);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
@@ -541,22 +627,44 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsReallocatedResidentWindowRi
   };
   PagedCacheReservation reservation{pool, tables, requests, &window_pool, 2};
   const auto original_ids = std::array{
-      tables[0].window_blocks[0]->Id(),
-      tables[0].window_blocks[1]->Id(),
+      tables[0].WindowBlocks()[0]->Id(),
+      tables[0].WindowBlocks()[1]->Id(),
   };
 
-  window_pool.Free(tables[0].window_blocks);
+  window_pool.Free(tables[0].WindowBlocks());
   auto replacements = window_pool.AllocateBlocks(2 * kBlockSize);
   ASSERT_EQ(replacements.size(), 2u);
   ASSERT_EQ(replacements[0]->Id(), original_ids[0]);
   ASSERT_EQ(replacements[1]->Id(), original_ids[1]);
-  tables[0].window_blocks = std::move(replacements);
+  tables[0].ReplaceWindowBlocks(std::move(replacements));
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_EQ(tables[0].window_blocks[0]->Id(), original_ids[0]);
-  EXPECT_EQ(tables[0].window_blocks[1]->Id(), original_ids[1]);
-  EXPECT_EQ(tables[0].committed_slots, 4u);
+  EXPECT_EQ(tables[0].WindowBlocks()[0]->Id(), original_ids[0]);
+  EXPECT_EQ(tables[0].WindowBlocks()[1]->Id(), original_ids[1]);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ReservationRejectsSharedResidentWindowBlock) {
+  BlockPool pool{kBlockSize, 2};
+  BlockPool window_pool{kBlockSize, 3};
+  auto shared_window = window_pool.AllocateBlocks(kBlockSize);
+  auto other_window = window_pool.AllocateBlocks(kBlockSize);
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 3, pool.AllocateBlocks(3), {shared_window[0], other_window[0]}},
+      PagedCacheBlockTable{kRequestB, 3, pool.AllocateBlocks(3), {shared_window[0], other_window[0]}},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 4, false},
+      PagedCacheReservationRequest{kRequestB, 4, false},
+  };
+
+  EXPECT_THROW(
+      (PagedCacheReservation{pool, tables, requests, &window_pool, 2}),
+      std::logic_error);
+  EXPECT_EQ(tables[0].Blocks()[0]->Size(), 3u);
+  EXPECT_EQ(tables[1].Blocks()[0]->Size(), 3u);
+  EXPECT_EQ(window_pool.AvailableBlocks(), 1u);
 }
 
 // The blocks.capacity() guard is the sole guarantee that CommitValidated's insert into an existing
@@ -573,21 +681,21 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsExhaustedPreallocatedCapaci
   PagedCacheReservation reservation{pool, tables, requests};
   ASSERT_EQ(reservation.ReservedBlockCount(), 1u);
 
-  tables[0].blocks.shrink_to_fit();
-  if (tables[0].blocks.capacity() >=
-      tables[0].blocks.size() + reservation.ReservedBlockCount()) {
+  tables[0].ShrinkCommittedBlockCapacity();
+  if (tables[0].Blocks().capacity() >=
+      tables[0].Blocks().size() + reservation.ReservedBlockCount()) {
     GTEST_SKIP() << "This standard library retained vector headroom after shrink_to_fit.";
   }
-  const size_t reduced_capacity = tables[0].blocks.capacity();
-  ASSERT_EQ(tables[0].blocks.size(), 1u);
+  const size_t reduced_capacity = tables[0].Blocks().capacity();
+  ASSERT_EQ(tables[0].Blocks().size(), 1u);
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_THROW(reservation.Commit(), std::logic_error);
 
   // Nothing was published: the reserved block was not appended and no slots advanced.
-  EXPECT_EQ(tables[0].blocks.size(), 1u);
-  EXPECT_EQ(tables[0].blocks.capacity(), reduced_capacity);
-  EXPECT_EQ(tables[0].committed_slots, 4u);
+  EXPECT_EQ(tables[0].Blocks().size(), 1u);
+  EXPECT_EQ(tables[0].Blocks().capacity(), reduced_capacity);
+  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
   EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 

--- a/test/cpp/engine/paged_cache_reservation_tests.cpp
+++ b/test/cpp/engine/paged_cache_reservation_tests.cpp
@@ -19,16 +19,25 @@ const char kRequestStorageB{};
 const void* const kRequestA = &kRequestStorageA;
 const void* const kRequestB = &kRequestStorageB;
 
-TEST(PagedCacheReservationTest, ExternalMutationOperationsAdvanceGeneration) {
+void ReplaceTable(
+    PagedCacheBlockTable& table,
+    size_t committed_slots,
+    std::vector<std::shared_ptr<Block>> blocks,
+    std::vector<std::shared_ptr<Block>> window_blocks = {}) {
+  table = PagedCacheBlockTable{
+      table.RequestId(), committed_slots, std::move(blocks),
+      std::move(window_blocks)};
+}
+
+TEST(PagedCacheReservationTest, TableReplacementAdvancesGeneration) {
   PagedCacheBlockTable table{kRequestA, 0};
 
   EXPECT_EQ(table.MutationGeneration(), 0u);
-  table.SetCommittedSlots(1);
+  ReplaceTable(table, 1, {});
   EXPECT_EQ(table.MutationGeneration(), 1u);
-  table.ReplaceCommittedBlocks({});
+  PagedCacheBlockTable replacement{kRequestA, 2};
+  table = replacement;
   EXPECT_EQ(table.MutationGeneration(), 2u);
-  table.ReplaceWindowBlocks({});
-  EXPECT_EQ(table.MutationGeneration(), 3u);
 }
 
 TEST(PagedCacheReservationTest, SumsPerRequestBlockCeilings) {
@@ -408,7 +417,8 @@ TEST(PagedCacheReservationTest, CommitValidatedPreflightsAllRequestsBeforePublic
 
   // Invalidate only the later request after validation. Publication must reject this before the
   // first request consumes or appends any reserved state.
-  tables[1].SetCommittedSlots(3);
+  ReplaceTable(
+      tables[1], 3, tables[1].Blocks(), tables[1].WindowBlocks());
 
   EXPECT_THROW(reservation.CommitValidated(), std::logic_error);
   EXPECT_EQ(tables[0].CommittedSlots(), 4u);
@@ -435,7 +445,9 @@ TEST(PagedCacheReservationTest, CommitValidatedRejectsTailAliasingBeforePublicat
 
   // Mapping mutation cannot alias a later request's touched tail after validation and allow the
   // first request to publish.
-  tables[1].ReplaceCommittedBlock(0, tables[0].Blocks()[0]);
+  auto aliased_blocks = tables[1].Blocks();
+  aliased_blocks[0] = tables[0].Blocks()[0];
+  ReplaceTable(tables[1], 3, std::move(aliased_blocks));
 
   EXPECT_THROW(reservation.CommitValidated(), std::logic_error);
   EXPECT_EQ(tables[0].CommittedSlots(), 3u);
@@ -460,7 +472,8 @@ TEST(PagedCacheReservationTest, CommitValidatedRejectsOmittedResidentMutationBef
 
   // B is omitted from this step, but it must not be allowed to claim A's reserved block without
   // invalidating the publication preflight after the earlier validation succeeded.
-  tables[1].ReplaceCommittedBlock(0, reservation.ReservedBlocks()[0]);
+  ReplaceTable(
+      tables[1], 4, {reservation.ReservedBlocks()[0]});
 
   EXPECT_THROW(reservation.CommitValidated(), std::logic_error);
   EXPECT_EQ(tables[0].CommittedSlots(), 4u);
@@ -479,7 +492,8 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsOmittedResidentMutation) {
   };
   PagedCacheReservation reservation{pool, tables, requests};
 
-  tables[1].ReplaceCommittedBlock(0, reservation.ReservedBlocks()[0]);
+  ReplaceTable(
+      tables[1], 4, {reservation.ReservedBlocks()[0]});
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_EQ(tables[0].CommittedSlots(), 4u);
@@ -645,7 +659,8 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsTokenBoundaryChangeBeforePu
 
   // Another transaction moved this request's committed boundary backward after the reservation
   // planned against committed_slots == 3.
-  tables[0].SetCommittedSlots(2);
+  ReplaceTable(
+      tables[0], 2, tables[0].Blocks(), tables[0].WindowBlocks());
   const size_t blocks_before = tables[0].Blocks().size();
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
@@ -669,7 +684,9 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsReorderedCommittedBlocks) {
   const auto first_id = tables[0].Blocks()[0]->Id();
   const auto second_id = tables[0].Blocks()[1]->Id();
 
-  tables[0].SwapCommittedBlocks(0, 1);
+  auto reordered_blocks = tables[0].Blocks();
+  std::swap(reordered_blocks[0], reordered_blocks[1]);
+  ReplaceTable(tables[0], 8, std::move(reordered_blocks));
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_EQ(tables[0].Blocks()[0]->Id(), second_id);
@@ -689,7 +706,9 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsDuplicateCommittedBlocks) {
   PagedCacheReservation reservation{pool, tables, requests};
   ASSERT_EQ(tables[0].Blocks().size(), 2u);
 
-  tables[0].ReplaceCommittedBlock(1, tables[0].Blocks()[0]);
+  auto duplicate_blocks = tables[0].Blocks();
+  duplicate_blocks[1] = duplicate_blocks[0];
+  ReplaceTable(tables[0], 8, std::move(duplicate_blocks));
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_EQ(tables[0].Blocks()[0], tables[0].Blocks()[1]);
@@ -709,8 +728,10 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsForeignSameIdCommittedBlock
   ASSERT_EQ(tables[0].Blocks().size(), 2u);
   const size_t second_id = tables[0].Blocks()[1]->Id();
 
-  tables[0].ReplaceCommittedBlock(
-      1, std::make_shared<Block>(second_id, kBlockSize, kBlockSize));
+  auto foreign_blocks = tables[0].Blocks();
+  foreign_blocks[1] =
+      std::make_shared<Block>(second_id, kBlockSize, kBlockSize);
+  ReplaceTable(tables[0], 8, std::move(foreign_blocks));
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_EQ(tables[0].Blocks()[1]->Id(), second_id);
@@ -734,7 +755,7 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsReallocatedSameIdCommittedB
   auto replacement = pool.AllocateBlocks(4);
   ASSERT_EQ(replacement.size(), 1u);
   ASSERT_EQ(replacement[0]->Id(), original_id);
-  tables[0].ReplaceCommittedBlocks(std::move(replacement));
+  ReplaceTable(tables[0], 4, std::move(replacement));
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_EQ(tables[0].Blocks()[0]->Id(), original_id);
@@ -778,7 +799,11 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsReorderedResidentWindowRing
   const auto first_id = tables[0].WindowBlocks()[0]->Id();
   const auto second_id = tables[0].WindowBlocks()[1]->Id();
 
-  tables[0].SwapWindowBlocks(0, 1);
+  auto reordered_window_blocks = tables[0].WindowBlocks();
+  std::swap(reordered_window_blocks[0], reordered_window_blocks[1]);
+  ReplaceTable(
+      tables[0], 4, tables[0].Blocks(),
+      std::move(reordered_window_blocks));
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_EQ(tables[0].WindowBlocks()[0]->Id(), second_id);
@@ -808,7 +833,8 @@ TEST(PagedCacheReservationTest, ValidateCommitRejectsReallocatedResidentWindowRi
   ASSERT_EQ(replacements.size(), 2u);
   ASSERT_EQ(replacements[0]->Id(), original_ids[0]);
   ASSERT_EQ(replacements[1]->Id(), original_ids[1]);
-  tables[0].ReplaceWindowBlocks(std::move(replacements));
+  ReplaceTable(
+      tables[0], 4, tables[0].Blocks(), std::move(replacements));
 
   EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
   EXPECT_EQ(tables[0].WindowBlocks()[0]->Id(), original_ids[0]);
@@ -837,38 +863,6 @@ TEST(PagedCacheReservationTest, ReservationRejectsSharedResidentWindowBlock) {
   EXPECT_EQ(tables[0].Blocks()[0]->Size(), 3u);
   EXPECT_EQ(tables[1].Blocks()[0]->Size(), 3u);
   EXPECT_EQ(window_pool.AvailableBlocks(), 1u);
-}
-
-// The blocks.capacity() guard is the sole guarantee that CommitValidated's insert into an existing
-// table cannot reallocate. If that headroom is released between reserve and commit while the table
-// mapping and occupancy stay unchanged, ValidateCommit must reject it before publication.
-TEST(PagedCacheReservationTest, ValidateCommitRejectsExhaustedPreallocatedCapacityBeforePublication) {
-  BlockPool pool{kBlockSize, 2};
-  std::vector<PagedCacheBlockTable> tables{
-      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
-  };
-  const std::array requests{
-      PagedCacheReservationRequest{kRequestA, 5, false},
-  };
-  PagedCacheReservation reservation{pool, tables, requests};
-  ASSERT_EQ(reservation.ReservedBlockCount(), 1u);
-
-  tables[0].ShrinkCommittedBlockCapacity();
-  if (tables[0].Blocks().capacity() >=
-      tables[0].Blocks().size() + reservation.ReservedBlockCount()) {
-    GTEST_SKIP() << "This standard library retained vector headroom after shrink_to_fit.";
-  }
-  const size_t reduced_capacity = tables[0].Blocks().capacity();
-  ASSERT_EQ(tables[0].Blocks().size(), 1u);
-
-  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
-  EXPECT_THROW(reservation.Commit(), std::logic_error);
-
-  // Nothing was published: the reserved block was not appended and no slots advanced.
-  EXPECT_EQ(tables[0].Blocks().size(), 1u);
-  EXPECT_EQ(tables[0].Blocks().capacity(), reduced_capacity);
-  EXPECT_EQ(tables[0].CommittedSlots(), 4u);
-  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
 }
 
 }  // namespace

--- a/test/cpp/engine/paged_cache_reservation_tests.cpp
+++ b/test/cpp/engine/paged_cache_reservation_tests.cpp
@@ -256,5 +256,340 @@ TEST(PagedCacheReservationTest, WindowTableUsesReservedRingBeforeCommit) {
   EXPECT_EQ(tables[0].window_blocks[1]->Id(), 1u);
 }
 
+// ValidateCommit must be a pure precondition check: it may not touch the committed cache, the
+// block pool, the reserved blocks, or the reservation's own state, so a composite transaction can
+// validate every reservation up front before any of them publish.
+TEST(PagedCacheReservationTest, ValidateCommitDoesNotMutateAndIsRepeatable) {
+  BlockPool pool{kBlockSize, 2};
+  std::vector<PagedCacheBlockTable> tables;
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, true},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  const size_t available_before = pool.AvailableBlocks();
+
+  reservation.ValidateCommit();
+  reservation.ValidateCommit();
+
+  // Nothing was published or consumed and the reservation is still committable.
+  EXPECT_TRUE(tables.empty());
+  EXPECT_EQ(pool.AvailableBlocks(), available_before);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+  EXPECT_EQ(reservation.ReservedBlockCount(), 2u);
+
+  // The still-Reserved reservation commits normally afterwards.
+  reservation.CommitValidated();
+  ASSERT_EQ(tables.size(), 1u);
+  EXPECT_EQ(tables[0].committed_slots, 5u);
+  EXPECT_EQ(tables[0].blocks.size(), 2u);
+}
+
+// CommitValidated publishes a reservation that ValidateCommit already accepted, producing exactly
+// the same committed state as the single-call Commit wrapper.
+TEST(PagedCacheReservationTest, CommitValidatedPublishesPreviouslyValidatedReservation) {
+  BlockPool pool{kBlockSize, 2};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+
+  reservation.ValidateCommit();
+  reservation.CommitValidated();
+
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Committed);
+  ASSERT_EQ(tables.size(), 1u);
+  EXPECT_EQ(tables[0].committed_slots, 5u);
+  ASSERT_EQ(tables[0].blocks.size(), 2u);
+  // Committing again is rejected exactly as the legacy single-call path is.
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_THROW(reservation.CommitValidated(), std::logic_error);
+  EXPECT_THROW(reservation.Commit(), std::logic_error);
+}
+
+// If ownership changes between reserve and commit -- here a committed table for the request
+// appears after a newly-admitted reservation was taken -- ValidateCommit rejects it before any
+// block is published.
+TEST(PagedCacheReservationTest, ValidateCommitRejectsOwnershipChangeBeforePublication) {
+  BlockPool pool{kBlockSize, 3};
+  std::vector<PagedCacheBlockTable> tables;
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 1, true},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+
+  // Simulate another transaction admitting the same request id first.
+  tables.push_back(PagedCacheBlockTable{kRequestA, 1, pool.AllocateBlocks(1)});
+  const size_t blocks_before = tables[0].blocks.size();
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_THROW(reservation.Commit(), std::logic_error);
+
+  // The pre-existing table was not extended and the reservation never published.
+  EXPECT_EQ(tables[0].blocks.size(), blocks_before);
+  EXPECT_EQ(tables[0].committed_slots, 1u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+// If the committed token boundary changes under an existing-request reservation,
+// ValidateCommit rejects it before publication rather than publishing against stale state.
+TEST(PagedCacheReservationTest, ValidateCommitRejectsTokenBoundaryChangeBeforePublication) {
+  BlockPool pool{kBlockSize, 2};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 3, pool.AllocateBlocks(3)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 4, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+
+  // Another transaction moved this request's committed boundary backward after the reservation
+  // planned against committed_slots == 3.
+  tables[0].committed_slots = 2;
+  const size_t blocks_before = tables[0].blocks.size();
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+
+  // Validation did not further change the boundary or append the reserved block.
+  EXPECT_EQ(tables[0].committed_slots, 2u);
+  EXPECT_EQ(tables[0].blocks.size(), blocks_before);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsChangedCommittedBlockOccupancy) {
+  BlockPool pool{kBlockSize, 3};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 3, pool.AllocateBlocks(3)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  const size_t available_before = pool.AvailableBlocks();
+
+  // The scalar boundary is unchanged, but the physical block now claims one extra committed slot.
+  tables[0].blocks[0]->AddSlot();
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].committed_slots, 3u);
+  ASSERT_EQ(tables[0].blocks.size(), 1u);
+  EXPECT_EQ(tables[0].blocks[0]->Size(), 4u);
+  EXPECT_EQ(pool.AvailableBlocks(), available_before);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsNonemptyReservedBlock) {
+  BlockPool pool{kBlockSize, 2};
+  std::vector<PagedCacheBlockTable> tables;
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 1, true},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  ASSERT_EQ(reservation.ReservedBlocks().size(), 1u);
+  reservation.ReservedBlocks()[0]->AddSlot();
+  const size_t available_before = pool.AvailableBlocks();
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_TRUE(tables.empty());
+  EXPECT_EQ(reservation.ReservedBlocks()[0]->Size(), 1u);
+  EXPECT_EQ(pool.AvailableBlocks(), available_before);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsReorderedCommittedBlocks) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 8, pool.AllocateBlocks(8)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 9, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  ASSERT_EQ(tables[0].blocks.size(), 2u);
+  const auto first_id = tables[0].blocks[0]->Id();
+  const auto second_id = tables[0].blocks[1]->Id();
+
+  std::swap(tables[0].blocks[0], tables[0].blocks[1]);
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].blocks[0]->Id(), second_id);
+  EXPECT_EQ(tables[0].blocks[1]->Id(), first_id);
+  EXPECT_EQ(tables[0].committed_slots, 8u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsDuplicateCommittedBlocks) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 8, pool.AllocateBlocks(8)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 9, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  ASSERT_EQ(tables[0].blocks.size(), 2u);
+
+  tables[0].blocks[1] = tables[0].blocks[0];
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].blocks[0], tables[0].blocks[1]);
+  EXPECT_EQ(tables[0].committed_slots, 8u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsForeignSameIdCommittedBlock) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 8, pool.AllocateBlocks(8)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 9, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  ASSERT_EQ(tables[0].blocks.size(), 2u);
+  const size_t second_id = tables[0].blocks[1]->Id();
+
+  tables[0].blocks[1] =
+      std::make_shared<Block>(second_id, kBlockSize, kBlockSize);
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].blocks[1]->Id(), second_id);
+  EXPECT_EQ(tables[0].blocks[1]->Size(), kBlockSize);
+  EXPECT_EQ(tables[0].committed_slots, 8u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsReallocatedSameIdCommittedBlock) {
+  BlockPool pool{kBlockSize, 3};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  const size_t original_id = tables[0].blocks[0]->Id();
+
+  pool.Free(tables[0].blocks);
+  auto replacement = pool.AllocateBlocks(4);
+  ASSERT_EQ(replacement.size(), 1u);
+  ASSERT_EQ(replacement[0]->Id(), original_id);
+  tables[0].blocks = std::move(replacement);
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].blocks[0]->Id(), original_id);
+  EXPECT_EQ(tables[0].committed_slots, 4u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsDuplicateCommittedRequestTable) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  tables.push_back(
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)});
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  ASSERT_EQ(tables.size(), 2u);
+  EXPECT_EQ(tables[0].request_id, kRequestA);
+  EXPECT_EQ(tables[1].request_id, kRequestA);
+  EXPECT_EQ(tables[0].committed_slots, 4u);
+  EXPECT_EQ(tables[1].committed_slots, 4u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsReorderedResidentWindowRing) {
+  BlockPool pool{kBlockSize, 2};
+  BlockPool window_pool{kBlockSize, 3};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4),
+                           window_pool.AllocateBlocks(2 * kBlockSize)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests, &window_pool, 2};
+  ASSERT_EQ(tables[0].window_blocks.size(), 2u);
+  const auto first_id = tables[0].window_blocks[0]->Id();
+  const auto second_id = tables[0].window_blocks[1]->Id();
+
+  std::swap(tables[0].window_blocks[0], tables[0].window_blocks[1]);
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].window_blocks[0]->Id(), second_id);
+  EXPECT_EQ(tables[0].window_blocks[1]->Id(), first_id);
+  EXPECT_EQ(tables[0].committed_slots, 4u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+TEST(PagedCacheReservationTest, ValidateCommitRejectsReallocatedResidentWindowRing) {
+  BlockPool pool{kBlockSize, 2};
+  BlockPool window_pool{kBlockSize, 2};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4),
+                           window_pool.AllocateBlocks(2 * kBlockSize)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests, &window_pool, 2};
+  const auto original_ids = std::array{
+      tables[0].window_blocks[0]->Id(),
+      tables[0].window_blocks[1]->Id(),
+  };
+
+  window_pool.Free(tables[0].window_blocks);
+  auto replacements = window_pool.AllocateBlocks(2 * kBlockSize);
+  ASSERT_EQ(replacements.size(), 2u);
+  ASSERT_EQ(replacements[0]->Id(), original_ids[0]);
+  ASSERT_EQ(replacements[1]->Id(), original_ids[1]);
+  tables[0].window_blocks = std::move(replacements);
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_EQ(tables[0].window_blocks[0]->Id(), original_ids[0]);
+  EXPECT_EQ(tables[0].window_blocks[1]->Id(), original_ids[1]);
+  EXPECT_EQ(tables[0].committed_slots, 4u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
+// The blocks.capacity() guard is the sole guarantee that CommitValidated's insert into an existing
+// table cannot reallocate. If that headroom is released between reserve and commit while the table
+// mapping and occupancy stay unchanged, ValidateCommit must reject it before publication.
+TEST(PagedCacheReservationTest, ValidateCommitRejectsExhaustedPreallocatedCapacityBeforePublication) {
+  BlockPool pool{kBlockSize, 2};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 5, false},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  ASSERT_EQ(reservation.ReservedBlockCount(), 1u);
+
+  tables[0].blocks.shrink_to_fit();
+  if (tables[0].blocks.capacity() >=
+      tables[0].blocks.size() + reservation.ReservedBlockCount()) {
+    GTEST_SKIP() << "This standard library retained vector headroom after shrink_to_fit.";
+  }
+  const size_t reduced_capacity = tables[0].blocks.capacity();
+  ASSERT_EQ(tables[0].blocks.size(), 1u);
+
+  EXPECT_THROW(reservation.ValidateCommit(), std::logic_error);
+  EXPECT_THROW(reservation.Commit(), std::logic_error);
+
+  // Nothing was published: the reserved block was not appended and no slots advanced.
+  EXPECT_EQ(tables[0].blocks.size(), 1u);
+  EXPECT_EQ(tables[0].blocks.capacity(), reduced_capacity);
+  EXPECT_EQ(tables[0].committed_slots, 4u);
+  EXPECT_EQ(reservation.State(), PagedCacheReservationState::Reserved);
+}
+
 }  // namespace
 }  // namespace Generators

--- a/test/cpp/engine/paged_cache_reservation_tests.cpp
+++ b/test/cpp/engine/paged_cache_reservation_tests.cpp
@@ -67,7 +67,6 @@ TEST(PagedCacheReservationTest, CommitConsumesExistingTailWithoutNewBlock) {
 
   PagedCacheReservation reservation{pool, tables, requests};
   ASSERT_EQ(reservation.Deltas().size(), 1u);
-  EXPECT_EQ(reservation.Deltas()[0].tail_slots_to_consume, 1u);
   EXPECT_EQ(reservation.ReservedBlockCount(), 0u);
 
   reservation.Commit();


### PR DESCRIPTION
## Summary

This PR splits `PagedCacheReservation::Commit()` into an explicit non-mutating validation phase and a publication phase:

- `ValidateCommit()` verifies that the reservation can still be published without mutating the committed cache, block pools, reserved blocks, or reservation state.
- `CommitValidated()` publishes a reservation that has already passed validation.
- `Commit()` remains the compatibility wrapper and calls both methods in order.

The split provides the preflight boundary required by a later composite Engine transaction. That transaction must validate paged KV state, fixed decoder state, and other request-owned resources before publishing any of them.

## Motivation

The original `Commit()` validated and published paged-cache changes in one operation. That is sufficient while paged KV is the only transaction-owned decoder state, but it cannot safely participate in a multi-resource commit: if paged KV publishes before another resource fails validation, the request is left partially committed.

This change makes paged-cache validation independently callable and repeatable. A composite transaction can validate every resource first and enter publication only after all preconditions are known to hold.

## What changed

### Added `ValidateCommit()`

`ValidateCommit()` is `const` and does not publish or release anything. It re-derives the assumptions needed by publication from the current committed cache and rejects the reservation if:

- the reservation is no longer in the `Reserved` state;
- its owning block pool or committed-table collection is missing;
- sliding-window reservation configuration is inconsistent;
- a request identity is null or duplicated;
- request ownership changed after reservation;
- an existing request's committed token boundary changed;
- a delta regresses below its committed boundary;
- reserved block or sliding-window block offsets are not contiguous and complete;
- a delta refers beyond its reserved block spans;
- committed plus reserved blocks cannot reach the target token boundary;
- an existing table no longer has the preallocated capacity needed for publication;
- reserved block accounting, window block accounting, or new-table accounting no longer matches the reservation;
- the committed-table vector no longer has this reservation's required headroom.

Because validation is non-mutating, callers may validate more than once before publication.

### Added `CommitValidated()`

`CommitValidated()` contains the existing publication logic. It moves preallocated block handles and tables into the committed cache and advances committed token boundaries.

The method performs a state-only guard before mutation to reject double publication. It intentionally does not repeat ownership, token-boundary, layout, reachability, or capacity validation; those checks belong to `ValidateCommit()` so a composite transaction can run all fallible preflight checks before publishing any resource.

`CommitValidated()` is intentionally not declared `noexcept`. Although the validated single-reservation path performs no new allocation or device work, the standard-library insertion and bounds-checked operations it uses are not `noexcept`-declared. Keeping the honest potentially-throwing signature avoids converting an unexpected precondition violation into `std::terminate`.

### Preserved the existing API

`Commit()` retains its existing behavior:

```cpp
void PagedCacheReservation::Commit() {
  ValidateCommit();
  CommitValidated();
}
```

Existing callers do not need to change in this PR.

## Transaction flow

```mermaid
flowchart LR
    Reserve["Reserve paged blocks and table capacity"] --> Reserved["Reservation state: Reserved"]
    Reserved --> Validate["ValidateCommit()<br/>const and non-mutating"]
    Validate -- "validation fails" --> Unchanged["Reservation and committed cache remain unchanged"]
    Validate -- "validation succeeds" --> Ready["Validated publication preconditions"]
    Ready --> Publish["CommitValidated()<br/>publish preallocated blocks and tables"]
    Publish --> Committed["Reservation state: Committed"]

    Composite["Later composite transaction"] -. "validate paged KV" .-> Validate
    Composite -. "validate fixed state and sibling resources" .-> Other["Other resource validation"]
    Ready -. "publish only after all validations pass" .-> CompositePublish["Composite publication boundary"]
    Other -.-> CompositePublish
    CompositePublish -.-> Publish
```