### PR TITLE
Add Gemma 4 assistant-head speculative decoding

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -194,6 +194,54 @@ See [examples/python/qwen-3.6-mtp.md](../examples/python/qwen-3.6-mtp.md) for th
 recipe and [examples/python/qwen-3.6-mtp.py](../examples/python/qwen-3.6-mtp.py) for a runnable
 example.
 
+### Gemma4 assistant heads
+
+`OgaCreateMtpGenerator` also accepts a Gemma4 *assistant* head (`model.type` =
+`"gemma4_assistant"`). It differs from the Qwen-style head in two ways: it consumes the target's
+token embedding concatenated with the carried hidden state, and it reads the target's present KV
+for a few layers instead of owning a cache. Both are declared in the target's `mtp` block:
+
+```jsonc
+"mtp": {
+  "filename": "assistant.onnx",
+  "main_hidden_states": "final_hidden_state",   // target output: final hidden state
+  "main_inputs_embeds": "inputs_embeds",        // target output: token embeddings
+  "shared_kv_layers": [22, 23],                 // target layers whose present KV the head reads
+  "inputs": {
+    "hidden_states": "inputs_embeds",           // head input: embedding ++ hidden, [1, 1, 2H]
+    "attention_mask": "attention_mask",
+    "shared_key_names": ["shared_kv.sliding_attention.key", "shared_kv.full_attention.key"],
+    "shared_value_names": ["shared_kv.sliding_attention.value", "shared_kv.full_attention.value"]
+  },
+  "outputs": {
+    "logits": "logits",
+    "hidden_states": "projected_state"          // head output fed back into the next draft
+  }
+}
+```
+
+`shared_key_names[i]` / `shared_value_names[i]` are bound to the target's present key/value for
+`shared_kv_layers[i]`, composed from `model.decoder.outputs.present_key_names` and
+`present_value_names`. Buffer widths come from `model.decoder.hidden_size`.
+
+`main_inputs_embeds` must name an output the runtime *binds*, not merely one the ONNX graph
+declares — for a multi-modal package that is the embedding stage's
+`model.embedding.outputs.embeddings`.
+
+A target whose logits output has a bounded sequence dimension (it emits one row per input token
+only while the input fits that bound, and last-token logits for longer prefill forwards) must
+declare `model.decoder.max_logits_sequence_length`.
+
+`builder.py` has no Gemma 4 support, so both graphs come from an external exporter
+([mobius](https://github.com/onnxruntime/mobius)) plus a post-processing pass that adds the two
+extra target outputs and writes the `mtp` block;
+[examples/python/gemma-4-mtp-build.py](../examples/python/gemma-4-mtp-build.py) drives the whole
+pipeline.
+
+See [examples/python/gemma-4-mtp.md](../examples/python/gemma-4-mtp.md) for the full contract and
+build recipe, and [examples/python/gemma-4-mtp.py](../examples/python/gemma-4-mtp.py) for a
+runnable example.
+
 ### Runtime
 
 `MtpGenerator` ([src/mtp_generator.h](../src/mtp_generator.h),

--- a/examples/python/gemma-4-mtp-build.py
+++ b/examples/python/gemma-4-mtp-build.py
@@ -393,7 +393,8 @@ def write_assistant_config(package: Path, assistant_config: dict[str, Any], targ
 
 def validate(target_package: Path, assistant_package: Path | None) -> None:
     """Check every name in the target's mtp block against the graph that must provide it."""
-    mtp = json.loads((target_package / GENAI_CONFIG).read_text(encoding="utf-8"))["model"]["mtp"]
+    model_config = json.loads((target_package / GENAI_CONFIG).read_text(encoding="utf-8"))["model"]
+    mtp = model_config["mtp"]
     decoder = onnx.load(target_package / TARGET_MODEL_RELPATH, load_external_data=False)
     decoder_outputs = {output.name for output in decoder.graph.output}
     required = [mtp["main_hidden_states"]]
@@ -401,6 +402,12 @@ def validate(target_package: Path, assistant_package: Path | None) -> None:
     missing = [name for name in required if name not in decoder_outputs]
     if missing:
         raise ValueError(f"target is missing outputs: {', '.join(missing)}")
+
+    embedding_config = model_config["embedding"]
+    embedding = onnx.load(target_package / embedding_config["filename"], load_external_data=False)
+    embedding_outputs = {output.name for output in embedding.graph.output}
+    if mtp["main_inputs_embeds"] not in embedding_outputs:
+        raise ValueError(f"target embedding is missing output: {mtp['main_inputs_embeds']}")
 
     if assistant_package is None:
         return

--- a/examples/python/gemma-4-mtp-build.py
+++ b/examples/python/gemma-4-mtp-build.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Build a Gemma 4 target + assistant pair for speculative decoding with ``og.MtpGenerator``.
+
+``builder.py`` has no Gemma 4 support, so the graphs come from an external exporter --
+mobius (https://github.com/onnxruntime/mobius) -- and this script applies the post-processing
+that ``og.MtpGenerator`` needs on top of them. See ``gemma-4-mtp.md`` for the resulting contract
+and ``gemma-4-mtp.py`` to run the pair.
+
+    # Everything, including the two mobius exports (needs `uv` on PATH):
+    python gemma-4-mtp-build.py all --out-dir models
+
+    # Or drive the stages yourself:
+    python gemma-4-mtp-build.py target   <hf_config.json> <exported> <prepared> --assistant <head>
+    python gemma-4-mtp-build.py assistant <hf_config.json> <exported> <prepared> --target <prepared_target>
+    python gemma-4-mtp-build.py quantize <prepared> <quantized>
+
+``target``/``assistant`` need ``onnx``; ``quantize`` also needs ``onnxruntime`` and ``onnx_ir``.
+"""
+
+import argparse
+import errno
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import onnx
+from onnx import helper
+
+NAMESPACE = "ortgenai/mtp"
+DEFAULT_VERIFY_WINDOW = 6
+DEFAULT_TARGET_MODEL = "google/gemma-4-E4B-it"
+DEFAULT_ASSISTANT_MODEL = "google/gemma-4-E4B-it-assistant"
+# Graph and node names below depend on the exporter, so both pins are load-bearing.
+DEFAULT_MOBIUS_REF = "66e9c5edea92e9553d98be15f64126ae48be8a53"
+DEFAULT_TRANSFORMERS = "5.14.0"
+
+GENAI_CONFIG = "genai_config.json"
+MODEL_FILE = "model.onnx"
+# The target keeps its decoder in a subdirectory; the assistant is a single flat graph.
+TARGET_MODEL_RELPATH = f"decoder/{MODEL_FILE}"
+
+
+# ---------------------------------------------------------------------------- helpers
+
+
+def link_or_copy(source: str, destination: str) -> str:
+    """Hard-link multi-gigabyte weights when the destination is on the same filesystem."""
+    try:
+        os.link(source, destination)
+    except OSError as error:
+        if error.errno != errno.EXDEV:
+            raise
+        return shutil.copy2(source, destination)
+    return destination
+
+
+def tensor_shape(value: onnx.ValueInfoProto) -> list[int | str | None]:
+    return [
+        dim.dim_value if dim.HasField("dim_value") else dim.dim_param or None
+        for dim in value.type.tensor_type.shape.dim
+    ]
+
+
+def load_text_config(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise SystemExit(f"config not found: {path}")
+    config = json.loads(path.read_text(encoding="utf-8"))
+    return config.get("text_config", config)
+
+
+def save_graph(model: onnx.ModelProto, model_path: Path) -> None:
+    temporary = model_path.with_suffix(".onnx.tmp")
+    onnx.save(model, temporary)
+    temporary.replace(model_path)
+    # Catches malformed surgery (wrong node arity, unsorted nodes) here rather than at session load.
+    onnx.checker.check_model(str(model_path), full_check=False)
+
+
+def stage_package(source: Path, output: Path, model_relpath: str) -> Path:
+    """Copy a package, then unlink and re-copy the graph so edits do not touch the source."""
+    if not (source / model_relpath).is_file():
+        raise SystemExit(f"model not found: {source / model_relpath}")
+    if output.exists():
+        raise SystemExit(f"output already exists: {output}")
+    shutil.copytree(source, output, copy_function=link_or_copy)
+    staged = output / model_relpath
+    staged.unlink()
+    shutil.copy2(source / model_relpath, staged)
+    for extra in (source / model_relpath).parent.glob(f"{MODEL_FILE}.data*"):
+        target = staged.parent / extra.name
+        target.unlink(missing_ok=True)
+        shutil.copy2(extra, target)
+    return staged
+
+
+# ---------------------------------------------------------------------------- target
+
+
+def derive_shared_kv_layers(text_config: dict[str, Any]) -> list[int]:
+    """Cache indices the assistant reads: the last sliding and last full attention layer.
+
+    Gemma 4's trailing layers share the KV of earlier ones, so the cache is shorter than the layer
+    stack and the assistant binds the final sliding/full pair.
+    """
+    layer_types = text_config["layer_types"]
+    layer_count = text_config["num_hidden_layers"]
+    if len(layer_types) != layer_count:
+        raise ValueError(f"layer_types has {len(layer_types)} entries, expected {layer_count}")
+
+    cache_count = layer_count - text_config["num_kv_shared_layers"]
+    owned = layer_types[:cache_count]
+    sliding = max(i for i, kind in enumerate(owned) if kind == "sliding_attention")
+    full = max(i for i, kind in enumerate(owned) if kind == "full_attention")
+    if (sliding, full) != (cache_count - 2, cache_count - 1):
+        raise ValueError(
+            "final cache sources are not the adjacent trailing sliding/full pair: "
+            f"sliding={sliding}, full={full}, caches={cache_count}"
+        )
+    return [sliding, full]
+
+
+def add_int64_initializers(model: onnx.ModelProto, vectors: dict[str, list[int]], scalars: dict[str, int]) -> None:
+    model.graph.initializer.extend(
+        helper.make_tensor(name, onnx.TensorProto.INT64, [1], values) for name, values in vectors.items()
+    )
+    model.graph.initializer.extend(
+        helper.make_tensor(name, onnx.TensorProto.INT64, [], [value]) for name, value in scalars.items()
+    )
+
+
+def add_hidden_state_output(model, hidden_name: str, element_type: int, width: int, batch) -> None:
+    """Slice the LM head's input at the last position and expose it as `final_hidden_state`."""
+    vectors = {
+        f"{NAMESPACE}/hidden_starts": [-1],
+        f"{NAMESPACE}/hidden_ends": [2**63 - 1],
+        f"{NAMESPACE}/hidden_axes": [1],
+        f"{NAMESPACE}/hidden_steps": [1],
+    }
+    add_int64_initializers(model, vectors, {})
+    model.graph.node.append(
+        helper.make_node(
+            "Slice",
+            [
+                hidden_name,
+                f"{NAMESPACE}/hidden_starts",
+                f"{NAMESPACE}/hidden_ends",
+                f"{NAMESPACE}/hidden_axes",
+                f"{NAMESPACE}/hidden_steps",
+            ],
+            ["final_hidden_state"],
+            name=f"{NAMESPACE}/final_hidden_state",
+        )
+    )
+    model.graph.output.append(helper.make_tensor_value_info("final_hidden_state", element_type, [batch, 1, width]))
+
+
+def bound_verify_logits(model, head_index: int, logits, hidden_name: str, window: int) -> None:
+    """Gate the LM head so inputs longer than `window` produce last-token logits only.
+
+    A prefill over a long prompt would otherwise materialize [1, prompt_len, vocab] logits, while a
+    verify forward still needs one row per draft token.
+    """
+    vectors = {
+        f"{NAMESPACE}/logits_ends": [2**63 - 1],
+        f"{NAMESPACE}/logits_axes": [1],
+        f"{NAMESPACE}/logits_steps": [1],
+        f"{NAMESPACE}/logits_unsqueeze_axes": [0],
+    }
+    scalars = {
+        f"{NAMESPACE}/logits_zero": 0,
+        f"{NAMESPACE}/logits_one": 1,
+        f"{NAMESPACE}/logits_window": window,
+        f"{NAMESPACE}/logits_gather_index": 1,
+    }
+    add_int64_initializers(model, vectors, scalars)
+    chain = [
+        helper.make_node("Shape", [hidden_name], [f"{NAMESPACE}/hidden_shape"], name=f"{NAMESPACE}/hidden_shape"),
+        helper.make_node(
+            "Gather",
+            [f"{NAMESPACE}/hidden_shape", f"{NAMESPACE}/logits_gather_index"],
+            [f"{NAMESPACE}/sequence_length"],
+            name=f"{NAMESPACE}/sequence_length",
+            axis=0,
+        ),
+        helper.make_node(
+            "Greater",
+            [f"{NAMESPACE}/sequence_length", f"{NAMESPACE}/logits_window"],
+            [f"{NAMESPACE}/is_prefill"],
+            name=f"{NAMESPACE}/is_prefill",
+        ),
+        helper.make_node(
+            "Sub",
+            [f"{NAMESPACE}/sequence_length", f"{NAMESPACE}/logits_one"],
+            [f"{NAMESPACE}/last_index"],
+            name=f"{NAMESPACE}/last_index",
+        ),
+        helper.make_node(
+            "Where",
+            [f"{NAMESPACE}/is_prefill", f"{NAMESPACE}/last_index", f"{NAMESPACE}/logits_zero"],
+            [f"{NAMESPACE}/start_scalar"],
+            name=f"{NAMESPACE}/start_scalar",
+        ),
+        helper.make_node(
+            "Unsqueeze",
+            [f"{NAMESPACE}/start_scalar", f"{NAMESPACE}/logits_unsqueeze_axes"],
+            [f"{NAMESPACE}/logits_starts"],
+            name=f"{NAMESPACE}/logits_starts",
+        ),
+        helper.make_node(
+            "Slice",
+            [
+                hidden_name,
+                f"{NAMESPACE}/logits_starts",
+                f"{NAMESPACE}/logits_ends",
+                f"{NAMESPACE}/logits_axes",
+                f"{NAMESPACE}/logits_steps",
+            ],
+            [f"{NAMESPACE}/bounded_hidden_state"],
+            name=f"{NAMESPACE}/bounded_hidden_state",
+        ),
+    ]
+    # The chain feeds the LM head, so it has to precede it in the node list.
+    for offset, node in enumerate(chain):
+        model.graph.node.insert(head_index + offset, node)
+    model.graph.node[head_index + len(chain)].input[0] = f"{NAMESPACE}/bounded_hidden_state"
+    logits.type.tensor_type.shape.dim[1].dim_param = f"mtp_verify_sequence_len_{window}"
+
+
+def transform_target(model_path: Path, width: int, window: int) -> None:
+    model = onnx.load(model_path, load_external_data=False)
+    outputs = {output.name: output for output in model.graph.output}
+    if "logits" not in outputs:
+        raise ValueError("decoder does not expose logits")
+    if "final_hidden_state" in outputs:
+        raise ValueError("decoder already exposes final_hidden_state; package is already prepared")
+    logits = outputs["logits"]
+    logits_shape = tensor_shape(logits)
+    if len(logits_shape) != 3 or logits_shape[1] == 1:
+        raise ValueError(f"MTP target requires unpruned [batch, sequence, vocab] logits; found {logits_shape}")
+
+    heads = [
+        (index, node)
+        for index, node in enumerate(model.graph.node)
+        if node.op_type in {"MatMul", "MatMulNBits"} and "/lm_head/" in node.name
+    ]
+    if len(heads) != 1:
+        raise ValueError(f"expected exactly one LM-head projection, found {len(heads)}")
+    head_index, head = heads[0]
+    hidden_name = head.input[0]
+
+    add_hidden_state_output(model, hidden_name, logits.type.tensor_type.elem_type, width, logits_shape[0])
+    if window > 0:
+        bound_verify_logits(model, head_index, logits, hidden_name, window)
+    save_graph(model, model_path)
+
+
+def write_target_config(package: Path, shared_kv_layers: list[int], window: int) -> dict[str, Any]:
+    config_path = package / GENAI_CONFIG
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    model_config = config["model"]
+    decoder = model_config["decoder"]
+    decoder.setdefault("outputs", {})["hidden_states"] = "final_hidden_state"
+    if window > 0:
+        decoder["max_logits_sequence_length"] = window
+
+    # The assistant reads the target's token embeddings from the embedding stage, the only output
+    # carrying them that the runtime binds.
+    embeddings = model_config.get("embedding", {}).get("outputs", {}).get("embeddings", "inputs_embeds")
+    model_config["mtp"] = {
+        "main_hidden_states": "final_hidden_state",
+        "main_inputs_embeds": embeddings,
+        "shared_kv_layers": shared_kv_layers,
+        "inputs": {
+            "hidden_states": "inputs_embeds",
+            "attention_mask": "attention_mask",
+            "shared_key_names": ["shared_kv.sliding_attention.key", "shared_kv.full_attention.key"],
+            "shared_value_names": ["shared_kv.sliding_attention.value", "shared_kv.full_attention.value"],
+        },
+        "outputs": {"logits": "logits", "hidden_states": "projected_state"},
+    }
+    config_path.write_text(json.dumps(config, indent=4) + "\n", encoding="utf-8")
+    return model_config["mtp"]
+
+
+# ---------------------------------------------------------------------------- assistant
+
+
+def reachable_nodes(model: onnx.ModelProto) -> set[int]:
+    """Node indices still feeding a graph output, walked backwards to a fixed point."""
+    required = {output.name for output in model.graph.output}
+    retained: set[int] = set()
+    changed = True
+    while changed:
+        changed = False
+        for index, node in enumerate(model.graph.node):
+            if index in retained or not required.intersection(node.output):
+                continue
+            retained.add(index)
+            required.update(name for name in node.input if name)
+            changed = True
+    return retained
+
+
+def densify_assistant(model_path: Path) -> None:
+    """Replace the exporter's ordered (sampled-vocab) head with a dense LM projection.
+
+    Speculative verification compares full-vocabulary argmaxes, so the head must score every token.
+    """
+    model = onnx.load(model_path, load_external_data=False)
+    outputs = {output.name for output in model.graph.output}
+    missing = {"logits", "projected_state"} - outputs
+    if missing:
+        raise ValueError(f"assistant is missing outputs: {', '.join(sorted(missing))}")
+
+    post_projections = [
+        node for node in model.graph.node if node.op_type == "MatMul" and "post_projection" in node.name
+    ]
+    if len(post_projections) != 1:
+        raise ValueError(f"expected one post_projection MatMul, found {len(post_projections)}")
+    hidden_states = post_projections[0].input[0]
+
+    producers = [node for node in model.graph.node if "logits" in node.output]
+    if len(producers) != 1:
+        raise ValueError(f"expected one logits producer, found {len(producers)}")
+    producers[0].output[list(producers[0].output).index("logits")] = f"{NAMESPACE}/ordered_logits_unused"
+
+    kept = [node for node in model.graph.node if not node.name.startswith(f"{NAMESPACE}/lm_head/")]
+    del model.graph.node[:]
+    model.graph.node.extend(kept)
+    model.graph.node.extend(
+        [
+            helper.make_node(
+                "Transpose",
+                ["lm_head.weight"],
+                [f"{NAMESPACE}/lm_head.weight_t"],
+                name=f"{NAMESPACE}/lm_head/Transpose",
+                perm=[1, 0],
+            ),
+            helper.make_node(
+                "MatMul",
+                [hidden_states, f"{NAMESPACE}/lm_head.weight_t"],
+                ["logits"],
+                name=f"{NAMESPACE}/lm_head/MatMul",
+            ),
+        ]
+    )
+
+    retained = reachable_nodes(model)
+    nodes = [node for index, node in enumerate(model.graph.node) if index in retained]
+    del model.graph.node[:]
+    model.graph.node.extend(nodes)
+    used = {name for node in nodes for name in node.input if name}
+    initializers = [initializer for initializer in model.graph.initializer if initializer.name in used]
+    del model.graph.initializer[:]
+    model.graph.initializer.extend(initializers)
+    save_graph(model, model_path)
+
+
+def write_assistant_config(package: Path, assistant_config: dict[str, Any], target_package: Path) -> None:
+    """Derive the head's genai_config from its HF config, taking vocab/EOS from the target."""
+    target = json.loads((target_package / GENAI_CONFIG).read_text(encoding="utf-8"))["model"]
+    config = {
+        "model": {
+            "type": "gemma4_assistant",
+            "vocab_size": target["vocab_size"],
+            "context_length": target["context_length"],
+            "decoder": {
+                "filename": MODEL_FILE,
+                "hidden_size": assistant_config["hidden_size"],
+                "head_size": assistant_config["head_dim"],
+                "num_attention_heads": assistant_config["num_attention_heads"],
+                "num_hidden_layers": assistant_config["num_hidden_layers"],
+                "num_key_value_heads": assistant_config["num_key_value_heads"],
+                "inputs": {"inputs_embeds": "inputs_embeds", "attention_mask": "attention_mask"},
+                "outputs": {"logits": "logits", "hidden_states": "projected_state"},
+            },
+            "eos_token_id": target["eos_token_id"],
+            "pad_token_id": target["pad_token_id"],
+        }
+    }
+    (package / GENAI_CONFIG).write_text(json.dumps(config, indent=4) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------- validation
+
+
+def validate(target_package: Path, assistant_package: Path | None) -> None:
+    """Check every name in the target's mtp block against the graph that must provide it."""
+    mtp = json.loads((target_package / GENAI_CONFIG).read_text(encoding="utf-8"))["model"]["mtp"]
+    decoder = onnx.load(target_package / TARGET_MODEL_RELPATH, load_external_data=False)
+    decoder_outputs = {output.name for output in decoder.graph.output}
+    required = [mtp["main_hidden_states"]]
+    required += [f"present.{layer}.{kind}" for layer in mtp["shared_kv_layers"] for kind in ("key", "value")]
+    missing = [name for name in required if name not in decoder_outputs]
+    if missing:
+        raise ValueError(f"target is missing outputs: {', '.join(missing)}")
+
+    if assistant_package is None:
+        return
+    head = onnx.load(assistant_package / MODEL_FILE, load_external_data=False)
+    head_inputs = {value.name for value in head.graph.input}
+    head_outputs = {output.name for output in head.graph.output}
+    expected = [mtp["inputs"]["hidden_states"], mtp["inputs"]["attention_mask"]]
+    expected += mtp["inputs"]["shared_key_names"] + mtp["inputs"]["shared_value_names"]
+    missing = [name for name in expected if name not in head_inputs]
+    missing += [name for name in mtp["outputs"].values() if name not in head_outputs]
+    if missing:
+        raise ValueError(f"assistant head is missing: {', '.join(missing)}")
+
+
+# ---------------------------------------------------------------------------- stages
+
+
+def stage_target(args) -> None:
+    text_config = load_text_config(args.hf_config)
+    shared_kv_layers = derive_shared_kv_layers(text_config)
+    staged = stage_package(args.source, args.output, TARGET_MODEL_RELPATH)
+    try:
+        transform_target(staged, int(text_config["hidden_size"]), args.verify_window)
+        write_target_config(args.output, shared_kv_layers, args.verify_window)
+        validate(args.output, args.assistant)
+    except Exception:
+        shutil.rmtree(args.output, ignore_errors=True)
+        raise
+    print(f"wrote {args.output} (shared_kv_layers={shared_kv_layers}, verify_window={args.verify_window})")
+
+
+def stage_assistant(args) -> None:
+    assistant_config = load_text_config(args.hf_config)
+    staged = stage_package(args.source, args.output, MODEL_FILE)
+    try:
+        densify_assistant(staged)
+        write_assistant_config(args.output, assistant_config, args.target)
+        validate(args.target, args.output)
+    except Exception:
+        shutil.rmtree(args.output, ignore_errors=True)
+        raise
+    print(f"wrote {args.output}")
+
+
+def stage_quantize(args) -> None:
+    # Deferred so the graph-editing stages only need onnx.
+    try:
+        from onnxruntime.quantization import matmul_nbits_quantizer, quant_utils  # noqa: PLC0415
+    except ImportError as error:
+        raise SystemExit(f"the quantize stage needs onnxruntime and its quantization extras: {error}") from error
+
+    source_model = args.source / TARGET_MODEL_RELPATH
+    if not source_model.is_file():
+        raise SystemExit(f"decoder not found: {source_model}")
+
+    def skip_weights(path: str, names: list[str]) -> set[str]:
+        if Path(path) == args.source / "decoder":
+            return {name for name in names if name.startswith(MODEL_FILE)}
+        return set()
+
+    shutil.rmtree(args.output, ignore_errors=True)
+    shutil.copytree(args.source, args.output, ignore=skip_weights)
+    config = matmul_nbits_quantizer.DefaultWeightOnlyQuantConfig(
+        block_size=32,
+        is_symmetric=True,
+        accuracy_level=4,
+        quant_format=quant_utils.QuantFormat.QOperator,
+        op_types_to_quantize=("MatMul", "Gather"),
+        quant_axes=(("MatMul", 0), ("Gather", 1)),
+    )
+    quantizer = matmul_nbits_quantizer.MatMulNBitsQuantizer(str(source_model), algo_config=config)
+    quantizer.process()
+    quantizer.model.save_model_to_file(str(args.output / TARGET_MODEL_RELPATH), True)
+    print(f"wrote {args.output}")
+
+
+def mobius_export(args, model_id: str, output: Path, extra: list[str]) -> None:
+    spec = f"mobius-onnx[ort-genai] @ git+https://github.com/onnxruntime/mobius.git@{args.mobius_ref}"
+    command = [
+        "uvx",
+        "--from",
+        spec,
+        "--with",
+        f"transformers=={args.transformers}",
+        "mobius",
+        "build",
+        "--model",
+        model_id,
+        str(output),
+        "--ep",
+        args.ep,
+        "--dtype",
+        "f16",
+        *extra,
+    ]
+    print(">>", " ".join(command))
+    subprocess.run(command, check=True)
+
+
+def stage_all(args) -> None:
+    if shutil.which("uvx") is None:
+        raise SystemExit("uvx is required to run the pinned mobius exporter; install uv first")
+    out = args.out_dir
+    out.mkdir(parents=True, exist_ok=True)
+
+    hf_target = out / "target-config.json"
+    hf_assistant = out / "assistant-config.json"
+    for path in (hf_target, hf_assistant):
+        if not path.is_file():
+            raise SystemExit(
+                f"missing {path}; download config.json for {args.target_model} and "
+                f"{args.assistant_model} and save them as target-config.json / assistant-config.json"
+            )
+
+    exported_target, exported_assistant = out / "target-fp16", out / "assistant-ordered"
+    if not exported_target.exists():
+        mobius_export(args, args.target_model, exported_target, ["--runtime", "ort-genai"])
+    if not exported_assistant.exists():
+        mobius_export(args, args.assistant_model, exported_assistant, ["--task", "gemma4-assistant"])
+
+    prepared_target = out / "target-mtp-fp16"
+    stage_target(
+        argparse.Namespace(
+            hf_config=hf_target,
+            source=exported_target,
+            output=prepared_target,
+            verify_window=args.verify_window,
+            assistant=None,
+        )
+    )
+    stage_assistant(
+        argparse.Namespace(
+            hf_config=hf_assistant,
+            source=exported_assistant,
+            output=out / "assistant-fp16",
+            target=prepared_target,
+        )
+    )
+    if not args.no_quantize:
+        stage_quantize(argparse.Namespace(source=prepared_target, output=out / "target-mtp-int4"))
+
+
+# ---------------------------------------------------------------------------- cli
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="stage", required=True)
+
+    target = sub.add_parser("target", help="Add the MTP outputs and mtp config block to a target package")
+    target.add_argument("hf_config", type=Path, help="config.json of the Hugging Face target model")
+    target.add_argument("source", type=Path, help="Exported target package")
+    target.add_argument("output", type=Path, help="Destination package (must not exist)")
+    target.add_argument("--assistant", type=Path, default=None, help="Assistant package to cross-check names against")
+    target.set_defaults(func=stage_target)
+
+    assistant = sub.add_parser("assistant", help="Densify the assistant head and write its genai_config")
+    assistant.add_argument("hf_config", type=Path, help="config.json of the Hugging Face assistant model")
+    assistant.add_argument("source", type=Path, help="Exported assistant package")
+    assistant.add_argument("output", type=Path, help="Destination package (must not exist)")
+    assistant.add_argument("--target", type=Path, required=True, help="Prepared target package")
+    assistant.set_defaults(func=stage_assistant)
+
+    quantize = sub.add_parser("quantize", help="Quantize a prepared target package to INT4 weights")
+    quantize.add_argument("source", type=Path)
+    quantize.add_argument("output", type=Path)
+    quantize.set_defaults(func=stage_quantize)
+
+    every = sub.add_parser("all", help="Export both models with mobius, then run every stage")
+    every.add_argument("--out-dir", type=Path, default=Path("models"))
+    every.add_argument("--target-model", default=DEFAULT_TARGET_MODEL)
+    every.add_argument("--assistant-model", default=DEFAULT_ASSISTANT_MODEL)
+    every.add_argument("--mobius-ref", default=DEFAULT_MOBIUS_REF)
+    every.add_argument("--transformers", default=DEFAULT_TRANSFORMERS)
+    every.add_argument("--ep", default="webgpu")
+    every.add_argument("--no-quantize", action="store_true")
+    every.set_defaults(func=stage_all)
+
+    for command in (target, every):
+        command.add_argument(
+            "--verify-window",
+            type=int,
+            default=DEFAULT_VERIFY_WINDOW,
+            help="Bound the logits sequence dimension to this many rows; 0 leaves the logits unbounded",
+        )
+
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except (ValueError, KeyError, OSError, subprocess.CalledProcessError) as error:
+        sys.exit(f"error: {error}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/gemma-4-mtp.md
+++ b/examples/python/gemma-4-mtp.md
@@ -1,0 +1,161 @@
+# Gemma 4 assistant-head speculative decoding
+
+Gemma 4 pairs its decoder with a small **assistant** head that drafts tokens for the target to
+verify. `og.MtpGenerator` drives the draft/verify loop in-engine, so the embedding and hidden-state
+handoff between the two graphs stays on-device.
+
+Build the pair with [gemma-4-mtp-build.py](gemma-4-mtp-build.py), then run it with
+[gemma-4-mtp.py](gemma-4-mtp.py):
+
+```bash
+python gemma-4-mtp-build.py all --out-dir models
+
+python gemma-4-mtp.py \
+  -m models/target-mtp-int4 \
+  -d models/assistant-fp16 \
+  --baseline
+```
+
+Greedy speculative decoding is lossless, so `--baseline` should print identical text and a speedup
+greater than 1. Divergence means the pairing is misconfigured.
+
+## How it differs from the Qwen3.6 MTP head
+
+Both are driven through the same `og.MtpGenerator` API, but the graphs are wired differently. The
+runtime picks the Gemma path when the draft model's `model.type` is `gemma4_assistant`.
+
+| | Qwen3.6 MTP head | Gemma 4 assistant |
+| --- | --- | --- |
+| Token input | `input_ids`; the head embeds internally | the target's embedding tensor, concatenated with the carried hidden state |
+| KV cache | its own | reads the target's present KV for a few layers |
+| Feedback | `hidden_states_out` | `projected_state` |
+| Verify width | any | bounded by `model.decoder.max_logits_sequence_length` |
+
+## Target contract
+
+The target must expose three things beyond a normal decoder:
+
+1. **Full per-token logits over the verify window.** A pruned decoder that only emits last-token
+   logits cannot verify a multi-token draft. If the graph bounds its logits sequence dimension,
+   declare that bound as `model.decoder.max_logits_sequence_length`; the runtime then expects one
+   logits row per input token up to that bound, and last-token logits only for longer prefill
+   forwards.
+2. **Its final hidden state** as an output, named by `model.decoder.outputs.hidden_states`. This is
+   the same `include_hidden_states` export the Qwen MTP head needs.
+3. **Its token embeddings.** `model.mtp.main_inputs_embeds` must name an output the runtime
+   *binds*, not merely one the ONNX graph declares. For a multi-modal Gemma package that is the
+   embedding stage's output, `model.embedding.outputs.embeddings` (`inputs_embeds` by default);
+   adding a separate pass-through output to the decoder graph will not resolve.
+
+## Config
+
+Everything is declared in the **target's** `genai_config.json`. The assistant is loaded as an
+ordinary `og.Model` from its own folder.
+
+```jsonc
+{
+  "model": {
+    "decoder": {
+      "filename": "model.onnx",
+      "hidden_size": 2560,
+      "max_logits_sequence_length": 6,
+      "outputs": {
+        "logits": "logits",
+        "hidden_states": "final_hidden_state"
+      }
+    },
+    "mtp": {
+      "filename": "assistant.onnx",
+      "main_hidden_states": "final_hidden_state",
+      "main_inputs_embeds": "inputs_embeds",
+      "shared_kv_layers": [22, 23],
+      "inputs": {
+        "hidden_states": "inputs_embeds",
+        "attention_mask": "attention_mask",
+        "shared_key_names": [
+          "shared_kv.sliding_attention.key",
+          "shared_kv.full_attention.key"
+        ],
+        "shared_value_names": [
+          "shared_kv.sliding_attention.value",
+          "shared_kv.full_attention.value"
+        ]
+      },
+      "outputs": {
+        "logits": "logits",
+        "hidden_states": "projected_state"
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+- `shared_key_names[i]` and `shared_value_names[i]` are bound to the target's present key/value for
+  `shared_kv_layers[i]`. The target-side names are composed from
+  `model.decoder.outputs.present_key_names` / `present_value_names`, so layer indices are all you
+  supply. All three arrays must be the same length.
+- Buffer widths come from `model.decoder.hidden_size`. The head's `inputs.hidden_states` input is
+  `[1, 1, 2 * hidden_size]`: the token embedding followed by the carried hidden state.
+- `inputs.hidden_states` and `outputs.hidden_states` name the head's own tensors, so they can be
+  called whatever the export produced (`inputs_embeds` and `projected_state` above).
+- The assistant folder's `genai_config.json` must set `"type": "gemma4_assistant"` and declare the
+  same vocabulary size as the target.
+
+## Build
+
+`builder.py` has no Gemma 4 support — it stops at `Gemma3ForConditionalGeneration` — so every
+Gemma 4 package, MTP or not, comes from an external exporter. [gemma-4-mtp-build.py](gemma-4-mtp-build.py)
+drives [mobius](https://github.com/onnxruntime/mobius) and applies the post-processing this pairing
+needs on top of it.
+
+Save the two Hugging Face `config.json` files first, then run the whole pipeline:
+
+```bash
+mkdir -p models
+hf download google/gemma-4-E4B-it config.json --local-dir /tmp/t \
+  && cp /tmp/t/config.json models/target-config.json
+hf download google/gemma-4-E4B-it-assistant config.json --local-dir /tmp/a \
+  && cp /tmp/a/config.json models/assistant-config.json
+
+python gemma-4-mtp-build.py all --out-dir models
+```
+
+That produces `models/target-mtp-int4` and `models/assistant-fp16`, which is what
+[gemma-4-mtp.py](gemma-4-mtp.py) expects. `uv` must be on `PATH`; the exporter and `transformers`
+versions are pinned in the script because the graph and node names below depend on them. The
+`target` and `assistant` stages need `onnx`; `quantize` also needs `onnxruntime` and `onnx_ir`.
+
+The stages can also be run individually — `target`, `assistant`, `quantize` — if you already have
+mobius output, or want a different export configuration:
+
+```bash
+python gemma-4-mtp-build.py target models/target-config.json models/target-fp16 models/target-mtp-fp16
+python gemma-4-mtp-build.py assistant models/assistant-config.json models/assistant-ordered \
+  models/assistant-fp16 --target models/target-mtp-fp16
+python gemma-4-mtp-build.py quantize models/target-mtp-fp16 models/target-mtp-int4
+```
+
+What each stage does:
+
+| Stage | Work |
+| --- | --- |
+| `target` | Slices the LM head's input at the last position into a `final_hidden_state` output; gates the LM head so inputs longer than `--verify-window` produce last-token logits only (otherwise a long prefill materializes `[1, prompt_len, vocab]`); derives `shared_kv_layers` from the HF config's `layer_types` and `num_kv_shared_layers`; writes the `mtp` block |
+| `assistant` | Replaces the exporter's ordered (sampled-vocab) head with a dense LM projection, since verification compares full-vocabulary argmaxes; prunes the now-unreachable nodes and initializers; writes the head's `genai_config.json` with `"type": "gemma4_assistant"` |
+| `quantize` | INT4 weight-only quantization of the prepared target |
+
+Both `target` and `assistant` validate the result: every name in the `mtp` block must exist in the
+graph that has to provide it. At runtime the generator reports the first name that does not, for
+example `Gemma4AssistantGenerator: missing target output 'present.22.key'`. A name that exists in
+the graph but is never bound by the runtime is reported separately as
+`target output '...' is not bound by the target model's state` — that is what you get by adding a
+pass-through output to the decoder graph instead of pointing `main_inputs_embeds` at the embedding
+stage.
+
+## Limitations
+
+- Greedy only, batch size 1, no guidance — the same restrictions `ValidateMtpPair` applies to the
+  Qwen MTP path.
+- `max_draft_tokens` must not exceed `max_logits_sequence_length`, since the verify forward is that
+  many tokens wide.

--- a/examples/python/gemma-4-mtp.py
+++ b/examples/python/gemma-4-mtp.py
@@ -1,0 +1,124 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Gemma 4 assistant-head self-speculative decoding example.
+
+Gemma 4 pairs its decoder with a small *assistant* head. Unlike the Qwen3.6 MTP head,
+which is handed the just-emitted token and looks the embedding up itself, the Gemma
+assistant consumes the target's token embedding concatenated with the target's final
+hidden state, and reads the target's present KV for a couple of layers instead of
+keeping a cache of its own. ``og.MtpGenerator`` runs that draft/verify loop in-engine,
+so the handoff stays on-device.
+
+Requires a target and an assistant package built by the recipe in ``gemma-4-mtp.md``.
+The pairing is driven entirely by the target's ``model.mtp`` config block; the runtime
+picks this path when the draft model's ``model.type`` is ``gemma4_assistant``.
+
+Pass ``--baseline`` to also decode the same prompt with a plain ``og.Generator`` and
+report the end-to-end speedup.
+"""
+
+import argparse
+import time
+
+import numpy as np
+import onnxruntime_genai as og
+
+
+def run_speculative(target_model, assistant_model, prompt_tokens, args):
+    """Decode with the assistant head and return (tokens, stats, seconds)."""
+    params = og.GeneratorParams(target_model)
+    params.set_search_options(max_length=args.max_length, do_sample=False)
+    params.set_speculative_options(max_draft_tokens=args.max_draft_tokens)
+    generator = og.MtpGenerator(target_model, assistant_model, params)
+
+    n_prompt = len(prompt_tokens)
+    generator.append_tokens(np.asarray(prompt_tokens, dtype=np.int32))
+    start = time.perf_counter()
+    while not generator.is_done() and len(generator.get_sequence()) < n_prompt + args.max_new_tokens:
+        generator.generate_next_token()
+    elapsed = time.perf_counter() - start
+
+    return generator.get_sequence().tolist()[n_prompt:], generator.get_stats(), elapsed
+
+
+def run_baseline(target_model, prompt_tokens, args):
+    """Decode the same prompt with plain greedy decoding, for a speedup reference."""
+    params = og.GeneratorParams(target_model)
+    params.set_search_options(max_length=args.max_length, do_sample=False)
+    generator = og.Generator(target_model, params)
+
+    n_prompt = len(prompt_tokens)
+    generator.append_tokens(np.asarray(prompt_tokens, dtype=np.int32))
+    start = time.perf_counter()
+    while not generator.is_done() and len(generator.get_sequence(0)) < n_prompt + args.max_new_tokens:
+        generator.generate_next_token()
+    elapsed = time.perf_counter() - start
+
+    return generator.get_sequence(0).tolist()[n_prompt:], elapsed
+
+
+def main(args):
+    print("Loading target model...")
+    target_model = og.Model(args.target_model_path)
+    tokenizer = og.Tokenizer(target_model)
+    print("Loading assistant head...")
+    assistant_model = og.Model(args.assistant_model_path)
+
+    prompts = args.prompts or ["Explain how photosynthesis works in plants, step by step."]
+    for prompt in prompts:
+        text = f"<start_of_turn>user\n{prompt}<end_of_turn>\n<start_of_turn>model\n"
+        prompt_tokens = tokenizer.encode(text)
+
+        tokens, stats, elapsed = run_speculative(target_model, assistant_model, prompt_tokens, args)
+
+        print("\n" + "=" * 80)
+        print(f"Prompt: {prompt}")
+        print(tokenizer.decode(tokens))
+        print("-" * 80)
+        accepted, evaluated = stats["accepts"], stats["trials"]
+        print(
+            f"accept rate: {accepted / max(evaluated, 1):.1%} ({accepted}/{evaluated})  |  "
+            f"tokens/forward: {len(tokens) / max(stats['forwards'], 1):.2f}  |  "
+            f"{len(tokens)} tokens in {elapsed:.2f}s ({len(tokens) / elapsed:.1f} tok/s)"
+        )
+
+        if args.baseline:
+            baseline_tokens, baseline_elapsed = run_baseline(target_model, prompt_tokens, args)
+            print(
+                f"baseline: {len(baseline_tokens)} tokens in {baseline_elapsed:.2f}s "
+                f"({len(baseline_tokens) / baseline_elapsed:.1f} tok/s)  |  "
+                f"speedup: {baseline_elapsed / elapsed:.2f}x"
+            )
+            # Greedy speculative decoding is lossless, so any divergence is a real bug
+            # (or a floating-point near-tie in the batched verify forward).
+            if tokens != baseline_tokens:
+                print("WARNING: speculative output diverged from greedy baseline")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Gemma 4 assistant-head speculative decoding")
+    parser.add_argument(
+        "-m",
+        "--target_model_path",
+        required=True,
+        help="Path to the target model folder (its genai_config.json must declare a model.mtp block)",
+    )
+    parser.add_argument(
+        "-d",
+        "--assistant_model_path",
+        required=True,
+        help="Path to the assistant head folder (model.type must be gemma4_assistant)",
+    )
+    parser.add_argument("-n", "--max_new_tokens", type=int, default=128, help="Number of tokens to generate per prompt")
+    parser.add_argument("--max_length", type=int, default=4096, help="Max sequence length")
+    parser.add_argument(
+        "-k",
+        "--max_draft_tokens",
+        type=int,
+        default=4,
+        help="Draft tokens proposed per round; must not exceed model.decoder.max_logits_sequence_length",
+    )
+    parser.add_argument("-p", "--prompts", nargs="*", default=None, help="Prompt(s) to run")
+    parser.add_argument("--baseline", action="store_true", help="Also decode greedily and report the speedup")
+    main(parser.parse_args())

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -841,6 +841,9 @@ struct Mtp_Element : JSON::Element {
     if (name == "shared_kv_layers") {
       return shared_kv_layers_;
     }
+    if (name == "shared_initializers") {
+      return shared_initializers_;
+    }
     throw JSON::unknown_value_error{};
   }
 
@@ -860,13 +863,6 @@ struct Mtp_Element : JSON::Element {
     }
     if (name == "outputs") {
       return outputs_;
-    }
-    throw JSON::unknown_value_error{};
-  }
-
-  Element& OnArray(std::string_view name) override {
-    if (name == "shared_initializers") {
-      return shared_initializers_;
     }
     throw JSON::unknown_value_error{};
   }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -633,6 +633,9 @@ struct Decoder_Element : JSON::Element {
       v_.num_key_value_heads = SafeDoubleToInt(JSON::Get<double>(value), name);
     } else if (name == "head_size") {
       v_.head_size = SafeDoubleToInt(JSON::Get<double>(value), name);
+    } else if (name == "max_logits_sequence_length") {
+      v_.max_logits_sequence_length = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (v_.max_logits_sequence_length < 0) throw std::runtime_error("max_logits_sequence_length must be >= 0");
     } else if (name == "conv_cache_size") {
       v_.conv_cache_size = SafeDoubleToInt(JSON::Get<double>(value), name);
     } else {
@@ -711,8 +714,20 @@ struct MtpInputs_Element : JSON::Element {
     }
   }
 
+  Element& OnArray(std::string_view name) override {
+    if (name == "shared_key_names") {
+      return shared_key_names_;
+    }
+    if (name == "shared_value_names") {
+      return shared_value_names_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
  private:
   Config::Model::Mtp::Inputs& v_;
+  StringArray_Element shared_key_names_{v_.shared_key_names};
+  StringArray_Element shared_value_names_{v_.shared_value_names};
 };
 
 struct MtpOutputs_Element : JSON::Element {
@@ -753,9 +768,18 @@ struct Mtp_Element : JSON::Element {
       if (v_.head_size <= 0) throw std::out_of_range("head_size must be > 0");
     } else if (name == "main_hidden_states") {
       v_.main_hidden_states = JSON::Get<std::string_view>(value);
+    } else if (name == "main_inputs_embeds") {
+      v_.main_inputs_embeds = JSON::Get<std::string_view>(value);
     } else {
       throw JSON::unknown_value_error{};
     }
+  }
+
+  Element& OnArray(std::string_view name) override {
+    if (name == "shared_kv_layers") {
+      return shared_kv_layers_;
+    }
+    throw JSON::unknown_value_error{};
   }
 
   Element& OnObject(std::string_view name) override {
@@ -782,6 +806,7 @@ struct Mtp_Element : JSON::Element {
   Config::Model::Mtp& v_;
   std::unique_ptr<SessionOptions_Element> session_options_;
   std::unique_ptr<RunOptions_Element> run_options_;
+  IntArray_Element shared_kv_layers_{v_.shared_kv_layers};
   MtpInputs_Element inputs_{v_.inputs};
   MtpOutputs_Element outputs_{v_.outputs};
 };

--- a/src/config.h
+++ b/src/config.h
@@ -346,6 +346,12 @@ struct Config {
       int num_hidden_layers{};
       int head_size{};
 
+      // Positions the logits output covers. 0 (the default) means one row per input token. A
+      // positive value marks a graph whose logits sequence dimension is bounded: it emits one row
+      // per input token while the input is at most this long, and last-token logits only for longer
+      // (prefill) forwards. Set by MTP verify graphs exported with a fixed verify width.
+      int max_logits_sequence_length{};
+
       // Hybrid SSM+Attention (LFM2) parameters
       std::vector<std::string> layer_types;  // Per-layer type: "conv" or "full_attention"
       int conv_cache_size{};                 // Convolution cache width (conv_L_cache from HF config)
@@ -466,6 +472,13 @@ struct Config {
       // The main model must be exported with this output exposed (include_hidden_states).
       std::string main_hidden_states{Defaults::HiddenStatesName};
 
+      // Assistant-style heads (Gemma4) additionally consume the main decoder's token embeddings
+      // and read its present KV directly instead of owning a cache. Empty for Qwen-style heads.
+      std::string main_inputs_embeds;
+      // Main-decoder layer indices whose present KV the head shares, paired positionally with
+      // inputs.shared_key_names and inputs.shared_value_names.
+      std::vector<int> shared_kv_layers;
+
       struct Inputs {
         std::string input_ids{Defaults::InputIdsName};
         std::string hidden_states{Defaults::HiddenStatesName};
@@ -473,6 +486,9 @@ struct Config {
         std::string position_ids{Defaults::PositionIdsName};
         std::string past_key_names{Defaults::PastKeyName};
         std::string past_value_names{Defaults::PastValueName};
+        // Head inputs bound to the main decoder's present KV, one per shared_kv_layers entry.
+        std::vector<std::string> shared_key_names;
+        std::vector<std::string> shared_value_names;
       } inputs;
 
       struct Outputs {

--- a/src/gemma4_assistant_generator.cpp
+++ b/src/gemma4_assistant_generator.cpp
@@ -1,0 +1,308 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gemma4_assistant_generator.h"
+
+#include <algorithm>
+#include <array>
+#include <stdexcept>
+
+#include "generators.h"
+#include "models/decoder_only.h"
+#include "models/kv_cache.h"
+#include "models/model.h"
+#include "models/multi_modal.h"
+#include "models/utils.h"
+
+namespace Generators {
+namespace {
+
+void RequireInputs(const Model& model, const std::vector<std::string>& names, const char* role) {
+  for (const auto& name : names)
+    if (name.empty() || !model.session_info_.HasInput(name))
+      throw std::runtime_error(std::string{"Gemma4AssistantGenerator: missing "} + role + " input '" + name + "'");
+}
+
+void RequireOutputs(const Model& model, const std::vector<std::string>& names, const char* role) {
+  for (const auto& name : names)
+    if (name.empty() || !model.session_info_.HasOutput(name))
+      throw std::runtime_error(std::string{"Gemma4AssistantGenerator: missing "} + role + " output '" + name + "'");
+}
+
+std::vector<const char*> AsCStrings(const std::vector<std::string>& names) {
+  std::vector<const char*> result;
+  result.reserve(names.size());
+  for (const auto& name : names) result.push_back(name.c_str());
+  return result;
+}
+
+template <typename T>
+const T& RequireModel(const Model& model, const char* role) {
+  const auto* typed = dynamic_cast<const T*>(&model);
+  if (!typed)
+    throw std::runtime_error(std::string{"Gemma4AssistantGenerator: "} + role + " model of type '" +
+                             model.config_->model.type + "' is not compatible");
+  return *typed;
+}
+
+}  // namespace
+
+Gemma4AssistantGenerator::Gemma4AssistantGenerator(
+    const Model& target_model, const Model& assistant_model, const GeneratorParams& params)
+    : target_model_{RequireModel<MultiModalLanguageModel>(target_model, "target")},
+      assistant_model_{RequireModel<DecoderOnly_Model>(assistant_model, "assistant")},
+      assistant_run_options_{OrtRunOptions::Create()},
+      embedding_run_options_{OrtRunOptions::Create()} {
+  ValidateMtpPair(target_model_, assistant_model_, params);
+  if (params.search.do_sample && params.search.temperature > 0.0f)
+    throw std::runtime_error("Gemma4AssistantGenerator currently supports greedy generation only");
+
+  const auto& mtp = target_model_.config_->model.mtp;
+  const auto& target_decoder = target_model_.config_->model.decoder;
+  hidden_size_ = target_decoder.hidden_size;
+  if (hidden_size_ <= 0)
+    throw std::runtime_error("Gemma4AssistantGenerator requires model.decoder.hidden_size in the target config");
+  if (mtp.shared_kv_layers.empty())
+    throw std::runtime_error("Gemma4AssistantGenerator requires model.mtp.shared_kv_layers in the target config");
+  if (mtp.inputs.shared_key_names.size() != mtp.shared_kv_layers.size() ||
+      mtp.inputs.shared_value_names.size() != mtp.shared_kv_layers.size())
+    throw std::runtime_error(
+        "Gemma4AssistantGenerator requires model.mtp.shared_kv_layers, shared_key_names and shared_value_names to be the same length");
+
+  target_embeddings_name_ = mtp.main_inputs_embeds;
+  target_hidden_states_name_ = mtp.main_hidden_states;
+  target_attention_mask_name_ = target_decoder.inputs.attention_mask;
+
+  assistant_input_name_storage_ = {mtp.inputs.hidden_states, mtp.inputs.attention_mask};
+  for (size_t index = 0; index < mtp.shared_kv_layers.size(); ++index) {
+    assistant_input_name_storage_.push_back(mtp.inputs.shared_key_names[index]);
+    assistant_input_name_storage_.push_back(mtp.inputs.shared_value_names[index]);
+    shared_kv_target_names_.push_back(
+        ComposeKeyValueName(target_decoder.outputs.present_key_names, mtp.shared_kv_layers[index]));
+    shared_kv_target_names_.push_back(
+        ComposeKeyValueName(target_decoder.outputs.present_value_names, mtp.shared_kv_layers[index]));
+  }
+  assistant_output_name_storage_ = {mtp.outputs.logits, mtp.outputs.hidden_states};
+
+  std::vector<std::string> target_outputs{target_embeddings_name_, target_hidden_states_name_};
+  target_outputs.insert(target_outputs.end(), shared_kv_target_names_.begin(), shared_kv_target_names_.end());
+  RequireOutputs(target_model_, target_outputs, "target");
+  RequireInputs(assistant_model_, assistant_input_name_storage_, "assistant");
+  RequireOutputs(assistant_model_, assistant_output_name_storage_, "assistant");
+
+  assistant_input_names_ = AsCStrings(assistant_input_name_storage_);
+  assistant_output_names_ = AsCStrings(assistant_output_name_storage_);
+  assistant_inputs_.resize(assistant_input_names_.size());
+  assistant_outputs_.resize(assistant_output_names_.size());
+
+  target_params_ = std::make_shared<GeneratorParams>(target_model_);
+  target_params_->search = params.search;
+  target_params_->max_batch_size = params.max_batch_size;
+  target_params_->use_graph_capture = params.use_graph_capture;
+  num_speculative_tokens_ = std::max(1, params.speculative.max_draft_tokens);
+  target_params_->max_graph_capture_length = num_speculative_tokens_;
+  target_ = CreateGenerator(target_model_, *target_params_);
+
+  vocab_size_ = target_model_.config_->model.vocab_size;
+  max_length_ = params.search.max_length;
+  eos_token_ids_ = target_model_.config_->model.eos_token_id;
+  drafts_.resize(num_speculative_tokens_);
+  verify_argmax_.resize(num_speculative_tokens_);
+
+  const auto embedding_type = target_model_.session_info_.GetOutputDataType(target_embeddings_name_);
+  const auto hidden_type = target_model_.session_info_.GetOutputDataType(target_hidden_states_name_);
+  const auto assistant_input_type = assistant_model_.session_info_.GetInputDataType(mtp.inputs.hidden_states);
+  if (embedding_type != hidden_type || hidden_type != assistant_input_type)
+    throw std::runtime_error("Gemma4AssistantGenerator requires matching embedding and hidden-state types");
+
+  const int64_t hidden = hidden_size_;
+  current_embedding_ = std::make_shared<Tensor>(target_model_.p_device_inputs_, embedding_type);
+  current_embedding_->CreateTensor(std::array<int64_t, 3>{1, 1, hidden});
+  carried_hidden_ = std::make_shared<Tensor>(target_model_.p_device_inputs_, hidden_type);
+  carried_hidden_->CreateTensor(std::array<int64_t, 3>{1, 1, hidden});
+  // The head consumes the token embedding concatenated with the carried hidden state.
+  assistant_input_ = std::make_shared<Tensor>(assistant_model_.p_device_inputs_, assistant_input_type);
+  assistant_input_->CreateTensor(std::array<int64_t, 3>{1, 1, 2 * hidden});
+  assistant_logits_ = std::make_shared<Tensor>(
+      assistant_model_.p_device_logits_, assistant_model_.session_info_.GetOutputDataType(mtp.outputs.logits));
+  assistant_logits_->CreateTensor(std::array<int64_t, 3>{1, 1, vocab_size_});
+  assistant_projected_ = std::make_shared<Tensor>(
+      assistant_model_.p_device_inputs_, assistant_model_.session_info_.GetOutputDataType(mtp.outputs.hidden_states));
+  assistant_projected_->CreateTensor(std::array<int64_t, 3>{1, 1, hidden});
+
+  const auto token_type = target_model_.session_info_.GetInputDataType(
+      target_model_.config_->model.embedding.inputs.input_ids);
+  embedding_token_ = OrtValue::CreateTensor(
+      target_model_.p_device_inputs_->GetAllocator(), std::array<int64_t, 2>{1, 1}, token_type);
+}
+
+void Gemma4AssistantGenerator::CaptureTargetState(int row) {
+  CopyTensorRow(*ResolveTargetOutput(target_embeddings_name_), row, *current_embedding_,
+                *target_model_.p_device_);
+  CopyTensorRow(*ResolveTargetOutput(target_hidden_states_name_), 0, *carried_hidden_,
+                *target_model_.p_device_);
+}
+
+// A name can be a real graph output yet never be bound by the runtime, in which case GetOutput
+// returns null; report that rather than dereferencing it.
+OrtValue* Gemma4AssistantGenerator::ResolveTargetOutput(const std::string& name) const {
+  OrtValue* value = target_->state_->GetOutput(name.c_str());
+  if (!value)
+    throw std::runtime_error("Gemma4AssistantGenerator: target output '" + name +
+                             "' is not bound by the target model's state");
+  return value;
+}
+
+void Gemma4AssistantGenerator::UpdateTargetPrediction(int row, bool capture_state) {
+  auto logits = target_->GetLogits();
+  if (!target_model_.p_device_->ArgMax(logits.Span().data(), Ort::TypeToTensorType<float>, 1,
+                                       vocab_size_, &target_next_)) {
+    auto host = logits.CopyDeviceToCpu();
+    target_next_ = ArgmaxRow(host.data(), vocab_size_);
+  }
+  if (capture_state) CaptureTargetState(row);
+}
+
+void Gemma4AssistantGenerator::SynchronizeTarget() {
+  const int32_t token = sequence_.back();
+  target_->AppendTokens(cpu_span<const int32_t>(&token, 1));
+  stats_.target_forward_passes++;
+  UpdateTargetPrediction(0);
+  target_sync_pending_ = false;
+}
+
+void Gemma4AssistantGenerator::EmbedToken(int32_t token) {
+  const auto type = embedding_token_->GetTensorTypeAndShapeInfo()->GetElementType();
+  if (type == Ort::TypeToTensorType<int64_t>)
+    *embedding_token_->GetTensorMutableData<int64_t>() = token;
+  else if (type == Ort::TypeToTensorType<int32_t>)
+    *embedding_token_->GetTensorMutableData<int32_t>() = token;
+  else
+    throw std::runtime_error("Gemma4AssistantGenerator: embedding token input must be int32 or int64");
+
+  const std::array<const char*, 3> names{
+      target_model_.config_->model.embedding.inputs.input_ids.c_str(),
+      target_model_.config_->model.embedding.inputs.image_features.c_str(),
+      target_model_.config_->model.embedding.inputs.audio_features.c_str()};
+  const std::array<const OrtValue*, 3> inputs{
+      embedding_token_.get(), target_->state_->GetInput(names[1]), target_->state_->GetInput(names[2])};
+  const char* output_name = target_model_.config_->model.embedding.outputs.embeddings.c_str();
+  OrtValue* output = current_embedding_->GetOrtTensor();
+  target_model_.embedding_session_->Run(embedding_run_options_.get(), names.data(), inputs.data(),
+                                        inputs.size(), &output_name, &output, 1);
+}
+
+int32_t Gemma4AssistantGenerator::ArgmaxAssistant() {
+  int32_t token{};
+  auto* logits = assistant_logits_->GetOrtTensor();
+  const auto type = logits->GetTensorTypeAndShapeInfo()->GetElementType();
+  if (assistant_model_.p_device_->ArgMax(logits->GetTensorRawData(), type, 1, vocab_size_, &token))
+    return token;
+  auto cpu = assistant_logits_->GetByteSpan().CopyDeviceToCpu();
+  return ArgmaxRow(cpu.data(), type, vocab_size_);
+}
+
+int32_t Gemma4AssistantGenerator::Draft() {
+  auto input = assistant_input_->GetByteSpan();
+  const size_t half = input.size() / 2;
+  input.subspan(0, half).CopyFrom(current_embedding_->GetByteSpan());
+  input.subspan(half, half).CopyFrom(carried_hidden_->GetByteSpan());
+  assistant_inputs_[0] = assistant_input_->GetOrtTensor();
+  assistant_inputs_[1] = target_->state_->GetInput(target_attention_mask_name_.c_str());
+  for (size_t index = 0; index < shared_kv_target_names_.size(); ++index)
+    assistant_inputs_[2 + index] = ResolveTargetOutput(shared_kv_target_names_[index]);
+  assistant_outputs_[0] = assistant_logits_->GetOrtTensor();
+  assistant_outputs_[1] = assistant_projected_->GetOrtTensor();
+  assistant_model_.session_decoder_->Run(
+      assistant_run_options_.get(), assistant_input_names_.data(), assistant_inputs_.data(), assistant_inputs_.size(),
+      assistant_output_names_.data(), assistant_outputs_.data(), assistant_outputs_.size());
+  stats_.draft_forward_passes++;
+  const int32_t draft = ArgmaxAssistant();
+  carried_hidden_->GetByteSpan().CopyFrom(assistant_projected_->GetByteSpan());
+  EmbedToken(draft);
+  return draft;
+}
+
+void Gemma4AssistantGenerator::ArgmaxTargetRows(int first_row, int count, int32_t* output) {
+  auto& pipeline = dynamic_cast<MultiModalPipelineState&>(*target_->state_);
+  auto cpu = pipeline.GetAllLogits().CopyDeviceToCpu();
+  for (int row = 0; row < count; ++row)
+    output[row] = ArgmaxRow(
+        cpu.data() + (static_cast<size_t>(first_row + row) * vocab_size_), vocab_size_);
+}
+
+void Gemma4AssistantGenerator::AppendTokens(cpu_span<const int32_t> input_ids) {
+  if (primed_) throw std::runtime_error("Gemma4AssistantGenerator: AppendTokens can only be called once");
+  primed_ = true;
+  target_->AppendTokens(input_ids);
+  sequence_.assign(input_ids.begin(), input_ids.end());
+  emitted_sequence_ = sequence_;
+  length_ = sequence_.size();
+  if (length_ >= static_cast<size_t>(max_length_)) {
+    done_ = true;
+    return;
+  }
+  UpdateTargetPrediction(static_cast<int>(input_ids.size()) - 1, false);
+
+  // The prefill already predicted the first generated token, so commit it here; the target only
+  // consumes it at the start of the first round.
+  sequence_.push_back(target_next_);
+  length_++;
+  QueueCommittedTokens(length_ - 1);
+  target_sync_pending_ = !done_;
+}
+
+void Gemma4AssistantGenerator::RunRound() {
+  if (target_sync_pending_) SynchronizeTarget();
+  const size_t remaining = length_ < static_cast<size_t>(max_length_) ? static_cast<size_t>(max_length_) - length_ : 0;
+  const int count = static_cast<int>(std::min(static_cast<size_t>(num_speculative_tokens_), remaining));
+  if (count <= 0) {
+    done_ = true;
+    return;
+  }
+  stats_.rounds++;
+  stats_.completed_rounds++;
+  stats_.draft_tokens_proposed += static_cast<size_t>(count);
+  for (int index = 0; index < count; ++index) {
+    try {
+      drafts_[index] = Draft();
+    } catch (const std::exception& error) {
+      throw std::runtime_error(
+          "Gemma4AssistantGenerator: assistant draft failed: " + std::string{error.what()});
+    }
+  }
+
+  target_->SnapshotState();
+  try {
+    target_->AppendTokens(cpu_span<const int32_t>(drafts_.data(), count));
+    stats_.target_forward_passes++;
+    ArgmaxTargetRows(0, count, verify_argmax_.data());
+  } catch (const std::exception& error) {
+    throw std::runtime_error(
+        "Gemma4AssistantGenerator: target verification failed: " + std::string{error.what()});
+  }
+  const int accepted = CountAcceptedDrafts(drafts_.data(), verify_argmax_.data(), count, target_next_);
+  stats_.draft_tokens_evaluated += static_cast<size_t>(accepted < count ? accepted + 1 : count);
+  stats_.draft_tokens_accepted += static_cast<size_t>(accepted);
+
+  if (accepted == count) {
+    stats_.bonus_tokens++;
+    sequence_.insert(sequence_.end(), drafts_.begin(), drafts_.begin() + accepted);
+    length_ += static_cast<size_t>(accepted);
+    target_next_ = verify_argmax_[count - 1];
+    CaptureTargetState(count - 1);
+  } else {
+    stats_.correction_tokens++;
+    const int32_t correction = accepted == 0 ? target_next_ : verify_argmax_[accepted - 1];
+    target_->RewindToLength(length_);
+    std::vector<int32_t> committed(drafts_.begin(), drafts_.begin() + accepted);
+    committed.push_back(correction);
+    target_->AppendTokens(cpu_span<const int32_t>(committed.data(), committed.size()));
+    stats_.target_forward_passes++;
+    sequence_.insert(sequence_.end(), committed.begin(), committed.end());
+    length_ += committed.size();
+    UpdateTargetPrediction(static_cast<int>(committed.size()) - 1);
+  }
+}
+
+}  // namespace Generators

--- a/src/gemma4_assistant_generator.cpp
+++ b/src/gemma4_assistant_generator.cpp
@@ -47,6 +47,18 @@ const T& RequireModel(const Model& model, const char* role) {
 
 }  // namespace
 
+void ValidateGemma4AssistantOptions(const Config::Search& search, const Config::Speculative& speculative,
+                                    int max_logits_sequence_length) {
+  if (search.do_sample && search.temperature > 0.0f)
+    throw std::runtime_error("Gemma4AssistantGenerator currently supports greedy generation only");
+  if (search.min_length > 0 || search.repetition_penalty != 1.0f || search.no_repeat_ngram_size > 0)
+    throw std::runtime_error(
+        "Gemma4AssistantGenerator does not support min_length, repetition_penalty, or no_repeat_ngram_size");
+  if (max_logits_sequence_length > 0 && speculative.max_draft_tokens > max_logits_sequence_length)
+    throw std::runtime_error(
+        "Gemma4AssistantGenerator requires max_draft_tokens <= model.decoder.max_logits_sequence_length");
+}
+
 Gemma4AssistantGenerator::Gemma4AssistantGenerator(
     const Model& target_model, const Model& assistant_model, const GeneratorParams& params)
     : target_model_{RequireModel<MultiModalLanguageModel>(target_model, "target")},
@@ -54,11 +66,10 @@ Gemma4AssistantGenerator::Gemma4AssistantGenerator(
       assistant_run_options_{OrtRunOptions::Create()},
       embedding_run_options_{OrtRunOptions::Create()} {
   ValidateMtpPair(target_model_, assistant_model_, params);
-  if (params.search.do_sample && params.search.temperature > 0.0f)
-    throw std::runtime_error("Gemma4AssistantGenerator currently supports greedy generation only");
 
   const auto& mtp = target_model_.config_->model.mtp;
   const auto& target_decoder = target_model_.config_->model.decoder;
+  ValidateGemma4AssistantOptions(params.search, params.speculative, target_decoder.max_logits_sequence_length);
   hidden_size_ = target_decoder.hidden_size;
   if (hidden_size_ <= 0)
     throw std::runtime_error("Gemma4AssistantGenerator requires model.decoder.hidden_size in the target config");
@@ -68,6 +79,10 @@ Gemma4AssistantGenerator::Gemma4AssistantGenerator(
       mtp.inputs.shared_value_names.size() != mtp.shared_kv_layers.size())
     throw std::runtime_error(
         "Gemma4AssistantGenerator requires model.mtp.shared_kv_layers, shared_key_names and shared_value_names to be the same length");
+  if (target_model_.config_->model.embedding.run_options)
+    SetRunOptions(*embedding_run_options_, *target_model_.config_->model.embedding.run_options);
+  if (assistant_model_.config_->model.decoder.run_options)
+    SetRunOptions(*assistant_run_options_, *assistant_model_.config_->model.decoder.run_options);
 
   target_embeddings_name_ = mtp.main_inputs_embeds;
   target_hidden_states_name_ = mtp.main_hidden_states;
@@ -180,12 +195,15 @@ void Gemma4AssistantGenerator::EmbedToken(int32_t token) {
   else
     throw std::runtime_error("Gemma4AssistantGenerator: embedding token input must be int32 or int64");
 
-  const std::array<const char*, 3> names{
-      target_model_.config_->model.embedding.inputs.input_ids.c_str(),
-      target_model_.config_->model.embedding.inputs.image_features.c_str(),
-      target_model_.config_->model.embedding.inputs.audio_features.c_str()};
-  const std::array<const OrtValue*, 3> inputs{
-      embedding_token_.get(), target_->state_->GetInput(names[1]), target_->state_->GetInput(names[2])};
+  std::vector<const char*> names{target_model_.config_->model.embedding.inputs.input_ids.c_str()};
+  std::vector<const OrtValue*> inputs{embedding_token_.get()};
+  for (const std::string* optional_name : {&target_model_.config_->model.embedding.inputs.image_features,
+                                           &target_model_.config_->model.embedding.inputs.audio_features}) {
+    if (OrtValue* input = target_->state_->GetInput(optional_name->c_str())) {
+      names.push_back(optional_name->c_str());
+      inputs.push_back(input);
+    }
+  }
   const char* output_name = target_model_.config_->model.embedding.outputs.embeddings.c_str();
   OrtValue* output = current_embedding_->GetOrtTensor();
   target_model_.embedding_session_->Run(embedding_run_options_.get(), names.data(), inputs.data(),
@@ -224,6 +242,20 @@ int32_t Gemma4AssistantGenerator::Draft() {
 }
 
 void Gemma4AssistantGenerator::ArgmaxTargetRows(int first_row, int count, int32_t* output) {
+  OrtValue* raw = ResolveTargetOutput(target_model_.config_->model.decoder.outputs.logits);
+  const auto type = raw->GetTensorTypeAndShapeInfo()->GetElementType();
+  const auto* base = static_cast<const uint8_t*>(raw->GetTensorRawData());
+  const size_t row_bytes = static_cast<size_t>(vocab_size_) * Ort::SizeOf(type);
+  bool all_device = true;
+  for (int row = 0; row < count; ++row) {
+    const void* values = base + static_cast<size_t>(first_row + row) * row_bytes;
+    if (!target_model_.p_device_->ArgMax(values, type, 1, vocab_size_, output + row)) {
+      all_device = false;
+      break;
+    }
+  }
+  if (all_device) return;
+
   auto& pipeline = dynamic_cast<MultiModalPipelineState&>(*target_->state_);
   auto cpu = pipeline.GetAllLogits().CopyDeviceToCpu();
   for (int row = 0; row < count; ++row)

--- a/src/gemma4_assistant_generator.h
+++ b/src/gemma4_assistant_generator.h
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "models/onnxruntime_api.h"
+#include "mtp_generator_common.h"
+#include "smartptrs.h"
+#include "speculative_stats.h"
+
+namespace Generators {
+
+struct DecoderOnly_Model;
+struct Generator;
+struct GeneratorParams;
+struct Model;
+struct MultiModalLanguageModel;
+struct Tensor;
+
+struct Gemma4AssistantGenerator : MtpGeneratorBase {
+  Gemma4AssistantGenerator(const Model& target_model, const Model& assistant_model,
+                           const GeneratorParams& params);
+
+  void AppendTokens(cpu_span<const int32_t> input_ids) override;
+
+ private:
+  void RunRound() override;
+  int32_t Draft();
+  void EmbedToken(int32_t token);
+  void CaptureTargetState(int row);
+  void UpdateTargetPrediction(int row, bool capture_state = true);
+  void SynchronizeTarget();
+  void ArgmaxTargetRows(int first_row, int count, int32_t* output);
+  int32_t ArgmaxAssistant();
+  OrtValue* ResolveTargetOutput(const std::string& name) const;
+
+  const MultiModalLanguageModel& target_model_;
+  const DecoderOnly_Model& assistant_model_;
+  std::shared_ptr<GeneratorParams> target_params_;
+  std::unique_ptr<Generator> target_;
+  std::unique_ptr<OrtRunOptions> assistant_run_options_;
+  std::unique_ptr<OrtRunOptions> embedding_run_options_;
+  std::unique_ptr<OrtValue> embedding_token_;
+  std::shared_ptr<Tensor> current_embedding_;
+  std::shared_ptr<Tensor> carried_hidden_;
+  std::shared_ptr<Tensor> assistant_input_;
+  std::shared_ptr<Tensor> assistant_logits_;
+  std::shared_ptr<Tensor> assistant_projected_;
+  std::string target_embeddings_name_;
+  std::string target_hidden_states_name_;
+  std::string target_attention_mask_name_;
+  // Target present-KV outputs bound to the head, interleaved key/value per shared layer.
+  std::vector<std::string> shared_kv_target_names_;
+  std::vector<std::string> assistant_input_name_storage_;
+  std::vector<std::string> assistant_output_name_storage_;
+  std::vector<const char*> assistant_input_names_;
+  std::vector<const char*> assistant_output_names_;
+  std::vector<const OrtValue*> assistant_inputs_;
+  std::vector<OrtValue*> assistant_outputs_;
+  std::vector<int32_t> drafts_;
+  std::vector<int32_t> verify_argmax_;
+  int32_t target_next_{};
+  int num_speculative_tokens_{1};
+  int vocab_size_{};
+  int hidden_size_{};
+  size_t length_{};
+  // The target has not yet consumed the last committed token; the next round must feed it first.
+  bool target_sync_pending_{};
+};
+
+}  // namespace Generators

--- a/src/gemma4_assistant_generator.h
+++ b/src/gemma4_assistant_generator.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "config.h"
 #include "models/onnxruntime_api.h"
 #include "mtp_generator_common.h"
 #include "smartptrs.h"
@@ -19,6 +20,9 @@ struct GeneratorParams;
 struct Model;
 struct MultiModalLanguageModel;
 struct Tensor;
+
+void ValidateGemma4AssistantOptions(const Config::Search& search, const Config::Speculative& speculative,
+                                    int max_logits_sequence_length);
 
 struct Gemma4AssistantGenerator : MtpGeneratorBase {
   Gemma4AssistantGenerator(const Model& target_model, const Model& assistant_model,

--- a/src/models/hidden_states.cpp
+++ b/src/models/hidden_states.cpp
@@ -93,6 +93,11 @@ HiddenStatesOutputs::HiddenStatesOutputs(State& state)
   const std::string& name = model_.config_->model.decoder.outputs.hidden_states;
   type_ = model_.session_info_.GetOutputDataType(name);
   shape_ = {state_.params_->BatchBeamSize(), 0, model_.config_->model.decoder.hidden_size};
+  // A graph that declares a static sequence dimension (e.g. a head that only ever emits the last
+  // position) must be bound a buffer of exactly that length, whatever the input length is.
+  const auto output_shape = model_.session_info_.GetOutputShape(name);
+  if (output_shape.size() == 3 && output_shape[1] > 0)
+    fixed_sequence_length_ = static_cast<int>(output_shape[1]);
 }
 
 void HiddenStatesOutputs::Add() {
@@ -103,6 +108,7 @@ void HiddenStatesOutputs::Add() {
 }
 
 Tensor* HiddenStatesOutputs::GetOrCreateBuffer(int sequence_length) {
+  if (fixed_sequence_length_ > 0) sequence_length = fixed_sequence_length_;
   const bool capture_length = state_.params_->use_graph_capture &&
                               sequence_length <= state_.params_->max_graph_capture_length;
   if (capture_length) {

--- a/src/models/hidden_states.h
+++ b/src/models/hidden_states.h
@@ -71,6 +71,7 @@ struct HiddenStatesOutputs {
 
   std::array<int64_t, 3> shape_{};
   ONNXTensorElementDataType type_;
+  int fixed_sequence_length_{};
   // Dedicated stable buffers only for graph-captured lengths (1, 2, ..., N+1).
   std::unordered_map<int, std::unique_ptr<Tensor>> buffers_by_len_;
   std::unique_ptr<Tensor> dynamic_buffer_;

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -15,6 +15,8 @@ Logits::Logits(State& state)
       type_{model_.session_info_.GetOutputDataType(model_.config_->model.decoder.outputs.logits)} {
   output_raw_ = std::make_unique<Tensor>(model_.p_device_logits_, type_);
 
+  max_output_sequence_length_ = static_cast<size_t>(std::max(0, model_.config_->model.decoder.max_logits_sequence_length));
+
   input_sequence_lengths.resize(state_.params_->search.batch_size);
 
   if (IsOpenVINOStatefulModel(state.model_) || state.model_.IsPruned()) {
@@ -28,6 +30,18 @@ Logits::Logits(State& state)
 
     trimmed_prefill_logits_ = true;
   }
+}
+
+DeviceSpan<float> Logits::GetAll() {
+  OrtValue* logits = output_raw_->GetOrtTensor();
+  if (type_ == Ort::TypeToTensorType<Ort::Float16_t> ||
+      type_ == Ort::TypeToTensorType<Ort::BFloat16_t>) {
+    Cast(*logits, all_logits_fp32_, *model_.p_device_logits_, Ort::TypeToTensorType<float>);
+    logits = all_logits_fp32_.get();
+  }
+  if (all_logits_.empty() || logits->GetTensorMutableRawData() != all_logits_.Span().data())
+    all_logits_ = WrapTensor<float>(*model_.p_device_logits_, *logits);
+  return all_logits_;
 }
 
 DeviceSpan<float> Logits::Get() {
@@ -86,6 +100,12 @@ void Logits::Update(const DeviceSpan<int32_t>& next_tokens, size_t new_kv_length
     new_kv_length = 1;
   }
 
+  // A bounded logits output only covers every input position while the input fits within it;
+  // longer (prefill) forwards emit last-token logits only.
+  const size_t input_kv_length = new_kv_length;
+  if (max_output_sequence_length_ > 0 && new_kv_length > max_output_sequence_length_)
+    new_kv_length = 1;
+
   if (output_raw_->ort_tensor_ && static_cast<size_t>(output_raw_->GetShape()[1]) == new_kv_length && new_kv_length == 1) {
     return;
   }
@@ -93,13 +113,17 @@ void Logits::Update(const DeviceSpan<int32_t>& next_tokens, size_t new_kv_length
   // Store length of input sequence for each batch for the get step
   for (int b = 0; b < state_.params_->search.batch_size; b++) {
     // Find the first non pad token from the end
-    size_t token_index = new_kv_length;
+    size_t token_index = input_kv_length;
     while (token_index-- > 0) {
-      auto next_token = const_cast<DeviceSpan<int32_t>&>(next_tokens).CpuSpan()[b * new_kv_length + token_index];
+      auto next_token = const_cast<DeviceSpan<int32_t>&>(next_tokens).CpuSpan()[b * input_kv_length + token_index];
       if (next_token != model_.config_->model.pad_token_id)
         break;
     }
-    input_sequence_lengths[b] = static_cast<int>(token_index + 1);
+    size_t length = token_index + 1;
+    // Non-zero only for a bounded output that dropped rows: rebase onto the rows actually emitted.
+    if (const size_t dropped_rows = input_kv_length - new_kv_length; dropped_rows > 0)
+      length = length > dropped_rows ? length - dropped_rows : 1;
+    input_sequence_lengths[b] = static_cast<int>(length);
   }
 
   if (output_raw_->ort_tensor_ && static_cast<size_t>(output_raw_->GetShape()[1]) == new_kv_length) {

--- a/src/models/logits.cpp
+++ b/src/models/logits.cpp
@@ -9,6 +9,19 @@
 
 namespace Generators {
 
+namespace {
+
+// Tokens up to and including the last non-pad one; zero if the row is entirely padding.
+size_t NonPadLength(std::span<const int32_t> row, int32_t pad_token_id) {
+  for (size_t index = row.size(); index-- > 0;) {
+    if (row[index] != pad_token_id)
+      return index + 1;
+  }
+  return 0;
+}
+
+}  // namespace
+
 Logits::Logits(State& state)
     : state_{state},
       shape_{static_cast<int64_t>(state_.params_->BatchBeamSize()), 0, model_.config_->model.vocab_size},
@@ -106,27 +119,14 @@ void Logits::Update(const DeviceSpan<int32_t>& next_tokens, size_t new_kv_length
   if (max_output_sequence_length_ > 0 && new_kv_length > max_output_sequence_length_)
     new_kv_length = 1;
 
-  if (output_raw_->ort_tensor_ && static_cast<size_t>(output_raw_->GetShape()[1]) == new_kv_length && new_kv_length == 1) {
+  const bool shape_is_current = output_raw_->ort_tensor_ && static_cast<size_t>(output_raw_->GetShape()[1]) == new_kv_length;
+  if (shape_is_current && new_kv_length == 1) {
     return;
   }
 
-  // Store length of input sequence for each batch for the get step
-  for (int b = 0; b < state_.params_->search.batch_size; b++) {
-    // Find the first non pad token from the end
-    size_t token_index = input_kv_length;
-    while (token_index-- > 0) {
-      auto next_token = const_cast<DeviceSpan<int32_t>&>(next_tokens).CpuSpan()[b * input_kv_length + token_index];
-      if (next_token != model_.config_->model.pad_token_id)
-        break;
-    }
-    size_t length = token_index + 1;
-    // Non-zero only for a bounded output that dropped rows: rebase onto the rows actually emitted.
-    if (const size_t dropped_rows = input_kv_length - new_kv_length; dropped_rows > 0)
-      length = length > dropped_rows ? length - dropped_rows : 1;
-    input_sequence_lengths[b] = static_cast<int>(length);
-  }
+  UpdateInputSequenceLengths(next_tokens, input_kv_length, input_kv_length - new_kv_length);
 
-  if (output_raw_->ort_tensor_ && static_cast<size_t>(output_raw_->GetShape()[1]) == new_kv_length) {
+  if (shape_is_current) {
     return;
   }
 
@@ -136,6 +136,19 @@ void Logits::Update(const DeviceSpan<int32_t>& next_tokens, size_t new_kv_length
   const size_t static_cap_bytes = use_static ? static_cast<size_t>(shape_[0]) * max_cap * shape_[2] * Ort::SizeOf(type_) : 0;
   output_raw_->CreateTensor(shape_, use_static, static_cap_bytes);
   state_.outputs_[output_index_] = output_raw_->GetOrtTensor();
+}
+
+// Store length of input sequence for each batch for the get step.
+void Logits::UpdateInputSequenceLengths(const DeviceSpan<int32_t>& next_tokens, size_t input_kv_length, size_t dropped_rows) {
+  const auto tokens = const_cast<DeviceSpan<int32_t>&>(next_tokens).CpuSpan();
+  for (int b = 0; b < state_.params_->search.batch_size; b++) {
+    size_t length = NonPadLength(tokens.subspan(b * input_kv_length, input_kv_length),
+                                 model_.config_->model.pad_token_id);
+    // Rebase onto the rows actually emitted.
+    if (dropped_rows > 0)
+      length = length > dropped_rows ? length - dropped_rows : 1;
+    input_sequence_lengths[b] = static_cast<int>(length);
+  }
 }
 
 void Logits::Add() {

--- a/src/models/logits.h
+++ b/src/models/logits.h
@@ -9,6 +9,7 @@ struct Logits {
 
   // Register input_ids as ORT session input.
   void Add();
+  DeviceSpan<float> GetAll();
   // For first iteration, find last token of each beam and store it in output_last_tokens_.
   DeviceSpan<float> Get();
 
@@ -22,18 +23,21 @@ struct Logits {
 
   std::array<int64_t, 3> shape_{};
   ONNXTensorElementDataType type_;
+  size_t max_output_sequence_length_{};
 
   // Tensor to keep the logits of the last tokens. It is used in the 2 cases below. Otherwhise, it is not used.
   // 1. prompt: store the last tokens logits from output_raw_
   // 2. token gen: store the converted fp32 logits if output_raw_ is fp16.
   std::unique_ptr<OrtValue> output_last_tokens_;
   std::unique_ptr<OrtValue> logits_of_last_token_fp32_;
+  std::unique_ptr<OrtValue> all_logits_fp32_;
 
   std::unique_ptr<Tensor> output_raw_;  // Raw logits output from model
 
   std::vector<int> input_sequence_lengths;
   // OrtValue wrapped in a DeviceMemory object to make it universal
   DeviceSpan<float> logits_;
+  DeviceSpan<float> all_logits_;
 
   // Set to true when prefill will generate the already 'trimmed' logits required for sampling.
   bool trimmed_prefill_logits_ = false;

--- a/src/models/logits.h
+++ b/src/models/logits.h
@@ -17,6 +17,9 @@ struct Logits {
   void Update(const DeviceSpan<int32_t>& next_tokens, size_t new_kv_length);
 
  private:
+  // dropped_rows is the count of input positions the model did not emit logits for.
+  void UpdateInputSequenceLengths(const DeviceSpan<int32_t>& next_tokens, size_t input_kv_length, size_t dropped_rows);
+
   State& state_;
   const Model& model_{state_.model_};
   size_t output_index_{~0U};

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -184,14 +184,12 @@ void State::Run(OrtSession& session, bool graph_capture_this_run, int graph_capt
   DumpOutputs();
 }
 
-void State::SetRunOption(const char* key, const char* value) {
+void SetRunOption(OrtRunOptions& run_options, const char* key, const char* value) {
   if (strcmp(key, "terminate_session") == 0) {
     if (strcmp(value, "0") == 0) {
-      session_terminated_ = false;
-      run_options_->UnsetTerminate();
+      run_options.UnsetTerminate();
     } else if (strcmp(value, "1") == 0) {
-      session_terminated_ = true;
-      run_options_->SetTerminate();
+      run_options.SetTerminate();
     } else {
       // Value not expected
       throw std::runtime_error(std::string("terminate_session key value unexpected: ") + value);
@@ -200,20 +198,35 @@ void State::SetRunOption(const char* key, const char* value) {
   } else if (strcmp(key, "enable_profiling") == 0) {
 #if ORT_API_VERSION >= 25
     if (strcmp(value, "0") == 0) {
-      run_options_->DisableProfiling();
+      run_options.DisableProfiling();
     } else {
       // Enable run-level profiling. The profiling output file is named: <prefix>_<timestamp>.json
       // Value "1" uses the default prefix; any other value is treated as a custom prefix.
       constexpr const char* default_profile_prefix = "onnxruntime_run_profile";
       const char* prefix = (strcmp(value, "1") == 0) ? default_profile_prefix : value;
-      run_options_->EnableProfiling(fs::path(prefix).c_str());
+      run_options.EnableProfiling(fs::path(prefix).c_str());
     }
 #else
     throw std::runtime_error("enable_profiling requires ONNX Runtime 1.25 or later");
 #endif
     return;
   }
-  run_options_->AddConfigEntry(key, value);
+  run_options.AddConfigEntry(key, value);
+}
+
+void SetRunOptions(OrtRunOptions& run_options, const Config::RunOptions& config_run_options) {
+  for (const auto& [key, value] : config_run_options)
+    SetRunOption(run_options, key.c_str(), value.c_str());
+}
+
+void State::SetRunOption(const char* key, const char* value) {
+  if (strcmp(key, "terminate_session") == 0) {
+    if (strcmp(value, "0") == 0)
+      session_terminated_ = false;
+    else if (strcmp(value, "1") == 0)
+      session_terminated_ = true;
+  }
+  Generators::SetRunOption(*run_options_, key, value);
 }
 
 /*
@@ -221,9 +234,8 @@ void State::SetRunOption(const char* key, const char* value) {
  * Reference: https://github.com/microsoft/onnxruntime/blob/main/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h
  */
 void State::SetRunOptions(const Config::RunOptions& config_run_options) {
-  for (auto& config_entry : config_run_options) {
-    SetRunOption(config_entry.first.c_str(), config_entry.second.c_str());
-  }
+  for (const auto& [key, value] : config_run_options)
+    SetRunOption(key.c_str(), value.c_str());
 }
 
 OrtValue* State::GetInput(const char* name) {

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -24,6 +24,8 @@ struct Tokenizer;
 
 void Cast(OrtValue& input, std::unique_ptr<OrtValue>& output, DeviceInterface& device, ONNXTensorElementDataType type);
 void CheckResult(extError_t error);
+void SetRunOption(OrtRunOptions& run_options, const char* key, const char* value);
+void SetRunOptions(OrtRunOptions& run_options, const Config::RunOptions& config_run_options);
 
 struct State {
   State(const GeneratorParams& params, const Model& model_);

--- a/src/models/model_type.h
+++ b/src/models/model_type.h
@@ -17,7 +17,7 @@ namespace Generators {
 struct ModelType {
   inline static bool IsLLM(const std::string& model_type) {
     // Large-language model (LLM)
-    static constexpr std::array<std::string_view, 27> LLM = {"chatglm", "decoder", "ernie4_5", "gemma", "gemma2", "gemma3_text", "gemma4_text", "gpt2", "gptoss", "granite", "granitemoehybrid", "hunyuandensev1", "internlm2", "lfm2", "llama", "mistral", "nemotron", "olmo", "phi", "phimoe", "phi3", "phi3small", "qwen2", "qwen3", "qwen3_5_moe_text", "qwen3_5_text", "smollm3"};
+    static constexpr std::array<std::string_view, 28> LLM = {"chatglm", "decoder", "ernie4_5", "gemma", "gemma2", "gemma3_text", "gemma4_assistant", "gemma4_text", "gpt2", "gptoss", "granite", "granitemoehybrid", "hunyuandensev1", "internlm2", "lfm2", "llama", "mistral", "nemotron", "olmo", "phi", "phimoe", "phi3", "phi3small", "qwen2", "qwen3", "qwen3_5_moe_text", "qwen3_5_text", "smollm3"};
     return std::find(LLM.begin(), LLM.end(), model_type) != LLM.end();
   }
 
@@ -36,6 +36,11 @@ struct ModelType {
   inline static bool IsPixtralFamily(const std::string& model_type) {
     // Pixtral family: per-image vision loop with variable resolution
     return model_type == "mistral3";
+  }
+
+  inline static bool IsGemma4Assistant(const std::string& model_type) {
+    // Gemma4 speculative assistant head; only ever loaded as the draft half of an MTP pair.
+    return model_type == "gemma4_assistant";
   }
 
   inline static bool IsALM(const std::string& model_type) {

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -709,6 +709,18 @@ DeviceSpan<float> DecoderState::Run(int current_length, DeviceSpan<int32_t>& nex
   return logits_.Get();
 }
 
+void DecoderState::RewindTo(size_t index) {
+  position_inputs_->RewindTo(index);
+  kv_cache_.RewindTo(index);
+  if (recurrent_state_)
+    recurrent_state_->RewindTo(index);
+}
+
+void DecoderState::SnapshotState(size_t position) {
+  if (recurrent_state_)
+    recurrent_state_->Snapshot(position);
+}
+
 void DecoderState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int total_length, DeviceSpan<int32_t> beam_indices) {
   int batch_size = static_cast<int>(inputs_embeds_.GetShape()[0]);
   size_t new_length = next_tokens.size() / batch_size;
@@ -851,6 +863,14 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
   }
   embedding_state_->Run(current_length, next_tokens, next_indices);
   return decoder_state_->Run(current_length, next_tokens, next_indices);
+}
+
+void MultiModalPipelineState::RewindTo(size_t index) {
+  decoder_state_->RewindTo(index);
+}
+
+void MultiModalPipelineState::SnapshotState(size_t position) {
+  decoder_state_->SnapshotState(position);
 }
 
 OrtValue* MultiModalPipelineState::GetInput(const char* name) {

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -688,6 +688,12 @@ DecoderState::DecoderState(const MultiModalLanguageModel& model, DeviceSpan<int3
 
   position_inputs_->Add();
   logits_.Add();
+  // Same as DecoderOnly_State: a decoder exported with include_hidden_states registers that output
+  // as a managed one so it survives CUDA-graph capture.
+  if (!model_.config_->model.decoder.outputs.hidden_states.empty()) {
+    hidden_states_output_ = std::make_unique<HiddenStatesOutputs>(*this);
+    hidden_states_output_->Add();
+  }
   kv_cache_.Add();
   if (recurrent_state_)
     recurrent_state_->Add();
@@ -712,6 +718,8 @@ void DecoderState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int tot
   if (recurrent_state_)
     recurrent_state_->Update();
   logits_.Update(next_tokens, new_length);
+  if (hidden_states_output_)
+    hidden_states_output_->Update(static_cast<int>(new_length));
   inputs_embeds_.UpdateSequenceLength(new_length);
   if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
 }
@@ -723,6 +731,8 @@ void DecoderState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int tot
   if (recurrent_state_)
     recurrent_state_->Update();
   logits_.Update(next_tokens, new_length);
+  if (hidden_states_output_)
+    hidden_states_output_->Update(static_cast<int>(new_length));
   inputs_embeds_.UpdateSequenceLength(new_length);
   if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
 }

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -178,6 +178,8 @@ struct DecoderState : State {
   DecoderState& operator=(const DecoderState&) = delete;
 
   DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices) override;
+  void RewindTo(size_t index) override;
+  void SnapshotState(size_t position) override;
   void UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int current_length, DeviceSpan<int32_t> beam_indices);
 
  private:
@@ -207,6 +209,8 @@ struct MultiModalPipelineState : State {
 
   DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens,
                         DeviceSpan<int32_t> next_indices) override;
+  void RewindTo(size_t index) override;
+  void SnapshotState(size_t position) override;
 
   OrtValue* GetInput(const char* name) override;
 

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -19,6 +19,7 @@
 #include "position_inputs.h"
 #include "model_type.h"
 #include "recurrent_state.h"
+#include "hidden_states.h"
 
 namespace Generators {
 
@@ -193,6 +194,7 @@ struct DecoderState : State {
   DefaultKeyValueCache kv_cache_{*this};                // Model input
   std::unique_ptr<RecurrentState> recurrent_state_;     // Model input (for hybrid models)
   Logits logits_{*this};                                // Model output
+  std::unique_ptr<HiddenStatesOutputs> hidden_states_output_;
 };
 
 struct MultiModalPipelineState : State {
@@ -209,6 +211,8 @@ struct MultiModalPipelineState : State {
   OrtValue* GetInput(const char* name) override;
 
   OrtValue* GetOutput(const char* name) override;
+
+  DeviceSpan<float> GetAllLogits() { return decoder_state_->logits_.GetAll(); }
 
  private:
   void UpdateInputsOutputs(const DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices,

--- a/src/mtp_generator.cpp
+++ b/src/mtp_generator.cpp
@@ -15,37 +15,9 @@
 
 namespace Generators {
 
-namespace {
-// Greedy argmax over a contiguous vocab row of fp32 logits on the CPU.
-int32_t ArgmaxRow(const float* row, int vocab_size) {
-  int32_t best = 0;
-  float best_val = row[0];
-  for (int i = 1; i < vocab_size; ++i) {
-    if (row[i] > best_val) {
-      best_val = row[i];
-      best = i;
-    }
-  }
-  return best;
-}
-
-}  // namespace
-
 MtpGenerator::MtpGenerator(const Model& main_model, const Model& mtp_model, const GeneratorParams& params)
     : main_model_{main_model}, mtp_model_{mtp_model} {
-  if (params.search.batch_size != 1 || params.search.num_beams != 1 ||
-      params.search.num_return_sequences != 1) {
-    throw std::runtime_error("MtpGenerator supports only batch_size=1, num_beams=1, and num_return_sequences=1");
-  }
-  if (!params.guidance_type.empty()) {
-    throw std::runtime_error("MtpGenerator does not support guided generation");
-  }
-  if (main_model_.p_device_->GetType() != mtp_model_.p_device_->GetType()) {
-    throw std::runtime_error("MtpGenerator requires the main model and MTP head on the same device type");
-  }
-  if (main_model_.config_->model.vocab_size != mtp_model_.config_->model.vocab_size) {
-    throw std::runtime_error("MtpGenerator requires matching main-model and MTP-head vocabulary sizes");
-  }
+  ValidateMtpPair(main_model_, mtp_model_, params);
   if (main_model_.config_->model.decoder.hidden_size != mtp_model_.config_->model.decoder.hidden_size) {
     throw std::runtime_error("MtpGenerator requires matching main-model and MTP-head hidden sizes");
   }
@@ -127,6 +99,7 @@ MtpGenerator::MtpGenerator(const Model& main_model, const Model& mtp_model, cons
   hidden_size_ = main_model_.config_->model.decoder.hidden_size;
   vocab_size_ = main_model_.config_->model.vocab_size;
   max_length_ = params.search.max_length;
+  eos_token_ids_ = main_model_.config_->model.eos_token_id;
 
   // Speculative sampling: when the caller requests randomized sampling (do_sample) with a positive
   // temperature, drafts are sampled from their truncated distribution and accepted via the
@@ -208,11 +181,7 @@ void MtpGenerator::ExtractHiddenPosition(OrtValue* hidden, int position) {
 }
 
 void MtpGenerator::CopyHiddenRow(OrtValue* hidden, int position, Tensor& dst) {
-  // hidden is [1, S, H] on the main model device; copy row `position` into dst ([1,1,H]).
-  auto src = ByteWrapTensor(*main_model_.p_device_, *hidden);
-  const size_t row_bytes = dst.GetByteSpan().size();
-  auto src_row = src.subspan(static_cast<size_t>(position) * row_bytes, row_bytes);
-  dst.GetByteSpan().CopyFrom(src_row);
+  CopyTensorRow(*hidden, position, dst, *main_model_.p_device_);
 }
 
 int32_t MtpGenerator::DraftHeadStep(int32_t token, bool need_draft) {
@@ -604,31 +573,13 @@ void MtpGenerator::AppendTokens(cpu_span<const int32_t> input_ids) {
   primed_ = true;
 }
 
-void MtpGenerator::GenerateNextToken() {
-  if (!primed_) throw std::runtime_error("MtpGenerator: AppendTokens must be called before GenerateNextToken");
-  if (pending_tokens_.empty() && !done_) {
-    const size_t previous_size = sequence_.size();
-    RunRound();
-    pending_tokens_.insert(pending_tokens_.end(),
-                           sequence_.begin() + static_cast<ptrdiff_t>(previous_size),
-                           sequence_.end());
-    stats_.tokens_queued += sequence_.size() - previous_size;
-  }
-
-  if (!pending_tokens_.empty()) {
-    emitted_sequence_.push_back(pending_tokens_.front());
-    pending_tokens_.pop_front();
-    stats_.tokens_emitted++;
-  }
-}
-
 void MtpGenerator::RunRound() {
   if (done_) return;
 
   // Commit the token predicted for position length_.
   const int32_t t = next_token_;
   sequence_.push_back(t);
-  if (contains(main_model_.config_->model.eos_token_id, t) || sequence_.size() >= static_cast<size_t>(max_length_)) {
+  if (IsEos(t) || sequence_.size() >= static_cast<size_t>(max_length_)) {
     done_ = true;
     return;
   }
@@ -1042,27 +993,6 @@ void MtpGenerator::GenerateStepMultiSample(int32_t t) {
     CopyHiddenRow(rhidden, a, *hidden_slice_);  // hidden paired with the correction token
     length_ += static_cast<size_t>(a) + 1;
   }
-}
-
-bool MtpGenerator::IsDone() const {
-  return done_ && pending_tokens_.empty();
-}
-
-SpeculativeStats MtpGenerator::GetSpeculativeStats() const {
-  SpeculativeStats stats = stats_;
-  stats.tokens_buffered = pending_tokens_.size();
-  if (stats.draft_tokens_evaluated > 0) {
-    stats.acceptance_rate =
-        static_cast<float>(stats.draft_tokens_accepted) /
-        static_cast<float>(stats.draft_tokens_evaluated);
-  }
-  if (stats.rounds > 0) {
-    stats.avg_draft_tokens_per_round =
-        static_cast<float>(stats.draft_tokens_proposed) / static_cast<float>(stats.rounds);
-    stats.mean_emitted_tokens_per_round =
-        static_cast<float>(stats.tokens_emitted) / static_cast<float>(stats.rounds);
-  }
-  return stats;
 }
 
 }  // namespace Generators

--- a/src/mtp_generator.h
+++ b/src/mtp_generator.h
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include <deque>
 #include <memory>
 #include <random>
 #include <vector>
 
 #include "sampling_distribution.h"
+#include "mtp_generator_common.h"
 #include "speculative_stats.h"
 
 namespace Generators {
@@ -28,29 +28,14 @@ struct DeviceInterface;
 // round-trip), and the draft is verified against the main model in a single 2-token forward.
 // Greedy, batch size 1. The output is identical to plain greedy decoding (lossless), modulo
 // floating-point near-ties in the batched verify forward.
-struct MtpGenerator {
+struct MtpGenerator : MtpGeneratorBase {
   MtpGenerator(const Model& main_model, const Model& mtp_model, const GeneratorParams& params);
 
   // Seed the prompt (runs the main model's prefill).
-  void AppendTokens(cpu_span<const int32_t> input_ids);
-
-  // Produce exactly one user-visible token. A speculative round may commit several tokens
-  // internally; later calls drain those buffered tokens before another round runs.
-  void GenerateNextToken();
-
-  bool IsDone() const;
-
-  // The full committed token sequence (batch index 0).
-  const std::vector<int32_t>& GetSequence() const { return emitted_sequence_; }
-
-  // Speculative-decoding statistics.
-  SpeculativeStats GetSpeculativeStats() const;
-  size_t Forwards() const { return stats_.target_forward_passes; }
-  size_t Accepts() const { return stats_.draft_tokens_accepted; }
-  size_t Trials() const { return stats_.draft_tokens_evaluated; }
+  void AppendTokens(cpu_span<const int32_t> input_ids) override;
 
  private:
-  void RunRound();
+  void RunRound() override;
 
   // Run the MTP head on a single (hidden_state, token) pair. When `need_draft` is true, returns the
   // head's greedy drafted next token; when false, only advances the head's KV cache (skipping the
@@ -142,12 +127,8 @@ struct MtpGenerator {
   std::vector<std::shared_ptr<Tensor>> refeed_multi_;
   std::unique_ptr<OrtValue> logits_fp32_;  // reusable fp32 cast of the main model's raw logits
 
-  std::vector<int32_t> sequence_;          // internally committed tokens (may include lookahead)
-  std::vector<int32_t> emitted_sequence_;  // prompt + tokens exposed through GenerateNextToken
-  std::deque<int32_t> pending_tokens_;     // internally committed tokens waiting to be exposed
   int hidden_size_{};
   int vocab_size_{};
-  int max_length_{};
 
   // Number of speculative draft tokens per step (N). 1 = the original single-token fast path;
   // >1 chains the single MTP module N times (Qwen3.6 / vLLM-style). Taken from
@@ -192,8 +173,6 @@ struct MtpGenerator {
   // Loop carry state (see the design doc draft/verify invariant):
   int32_t next_token_{};  // token predicted for the current cache length L (not yet committed)
   size_t length_{};       // committed cache length L
-  bool primed_{false};    // whether AppendTokens has run the prompt
-  bool done_{false};
   // Pipelined draft: on an accepted step the next step's draft is computed ahead (fused into the
   // post-accept KV-advance as one 2-token MTP forward), so the next GenerateNextToken reuses it
   // instead of issuing a separate draft forward.

--- a/src/mtp_generator_common.cpp
+++ b/src/mtp_generator_common.cpp
@@ -7,8 +7,10 @@
 #include <cstring>
 #include <stdexcept>
 
+#include "gemma4_assistant_generator.h"
 #include "generators.h"
 #include "models/model.h"
+#include "models/model_type.h"
 #include "models/utils.h"
 #include "mtp_generator.h"
 
@@ -16,6 +18,8 @@ namespace Generators {
 
 std::unique_ptr<MtpGeneratorInterface> CreateMtpGenerator(
     const Model& target_model, const Model& draft_model, const GeneratorParams& params) {
+  if (ModelType::IsGemma4Assistant(draft_model.config_->model.type))
+    return std::make_unique<Gemma4AssistantGenerator>(target_model, draft_model, params);
   return std::make_unique<MtpGenerator>(target_model, draft_model, params);
 }
 

--- a/src/mtp_generator_common.cpp
+++ b/src/mtp_generator_common.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "mtp_generator_common.h"
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+
+#include "generators.h"
+#include "models/model.h"
+#include "models/utils.h"
+#include "mtp_generator.h"
+
+namespace Generators {
+
+std::unique_ptr<MtpGeneratorInterface> CreateMtpGenerator(
+    const Model& target_model, const Model& draft_model, const GeneratorParams& params) {
+  return std::make_unique<MtpGenerator>(target_model, draft_model, params);
+}
+
+void MtpGeneratorBase::GenerateNextToken() {
+  if (!primed_)
+    throw std::runtime_error("MTP generation requires AppendTokens before GenerateNextToken");
+
+  if (pending_tokens_.empty() && !done_) {
+    const size_t committed = sequence_.size();
+    RunRound();
+    QueueCommittedTokens(committed);
+  }
+
+  if (pending_tokens_.empty()) return;
+  emitted_sequence_.push_back(pending_tokens_.front());
+  pending_tokens_.pop_front();
+  stats_.tokens_emitted++;
+}
+
+void MtpGeneratorBase::QueueCommittedTokens(size_t first_index) {
+  for (size_t index = first_index; index < sequence_.size(); ++index) {
+    pending_tokens_.push_back(sequence_[index]);
+    stats_.tokens_queued++;
+    if (IsEos(sequence_[index]) || index + 1 >= static_cast<size_t>(max_length_)) {
+      done_ = true;
+      return;
+    }
+  }
+}
+
+bool MtpGeneratorBase::IsEos(int32_t token) const {
+  return contains(eos_token_ids_, token);
+}
+
+int CountAcceptedDrafts(const int32_t* drafts, const int32_t* verify_argmax, int count,
+                        int32_t target_prediction) {
+  if (count <= 0 || drafts[0] != target_prediction) return 0;
+  int accepted = 1;
+  while (accepted < count && drafts[accepted] == verify_argmax[accepted - 1]) ++accepted;
+  return accepted;
+}
+
+void ValidateMtpPair(const Model& target_model, const Model& draft_model,
+                     const GeneratorParams& params) {
+  if (params.search.batch_size != 1 || params.search.num_beams != 1 ||
+      params.search.num_return_sequences != 1)
+    throw std::runtime_error(
+        "MTP generation supports only batch_size=1, num_beams=1, and num_return_sequences=1");
+  if (!params.guidance_type.empty())
+    throw std::runtime_error("MTP generation does not support guided generation");
+  if (target_model.p_device_->GetType() != draft_model.p_device_->GetType())
+    throw std::runtime_error("MTP generation requires target and draft models on the same device type");
+  if (target_model.config_->model.vocab_size != draft_model.config_->model.vocab_size)
+    throw std::runtime_error("MTP generation requires matching target and draft vocabularies");
+}
+
+int32_t ArgmaxRow(const float* values, int vocab_size) {
+  return static_cast<int32_t>(std::max_element(values, values + vocab_size) - values);
+}
+
+template <typename T>
+int32_t ArgmaxHalfRow(const uint8_t* values, int vocab_size) {
+  const auto* typed_values = reinterpret_cast<const T*>(values);
+  int32_t best = 0;
+  float best_value = ToFloat32(typed_values[0]);
+  for (int index = 1; index < vocab_size; ++index) {
+    const float value = ToFloat32(typed_values[index]);
+    if (value > best_value) {
+      best = index;
+      best_value = value;
+    }
+  }
+  return best;
+}
+
+int32_t ArgmaxRow(const uint8_t* values, ONNXTensorElementDataType type, int vocab_size) {
+  if (type == Ort::TypeToTensorType<float>)
+    return ArgmaxRow(reinterpret_cast<const float*>(values), vocab_size);
+  if (type == Ort::TypeToTensorType<Ort::Float16_t>)
+    return ArgmaxHalfRow<Ort::Float16_t>(values, vocab_size);
+  if (type == Ort::TypeToTensorType<Ort::BFloat16_t>)
+    return ArgmaxHalfRow<Ort::BFloat16_t>(values, vocab_size);
+  throw std::runtime_error("MTP generation encountered an unsupported logits type");
+}
+
+void CopyTensorRow(OrtValue& source, int row, Tensor& destination, DeviceInterface& device) {
+  if (source.GetTensorTypeAndShapeInfo()->GetElementType() != destination.GetType())
+    throw std::runtime_error("MTP generation encountered a tensor type mismatch");
+  const size_t row_bytes = destination.GetByteSpan().size();
+  const size_t offset = static_cast<size_t>(row) * row_bytes;
+  if (source.GetTensorMemoryInfo().GetDeviceType() == OrtMemoryInfoDeviceType_CPU) {
+    auto host = destination.GetByteSpan().CpuSpan();
+    std::memcpy(host.data(), static_cast<const uint8_t*>(source.GetTensorRawData()) + offset, row_bytes);
+    destination.GetByteSpan().CopyCpuToDevice();
+    return;
+  }
+  auto source_bytes = ByteWrapTensor(device, source);
+  destination.GetByteSpan().CopyFrom(source_bytes.subspan(offset, row_bytes));
+}
+
+SpeculativeStats FinalizeSpeculativeStats(SpeculativeStats stats, size_t buffered_tokens) {
+  stats.tokens_buffered = buffered_tokens;
+  if (stats.draft_tokens_evaluated > 0)
+    stats.acceptance_rate = static_cast<float>(stats.draft_tokens_accepted) /
+                            static_cast<float>(stats.draft_tokens_evaluated);
+  if (stats.rounds > 0) {
+    stats.avg_draft_tokens_per_round = static_cast<float>(stats.draft_tokens_proposed) /
+                                       static_cast<float>(stats.rounds);
+    stats.mean_emitted_tokens_per_round = static_cast<float>(stats.tokens_emitted) /
+                                          static_cast<float>(stats.rounds);
+  }
+  return stats;
+}
+
+}  // namespace Generators

--- a/src/mtp_generator_common.h
+++ b/src/mtp_generator_common.h
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <vector>
+
+#include "models/onnxruntime_api.h"
+#include "smartptrs.h"
+#include "speculative_stats.h"
+
+namespace Generators {
+
+struct DeviceInterface;
+struct GeneratorParams;
+struct Model;
+struct Tensor;
+
+struct MtpGeneratorInterface {
+  virtual ~MtpGeneratorInterface() = default;
+  virtual void AppendTokens(cpu_span<const int32_t> input_ids) = 0;
+  virtual void GenerateNextToken() = 0;
+  virtual bool IsDone() const = 0;
+  virtual const std::vector<int32_t>& GetSequence() const = 0;
+  virtual SpeculativeStats GetSpeculativeStats() const = 0;
+  virtual size_t Forwards() const = 0;
+  virtual size_t Accepts() const = 0;
+  virtual size_t Trials() const = 0;
+};
+
+void ValidateMtpPair(const Model& target_model, const Model& draft_model,
+                     const GeneratorParams& params);
+int32_t ArgmaxRow(const float* values, int vocab_size);
+int32_t ArgmaxRow(const uint8_t* values, ONNXTensorElementDataType type, int vocab_size);
+void CopyTensorRow(OrtValue& source, int row, Tensor& destination, DeviceInterface& device);
+SpeculativeStats FinalizeSpeculativeStats(SpeculativeStats stats, size_t buffered_tokens);
+
+// Length of the longest prefix of `drafts` the target agrees with: draft 0 must match the target's
+// standing prediction, and each later draft must match the target's argmax at the preceding verify
+// row. `verify_argmax` is only read when at least one draft is accepted.
+int CountAcceptedDrafts(const int32_t* drafts, const int32_t* verify_argmax, int count,
+                        int32_t target_prediction);
+
+// Delivery plumbing shared by the MTP generators: a round commits several tokens at once, so they
+// are buffered here and handed out one per GenerateNextToken call. Subclasses only implement the
+// prompt and the round itself.
+struct MtpGeneratorBase : MtpGeneratorInterface {
+  void GenerateNextToken() override;
+  bool IsDone() const override { return done_ && pending_tokens_.empty(); }
+  const std::vector<int32_t>& GetSequence() const override { return emitted_sequence_; }
+  SpeculativeStats GetSpeculativeStats() const override { return FinalizeSpeculativeStats(stats_, pending_tokens_.size()); }
+  size_t Forwards() const override { return stats_.target_forward_passes; }
+  size_t Accepts() const override { return stats_.draft_tokens_accepted; }
+  size_t Trials() const override { return stats_.draft_tokens_evaluated; }
+
+ protected:
+  // Buffers sequence_[first_index..] for delivery, finishing at an eos token or max_length_.
+  void QueueCommittedTokens(size_t first_index);
+  bool IsEos(int32_t token) const;
+
+  std::vector<int32_t> eos_token_ids_;
+  int max_length_{};
+
+  std::vector<int32_t> sequence_;          // internally committed tokens (may include lookahead)
+  std::vector<int32_t> emitted_sequence_;  // prompt + tokens exposed through GenerateNextToken
+  std::deque<int32_t> pending_tokens_;     // committed tokens waiting to be exposed
+  SpeculativeStats stats_{};
+  bool primed_{false};  // whether AppendTokens has run the prompt
+  bool done_{false};
+
+ private:
+  // Only GenerateNextToken drives a round, so subclasses override this without calling it.
+  virtual void RunRound() = 0;
+};
+
+std::unique_ptr<MtpGeneratorInterface> CreateMtpGenerator(
+    const Model& target_model, const Model& draft_model, const GeneratorParams& params);
+
+}  // namespace Generators

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -14,7 +14,7 @@
 #include "runtime_settings.h"
 #include "search.h"
 #include "smartptrs.h"
-#include "mtp_generator.h"
+#include "mtp_generator_common.h"
 #include "engine/engine.h"
 #include "models/streaming_processor.h"
 #include "models/nemotron_speech.h"
@@ -67,7 +67,17 @@ struct OgaAudios : Generators::Audios, OgaAbstract {};
 struct OgaConfig : Generators::Config, OgaAbstract {};
 struct OgaGenerator : Generators::Generator, OgaAbstract {};
 struct OgaGeneratorParams : Generators::GeneratorParams, OgaAbstract {};
-struct OgaMtpGenerator : Generators::MtpGenerator, OgaAbstract {};
+// Unlike the handles above, this one owns the implementation rather than deriving from it (the
+// concrete generator is chosen at runtime), so `OgaDestroyMtpGenerator` deletes it as itself.
+struct OgaMtpGenerator {
+  explicit OgaMtpGenerator(std::unique_ptr<Generators::MtpGeneratorInterface> implementation)
+      : implementation_{std::move(implementation)} {}
+
+  Generators::MtpGeneratorInterface& Impl() { return *implementation_; }
+  const Generators::MtpGeneratorInterface& Impl() const { return *implementation_; }
+
+  std::unique_ptr<Generators::MtpGeneratorInterface> implementation_;
+};
 struct OgaImages : Generators::Images, OgaAbstract {};
 struct OgaModel : Generators::Model, OgaAbstract {};
 struct OgaMultiModalProcessor : Generators::MultiModalProcessor, OgaAbstract {};
@@ -500,47 +510,47 @@ OgaResult* OgaCreateGenerator(const OgaModel* model, const OgaGeneratorParams* p
 
 OgaResult* OGA_API_CALL OgaCreateMtpGenerator(const OgaModel* main_model, const OgaModel* mtp_model, const OgaGeneratorParams* params, OgaMtpGenerator** out) {
   OGA_TRY
-  *out = ReturnUnique<OgaMtpGenerator>(std::make_unique<Generators::MtpGenerator>(*main_model, *mtp_model, *params));
+  *out = std::make_unique<OgaMtpGenerator>(Generators::CreateMtpGenerator(*main_model, *mtp_model, *params)).release();
   return nullptr;
   OGA_CATCH
 }
 
 OgaResult* OGA_API_CALL OgaMtpGenerator_AppendTokens(OgaMtpGenerator* generator, const int32_t* input_ids, size_t input_ids_count) {
   OGA_TRY
-  generator->AppendTokens(Generators::cpu_span<const int32_t>(input_ids, input_ids_count));
+  generator->Impl().AppendTokens(Generators::cpu_span<const int32_t>(input_ids, input_ids_count));
   return nullptr;
   OGA_CATCH
 }
 
 OgaResult* OGA_API_CALL OgaMtpGenerator_GenerateNextToken(OgaMtpGenerator* generator) {
   OGA_TRY
-  generator->GenerateNextToken();
+  generator->Impl().GenerateNextToken();
   return nullptr;
   OGA_CATCH
 }
 
 bool OGA_API_CALL OgaMtpGenerator_IsDone(const OgaMtpGenerator* generator) {
-  return generator->IsDone();
+  return generator->Impl().IsDone();
 }
 
 size_t OGA_API_CALL OgaMtpGenerator_GetSequenceCount(const OgaMtpGenerator* generator) {
-  return generator->GetSequence().size();
+  return generator->Impl().GetSequence().size();
 }
 
 const int32_t* OGA_API_CALL OgaMtpGenerator_GetSequenceData(const OgaMtpGenerator* generator) {
-  return generator->GetSequence().data();
+  return generator->Impl().GetSequence().data();
 }
 
 size_t OGA_API_CALL OgaMtpGenerator_GetForwardCount(const OgaMtpGenerator* generator) {
-  return generator->Forwards();
+  return generator->Impl().Forwards();
 }
 
 size_t OGA_API_CALL OgaMtpGenerator_GetAcceptCount(const OgaMtpGenerator* generator) {
-  return generator->Accepts();
+  return generator->Impl().Accepts();
 }
 
 size_t OGA_API_CALL OgaMtpGenerator_GetTrialCount(const OgaMtpGenerator* generator) {
-  return generator->Trials();
+  return generator->Impl().Trials();
 }
 
 OgaResult* OGA_API_CALL OgaMtpGenerator_GetSpeculativeStats(
@@ -549,12 +559,12 @@ OgaResult* OGA_API_CALL OgaMtpGenerator_GetSpeculativeStats(
   if (!out)
     throw std::invalid_argument("out must not be null.");
   *out = ReturnUnique<OgaSpeculativeStats>(
-      std::make_unique<Generators::SpeculativeStats>(generator->GetSpeculativeStats()));
+      std::make_unique<Generators::SpeculativeStats>(generator->Impl().GetSpeculativeStats()));
   return nullptr;
   OGA_CATCH
 }
 
-void OGA_API_CALL OgaDestroyMtpGenerator(OgaMtpGenerator* p) { delete static_cast<Generators::MtpGenerator*>(p); }
+void OGA_API_CALL OgaDestroyMtpGenerator(OgaMtpGenerator* p) { delete p; }
 
 bool OGA_API_CALL OgaGenerator_IsDone(OgaGenerator* generator) {
   return generator->IsDone();

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -563,17 +563,16 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateGenerator(const OgaModel* model, con
  */
 OGA_EXPORT void OGA_API_CALL OgaDestroyGenerator(OgaGenerator* generator);
 
-/* Multi-Token-Prediction (MTP) self-speculative decoding (e.g. Qwen3.6). The MtpGenerator
- * composes a main decoder and an MTP draft head and runs the draft/verify loop in-engine,
- * keeping the hidden-state handoff on-device. Greedy, batch size 1; the output is identical to
- * plain greedy decoding (lossless). */
+/* Multi-Token-Prediction (MTP) self-speculative decoding. The MtpGenerator composes a target
+ * decoder and a compatible draft model and runs the architecture-specific draft/verify loop
+ * in-engine. */
 typedef struct OgaMtpGenerator OgaMtpGenerator;
 
 /**
- * \brief Creates an MTP self-speculative generator from a main model and an MTP-head model.
- * \param[in] main_model The main decoder (exported with include_hidden_states).
- * \param[in] mtp_model The MTP head (mtp.onnx, with a hidden_states input).
- * \param[in] params The generation parameters (greedy, batch size 1).
+ * \brief Creates an MTP self-speculative generator from a target model and compatible draft model.
+ * \param[in] main_model The target decoder.
+ * \param[in] mtp_model The architecture-compatible draft model.
+ * \param[in] params The generation parameters.
  * \param[out] out The created MTP generator.
  * \return OgaResult containing the error message on failure.
  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ file(GLOB test_srcs CONFIGURE_DEPENDS
 # Keep tests with dedicated white-box executables out of the public-API unit_tests target.
 list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/reinit_tests.cpp")
 list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/search_checkpoint_tests.cpp")
+list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/mtp_generator_common_test.cpp")
 
 if(USE_CUDA AND CMAKE_CUDA_COMPILER AND ENABLE_CUDA_KERNEL_TESTS)
   message(STATUS "Including CUDA kernel tests in the build.")
@@ -96,6 +97,27 @@ if (NOT MSVC)
 endif()
 
 add_test(NAME UnitTests COMMAND unit_tests)
+
+# These tests exercise internal MTP helpers, which are not exported from the public shared library.
+add_executable(mtp_generator_common_tests "${CMAKE_CURRENT_SOURCE_DIR}/mtp_generator_common_test.cpp")
+target_include_directories(mtp_generator_common_tests PRIVATE
+  ${ORT_HEADER_DIR}
+  ${onnxruntime_extensions_SOURCE_DIR}/shared/api
+  ${CMAKE_SOURCE_DIR}/src
+)
+target_link_libraries(mtp_generator_common_tests PRIVATE
+  onnxruntime-genai-obj
+  GTest::gtest_main
+)
+add_dependencies(mtp_generator_common_tests onnxruntime-genai)
+set_target_properties(mtp_generator_common_tests PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "$<TARGET_FILE_DIR:onnxruntime-genai>"
+  FOLDER "Tests"
+)
+if(NOT MSVC)
+  target_compile_options(mtp_generator_common_tests PRIVATE "-fvisibility=hidden")
+endif()
+add_test(NAME MtpGeneratorCommonTests COMMAND mtp_generator_common_tests)
 
 # Standalone shutdown / re-initialization tests. Isolated in their own executable because they call
 # OgaShutdown(), which resets process-global GenAI state (env, device interfaces, add-on libraries,

--- a/test/model_tests.cpp
+++ b/test/model_tests.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <cstring>  // for memcmp
+#include <fstream>
 #include <iostream>
 #include <random>
 #include <filesystem>
@@ -54,6 +55,42 @@ TEST(ModelTests, DMLAdapterSelection) {
 
 // DML doesn't support GPT attention
 #if !USE_DML
+TEST(ModelTests, MultiModalRewindRegeneratesSameOutput) {
+  const std::filesystem::path source{MODEL_PATH "multimodal-decoder-with-input-ids"};
+  const auto model_path = std::filesystem::temp_directory_path() / "ortgenai_multimodal_rewind";
+  std::filesystem::remove_all(model_path);
+  std::filesystem::copy(source, model_path, std::filesystem::copy_options::recursive);
+
+  const auto config_path = model_path / "genai_config.json";
+  std::ifstream config_input{config_path};
+  std::string config{std::istreambuf_iterator<char>{config_input}, std::istreambuf_iterator<char>{}};
+  config.replace(config.find("\"phi3v\""), sizeof("\"phi3v\"") - 1, "\"gemma4\"");
+  config.replace(config.find("\"vision\": {"), sizeof("\"vision\": {") - 1,
+                 "\"speech\": {\"config_filename\": \"\"}, \"vision\": {");
+  std::ofstream{config_path} << config;
+
+  auto model = OgaModel::Create(model_path.string().c_str());
+  auto params = OgaGeneratorParams::Create(*model);
+  params->SetSearchOption("max_length", 8);
+  params->SetSearchOptionBool("past_present_share_buffer", false);
+
+  auto generator = OgaGenerator::Create(*model, *params);
+  constexpr std::array<int32_t, 1> prompt{2};
+  generator->AppendTokens(prompt);
+  while (!generator->IsDone())
+    generator->GenerateNextToken();
+  const auto first = generator->GetSequence(0);
+  const std::vector<int32_t> expected{first.begin(), first.end()};
+
+  generator->RewindTo(prompt.size());
+  while (!generator->IsDone())
+    generator->GenerateNextToken();
+
+  const auto actual = generator->GetSequence(0);
+  ASSERT_EQ(actual.size(), expected.size());
+  EXPECT_EQ(std::memcmp(actual.data(), expected.data(), expected.size() * sizeof(int32_t)), 0);
+}
+
 TEST(ModelTests, GreedySearchGptFp32) {
   std::vector<int64_t> input_ids_shape{2, 4};
   std::vector<int32_t> input_ids{0, 0, 0, 52, 0, 0, 195, 731};

--- a/test/mtp_config_test.cpp
+++ b/test/mtp_config_test.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <string_view>
 
 #include <gtest/gtest.h>
 
@@ -14,26 +15,40 @@ namespace {
 
 namespace fs_std = std::filesystem;
 
-fs_std::path WriteMtpConfig(const std::string& output_name) {
-  const auto root = fs_std::temp_directory_path() / ("ortgenai_mtp_config_" + output_name);
+fs_std::path WriteConfig(const std::string& name, std::string_view model_body) {
+  auto root = fs_std::temp_directory_path() / ("ortgenai_mtp_config_" + name);
   std::error_code ec;
   fs_std::remove_all(root, ec);
   fs_std::create_directories(root);
 
-  const std::string config =
-      "{ \"model\": { \"type\": \"tiny-test-model\","
-      " \"vocab_size\": 16, \"context_length\": 32,"
-      " \"decoder\": { \"filename\": \"model.onnx\" },"
-      " \"mtp\": { \"filename\": \"mtp.onnx\","
-      " \"main_hidden_states\": \"main_hidden\","
-      " \"outputs\": { \"" +
-      output_name +
-      "\": \"head_feedback\" } } },"
-      " \"search\": {} }";
   std::ofstream out(root / "genai_config.json", std::ios::binary);
-  out << config;
+  out << R"({ "model": { "type": "tiny-test-model", "vocab_size": 16, "context_length": 32,)"
+      << model_body << R"( }, "search": {} })";
   return root;
 }
+
+fs_std::path WriteMtpConfig(const std::string& output_name) {
+  return WriteConfig(output_name,
+                     R"( "decoder": { "filename": "model.onnx" },)"
+                     R"( "mtp": { "filename": "mtp.onnx",)"
+                     R"( "main_hidden_states": "main_hidden",)"
+                     R"( "outputs": { ")" +
+                         output_name + R"(": "head_feedback" } })");
+}
+
+// The Gemma4 assistant contract as emitted by the export tooling.
+constexpr std::string_view kAssistantMtpBody =
+    R"( "decoder": { "filename": "model.onnx", "hidden_size": 8,)"
+    R"( "max_logits_sequence_length": 6,)"
+    R"( "outputs": { "hidden_states": "final_hidden_state" } },)"
+    R"( "mtp": { "filename": "assistant.onnx",)"
+    R"( "main_hidden_states": "final_hidden_state",)"
+    R"( "main_inputs_embeds": "inputs_embeds",)"
+    R"( "shared_kv_layers": [22, 23],)"
+    R"( "inputs": { "hidden_states": "inputs_embeds", "attention_mask": "attention_mask",)"
+    R"( "shared_key_names": ["shared_kv.sliding_attention.key", "shared_kv.full_attention.key"],)"
+    R"( "shared_value_names": ["shared_kv.sliding_attention.value", "shared_kv.full_attention.value"] },)"
+    R"( "outputs": { "logits": "logits", "hidden_states": "projected_state" } })";
 
 }  // namespace
 
@@ -44,6 +59,25 @@ TEST(MtpConfigTest, AcceptsConfigurableFeedbackOutput) {
 
 TEST(MtpConfigTest, RejectsMisspelledFeedbackOutput) {
   const auto root = WriteMtpConfig("hidden_state");
+  EXPECT_THROW(OgaConfig::Create(root.string().c_str()), std::exception);
+}
+
+TEST(MtpConfigTest, AcceptsAssistantHeadContract) {
+  const auto root = WriteConfig("assistant", kAssistantMtpBody);
+  EXPECT_NO_THROW(OgaConfig::Create(root.string().c_str()));
+}
+
+TEST(MtpConfigTest, RejectsNegativeMaxLogitsSequenceLength) {
+  const auto root = WriteConfig("negative_max_logits",
+                                " \"decoder\": { \"filename\": \"model.onnx\","
+                                " \"max_logits_sequence_length\": -1 }");
+  EXPECT_THROW(OgaConfig::Create(root.string().c_str()), std::exception);
+}
+
+TEST(MtpConfigTest, RejectsUnknownSharedKvKey) {
+  const auto root = WriteConfig("unknown_shared_kv",
+                                " \"decoder\": { \"filename\": \"model.onnx\" },"
+                                " \"mtp\": { \"shared_kv_layer\": [22] }");
   EXPECT_THROW(OgaConfig::Create(root.string().c_str()), std::exception);
 }
 

--- a/test/mtp_generator_common_test.cpp
+++ b/test/mtp_generator_common_test.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <array>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "mtp_generator_common.h"
+
+namespace Generators::test {
+namespace {
+
+// Drives MtpGeneratorBase with a scripted round so the delivery/stats plumbing can be tested
+// without a model.
+struct ScriptedMtpGenerator : MtpGeneratorBase {
+  void AppendTokens(cpu_span<const int32_t> input_ids) override {
+    sequence_.assign(input_ids.begin(), input_ids.end());
+    emitted_sequence_ = sequence_;
+    primed_ = true;
+  }
+
+  using MtpGeneratorBase::eos_token_ids_;
+  using MtpGeneratorBase::max_length_;
+
+  std::vector<int32_t> round_tokens_;
+
+ private:
+  void RunRound() override { sequence_.insert(sequence_.end(), round_tokens_.begin(), round_tokens_.end()); }
+};
+
+ScriptedMtpGenerator MakeGenerator(std::vector<int32_t> round_tokens, int max_length,
+                                   std::vector<int32_t> eos = {}) {
+  ScriptedMtpGenerator generator;
+  generator.round_tokens_ = std::move(round_tokens);
+  generator.max_length_ = max_length;
+  generator.eos_token_ids_ = std::move(eos);
+  return generator;
+}
+
+constexpr std::array<int32_t, 2> kPrompt{1, 2};
+
+}  // namespace
+
+TEST(MtpGeneratorCommonTest, ArgmaxSelectsLargestValue) {
+  constexpr std::array<float, 5> values{-2.0f, 4.0f, 3.5f, 8.0f, 1.0f};
+  EXPECT_EQ(ArgmaxRow(values.data(), static_cast<int>(values.size())), 3);
+}
+
+TEST(MtpGeneratorCommonTest, FinalizesDerivedStatistics) {
+  SpeculativeStats stats{};
+  stats.rounds = 2;
+  stats.draft_tokens_proposed = 6;
+  stats.draft_tokens_evaluated = 4;
+  stats.draft_tokens_accepted = 3;
+  stats.tokens_emitted = 8;
+
+  const auto finalized = FinalizeSpeculativeStats(stats, 2);
+
+  EXPECT_EQ(finalized.tokens_buffered, 2);
+  EXPECT_FLOAT_EQ(finalized.acceptance_rate, 0.75f);
+  EXPECT_FLOAT_EQ(finalized.avg_draft_tokens_per_round, 3.0f);
+  EXPECT_FLOAT_EQ(finalized.mean_emitted_tokens_per_round, 4.0f);
+}
+
+TEST(CountAcceptedDraftsTest, RejectsWhenFirstDraftDiffers) {
+  constexpr std::array<int32_t, 3> drafts{7, 8, 9};
+  // Deliberately empty: a rejected first draft must not read the verify rows at all.
+  EXPECT_EQ(CountAcceptedDrafts(drafts.data(), nullptr, static_cast<int>(drafts.size()), 5), 0);
+}
+
+TEST(CountAcceptedDraftsTest, AcceptsMatchingPrefix) {
+  constexpr std::array<int32_t, 4> drafts{5, 8, 9, 10};
+  constexpr std::array<int32_t, 4> verify{8, 99, 99, 99};
+  EXPECT_EQ(CountAcceptedDrafts(drafts.data(), verify.data(), static_cast<int>(drafts.size()), 5), 2);
+}
+
+TEST(CountAcceptedDraftsTest, AcceptsEveryDraft) {
+  constexpr std::array<int32_t, 3> drafts{5, 8, 9};
+  constexpr std::array<int32_t, 3> verify{8, 9, 11};
+  EXPECT_EQ(CountAcceptedDrafts(drafts.data(), verify.data(), static_cast<int>(drafts.size()), 5), 3);
+}
+
+TEST(CountAcceptedDraftsTest, HandlesEmptyRound) {
+  EXPECT_EQ(CountAcceptedDrafts(nullptr, nullptr, 0, 5), 0);
+}
+
+TEST(MtpGeneratorBaseTest, RequiresAppendTokensFirst) {
+  auto generator = MakeGenerator({3}, 100);
+  EXPECT_THROW(generator.GenerateNextToken(), std::runtime_error);
+}
+
+TEST(MtpGeneratorBaseTest, DeliversOneBufferedTokenPerCall) {
+  auto generator = MakeGenerator({3, 4}, 100);
+  generator.AppendTokens(cpu_span<const int32_t>(kPrompt.data(), kPrompt.size()));
+
+  generator.GenerateNextToken();
+  EXPECT_EQ(generator.GetSequence(), (std::vector<int32_t>{1, 2, 3}));
+  EXPECT_EQ(generator.GetSpeculativeStats().tokens_buffered, 1);
+
+  generator.GenerateNextToken();
+  EXPECT_EQ(generator.GetSequence(), (std::vector<int32_t>{1, 2, 3, 4}));
+
+  const auto stats = generator.GetSpeculativeStats();
+  EXPECT_EQ(stats.tokens_queued, 2);
+  EXPECT_EQ(stats.tokens_emitted, 2);
+  EXPECT_EQ(stats.tokens_buffered, 0);
+  EXPECT_FALSE(generator.IsDone());
+}
+
+TEST(MtpGeneratorBaseTest, StopsQueueingAtEos) {
+  auto generator = MakeGenerator({3, 4, 5}, 100, {4});
+  generator.AppendTokens(cpu_span<const int32_t>(kPrompt.data(), kPrompt.size()));
+
+  generator.GenerateNextToken();
+  generator.GenerateNextToken();
+
+  EXPECT_EQ(generator.GetSequence(), (std::vector<int32_t>{1, 2, 3, 4}));
+  EXPECT_EQ(generator.GetSpeculativeStats().tokens_queued, 2);
+  EXPECT_TRUE(generator.IsDone());
+}
+
+TEST(MtpGeneratorBaseTest, StopsQueueingAtMaxLength) {
+  auto generator = MakeGenerator({3, 4, 5}, 4);
+  generator.AppendTokens(cpu_span<const int32_t>(kPrompt.data(), kPrompt.size()));
+
+  generator.GenerateNextToken();
+  generator.GenerateNextToken();
+
+  EXPECT_EQ(generator.GetSequence(), (std::vector<int32_t>{1, 2, 3, 4}));
+  EXPECT_TRUE(generator.IsDone());
+}
+
+}  // namespace Generators::test

--- a/test/mtp_generator_common_test.cpp
+++ b/test/mtp_generator_common_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include "gemma4_assistant_generator.h"
 #include "mtp_generator_common.h"
 
 namespace Generators::test {
@@ -83,6 +84,34 @@ TEST(CountAcceptedDraftsTest, AcceptsEveryDraft) {
 
 TEST(CountAcceptedDraftsTest, HandlesEmptyRound) {
   EXPECT_EQ(CountAcceptedDrafts(nullptr, nullptr, 0, 5), 0);
+}
+
+TEST(Gemma4AssistantOptionsTest, RejectsDraftWidthBeyondLogitsWindow) {
+  Config::Search search;
+  Config::Speculative speculative;
+  speculative.max_draft_tokens = 7;
+  EXPECT_THROW(ValidateGemma4AssistantOptions(search, speculative, 6), std::runtime_error);
+}
+
+TEST(Gemma4AssistantOptionsTest, AcceptsUnboundedLogitsWindow) {
+  Config::Search search;
+  Config::Speculative speculative;
+  speculative.max_draft_tokens = 7;
+  EXPECT_NO_THROW(ValidateGemma4AssistantOptions(search, speculative, 0));
+}
+
+TEST(Gemma4AssistantOptionsTest, RejectsUnsupportedSearchConstraints) {
+  Config::Search search;
+  Config::Speculative speculative;
+
+  search.min_length = 2;
+  EXPECT_THROW(ValidateGemma4AssistantOptions(search, speculative, 6), std::runtime_error);
+  search.min_length = 0;
+  search.repetition_penalty = 1.1f;
+  EXPECT_THROW(ValidateGemma4AssistantOptions(search, speculative, 6), std::runtime_error);
+  search.repetition_penalty = 1.0f;
+  search.no_repeat_ngram_size = 2;
+  EXPECT_THROW(ValidateGemma4AssistantOptions(search, speculative, 6), std::runtime_error);
 }
 
 TEST(MtpGeneratorBaseTest, RequiresAppendTokensFirst) {


### PR DESCRIPTION
## Summary

Add assistant-head speculative decoding for Gemma 4 by reusing the existing multi-token prediction (MTP) path.

- Extract `MtpGeneratorInterface` and `MtpGeneratorBase` from `MtpGenerator` so multiple MTP implementations can share generator plumbing.
- Add `Gemma4AssistantGenerator` and configuration for assistant-head execution, shared KV layers, and main-model input embeddings.
- Extend logits, hidden-state, and multimodal handling required by the Gemma 4 path.
- Add a Python export/build example and usage documentation.
- Simplify `Logits::Update` and add focused configuration and shared-generator tests.

## Validation

Tested end-to-end with Gemma 4 assistant-head generation and verified lossless output relative to greedy decoding.

## Design discussion

https://github.com/microsoft/onnxruntime-genai/discussions/2439