### PR TITLE
Keep Python opaque data alive for the lifetime of the request

### DIFF
--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -748,9 +748,14 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def("has_unseen_tokens", &OgaRequest::HasUnseenTokens)
       .def("is_turn_complete", &OgaRequest::IsTurnComplete, "Return whether the current generation turn is complete.")
       .def("get_unseen_token", &OgaRequest::GetUnseenToken)
-      .def("set_opaque_data", [](OgaRequest& request, pybind11::object opaque_data) {
-        request.SetOpaqueData(opaque_data.ptr());
-      })
+      .def(
+          "set_opaque_data", [](OgaRequest& request, pybind11::object opaque_data) {
+            request.SetOpaqueData(opaque_data.ptr());
+          },
+          // The core stores the PyObject* unowned, so tie its lifetime to the request that
+          // holds it; otherwise passing a temporary frees it and get_opaque_data() returns
+          // a dangling pointer.
+          pybind11::keep_alive<1, 2>())
       .def("get_opaque_data", [](OgaRequest& request) -> pybind11::object {
         auto opaque_data = request.GetOpaqueData();
         if (!opaque_data)


### PR DESCRIPTION
Request.SetOpaqueData() stores the PyObject* unowned by design, and the Python binding passed opaque_data.ptr() straight through without holding a reference. Anything that is not independently kept alive by the caller is therefore freed as soon as set_opaque_data() returns, and get_opaque_data() hands back a dangling pointer.

The natural way to write it is a use-after-free:

    req.set_opaque_data(Sink(prompt))     # temporary, freed immediately
    ...
    sink = ready.get_opaque_data()        # dangling
    sink.text += ...                      # general protection fault in libpython

That faults inside libpython rather than raising, so it looks like a runtime bug rather than an ownership mistake. The shipped continuous-batching example only avoids it because it passes a long-lived RequestPool.

Add pybind11::keep_alive<1, 2> so the object lives as long as the request that references it.