### PR TITLE
Configure MTP heads for paged Engine decoding

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,6 +20,46 @@ namespace Generators {
 
 int64_t SafeDoubleToInt64(double x, std::string_view name);
 
+std::unique_ptr<Config> CreateMtpDecoderConfig(const Config& config) {
+  const auto& mtp = config.model.mtp;
+  if (mtp.filename.empty()) {
+    throw std::runtime_error("model.mtp.filename is required to create an MTP decoder.");
+  }
+  if (mtp.num_hidden_layers <= 0 || mtp.num_key_value_heads <= 0 || mtp.head_size <= 0) {
+    throw std::runtime_error("model.mtp layer count, KV head count, and head size must be positive.");
+  }
+
+  auto projected = std::make_unique<Config>(config);
+  auto& decoder = projected->model.decoder;
+  decoder.filename = mtp.filename;
+  if (mtp.session_options) {
+    decoder.session_options = *mtp.session_options;
+  }
+  decoder.run_options = mtp.run_options;
+  decoder.shared_initializers = mtp.shared_initializers;
+  decoder.num_hidden_layers = mtp.num_hidden_layers;
+  decoder.num_key_value_heads = mtp.num_key_value_heads;
+  decoder.head_size = mtp.head_size;
+
+  decoder.inputs.input_ids = mtp.inputs.input_ids;
+  decoder.inputs.hidden_states = mtp.inputs.hidden_states;
+  decoder.inputs.position_ids = mtp.inputs.position_ids;
+  decoder.inputs.past_key_names = mtp.inputs.past_key_names;
+  decoder.inputs.past_value_names = mtp.inputs.past_value_names;
+  decoder.outputs.logits = mtp.outputs.logits;
+  decoder.outputs.hidden_states = mtp.outputs.hidden_states;
+  decoder.outputs.present_key_names = mtp.outputs.present_key_names;
+  decoder.outputs.present_value_names = mtp.outputs.present_value_names;
+
+  // The MTP graph is one full-attention layer. Paged-attention metadata and block-table names are
+  // deliberately inherited above; fixed recurrent state and a main-model sliding window are not.
+  decoder.layer_types.assign(static_cast<size_t>(mtp.num_hidden_layers), "full_attention");
+  decoder.conv_cache_size = 0;
+  decoder.sliding_window.reset();
+  decoder.state_groups.reset();
+  return projected;
+}
+
 // Normalizes historical casings, short aliases, and full ORT names (e.g.
 // "CUDAExecutionProvider") to the canonical dispatch-table name; unknown names pass through.
 std::string_view NormalizeProviderName(std::string_view name) {

--- a/src/config.h
+++ b/src/config.h
@@ -597,6 +597,10 @@ void SetSearchNumber(Config::Search& search, std::string_view name, double value
 void SetSearchBool(Config::Search& search, std::string_view name, bool value);
 void SetSpeculativeNumber(Config::Speculative& speculative, std::string_view name, double value);
 void SetSpeculativeBool(Config::Speculative& speculative, std::string_view name, bool value);
+// Build the decoder-model view used to run model.mtp as an internal session. The projection keeps
+// the main model's device, batching and paged-attention contract, but replaces model-specific
+// decoder state with the single MTP attention layer.
+std::unique_ptr<Config> CreateMtpDecoderConfig(const Config& config);
 void ClearProviders(Config& config);
 void SetProviderOption(Config& config, std::string_view provider_name, std::string_view option_name, std::string_view option_value);
 void OverlayConfig(Config& config, std::string_view json);

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -130,6 +130,15 @@ VarlenGraphBuffers::VarlenGraphBuffers(DecoderOnly_Model& model) {
   logits->CreateTensor(std::vector<int64_t>{static_cast<int64_t>(max_batch_size),
                                             static_cast<int64_t>(model.config_->model.vocab_size)},
                        /*make_static=*/true);
+
+  const auto& hidden_states_name = model.config_->model.decoder.outputs.hidden_states;
+  if (!hidden_states_name.empty() && model.session_info_.HasOutput(hidden_states_name)) {
+    hidden_states = std::make_unique<Tensor>(model.p_device_inputs_,
+                                             model.session_info_.GetOutputDataType(hidden_states_name));
+    hidden_states->CreateTensor(std::vector<int64_t>{static_cast<int64_t>(max_batch_size),
+                                                     static_cast<int64_t>(model.config_->model.decoder.hidden_size)},
+                                /*make_static=*/true);
+  }
 }
 
 int VarlenGraphBuffers::GraphId(size_t batch_size, size_t block_table_columns) {
@@ -162,6 +171,7 @@ VarlenDecoderIO::VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
   PreparePositionIds(model, scheduled_requests);
   PrepareAttentionMetadata(model, scheduled_requests);
   PrepareLogits(model, scheduled_requests);
+  PrepareHiddenStates(model, scheduled_requests);
 
   auto cache = cache_manager->Cache();
   for (size_t i = 0; i < cache->input_names_.size(); ++i) {
@@ -380,17 +390,19 @@ void VarlenDecoderIO::PrepareAttentionMetadata(std::shared_ptr<DecoderOnly_Model
   owned_inputs_.push_back(std::move(metadata_tensor));
 }
 
-void VarlenDecoderIO::PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests) {
-  size_t logits_rows = scheduled_requests.size();
-  if (logits_are_per_token_) {
-    const StepPlan* plan = execution_context_ ? execution_context_->plan : nullptr;
-    logits_rows =
-        plan ? plan->token_count
-             : std::accumulate(scheduled_requests.begin(), scheduled_requests.end(), size_t{0},
-                               [](size_t sum, const std::shared_ptr<Request>& request) {
-                                 return sum + request->ScheduledTokenCount();
-                               });
+size_t VarlenDecoderIO::TokenCount(ScheduledRequests& scheduled_requests) const {
+  const StepPlan* plan = execution_context_ ? execution_context_->plan : nullptr;
+  if (plan) {
+    return plan->token_count;
   }
+  return std::accumulate(scheduled_requests.begin(), scheduled_requests.end(), size_t{0},
+                         [](size_t sum, const std::shared_ptr<Request>& request) {
+                           return sum + request->ScheduledTokenCount();
+                         });
+}
+
+void VarlenDecoderIO::PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests) {
+  const size_t logits_rows = logits_are_per_token_ ? TokenCount(scheduled_requests) : scheduled_requests.size();
   const std::vector<int64_t> logits_shape = {
       static_cast<int64_t>(logits_rows),
       static_cast<int64_t>(model->config_->model.vocab_size)};
@@ -407,6 +419,35 @@ void VarlenDecoderIO::PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, Sc
 
   output_names_.push_back(model->config_->model.decoder.outputs.logits.c_str());
   outputs_.push_back(active_logits_->GetOrtTensor());
+}
+
+void VarlenDecoderIO::PrepareHiddenStates(std::shared_ptr<DecoderOnly_Model> model,
+                                          ScheduledRequests& scheduled_requests) {
+  // Only models exported with include_hidden_states expose this; it is what an MTP draft head
+  // consumes. Leaving it unbound on every other model keeps their step byte-identical.
+  const auto& hidden_states_name = model->config_->model.decoder.outputs.hidden_states;
+  if (hidden_states_name.empty() || !model->session_info_.HasOutput(hidden_states_name)) {
+    return;
+  }
+
+  // Always one row per packed token, matching the packed input order, so a draft head can be fed
+  // the hidden state of whichever tokens the verify step accepted. Note this is not necessarily
+  // the logits row count: a pruned LM head emits only one logits row per request.
+  const std::vector<int64_t> hidden_states_shape = {
+      static_cast<int64_t>(TokenCount(scheduled_requests)),
+      static_cast<int64_t>(model->config_->model.decoder.hidden_size)};
+  if (graph_buffers_ != nullptr && graph_buffers_->hidden_states != nullptr) {
+    graph_buffers_->hidden_states->CreateTensor(hidden_states_shape, /*make_static=*/true);
+    active_hidden_states_ = graph_buffers_->hidden_states.get();
+  } else {
+    hidden_states_ = std::make_unique<Tensor>(model->p_device_inputs_,
+                                              model->session_info_.GetOutputDataType(hidden_states_name));
+    hidden_states_->CreateTensor(hidden_states_shape);
+    active_hidden_states_ = hidden_states_.get();
+  }
+
+  output_names_.push_back(hidden_states_name.c_str());
+  outputs_.push_back(active_hidden_states_->GetOrtTensor());
 }
 
 std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {

--- a/src/engine/decoders/varlen_decoder_io.h
+++ b/src/engine/decoders/varlen_decoder_io.h
@@ -52,6 +52,8 @@ struct VarlenGraphBuffers {
   std::unique_ptr<Tensor> cumulative_sequence_lengths;
   std::unique_ptr<Tensor> past_sequence_lengths;
   std::unique_ptr<Tensor> logits;
+  // Null unless the model was exported with include_hidden_states.
+  std::unique_ptr<Tensor> hidden_states;
   size_t max_batch_size{};
 };
 
@@ -69,6 +71,8 @@ struct VarlenGraphBuffers {
  * Outputs:
  * - Logits - float16/float32[batch_size, vocab_size] for one row per request, or
  *   float16/float32[total_num_tokens, vocab_size] for one row per packed token.
+ * - Hidden States - float16/float32[total_num_tokens, hidden_size], only when the model was
+ *   exported with include_hidden_states. This is what an MTP draft head consumes.
  *
  * The inputs prepared by this class are compatible with models that use the
  * PagedAttention operator.
@@ -82,11 +86,20 @@ struct VarlenDecoderIO : DecoderIO {
 
   std::vector<DeviceSpan<float>> ProcessLogits() override;
 
+  // The step's packed [total_num_tokens, hidden_size] hidden states, or null when the model does
+  // not expose them. Row i corresponds to packed token i, in the same order as the logits rows.
+  Tensor* HiddenStates() const { return active_hidden_states_; }
+
  private:
   void PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PreparePositionIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareAttentionMetadata(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
+  void PrepareHiddenStates(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
+
+  // Number of packed token rows in this step, which is what both the logits and the hidden states
+  // are indexed by.
+  size_t TokenCount(ScheduledRequests& scheduled_requests) const;
 
   // Non-null when this step is being captured or replayed, in which case the tensors below are
   // borrowed from the holder instead of being allocated fresh.
@@ -96,6 +109,8 @@ struct VarlenDecoderIO : DecoderIO {
   std::unique_ptr<Tensor> logits_;
   Tensor* active_logits_{};
   std::unique_ptr<Tensor> logits_fp32_;
+  std::unique_ptr<Tensor> hidden_states_;
+  Tensor* active_hidden_states_{};
   bool logits_are_per_token_{true};
 };
 

--- a/src/python/py/models/builders/qwen_mtp.py
+++ b/src/python/py/models/builders/qwen_mtp.py
@@ -107,10 +107,12 @@ class Qwen35MtpHead(Qwen35MoeTextModel):
         self._preserve_modelopt_mtp = self._should_preserve_modelopt_mtp(self.quant_type, extra_options)
 
         # The MTP head consumes the main model's last hidden state as an extra
-        # input (alongside the standard input_ids / position_ids / KV cache).
+        # input (alongside the standard input_ids / position_ids / KV cache). A paged
+        # head is fed packed token rows, so the shape follows the same convention as
+        # every other hidden state in the graph rather than a dense [B, S, H].
         self.input_names["hidden_states"] = "hidden_states"
         self.input_types["hidden_states"] = self.io_dtype
-        self.input_shapes["hidden_states"] = ["batch_size", "sequence_length", self.hidden_size]
+        self.input_shapes["hidden_states"] = self.hidden_state_shape()
 
     @staticmethod
     def _should_preserve_modelopt_mtp(quant_type, extra_options):
@@ -158,7 +160,7 @@ class Qwen35MtpHead(Qwen35MoeTextModel):
             outputs=[hs_out],
             name="/model/mtp/hidden_states_out/Identity",
         )
-        hs_val = self.make_value(hs_out, self.io_dtype, shape=["batch_size", "sequence_length", self.hidden_size])
+        hs_val = self.make_value(hs_out, self.io_dtype, shape=self.hidden_state_shape())
         self.model.graph.outputs.append(hs_val)
 
         self.make_postprocessing_nodes()
@@ -421,7 +423,7 @@ class Qwen35MtpHead(Qwen35MoeTextModel):
             axis=-1,
             stash_type=1,
         )
-        self.make_value(output, self.io_dtype, shape=["batch_size", "sequence_length", self.hidden_size])
+        self.make_value(output, self.io_dtype, shape=self.hidden_state_shape())
         return output
 
     def _make_mtp_input_projection(self):
@@ -440,7 +442,7 @@ class Qwen35MtpHead(Qwen35MoeTextModel):
             outputs=[embed_out],
             name=embed_gather,
         )
-        self.make_value(embed_out, self.io_dtype, shape=["batch_size", "sequence_length", self.hidden_size])
+        self.make_value(embed_out, self.io_dtype, shape=self.hidden_state_shape())
 
         # pre_fc_norm_embedding(embed) and pre_fc_norm_hidden(hidden_states)
         e_norm = self._make_offset_rmsnorm(
@@ -456,7 +458,7 @@ class Qwen35MtpHead(Qwen35MoeTextModel):
             concat_name,
             [e_norm, h_norm],
             self.io_dtype,
-            ["batch_size", "sequence_length", 2 * self.hidden_size],
+            self.hidden_state_shape(last_dim=2 * self.hidden_size),
             axis=-1,
         )
 
@@ -495,7 +497,7 @@ class Qwen35DenseMtpHead(Qwen35MtpHead):
 
         self.input_names["hidden_states"] = "hidden_states"
         self.input_types["hidden_states"] = self.io_dtype
-        self.input_shapes["hidden_states"] = ["batch_size", "sequence_length", self.hidden_size]
+        self.input_shapes["hidden_states"] = self.hidden_state_shape()
 
     def make_layer(self, layer_id, layer):
         return Qwen35TextModel.make_layer(self, layer_id, layer)

--- a/test/mtp_config_test.cpp
+++ b/test/mtp_config_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "ort_genai.h"
+#include "config.h"
 
 namespace Generators::test {
 namespace {
@@ -80,6 +81,48 @@ TEST(MtpConfigTest, RejectsFractionalSharedInitializerDimension) {
 TEST(MtpConfigTest, RejectsOutOfRangeSharedInitializerDimension) {
   const auto root = WriteSharedInitializerConfig("overflow", "9223372036854775808");
   EXPECT_THROW(OgaConfig::Create(root.string().c_str()), std::exception);
+}
+
+TEST(MtpConfigTest, ProjectsPagedMtpDecoderWithoutMainFixedState) {
+  Config config;
+  auto& decoder = config.model.decoder;
+  decoder.filename = "text.onnx";
+  decoder.num_hidden_layers = 64;
+  decoder.num_key_value_heads = 8;
+  decoder.head_size = 128;
+  decoder.inputs.block_table = "block_table";
+  decoder.inputs.cumulative_sequence_lengths = "cumulative_sequence_lengths";
+  decoder.inputs.past_sequence_lengths = "past_sequence_lengths";
+  decoder.inputs.attention_metadata = "attention_metadata";
+  decoder.sliding_window = Config::Model::Decoder::SlidingWindow{4096};
+  decoder.state_groups.emplace();
+  decoder.state_groups->push_back(Config::Model::Decoder::StateGroup{
+      Config::Model::Decoder::StateGroupKind::Fixed});
+
+  auto& mtp = config.model.mtp;
+  mtp.filename = "mtp.onnx";
+  mtp.num_hidden_layers = 1;
+  mtp.num_key_value_heads = 2;
+  mtp.head_size = 64;
+  mtp.inputs.hidden_states = "head_hidden";
+  mtp.outputs.hidden_states = "head_hidden_out";
+
+  auto projected = CreateMtpDecoderConfig(config);
+  const auto& head = projected->model.decoder;
+  EXPECT_EQ(head.filename, "mtp.onnx");
+  EXPECT_EQ(head.num_hidden_layers, 1);
+  EXPECT_EQ(head.num_key_value_heads, 2);
+  EXPECT_EQ(head.head_size, 64);
+  EXPECT_EQ(head.inputs.hidden_states, "head_hidden");
+  EXPECT_EQ(head.outputs.hidden_states, "head_hidden_out");
+  EXPECT_EQ(head.inputs.block_table, "block_table");
+  EXPECT_EQ(head.inputs.cumulative_sequence_lengths, "cumulative_sequence_lengths");
+  EXPECT_EQ(head.inputs.past_sequence_lengths, "past_sequence_lengths");
+  EXPECT_EQ(head.inputs.attention_metadata, "attention_metadata");
+  EXPECT_FALSE(head.sliding_window.has_value());
+  EXPECT_FALSE(head.state_groups.has_value());
+  ASSERT_EQ(head.layer_types.size(), 1u);
+  EXPECT_EQ(head.layer_types[0], "full_attention");
 }
 
 }  // namespace Generators::test


### PR DESCRIPTION
## Summary
- make the MTP builder follow the main model packed-token layout
- bind optional hidden-state output from the paged decoder
- project `model.mtp` into an internal paged decoder configuration
- validate the projected MTP configuration

## Stack
PR 5/6. Depends on `tlwu/20260823/gdn-paged-spec-api`.

## Validation
- final stacked branch: `engine_unit_tests` 322/322 passed
- MTP config projection and paged hidden-state binding tests are included