### PR TITLE
Fix recurrent CUDA graph selection for multimodal models

### DIFF
--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -698,8 +698,11 @@ DeviceSpan<float> DecoderState::Run(int current_length, DeviceSpan<int32_t>& nex
     State::SetRunOptions(model_.config_->model.decoder.run_options.value());
   }
 
-  bool graph_capture_this_run = params_->use_graph_capture && inputs_embeds_.GetShape()[1] == 1;
-  State::Run(*model_.decoder_session_, graph_capture_this_run);
+  const int seq_len = static_cast<int>(inputs_embeds_.GetShape()[1]);
+  const bool graph_capture_this_run =
+      params_->use_graph_capture && seq_len >= 1 && seq_len <= params_->max_graph_capture_length;
+  const int graph_capture_variant = recurrent_state_ ? recurrent_state_->GraphCaptureVariant() : 0;
+  State::Run(*model_.decoder_session_, graph_capture_this_run, seq_len, graph_capture_variant);
   return logits_.Get();
 }
 


### PR DESCRIPTION
### Description

Pass the decode sequence length and recurrent-state buffer variant to `State::Run` from the multimodal decoder, matching the decoder-only path.

CUDA graph capture uses distinct graph IDs for the two recurrent-state buffer orientations. The multimodal path swapped the recurrent buffers on every step but always used the default variant 0 graph ID. Once ORT began replaying the captured graph, it reused the capture-time buffer addresses for the wrong orientation and corrupted recurrent state.

This affects hybrid recurrent multimodal models such as Qwen3.5 and Qwen3.6 when `enable_cuda_graph=1`.

### Validation

Built current main against ONNX Runtime GPU 1.30 nightly and tested with decoder CUDA graph capture enabled:

- Qwen3.5-4B CUDA: coherent generation, 136.4 decode tokens/s
- Qwen3.6-35B-A3B KQuant CUDA: coherent generation, 60.96 decode tokens/s

Before this change, both models produced repetitive/corrupted output with CUDA graph capture enabled and generated coherently only when graph capture was disabled.