### PR TITLE
Warn when building gpt-oss with float16 I/O precision

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -501,6 +501,8 @@ def create_model(
         onnx_model = Gemma3Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
     elif config.architectures[0] == "GptOssForCausalLM":
         print("WARNING: This model only supports symmetric quantization for `QMoE`.")
+        if io_dtype == ir.DataType.FLOAT16:
+            print("WARNING: This model overflows the float16 range in its last layers, which produces NaN logits. Set `--precision bf16` or `--precision int4 --extra_options use_cuda_bf16=true`.")
         if hasattr(config, "quantization_config") and config.quantization_config.get("quant_method") != "quark":
             delattr(config, "quantization_config")
         onnx_model = GPTOSSModel(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)


### PR DESCRIPTION
gpt-oss activations grow through the decoder and exceed the float16 range in the final layers. Instrumenting the graph shows the max absolute activation climbing from ~35 at layer 0 to ~45,344 at layer 34; layer 35 passes the 65,504 ceiling and every logit comes back NaN. argmax over all-NaN returns index 0, so the model emits one repeated token ("!") instead of text.

This is silent: the build succeeds and the model loads and runs at full speed. Warn when io_dtype is float16, matching the existing Gemma2/Gemma3 warnings, and point at --precision bf16 or --extra_options use_cuda_bf16=true.

Should the builder instead default use_cuda_bf16=true for gpt-oss? A warning still lets users produce a model that only emits NaN, but defaulting would silently change the output dtype for anyone currently passing --precision int4 -e cuda.