### PR TITLE
Fix model builder for paged attention with sliding-window layers

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1042,7 +1042,13 @@ class Model:
         Modifies KV cache shape dimension names for models with alternating attention patterns.
         Sliding window layers get a distinct symbolic sequence dim so ONNX shape inference does not
         unify them with the full-attention layers, whose cache is allocated at max_length.
+
+        Paged caches use the same physical block shape for every layer; local attention is expressed
+        by the PagedAttention operator instead of a different cache sequence dimension.
         """
+        if self.use_paged_attention:
+            return shape
+
         if (
             self.ep in self.eps_with_windowed_kv_cache
             and hasattr(self, "is_local")
@@ -3040,9 +3046,11 @@ class Model:
             attributes["k_quant_type"] = self.kv_quant_type
             attributes["v_quant_type"] = self.kv_quant_type
 
-        if self.window_size is not None and self.window_size > 0 and self.ep in {"cuda", "cpu"}:
+        if self.window_size is not None and self.window_size > 0 and self.ep in {"cuda", "cpu"} and not self.use_paged_attention:
             # The past/present buffers of this layer are window-sized rather than max_length-sized,
             # so the kernel indexes them in cache-relative coordinates and evicts as the window moves.
+            # PagedAttention has no such buffer: the engine owns block-managed cache, and the op
+            # does not accept this attribute.
             attributes["sliding_window_cache"] = 1
 
         return attributes

--- a/test/python/builder/test_gqa_attributes.py
+++ b/test/python/builder/test_gqa_attributes.py
@@ -42,6 +42,7 @@ class _FakeGQAModel:
         self.ep = ep
         self.extra_options = {"fuse_qk_norm_gqa": fuse_qk_norm_gqa}
         self.kv_cache_quant_type = "none"
+        self.use_paged_attention = False
         self.num_attn_heads = 8
         self.num_kv_heads = 2
         self.head_size = 16
@@ -96,6 +97,7 @@ def test_fused_qk_norm_gqa_emits_qk_norm_epsilon_attribute():
 def test_paged_attention_preserves_sliding_window_size():
     model = _FakeGQAModel("cuda")
     model.window_size = 4096
+    model.use_paged_attention = True
 
     model.make_paged_attention(
         "/paged",
@@ -107,7 +109,10 @@ def test_paged_attention_preserves_sliding_window_size():
         block_table="block_table",
     )
 
-    assert model.nodes[-1]["attributes"]["local_window_size"] == 4096
+    attributes = model.nodes[-1]["attributes"]
+    assert attributes["local_window_size"] == 4096
+    # PagedAttention has no window-sized contiguous buffer and rejects this attribute.
+    assert "sliding_window_cache" not in attributes
 
 
 def test_quantized_gqa_emits_scale_inputs_and_attributes():

--- a/test/python/builder/test_windowed_kv_cache.py
+++ b/test/python/builder/test_windowed_kv_cache.py
@@ -60,6 +60,7 @@ def _make_gqa_model(ep, window_size):
     model.ep = ep
     model.extra_options = {}
     model.kv_cache_quant_type = "none"
+    model.use_paged_attention = False
     model.num_attn_heads = 8
     model.num_kv_heads = 2
     model.head_size = 16
@@ -139,6 +140,7 @@ _CACHE_SHAPE = ["batch_size", 2, "past_sequence_length", 16]
 def _make_shape_model(ep, local_layers=()):
     model = Model.__new__(Model)
     model.ep = ep
+    model.use_paged_attention = False
     model.eps_with_windowed_kv_cache = {"trt-rtx", "cuda", "cpu"}
     if local_layers is not None:
         model.is_local = lambda layer_id: layer_id in local_layers
@@ -177,6 +179,14 @@ def test_model_without_alternating_attention_keeps_sequence_dim():
     model = _make_shape_model("cuda", local_layers=None)
 
     assert model.make_key_value_cache_shape(0, list(_CACHE_SHAPE)) == _CACHE_SHAPE
+
+
+def test_paged_attention_keeps_physical_block_shape_on_sliding_layers():
+    model = _make_shape_model("cuda", local_layers=(0,))
+    model.use_paged_attention = True
+    paged_shape = ["num_blocks", 256, 2, 16]
+
+    assert model.make_key_value_cache_shape(0, list(paged_shape)) == paged_shape
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

Exporting a model that combines **paged attention** with **alternating sliding-window / full attention** (e.g. `openai/gpt-oss-20b`, `gpt-oss-120b`) fails in two separate places.

### 1. `AttributeError` in `make_key_value_cache_shape()`

The method assumed the cache sequence dimension is always a symbolic string and called `.replace()` on it. Paged caches use a fixed **integer** block dimension, so sliding-window layers raised:

```
AttributeError: 'int' object has no attribute 'replace'
```

Paged caches use the same physical block shape for every layer — locality is expressed by the `PagedAttention` operator, not by a different cache sequence dimension. The shape is now returned unchanged when paged attention is enabled.

### 2. ORT rejects the exported model

`sliding_window_cache` was emitted for sliding-window layers regardless of attention type, but `PagedAttention` does not accept it:

```
Unrecognized attribute: sliding_window_cache for operator PagedAttention
```

That attribute describes a window-sized past/present buffer, which `PagedAttention` does not have since the engine owns the block-managed cache. It is now emitted only on the non-paged path.

## Repro

```
python src/python/py/models/builder.py -m openai/gpt-oss-20b -o <out> -p int4 -e cuda \
  --extra_options use_paged_attention=true moe_quant_type=mxfp4 is_symmetric=true \
  paged_block_size=256
```

Fails at (1); after fixing (1), fails at (2) when loading the model.

## Tests

Added to the existing builder suites:

- `test_paged_attention_keeps_physical_block_shape_on_sliding_layers` — the paged path returns `["num_blocks", 256, 2, 16]` unchanged
- `test_paged_attention_preserves_sliding_window_size` — asserts no `sliding_window_cache` attribute is emitted when paged attention is enabled

Both fakes now set `use_paged_attention`, so the non-paged behavior stays covered.

```
$ python -m pytest test/python/builder/ -q
325 passed, 3 skipped
```

## Validation

Beyond unit tests, the resulting 24-layer gpt-oss-20b export was verified end to end through the continuous-batching Engine on an A100-80GB: single and 4-way concurrent requests with ragged prompts, **exact output parity** between concurrent and isolated runs (0 mismatches), repeat-stable across runs, and coherent generation.