### PR TITLE
Add MTP generator reset API

### DIFF
--- a/src/mtp_generator.cpp
+++ b/src/mtp_generator.cpp
@@ -623,6 +623,34 @@ void MtpGenerator::GenerateNextToken() {
   }
 }
 
+void MtpGenerator::Reset() {
+  main_->RewindToLength(0);
+  mtp_->RewindToLength(0);
+
+  if (sampling_) {
+    if (main_params_->search.random_seed == -1) {
+      std::random_device rd;
+      rng_.seed(rd());
+    } else {
+      rng_.seed(static_cast<uint32_t>(main_params_->search.random_seed));
+    }
+  }
+
+  sequence_.clear();
+  emitted_sequence_.clear();
+  pending_tokens_.clear();
+  stats_ = {};
+  next_token_ = 0;
+  length_ = 0;
+  head_len_ = 0;
+  primed_ = false;
+  done_ = false;
+  pending_draft_ = 0;
+  has_pending_draft_ = false;
+  pending_refeed_count_ = -1;
+  pending_refeed_head_len_ = 0;
+}
+
 void MtpGenerator::RunRound() {
   if (done_) return;
 

--- a/src/mtp_generator.h
+++ b/src/mtp_generator.h
@@ -38,6 +38,10 @@ struct MtpGenerator {
   // internally; later calls drain those buffered tokens before another round runs.
   void GenerateNextToken();
 
+  // Rewind both inner generators to an empty request while retaining their allocated state and
+  // captured graphs. This is a full reset, not an arbitrary sequence rewind.
+  void Reset();
+
   bool IsDone() const;
 
   // The full committed token sequence (batch index 0).

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -659,6 +659,10 @@ struct OgaMtpGenerator : OgaAbstract {
     OgaCheckResult(OgaMtpGenerator_GenerateNextToken(this));
   }
 
+  void Reset() {
+    OgaCheckResult(OgaMtpGenerator_Reset(this));
+  }
+
   bool IsDone() const {
     return OgaMtpGenerator_IsDone(this);
   }

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -519,6 +519,13 @@ OgaResult* OGA_API_CALL OgaMtpGenerator_GenerateNextToken(OgaMtpGenerator* gener
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaMtpGenerator_Reset(OgaMtpGenerator* generator) {
+  OGA_TRY
+  generator->Reset();
+  return nullptr;
+  OGA_CATCH
+}
+
 bool OGA_API_CALL OgaMtpGenerator_IsDone(const OgaMtpGenerator* generator) {
   return generator->IsDone();
 }

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -583,6 +583,8 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateMtpGenerator(const OgaModel* main_mo
 OGA_EXPORT OgaResult* OGA_API_CALL OgaMtpGenerator_AppendTokens(OgaMtpGenerator* generator, const int32_t* input_ids, size_t input_ids_count);
 /** \brief Produce the next token via the draft/verify loop. */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaMtpGenerator_GenerateNextToken(OgaMtpGenerator* generator);
+/** \brief Reset to an empty request while retaining allocated state and captured graphs. */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaMtpGenerator_Reset(OgaMtpGenerator* generator);
 /** \brief Whether generation has reached EOS or max length. */
 OGA_EXPORT bool OGA_API_CALL OgaMtpGenerator_IsDone(const OgaMtpGenerator* generator);
 /** \brief Number of committed tokens (prompt + generated). */

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -583,7 +583,10 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateMtpGenerator(const OgaModel* main_mo
 OGA_EXPORT OgaResult* OGA_API_CALL OgaMtpGenerator_AppendTokens(OgaMtpGenerator* generator, const int32_t* input_ids, size_t input_ids_count);
 /** \brief Produce the next token via the draft/verify loop. */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaMtpGenerator_GenerateNextToken(OgaMtpGenerator* generator);
-/** \brief Reset to an empty request while retaining allocated state and captured graphs. */
+/** \brief Reset to an un-primed, empty request while retaining allocated state and captured graphs.
+ * Call OgaMtpGenerator_AppendTokens before generating again. This invalidates any pointer
+ * previously returned by OgaMtpGenerator_GetSequenceData.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaMtpGenerator_Reset(OgaMtpGenerator* generator);
 /** \brief Whether generation has reached EOS or max length. */
 OGA_EXPORT bool OGA_API_CALL OgaMtpGenerator_IsDone(const OgaMtpGenerator* generator);

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -375,6 +375,7 @@ struct PyMtpGenerator {
   }
 
   void GenerateNextToken() { generator_->GenerateNextToken(); }
+  void Reset() { generator_->Reset(); }
   bool IsDone() const { return generator_->IsDone(); }
 
   pybind11::array_t<int32_t> GetSequence() {
@@ -621,6 +622,7 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def(pybind11::init<const OgaModel&, const OgaModel&, PyGeneratorParams&>())
       .def("append_tokens", &PyMtpGenerator::AppendTokens)
       .def("generate_next_token", &PyMtpGenerator::GenerateNextToken)
+      .def("reset", &PyMtpGenerator::Reset)
       .def("is_done", &PyMtpGenerator::IsDone)
       .def("get_sequence", &PyMtpGenerator::GetSequence)
       .def("get_stats", &PyMtpGenerator::GetStats);


### PR DESCRIPTION
## Summary

Expose reset support for `MtpGenerator` through the C++, C, and Python APIs so callers can reuse model sessions and captured CUDA graphs across independent requests.

## Key changes

- Reset both target and draft generators to position zero.
- Clear pending drafts, verification bookkeeping, token counters, and acceptance statistics.
- Reseed speculative sampling from the configured `random_seed` without recreating either model session.
- Add `OgaMtpGeneratorReset`, `MtpGenerator::Reset`, and Python `MtpGenerator.reset()`.

## Validation

- Built `python` and `unit_tests` with CUDA.
- Focused MTP/speculative suite: 51 passed.
- `lintrunner` and `git diff --check`: clean.
- Repeated sampled N=3 requests after reset converged to the same output hashes as fresh generators while retaining captured graph state.