### PR TITLE
Fix AttributeError in KV cache shape naming under paged attention

### DIFF
--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1056,6 +1056,10 @@ class Model:
         Sliding window layers get a distinct symbolic sequence dim so ONNX shape inference does not
         unify them with the full-attention layers, whose cache is allocated at max_length.
         """
+        # Paged layers share one [num_blocks, block_size, num_kv_heads, head_size] pool, so there
+        # is no per-layer sequence dim to rename and shape[2] is an int rather than a string.
+        if self.use_paged_attention:
+            return shape
         if (
             self.ep in self.eps_with_windowed_kv_cache
             and hasattr(self, "is_local")


### PR DESCRIPTION
make_key_value_cache_shape() renames the sequence dim of sliding-window layers so ONNX shape inference does not unify them with the full-attention layers. Under use_paged_attention the KV cache shape is

    [num_blocks, block_size, num_kv_heads, head_size]

so shape[2] is num_kv_heads (an int) and shape[2].replace("sequence", "sliding") raises AttributeError. This breaks any model with alternating attention built with use_paged_attention=true, such as gpt-oss.

Paged layers all share a single block pool and have no per-layer sequence dim to rename, so return the shape unchanged in that case.