### PR TITLE
Optimize greedy multi-token MTP scheduling

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -236,14 +236,14 @@ stream costs one main forward and one head forward per two tokens.
 
 The single head module is chained `N` times, feeding its own post-norm hidden forward
 (`head_out_hidden_`), the way vLLM's `AutoRegressiveSpeculator` does. Then `[t, d_0 .. d_{N-1}]` is
-verified in one `N+1`-wide main forward, `a` = length of the greedy-matching prefix, and one of four
+verified in one `N+1`-wide main forward, `a` = length of the greedy-matching prefix, and one of three
 finalize branches runs:
 
 | Branch | Condition | Cost |
 |---|---|---|
 | All accepted | `a == N` | No extra forward; bonus is verify row `N` |
-| Lossless crop + `M=1` replay | `a >= 1` and windowed recurrent state | Crop to `L+a`, replay the last committed token (1-wide, decode-consistent bonus) |
-| Snapshot rewind + replay | otherwise | `RewindToLength(L)` + replay `[t, d_0 .. d_{a-1}]` |
+| Windowed direct commit | `a < N` and windowed recurrent state | Crop to `L+a+1`; bonus is verify row `a` |
+| Snapshot rewind + replay | `a < N` otherwise | `RewindToLength(L)` + replay `[t, d_0 .. d_{a-1}]` |
 
 Re-materializing the `a` accepted drafts in the head's KV and drafting the next round's first token
 both consume *main-model* hidden states over consecutive positions, so they are **deferred and
@@ -263,9 +263,10 @@ forward, the reject path can crop instead of replaying whenever the recurrent st
 
 A wide (`M = N+1`) verify forward is numerically close to, but not bit-identical to, `M = 1` decode
 (different GEMM tiling; XQA vs. Flash attention). Only the **last** row of a forward matches a
-1-token decode. Greedy MTP is therefore "lossless modulo near-ties": the finalize branches are
-ordered so that the bonus token comes from a decode-consistent row wherever that is affordable.
-Under sampling this is a non-issue by construction.
+1-token decode. Greedy MTP is therefore "lossless modulo near-ties." On a partial accept, a
+windowed model commits verify row `a` directly because replaying from recurrent state produced by
+the same wide verify is not more decode-consistent; a non-windowed model restores its pre-verify
+snapshot and replays the committed prefix. Under sampling this is a non-issue by construction.
 
 ### Device offloads
 

--- a/src/mtp_generator.cpp
+++ b/src/mtp_generator.cpp
@@ -190,6 +190,10 @@ MtpGenerator::MtpGenerator(const Model& main_model, const Model& mtp_model, cons
       const int32_t head_non_pad = mtp_model_.config_->model.pad_token_id == 0 ? 1 : 0;
       std::fill(drafts_metadata_cpu.begin(), drafts_metadata_cpu.end(), head_non_pad);
 
+      head_tokens_upload_ = mtp_model_.p_device_->Allocate<int32_t>(num_speculative_tokens_ + 1);
+      auto head_tokens_upload_cpu = head_tokens_upload_.CpuSpan();
+      std::fill(head_tokens_upload_cpu.begin(), head_tokens_upload_cpu.end(), head_non_pad);
+
       head_tokens_device_ = mtp_model_.p_device_->Allocate<int32_t>(num_speculative_tokens_ + 1);
       auto head_tokens_cpu = head_tokens_device_.CpuSpan();
       std::fill(head_tokens_cpu.begin(), head_tokens_cpu.end(), head_non_pad);
@@ -776,10 +780,11 @@ void MtpGenerator::GenerateStepMulti(int32_t t) {
       mtp_->RewindToLength(pending_refeed_head_len_);  // drop last step's speculative drafts
       head_len_ = pending_refeed_head_len_;
       merged_tokens_[a_prev] = t;  // last row: the token committed at the top of this step
-      auto head_tokens_cpu = head_tokens_device_.CpuSpan();
-      std::copy_n(merged_tokens_.begin(), a_prev + 1, head_tokens_cpu.begin());
-      head_tokens_device_.CopyCpuToDevice();
+      auto head_tokens_upload_cpu = head_tokens_upload_.CpuSpan();
+      std::copy_n(merged_tokens_.begin(), a_prev + 1, head_tokens_upload_cpu.begin());
+      head_tokens_upload_.CopyCpuToDevice();
       auto head_tokens = head_tokens_device_.subspan(0, static_cast<size_t>(a_prev + 1));
+      head_tokens.CopyFrom(head_tokens_upload_.subspan(0, static_cast<size_t>(a_prev + 1)));
       current_token_device = head_tokens_device_.subspan(static_cast<size_t>(a_prev), 1);
       mtp_->SetHiddenStates(refeed_multi_[a_prev + 1]);
       DraftHeadStepMultiToDevice(head_tokens, drafts_device_.subspan(0, 1));
@@ -789,9 +794,10 @@ void MtpGenerator::GenerateStepMulti(int32_t t) {
         mtp_->RewindToLength(pending_refeed_head_len_);
         head_len_ = pending_refeed_head_len_;
       }
-      head_tokens_device_.CpuSpan()[0] = t;
-      head_tokens_device_.CopyCpuToDevice();
+      head_tokens_upload_.CpuSpan()[0] = t;
+      head_tokens_upload_.CopyCpuToDevice();
       current_token_device = head_tokens_device_.subspan(0, 1);
+      current_token_device.CopyFrom(head_tokens_upload_.subspan(0, 1));
       mtp_->SetHiddenStates(hidden_slice_);
       DraftHeadStepToDevice(current_token_device, drafts_device_.subspan(0, 1));
     }
@@ -830,8 +836,8 @@ void MtpGenerator::GenerateStepMulti(int32_t t) {
   //     forward validates N+1 tokens). The batched (M=N+1) forward is numerically ~equal but not
   //     bit-identical to single-token decode (different GEMM tiling for M=1 vs M>1, plus XQA-vs-
   //     Flash attention), so a greedy argmax can occasionally differ on near-ties. This is the same
-  //     tradeoff the N=1 verify already makes; the reject path below re-runs decode-consistently to
-  //     bound divergence from plain greedy. ---
+  //     tradeoff the N=1 verify already makes. The fallback reject path re-runs the committed prefix
+  //     from its snapshot; a windowed recurrent state crops and commits directly from this verify. ---
   // Snapshot the recurrent state so a rejected wide verify can replay the committed prefix with
   // decode-consistent numerics. A model exported with a recurrent-state window commits directly out
   // of the verify below and needs neither the replay nor the snapshot, which would otherwise cost

--- a/src/mtp_generator.cpp
+++ b/src/mtp_generator.cpp
@@ -182,6 +182,38 @@ MtpGenerator::MtpGenerator(const Model& main_model, const Model& mtp_model, cons
     drafts_device_ = mtp_model_.p_device_->Allocate<int32_t>(num_speculative_tokens_);
     verify_tokens_.resize(num_speculative_tokens_ + 1);
     verify_argmax_.resize(num_speculative_tokens_ + 1);
+    if (num_speculative_tokens_ > 1 && device_draft_chain_ && !sampling_) {
+      // Device-only draft ids are also passed back into the head as one-token inputs. Logits uses
+      // the host mirror only as padding metadata when its output shape transitions back to M=1,
+      // so initialize that mirror to a known non-pad value; the actual draft stays on device.
+      auto drafts_metadata_cpu = drafts_device_.CpuSpan();
+      const int32_t head_non_pad = mtp_model_.config_->model.pad_token_id == 0 ? 1 : 0;
+      std::fill(drafts_metadata_cpu.begin(), drafts_metadata_cpu.end(), head_non_pad);
+
+      head_tokens_device_ = mtp_model_.p_device_->Allocate<int32_t>(num_speculative_tokens_ + 1);
+      auto head_tokens_cpu = head_tokens_device_.CpuSpan();
+      std::fill(head_tokens_cpu.begin(), head_tokens_cpu.end(), head_non_pad);
+
+      verify_tokens_device_ = main_model_.p_device_->Allocate<int32_t>(num_speculative_tokens_ + 1);
+      // Logits::Update inspects the DeviceSpan's host mirror only to derive each row's unpadded
+      // length. Every token in an MTP verify is structurally valid, even if its numeric id happens
+      // to equal pad_token_id, so keep a persistent all-non-pad metadata mirror. The actual ids in
+      // device memory are filled below with D2D copies and never copied back through this mirror.
+      auto verify_tokens_cpu = verify_tokens_device_.CpuSpan();
+      const int32_t main_non_pad = main_model_.config_->model.pad_token_id == 0 ? 1 : 0;
+      std::fill(verify_tokens_cpu.begin(), verify_tokens_cpu.end(), main_non_pad);
+
+      verify_argmax_device_ = main_model_.p_device_->Allocate<int32_t>(num_speculative_tokens_ + 1);
+      (void)verify_argmax_device_.CpuSpan();
+
+      // Both sessions and all MTP-side CUDA operations use the shared GenAI stream. Let the CPU
+      // enqueue the chained head work and the main verify without an EP-end stream fence; the
+      // target argmax/logits readback below is the explicit synchronization before CPU acceptance.
+      // Scope this to the persistent device-input path: host-token, sampling, N=1, and non-CUDA
+      // generators retain their existing per-Run synchronization behavior.
+      main_->SetRuntimeOption("disable_synchronize_execution_providers", "1");
+      mtp_->SetRuntimeOption("disable_synchronize_execution_providers", "1");
+    }
     merged_tokens_.resize(static_cast<size_t>(num_speculative_tokens_) + 1);
     // Per-size [1,j,H] hidden buffers (j=1..N+1) so the post-verify head refeed of the j accepted
     // drafts runs as ONE batched head forward instead of one forward per token. The greedy path
@@ -261,15 +293,6 @@ void MtpGenerator::CaptureDraftToDevice(DeviceSpan<int32_t> draft) {
   draft.CopyCpuToDevice();
 }
 
-void MtpGenerator::DraftHeadStepToDevice(int32_t token, DeviceSpan<int32_t> draft) {
-  std::array<int32_t, 1> tok{token};
-  mtp_->AppendTokens(cpu_span<const int32_t>(tok));
-  stats_.draft_forward_passes++;
-  ++head_len_;
-  CaptureDraftToDevice(draft);
-  CaptureHeadFeedbackHidden();
-}
-
 void MtpGenerator::DraftHeadStepToDevice(DeviceSpan<int32_t> token, DeviceSpan<int32_t> draft) {
   mtp_->AppendTokens(token);
   stats_.draft_forward_passes++;
@@ -335,10 +358,10 @@ int32_t MtpGenerator::DraftHeadStepMulti(const int32_t* tokens, int count) {
   return draft;
 }
 
-void MtpGenerator::DraftHeadStepMultiToDevice(const int32_t* tokens, int count, DeviceSpan<int32_t> draft) {
-  mtp_->AppendTokens(cpu_span<const int32_t>(tokens, static_cast<size_t>(count)));
+void MtpGenerator::DraftHeadStepMultiToDevice(DeviceSpan<int32_t> tokens, DeviceSpan<int32_t> draft) {
+  mtp_->AppendTokens(tokens);
   stats_.draft_forward_passes++;
-  head_len_ += static_cast<size_t>(count);
+  head_len_ += tokens.size();
   CaptureDraftToDevice(draft);
   CaptureHeadFeedbackHidden();
 }
@@ -470,11 +493,33 @@ void MtpGenerator::ArgmaxMainRows(int first_row, int num_rows, int32_t* out) {
   // The CUDA distributed-select Top-K implementation is batch-1 only. The N=1 MTP verify uses
   // two rows and is covered by its existing tuned path, but N>1 verifies have 3+ rows. Submit
   // those rows independently so each invocation uses the proven batch-1 path while keeping the
-  // full logits device-resident. This is a compatibility bridge until Top-K has a native batched
-  // argmax path for the large Qwen vocabulary.
+  // full logits device-resident. Store all top-1 ids on device and copy them to the host together,
+  // reducing N+1 device-to-host synchronizations to one. This is a compatibility bridge until
+  // Top-K has a native batched argmax path for the large Qwen vocabulary.
   if (num_rows > 2) {
     const uint8_t* base = static_cast<const uint8_t*>(raw->GetTensorRawData());
     const size_t row_bytes = static_cast<size_t>(vocab_size_) * Ort::SizeOf(type);
+
+    if (verify_argmax_device_.size() >= static_cast<size_t>(num_rows)) {
+      bool all_device = true;
+      for (int row = 0; row < num_rows; ++row) {
+        const void* row_ptr = base + static_cast<size_t>(first_row + row) * row_bytes;
+        if (!main_model_.p_device_->ArgMaxDevice(
+                row_ptr, type, 1, vocab_size_,
+                verify_argmax_device_.subspan(static_cast<size_t>(row), 1))) {
+          all_device = false;
+          break;
+        }
+      }
+      if (all_device) {
+        auto device_argmax = verify_argmax_device_.CopyDeviceToCpu();
+        std::copy_n(device_argmax.begin(), num_rows, out);
+        return;
+      }
+    }
+
+    // Preserve the prior host-output path on non-CUDA devices and as a fallback if the CUDA
+    // device-output implementation does not support the logits type.
     bool all_device = true;
     for (int row = 0; row < num_rows; ++row) {
       const void* row_ptr = base + static_cast<size_t>(first_row + row) * row_bytes;
@@ -724,22 +769,31 @@ void MtpGenerator::GenerateStepMulti(int32_t t) {
   // this step's first draft from its last row -- exactly what a separate refeed forward plus an
   // M=1 draft forward produced, at one forward instead of two.
   size_t head_start = 0;
+  DeviceSpan<int32_t> current_token_device;
   if (device_draft_chain_) {
     if (pending_refeed_count_ > 0) {
       const int a_prev = pending_refeed_count_;
       mtp_->RewindToLength(pending_refeed_head_len_);  // drop last step's speculative drafts
       head_len_ = pending_refeed_head_len_;
       merged_tokens_[a_prev] = t;  // last row: the token committed at the top of this step
+      auto head_tokens_cpu = head_tokens_device_.CpuSpan();
+      std::copy_n(merged_tokens_.begin(), a_prev + 1, head_tokens_cpu.begin());
+      head_tokens_device_.CopyCpuToDevice();
+      auto head_tokens = head_tokens_device_.subspan(0, static_cast<size_t>(a_prev + 1));
+      current_token_device = head_tokens_device_.subspan(static_cast<size_t>(a_prev), 1);
       mtp_->SetHiddenStates(refeed_multi_[a_prev + 1]);
-      DraftHeadStepMultiToDevice(merged_tokens_.data(), a_prev + 1, drafts_device_.subspan(0, 1));
+      DraftHeadStepMultiToDevice(head_tokens, drafts_device_.subspan(0, 1));
     } else {
       if (pending_refeed_count_ == 0) {
         // Nothing was accepted last step: only the speculative drafts need dropping.
         mtp_->RewindToLength(pending_refeed_head_len_);
         head_len_ = pending_refeed_head_len_;
       }
+      head_tokens_device_.CpuSpan()[0] = t;
+      head_tokens_device_.CopyCpuToDevice();
+      current_token_device = head_tokens_device_.subspan(0, 1);
       mtp_->SetHiddenStates(hidden_slice_);
-      DraftHeadStepToDevice(t, drafts_device_.subspan(0, 1));
+      DraftHeadStepToDevice(current_token_device, drafts_device_.subspan(0, 1));
     }
     pending_refeed_count_ = -1;
     head_start = head_len_ - 1;  // head KV length before t was appended
@@ -748,8 +802,6 @@ void MtpGenerator::GenerateStepMulti(int32_t t) {
       DraftHeadStepToDevice(drafts_device_.subspan(static_cast<size_t>(k - 1), 1),
                             drafts_device_.subspan(static_cast<size_t>(k), 1));
     }
-    auto drafts_cpu = drafts_device_.CopyDeviceToCpu();
-    std::copy_n(drafts_cpu.begin(), N, drafts_.begin());
   } else {
     if (pending_refeed_count_ > 0) {
       const int a_prev = pending_refeed_count_;
@@ -786,11 +838,38 @@ void MtpGenerator::GenerateStepMulti(int32_t t) {
   // 2*num_layers device copies on EVERY step.
   const bool direct_commit = main_->CanCropRecurrentState();
   if (!direct_commit) main_->SnapshotState();
-  verify_tokens_[0] = t;
-  for (int k = 0; k < N; ++k) verify_tokens_[k + 1] = drafts_[k];
-  main_->AppendTokens(cpu_span<const int32_t>(verify_tokens_.data(), N + 1));
+
+  const bool device_verify_input = verify_tokens_device_.size() >= static_cast<size_t>(N + 1);
+  if (device_verify_input) {
+    // Keep the entire draft -> target dependency on the shared CUDA stream. In particular, do not
+    // call drafts_device_.CopyDeviceToCpu() before AppendTokens: that fence would expose the main
+    // CUDA-graph submission latency after both head graphs completed. The current token was already
+    // staged for the first/fused head input, and both D2D copies below follow the draft argmaxes in
+    // stream order.
+    verify_tokens_device_.subspan(0, 1).CopyFrom(current_token_device);
+    verify_tokens_device_.subspan(1, static_cast<size_t>(N))
+        .CopyFrom(drafts_device_.subspan(0, static_cast<size_t>(N)));
+    main_->AppendTokens(verify_tokens_device_.subspan(0, static_cast<size_t>(N + 1)));
+  } else {
+    verify_tokens_[0] = t;
+    for (int k = 0; k < N; ++k) verify_tokens_[k + 1] = drafts_[k];
+    main_->AppendTokens(cpu_span<const int32_t>(verify_tokens_.data(), N + 1));
+  }
   stats_.target_forward_passes++;
   ArgmaxMainRows(0, N + 1, verify_argmax_.data());  // main's real token after each verify position
+
+  if (device_verify_input) {
+    // ArgmaxMainRows is the existing CPU acceptance boundary and synchronizes the target result.
+    // Read the small draft-id vector only after the target graph and its argmax have been queued;
+    // the extra copy observes the same stream order and preserves the host acceptance logic below.
+    auto drafts_cpu = drafts_device_.CopyDeviceToCpu();
+    std::copy_n(drafts_cpu.begin(), N, drafts_.begin());
+    // Preserve the device ids but restore the CPU mirror's only contract for the next round: each
+    // chained draft input is structurally one valid token. This matters after a fused M>1 head run,
+    // when Logits::Update scans the next M=1 input's host mirror while resizing its output.
+    const int32_t head_non_pad = mtp_model_.config_->model.pad_token_id == 0 ? 1 : 0;
+    std::fill(drafts_cpu.begin(), drafts_cpu.end(), head_non_pad);
+  }
   OrtValue* vhidden = main_->state_->GetOutput(hs_name.c_str());
 
   // --- Longest accepted prefix (greedy match against the main model). ---

--- a/src/mtp_generator.cpp
+++ b/src/mtp_generator.cpp
@@ -67,6 +67,7 @@ MtpGenerator::MtpGenerator(const Model& main_model, const Model& mtp_model, cons
   // AutoRegressiveSpeculator does. Chaining needs the head to emit that hidden, so a head exported
   // without `mtp_emit_hidden=true` can only run N=1.
   num_speculative_tokens_ = std::max(1, params.speculative.max_draft_tokens);
+
   const std::string& head_hidden_states = main_model_.config_->model.mtp.outputs.hidden_states;
   if (num_speculative_tokens_ > 1 &&
       (head_hidden_states.empty() || !mtp_model_.session_info_.HasOutput(head_hidden_states))) {
@@ -780,9 +781,11 @@ void MtpGenerator::GenerateStepMulti(int32_t t) {
   //     tradeoff the N=1 verify already makes; the reject path below re-runs decode-consistently to
   //     bound divergence from plain greedy. ---
   // Snapshot the recurrent state so a rejected wide verify can replay the committed prefix with
-  // decode-consistent numerics. The snapshot is also needed when no draft is accepted, where there
-  // is no committed recurrent-state window slot to crop to.
-  main_->SnapshotState();
+  // decode-consistent numerics. A model exported with a recurrent-state window commits directly out
+  // of the verify below and needs neither the replay nor the snapshot, which would otherwise cost
+  // 2*num_layers device copies on EVERY step.
+  const bool direct_commit = main_->CanCropRecurrentState();
+  if (!direct_commit) main_->SnapshotState();
   verify_tokens_[0] = t;
   for (int k = 0; k < N; ++k) verify_tokens_[k + 1] = drafts_[k];
   main_->AppendTokens(cpu_span<const int32_t>(verify_tokens_.data(), N + 1));
@@ -839,25 +842,16 @@ void MtpGenerator::GenerateStepMulti(int32_t t) {
     next_token_ = verify_argmax_[a];
     CopyHiddenRow(vhidden, a, *hidden_slice_);
     length_ += static_cast<size_t>(N) + 1;
-  } else if (main_->CanCropRecurrentState() && a >= 1) {
-    // Partial accept (a>=1), LOSSLESS CROP fast-path (model exported with state_window).
-    // The batched verify's row a is an EARLY row of a wide (M=N+1) forward, whose argmax is NOT
-    // decode-consistent (only the LAST row of a forward matches a 1-token decode; §13.1). So we
-    // cannot take the bonus straight from the verify. Instead: crop the KV cache + recurrent state
-    // to L+a (state AFTER verify tokens 0..a-1 == window slot for position a-1) -- avoiding the wide
-    // (a+1)-token replay -- then M=1-decode the last committed token (d_{a-1}, at position L+a). Its
-    // row-0 logits ARE decode-consistent, giving a lossless bonus. This replaces the §13.5 wide
-    // replay (M=a+1) with a cheap M=1 forward.
-    // NOTE (§14.3): this is NOT actually lossless in practice -- the cropped state is itself derived
-    // from the wide batched verify and differs from sequential decode (~0.25 fp16), so greedy
-    // near-ties still flip. Kept for history/reference; the fallback replay below is the lossless path.
-    main_->CropToAccepted(length_ + static_cast<size_t>(a), static_cast<size_t>(a) - 1);
-    std::array<int32_t, 1> last{drafts_[a - 1]};  // committed token at position L+a
-    main_->AppendTokens(cpu_span<const int32_t>(last));
-    stats_.target_forward_passes++;
-    OrtValue* rhidden = main_->state_->GetOutput(hs_name.c_str());
-    ArgmaxMainRows(0, 1, &next_token_);         // decode-consistent bonus (M=1 last row)
-    CopyHiddenRow(rhidden, 0, *hidden_slice_);  // hidden paired with the bonus token
+  } else if (direct_commit) {
+    // Partial accept, DIRECT ARENA COMMIT: the batched verify already advanced the KV and the
+    // per-token recurrent window through every verify token, so crop both to the accepted length
+    // and take the bonus from verify row a -- no replay forward at all. Row a is an early row of a
+    // wide forward, so its argmax can differ from a sequential decode on near-ties, but cropping to
+    // L+a and re-decoding instead is no more decode-consistent in practice (the cropped state is
+    // itself derived from the same wide verify); it just costs an extra forward per partial accept.
+    main_->CropToAccepted(length_ + static_cast<size_t>(a) + 1, static_cast<size_t>(a));
+    next_token_ = verify_argmax_[a];
+    CopyHiddenRow(vhidden, a, *hidden_slice_);
     length_ += static_cast<size_t>(a) + 1;
   } else {
     // Rejection at position a: the batched verify over-appended N-a wrong tokens and cannot be

--- a/src/mtp_generator.h
+++ b/src/mtp_generator.h
@@ -71,8 +71,8 @@ struct MtpGenerator {
   // post-final-norm output (hidden_states_out, last row) into `head_out_hidden_` for the next
   // chained step, and returns the greedy draft (or 0 if need_draft is false).
   int32_t DraftHeadStep(int32_t token, bool need_draft = true);
-  // Greedy multi-token fast path: keep the draft on device so it can feed the next head forward.
-  void DraftHeadStepToDevice(int32_t token, DeviceSpan<int32_t> draft);
+  // Greedy multi-token fast path: keep the input and draft on device so adjacent head forwards
+  // can be submitted without temporary host-input lifetimes synchronizing the shared CUDA stream.
   void DraftHeadStepToDevice(DeviceSpan<int32_t> token, DeviceSpan<int32_t> draft);
   void CaptureDraftToDevice(DeviceSpan<int32_t> draft);
   // One MTP-head forward over `count` (hidden, token) pairs. The head's `hidden_states` input must
@@ -82,7 +82,7 @@ struct MtpGenerator {
   // for the token after tokens[count-1]. Used by the fused refeed+draft forward (see
   // pending_refeed_count_).
   int32_t DraftHeadStepMulti(const int32_t* tokens, int count);
-  void DraftHeadStepMultiToDevice(const int32_t* tokens, int count, DeviceSpan<int32_t> draft);
+  void DraftHeadStepMultiToDevice(DeviceSpan<int32_t> tokens, DeviceSpan<int32_t> draft);
   // Single-token (num_speculative_tokens == 1) draft/verify step (the original fast path).
   void GenerateStepSingle(int32_t t);
   // Multi-token (num_speculative_tokens > 1) chained draft/verify step: chains the single MTP
@@ -168,7 +168,15 @@ struct MtpGenerator {
   std::vector<int32_t> drafts_;         // scratch: the N chained draft tokens
   DeviceSpan<int32_t> drafts_device_;   // same drafts, kept on device between chained head forwards
   std::vector<int32_t> verify_tokens_;  // scratch: [t, d0..d_{N-1}] for the verify forward
+  // CUDA greedy fast path: persistent input buffers avoid per-forward pinned-host temporaries.
+  // `head_tokens_device_` stages the first/fused head input and also supplies its last token to the
+  // verify buffer; the rest of the verify input is assembled from `drafts_device_` with D2D copies.
+  DeviceSpan<int32_t> head_tokens_device_;
+  DeviceSpan<int32_t> verify_tokens_device_;
   std::vector<int32_t> verify_argmax_;  // scratch: main argmax of the N+1 verify rows
+  // CUDA scratch for the verify top-1 ids. ArgmaxMainRows launches the proven batch-1 device
+  // kernel for each row, then copies this whole span to the host with one synchronization.
+  DeviceSpan<int32_t> verify_argmax_device_;
 
   // --- Speculative-sampling (do_sample=true) state. ---
   bool sampling_{false};                // true when do_sample && temperature > 0: use rejection sampling

--- a/src/mtp_generator.h
+++ b/src/mtp_generator.h
@@ -169,8 +169,11 @@ struct MtpGenerator {
   DeviceSpan<int32_t> drafts_device_;   // same drafts, kept on device between chained head forwards
   std::vector<int32_t> verify_tokens_;  // scratch: [t, d0..d_{N-1}] for the verify forward
   // CUDA greedy fast path: persistent input buffers avoid per-forward pinned-host temporaries.
-  // `head_tokens_device_` stages the first/fused head input and also supplies its last token to the
-  // verify buffer; the rest of the verify input is assembled from `drafts_device_` with D2D copies.
+  // Actual first/fused head ids are uploaded through `head_tokens_upload_`, then copied D2D into
+  // `head_tokens_device_` so its CPU mirror remains valid non-pad metadata for Logits::Update.
+  // Its last device token supplies the verify buffer; the remaining verify input is assembled from
+  // `drafts_device_` with D2D copies.
+  DeviceSpan<int32_t> head_tokens_upload_;
   DeviceSpan<int32_t> head_tokens_device_;
   DeviceSpan<int32_t> verify_tokens_device_;
   std::vector<int32_t> verify_argmax_;  // scratch: main argmax of the N+1 verify rows

--- a/test/cuda_batched_sampler_tests/cuda_batched_sampler_tests.cpp
+++ b/test/cuda_batched_sampler_tests/cuda_batched_sampler_tests.cpp
@@ -52,6 +52,29 @@ TEST(ArgMaxTests, DeviceRowResultsAccumulateBeforeOneHostCopyCuda) {
   EXPECT_TRUE(std::equal(expected.begin(), expected.end(), top1_cpu.begin()));
 }
 
+TEST(DeviceSpanTests, DeviceInputKeepsPaddingMetadataSeparateFromTokenIdsCuda) {
+  constexpr int32_t pad_token_id = 0;
+  constexpr int32_t non_pad_metadata = 1;
+  const std::array<int32_t, 3> token_ids{{5, 7, pad_token_id}};
+  [[maybe_unused]] auto model = CreateCudaModel();
+  auto* device = Generators::GetDeviceInterface(Generators::DeviceType::CUDA);
+
+  auto upload = device->Allocate<int32_t>(token_ids.size());
+  std::copy(token_ids.begin(), token_ids.end(), upload.CpuSpan().begin());
+  auto input = device->Allocate<int32_t>(token_ids.size());
+  std::fill(input.CpuSpan().begin(), input.CpuSpan().end(), non_pad_metadata);
+
+  upload.CopyCpuToDevice();
+  input.CopyFrom(upload);
+
+  // MTP passes `input` to Generator, whose Logits::Update reads this mirror as structural padding
+  // metadata. The actual ids, including a trailing pad-valued generated token, stay on device.
+  EXPECT_TRUE(std::all_of(input.CpuSpan().begin(), input.CpuSpan().end(),
+                          [](int32_t token) { return token == non_pad_metadata; }));
+  auto input_ids = input.CopyDeviceToCpu();
+  EXPECT_TRUE(std::equal(token_ids.begin(), token_ids.end(), input_ids.begin()));
+}
+
 TEST(SamplingTests, SchedulerOwnedSamplerHandlesHeterogeneousRowsCuda) {
   constexpr int vocab_size = 5;
   [[maybe_unused]] auto model = CreateCudaModel();

--- a/test/cuda_batched_sampler_tests/cuda_batched_sampler_tests.cpp
+++ b/test/cuda_batched_sampler_tests/cuda_batched_sampler_tests.cpp
@@ -21,6 +21,37 @@ std::unique_ptr<OgaModel> CreateCudaModel() {
   return OgaModel::Create(*config);
 }
 
+TEST(ArgMaxTests, DeviceRowResultsAccumulateBeforeOneHostCopyCuda) {
+  constexpr int num_rows = 4;
+  constexpr int first_row = 1;
+  constexpr int total_rows = num_rows + 2;
+  constexpr int vocab_size = 248320;  // Qwen3.8 vocabulary; selects the batch-1 distributed path.
+  [[maybe_unused]] auto model = CreateCudaModel();
+  auto* device = Generators::GetDeviceInterface(Generators::DeviceType::CUDA);
+
+  auto logits = device->Allocate<float>(static_cast<size_t>(total_rows) * vocab_size);
+  auto logits_cpu = logits.CpuSpan();
+  std::fill(logits_cpu.begin(), logits_cpu.end(), -1.0f);
+  const std::array<int32_t, num_rows> expected{{3, 100001, vocab_size - 1, 17}};
+  for (int row = 0; row < num_rows; ++row) {
+    logits_cpu[static_cast<size_t>(first_row + row) * vocab_size + expected[row]] = 10.0f + row;
+  }
+  logits.CopyCpuToDevice();
+
+  auto top1_device = device->Allocate<int32_t>(num_rows);
+  for (int row = 0; row < num_rows; ++row) {
+    ASSERT_TRUE(device->ArgMaxDevice(
+        logits.Span().data() + static_cast<size_t>(first_row + row) * vocab_size,
+        Ort::TypeToTensorType<float>, 1, vocab_size,
+        top1_device.subspan(static_cast<size_t>(row), 1)));
+  }
+
+  // Mirrors the N>1 MTP verify path: all batch-1 kernels and their D2D result copies are queued
+  // first, followed by one D2H copy/synchronization for the complete set of token ids.
+  auto top1_cpu = top1_device.CopyDeviceToCpu();
+  EXPECT_TRUE(std::equal(expected.begin(), expected.end(), top1_cpu.begin()));
+}
+
 TEST(SamplingTests, SchedulerOwnedSamplerHandlesHeterogeneousRowsCuda) {
   constexpr int vocab_size = 5;
   [[maybe_unused]] auto model = CreateCudaModel();


### PR DESCRIPTION
## Summary

Remove redundant target replay from greedy multi-token MTP and keep CUDA verification inputs on device. The non-windowed recurrent-state fallback and sampling path remain unchanged.

## Key changes

- Commit accepted tokens directly from the wide target verification when recurrent state can be cropped.
- Avoid the unconditional state snapshot and the partial-accept target replay.
- Reuse persistent pinned and device buffers for chained draft tokens and target verification input.
- Assemble verify tokens with stream-ordered device copies and submit target verification before host draft readback.
- Accumulate target-row argmax results on device and copy them to the host once per round.
- Disable implicit EP-end synchronization only for the internal CUDA greedy N>1 states whose input lifetimes are now persistent.

## Performance

On H200 with a Qwen3.8-27B model, a 2K prompt and 2K greedy generated tokens at N=3 improved from 62.41 to 98.24 decode tok/s after removing snapshot/replay. The device-input path also removed pinned-buffer destructor fences; a graph-stable N=2 profile improved from 152.63 to 154.11 tok/s.

## Validation

- Built `python`, `unit_tests`, and `cuda_batched_sampler_tests` with CUDA.
- Focused MTP/speculative suite: 51 passed.
- `ArgMaxTests.DeviceRowResultsAccumulateBeforeOneHostCopyCuda`: passed.
- `lintrunner` and `git diff --check`: clean.
- Graph-stable sampled reset/replay smoke produced converged output hashes.