### PR TITLE
Run chained MTP drafting in the batch Engine

### DIFF
--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -471,6 +471,22 @@ StepPlanningResult PagedCacheManager::PlanStepResources(StepPlan& plan) const {
     return result;
   }
 
+  const bool has_prefill = std::any_of(
+      plan.requests.begin(), plan.requests.end(),
+      [](const RequestStepPlan& entry) { return entry.is_prefill; });
+  const bool has_drafts = std::any_of(
+      plan.requests.begin(), plan.requests.end(),
+      [](const RequestStepPlan& entry) { return entry.draft_token_count != 0; });
+  if (has_prefill && has_drafts) {
+    // Packed recurrent operators choose one execution plan for the whole batch. A long prefill
+    // selects the chunked GDN path, which only publishes final state and cannot provide the
+    // intermediate checkpoints needed to reject a draft. Keep every selected request progressing
+    // in this mixed step, but verify drafts only once the selected batch is decode-only.
+    for (auto& entry : plan.requests) {
+      entry.draft_token_count = 0;
+    }
+  }
+
   // Paged and fixed ownership advance together at commit, so their committed counts must agree
   // between steps. A divergence means a prior commit or removal left them out of step.
   // Uses cheap pool accessors (no per-step snapshot allocation) since planning runs every step.

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -194,11 +194,12 @@ class CompositeCacheStepReservation final : public CacheStepReservation {
 
 }  // namespace
 
-std::unique_ptr<CacheManager> CacheManager::Create(std::shared_ptr<Model> model) {
+std::unique_ptr<CacheManager> CacheManager::Create(std::shared_ptr<Model> model,
+                                                   size_t auxiliary_bytes_per_block) {
   const ModelStateManifest manifest{model->config_->model.decoder};
   if (model->config_->engine.dynamic_batching) {
     ModelStateManifest::ValidateDynamicEngineCompatibility(model->config_->model.decoder);
-    return std::make_unique<PagedCacheManager>(model);
+    return std::make_unique<PagedCacheManager>(model, auxiliary_bytes_per_block);
   }
   if (manifest.HasFixedStateGroups()) {
     throw std::runtime_error(
@@ -299,7 +300,8 @@ bool StaticCacheManager::IsResident(const std::shared_ptr<Request>& request) con
          cache_allocated_requests_.end();
 }
 
-PagedCacheManager::PagedCacheManager(std::shared_ptr<Model> model)
+PagedCacheManager::PagedCacheManager(std::shared_ptr<Model> model,
+                                     size_t auxiliary_bytes_per_block)
     : CacheManager(model),
       params_(std::make_shared<GeneratorParams>(*model_)) {
   // The paged cache resolves its own paged_kv group. The fixed pool is created only when the
@@ -329,7 +331,7 @@ PagedCacheManager::PagedCacheManager(std::shared_ptr<Model> model)
   // Allocate fixed banks before auto-sizing paged KV. ComputeNumBlocks queries current device free
   // memory, so the fixed pool's complete persistent footprint is already excluded without
   // duplicating its geometry/accounting in the paged cache.
-  key_value_cache_ = std::make_unique<PagedKeyValueCache>(model);
+  key_value_cache_ = std::make_unique<PagedKeyValueCache>(model, auxiliary_bytes_per_block);
   key_value_cache_state_ = std::make_unique<KeyValueCacheState>(*params_, *model_);
 }
 

--- a/src/engine/cache_manager.h
+++ b/src/engine/cache_manager.h
@@ -54,7 +54,8 @@ struct KeyValueCacheState : State {
 struct CacheManager {
   CacheManager(std::shared_ptr<Model> model) : model_{model} {}
 
-  static std::unique_ptr<CacheManager> Create(std::shared_ptr<Model> model);
+  static std::unique_ptr<CacheManager> Create(std::shared_ptr<Model> model,
+                                              size_t auxiliary_bytes_per_block = 0);
 
   virtual bool CanAllocate(const std::vector<std::shared_ptr<Request>>& requests) const = 0;
 
@@ -146,7 +147,8 @@ struct StaticCacheManager : CacheManager {
 };
 
 struct PagedCacheManager : CacheManager {
-  PagedCacheManager(std::shared_ptr<Model> model);
+  PagedCacheManager(std::shared_ptr<Model> model,
+                    size_t auxiliary_bytes_per_block = 0);
 
   bool CanAllocate(const std::vector<std::shared_ptr<Request>>& requests) const override;
 

--- a/src/engine/decoders/decoder.h
+++ b/src/engine/decoders/decoder.h
@@ -54,6 +54,8 @@ struct DecoderIO : ModelIO {
    */
   virtual std::vector<DeviceSpan<float>> ProcessLogits() = 0;
 
+  virtual Tensor* HiddenStates() const { return nullptr; }
+
  protected:
   ScheduledRequests& scheduled_requests_;
   std::shared_ptr<CacheManager> cache_manager_;

--- a/src/engine/decoders/hybrid_decoder_io.h
+++ b/src/engine/decoders/hybrid_decoder_io.h
@@ -18,6 +18,7 @@ struct HybridDecoderIO : DecoderIO {
                   const ExecutionContext& execution_context);
 
   std::vector<DeviceSpan<float>> ProcessLogits() override;
+  Tensor* HiddenStates() const override { return varlen_io_.HiddenStates(); }
 
  private:
   void BindFixedState();

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -131,6 +131,16 @@ VarlenGraphBuffers::VarlenGraphBuffers(DecoderOnly_Model& model) {
                                             static_cast<int64_t>(model.config_->model.vocab_size)},
                        /*make_static=*/true);
 
+  const auto& hidden_states_input_name = model.config_->model.decoder.inputs.hidden_states;
+  if (!hidden_states_input_name.empty() && model.session_info_.HasInput(hidden_states_input_name)) {
+    hidden_states_input = std::make_unique<Tensor>(
+        model.p_device_inputs_, model.session_info_.GetInputDataType(hidden_states_input_name));
+    hidden_states_input->CreateTensor(
+        std::vector<int64_t>{static_cast<int64_t>(max_batch_size),
+                             static_cast<int64_t>(model.config_->model.decoder.hidden_size)},
+        /*make_static=*/true);
+  }
+
   const auto& hidden_states_name = model.config_->model.decoder.outputs.hidden_states;
   if (!hidden_states_name.empty() && model.session_info_.HasOutput(hidden_states_name)) {
     hidden_states = std::make_unique<Tensor>(model.p_device_inputs_,
@@ -170,6 +180,7 @@ VarlenDecoderIO::VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
   PrepareInputIds(model, scheduled_requests);
   PreparePositionIds(model, scheduled_requests);
   PrepareAttentionMetadata(model, scheduled_requests);
+  PrepareHiddenStatesInput(model, scheduled_requests);
   PrepareLogits(model, scheduled_requests);
   PrepareHiddenStates(model, scheduled_requests);
 
@@ -183,6 +194,48 @@ VarlenDecoderIO::VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
     output_names_.push_back(cache->output_names_[i]);
     outputs_.push_back(cache->outputs_[i]);
   }
+}
+
+void VarlenDecoderIO::PrepareHiddenStatesInput(
+    std::shared_ptr<DecoderOnly_Model> model,
+    ScheduledRequests& scheduled_requests) {
+  const auto& hidden_states_name = model->config_->model.decoder.inputs.hidden_states;
+  if (hidden_states_name.empty() || !model->session_info_.HasInput(hidden_states_name)) {
+    return;
+  }
+  if (!execution_context_ || !execution_context_->hidden_states_input) {
+    throw std::runtime_error(
+        "The decoder requires a packed hidden_states input, but the execution context did not provide one.");
+  }
+
+  const auto info = execution_context_->hidden_states_input->GetTensorTypeAndShapeInfo();
+  const auto shape = info->GetShape();
+  const std::vector<int64_t> expected_shape = {
+      static_cast<int64_t>(TokenCount(scheduled_requests)),
+      static_cast<int64_t>(model->config_->model.decoder.hidden_size)};
+  if (shape != expected_shape) {
+    throw std::runtime_error(
+        "The packed hidden_states input shape does not match the scheduled token rows.");
+  }
+  if (info->GetElementType() != model->session_info_.GetInputDataType(hidden_states_name)) {
+    throw std::runtime_error(
+        "The packed hidden_states input type does not match the decoder input type.");
+  }
+
+  OrtValue* active_hidden_states_input = execution_context_->hidden_states_input;
+  if (graph_buffers_ != nullptr) {
+    if (!graph_buffers_->hidden_states_input) {
+      throw std::runtime_error(
+          "Captured decoder step has no persistent hidden_states input buffer.");
+    }
+    graph_buffers_->hidden_states_input->CreateTensor(expected_shape, /*make_static=*/true);
+    graph_buffers_->hidden_states_input->GetByteSpan().CopyFrom(
+        ByteWrapTensor(*model->p_device_inputs_, *execution_context_->hidden_states_input));
+    active_hidden_states_input = graph_buffers_->hidden_states_input->GetOrtTensor();
+  }
+
+  input_names_.push_back(hidden_states_name.c_str());
+  inputs_.push_back(active_hidden_states_input);
 }
 
 void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests) {

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -283,16 +283,32 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
   auto sequence_lengths_span = sequence_lengths_tensor->GetDeviceSpan<int32_t>();
   auto sequence_lengths_cpu_span = sequence_lengths_span.CpuSpan();
 
+  DeviceSpan<int32_t> device_input_ids =
+      execution_context_ ? execution_context_->input_ids : DeviceSpan<int32_t>{};
+  if (!device_input_ids.empty()) {
+    if (device_input_ids.size() != num_tokens) {
+      throw std::runtime_error("Packed device input IDs do not match the step token count.");
+    }
+    if (!model->p_device_inputs_->Cast(
+            device_input_ids.Span().data(), device_span.Span().data(),
+            Ort::TypeToTensorType<int32_t>, Ort::TypeToTensorType<int64_t>, num_tokens)) {
+      throw std::runtime_error("The model device cannot cast packed input IDs to int64.");
+    }
+  }
+
   for (size_t i = 0, running_length = 0; i < scheduled_requests.size(); ++i) {
     auto request = scheduled_requests[i];
-    auto input_ids = request->UnprocessedTokensCpu();
+    const size_t input_id_count = request->ScheduledTokenCount();
     const RequestStepPlan* entry = plan ? &plan->requests[i] : nullptr;
     if (entry && (entry->request != request ||
-                  entry->unprocessed_token_count != input_ids.size() ||
+                  entry->unprocessed_token_count != input_id_count ||
                   entry->packed_token_offset != running_length)) {
       throw std::runtime_error("Step plan token layout does not match the scheduled request.");
     }
-    std::copy(input_ids.begin(), input_ids.end(), cpu_span.begin() + running_length);
+    if (device_input_ids.empty()) {
+      auto input_ids = request->UnprocessedTokensCpu();
+      std::copy(input_ids.begin(), input_ids.end(), cpu_span.begin() + running_length);
+    }
 
     // The batch is represented as three coordinated arrays:
     //   input_ids                  = all pending tokens concatenated
@@ -310,11 +326,13 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
     }
     sequence_lengths_cpu_span[i] = static_cast<int32_t>(processed_sequence_length);
 
-    running_length += input_ids.size();
+    running_length += input_id_count;
     cumulative_sequence_lengths_cpu_span[i + 1] = static_cast<int32_t>(running_length);
   }
 
-  device_span.CopyCpuToDevice();
+  if (device_input_ids.empty()) {
+    device_span.CopyCpuToDevice();
+  }
   cumulative_sequence_lengths_span.CopyCpuToDevice();
   sequence_lengths_span.CopyCpuToDevice();
 

--- a/src/engine/decoders/varlen_decoder_io.h
+++ b/src/engine/decoders/varlen_decoder_io.h
@@ -52,6 +52,8 @@ struct VarlenGraphBuffers {
   std::unique_ptr<Tensor> cumulative_sequence_lengths;
   std::unique_ptr<Tensor> past_sequence_lengths;
   std::unique_ptr<Tensor> logits;
+  // Null unless the model consumes hidden_states (for example, an MTP head).
+  std::unique_ptr<Tensor> hidden_states_input;
   // Null unless the model was exported with include_hidden_states.
   std::unique_ptr<Tensor> hidden_states;
   size_t max_batch_size{};
@@ -88,12 +90,13 @@ struct VarlenDecoderIO : DecoderIO {
 
   // The step's packed [total_num_tokens, hidden_size] hidden states, or null when the model does
   // not expose them. Row i corresponds to packed token i, in the same order as the logits rows.
-  Tensor* HiddenStates() const { return active_hidden_states_; }
+  Tensor* HiddenStates() const override { return active_hidden_states_; }
 
  private:
   void PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PreparePositionIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareAttentionMetadata(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
+  void PrepareHiddenStatesInput(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareHiddenStates(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -53,6 +53,41 @@ std::vector<int32_t> GreedyTokens(
   return tokens;
 }
 
+bool TryGreedyTokensToDevice(
+    const std::shared_ptr<DecoderOnly_Model>& model,
+    std::vector<DeviceSpan<float>>& logits,
+    DeviceSpan<int32_t> tokens) {
+  if (tokens.size() != logits.size()) {
+    return false;
+  }
+
+  const size_t vocab_size = static_cast<size_t>(model->config_->model.vocab_size);
+  const bool contiguous = !logits.empty() && std::all_of(
+                                                 logits.begin(), logits.end(),
+                                                 [&](DeviceSpan<float>& row) {
+                                                   const size_t index = &row - logits.data();
+                                                   return row.size() == vocab_size &&
+                                                          row.SameBufferAs(logits.front()) &&
+                                                          row.Span().data() ==
+                                                              logits.front().Span().data() +
+                                                                  index * vocab_size;
+                                                 });
+  if (contiguous) {
+    return model->p_device_->ArgMaxDevice(
+        logits.front().Span().data(), Ort::TypeToTensorType<float>,
+        static_cast<int>(logits.size()), model->config_->model.vocab_size, tokens);
+  }
+
+  for (size_t i = 0; i < logits.size(); ++i) {
+    if (!model->p_device_->ArgMaxDevice(
+            logits[i].Span().data(), Ort::TypeToTensorType<float>, 1,
+            model->config_->model.vocab_size, tokens.subspan(i, 1))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace
 
 Engine::Engine(std::shared_ptr<Model> model)
@@ -164,9 +199,10 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       const auto& entry = target_plan.requests[i];
       const auto& result = target_results[i];
       const auto& search = entry.request->SearchOptions();
-      const bool greedy = !search.do_sample || search.top_k == 1 || search.temperature == 0;
+      const bool greedy =
+          !search.do_sample || search.top_k == 1 || search.temperature == 0;
       const int64_t committed_length_after_step =
-          entry.request->CurrentSequenceLength() + (result.token_appended ? 1 : 0);
+          entry.request->CurrentSequenceLength();
       const size_t max_draft_tokens = std::min({MaxDraftTokensPerStep(),
                                                 static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
                                                 committed_length_after_step + 1 < search.max_length
@@ -270,6 +306,41 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     }
     step->reservation = mtp_cache_manager_->ReserveStep(step->plan);
 
+    const size_t max_draft_tokens = std::max_element(
+                                        feeds.begin(), feeds.end(),
+                                        [](const Feed& left, const Feed& right) {
+                                          return left.max_draft_tokens < right.max_draft_tokens;
+                                        })
+                                        ->max_draft_tokens;
+    bool device_draft_chain =
+        max_draft_tokens > 1 && mtp_model_->p_device_->GetType() == DeviceType::CUDA;
+    DeviceSpan<int32_t> device_drafts;
+    DeviceSpan<int32_t> device_chain_inputs;
+    if (device_draft_chain) {
+      const size_t draft_capacity = feeds.size() * max_draft_tokens;
+      if (mtp_device_drafts_.size() < draft_capacity) {
+        mtp_device_drafts_ = mtp_model_->p_device_->Allocate<int32_t>(draft_capacity);
+      }
+      if (mtp_device_chain_inputs_.size() < feeds.size()) {
+        mtp_device_chain_inputs_ = mtp_model_->p_device_->Allocate<int32_t>(feeds.size());
+      }
+      device_drafts = mtp_device_drafts_.subspan(0, draft_capacity);
+      device_chain_inputs = mtp_device_chain_inputs_.subspan(0, feeds.size());
+    }
+    std::vector<std::vector<size_t>> device_stage_feed_indices;
+    device_stage_feed_indices.reserve(max_draft_tokens);
+
+    const auto materialize_device_drafts = [&]() {
+      auto draft_ids = device_drafts.CopyDeviceToCpu();
+      for (size_t stage = 0; stage < device_stage_feed_indices.size(); ++stage) {
+        const auto& feed_indices = device_stage_feed_indices[stage];
+        for (size_t row = 0; row < feed_indices.size(); ++row) {
+          step->drafts[feed_indices[row]].push_back(
+              draft_ids[stage * feeds.size() + row]);
+        }
+      }
+    };
+
     Tensor packed_hidden_states{mtp_model_->p_device_inputs_, hidden_type};
     const std::array<int64_t, 2> packed_hidden_shape{
         static_cast<int64_t>(total_rows), hidden_size};
@@ -290,13 +361,32 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     ExecutionContext context{&step->plan};
     context.cache_reservation = step->reservation->PagedReservation();
     context.hidden_states_input = packed_hidden_states.GetOrtTensor();
+    if (device_draft_chain) {
+      context.run_options->AddConfigEntry("disable_synchronize_execution_providers", "1");
+    }
     mtp_model_executor_->Decode(mtp_requests, context);
     ++speculative_stats_.draft_forward_passes;
     auto logits = mtp_requests.ProcessLogits();
-    const auto first_drafts = GreedyTokens(mtp_model_, logits);
-    for (size_t i = 0; i < first_drafts.size(); ++i) {
+    device_draft_chain =
+        device_draft_chain &&
+        TryGreedyTokensToDevice(
+            mtp_model_, logits, device_drafts.subspan(0, feeds.size()));
+    std::vector<int32_t> first_drafts;
+    if (device_draft_chain) {
+      std::vector<size_t> first_stage_feed_indices;
+      first_stage_feed_indices.reserve(feeds.size());
+      for (size_t i = 0; i < feeds.size(); ++i) {
+        first_stage_feed_indices.push_back(i);
+      }
+      device_stage_feed_indices.push_back(std::move(first_stage_feed_indices));
+    } else {
+      first_drafts = GreedyTokens(mtp_model_, logits);
+    }
+    for (size_t i = 0; i < feeds.size(); ++i) {
       step->drafts[i].reserve(feeds[i].max_draft_tokens);
-      step->drafts[i].push_back(first_drafts[i]);
+      if (!device_draft_chain) {
+        step->drafts[i].push_back(first_drafts[i]);
+      }
       step->plan.requests[i].request->CommitAuxiliaryDecoderStep();
     }
 
@@ -317,8 +407,10 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     };
 
     std::vector<size_t> active_feed_indices;
+    std::vector<size_t> previous_stage_rows(feeds.size());
     std::vector<size_t> feedback_rows;
     for (size_t i = 0; i < feeds.size(); ++i) {
+      previous_stage_rows[i] = i;
       if (feeds[i].max_draft_tokens > 1) {
         active_feed_indices.push_back(i);
         feedback_rows.push_back(step->plan.requests[i].logits_row_index);
@@ -336,6 +428,9 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       feedback_hidden = copy_hidden_rows(*head_hidden, feedback_rows);
     }
 
+    std::vector<std::unique_ptr<ScheduledRequests>> pending_device_requests;
+    pending_device_requests.reserve(max_draft_tokens - 1);
+
     for (size_t draft_index = 1; !active_feed_indices.empty(); ++draft_index) {
       StepPlan chain_plan;
       chain_plan.transaction_id = target_plan.transaction_id;
@@ -344,10 +439,22 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       chain_plan.proposed_block_table_columns = step->plan.proposed_block_table_columns;
       chain_plan.graph_capture_eligible = true;
       chain_plan.requests.reserve(active_feed_indices.size());
-      for (size_t feed_index : active_feed_indices) {
+      DeviceSpan<int32_t> packed_device_inputs;
+      if (device_draft_chain) {
+        packed_device_inputs = device_chain_inputs.subspan(0, active_feed_indices.size());
+      }
+      for (size_t row = 0; row < active_feed_indices.size(); ++row) {
+        const size_t feed_index = active_feed_indices[row];
         auto& shadow = feeds[feed_index].shadow;
-        const std::array<int32_t, 1> token{step->drafts[feed_index].back()};
-        shadow->AppendTokensForAuxiliaryDecoder(token);
+        if (device_draft_chain) {
+          auto token = packed_device_inputs.subspan(row, 1);
+          token.CopyFrom(device_drafts.subspan(
+              (draft_index - 1) * feeds.size() + previous_stage_rows[feed_index], 1));
+          shadow->AppendTokensForAuxiliaryDecoder(token);
+        } else {
+          const std::array<int32_t, 1> token{step->drafts[feed_index].back()};
+          shadow->AppendTokensForAuxiliaryDecoder(token);
+        }
         const size_t processed = static_cast<size_t>(shadow->ProcessedSequenceLength());
         chain_plan.requests.push_back(RequestStepPlan{
             shadow,
@@ -364,18 +471,44 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
         });
       }
 
-      ScheduledRequests chain_requests{chain_plan, mtp_model_, nullptr, nullptr};
+      auto chain_requests = std::make_unique<ScheduledRequests>(
+          chain_plan, mtp_model_, nullptr, nullptr);
       ExecutionContext chain_context{&chain_plan};
       chain_context.cache_reservation = step->reservation->PagedReservation();
       chain_context.hidden_states_input = feedback_hidden->GetOrtTensor();
-      mtp_model_executor_->Decode(chain_requests, chain_context);
+      if (device_draft_chain) {
+        chain_context.input_ids = packed_device_inputs;
+        chain_context.run_options->AddConfigEntry(
+            "disable_synchronize_execution_providers", "1");
+      }
+      mtp_model_executor_->Decode(*chain_requests, chain_context);
       ++speculative_stats_.draft_forward_passes;
-      auto chain_logits = chain_requests.ProcessLogits();
-      const auto chain_drafts = GreedyTokens(mtp_model_, chain_logits);
+      auto chain_logits = chain_requests->ProcessLogits();
+      bool stage_on_device = false;
+      if (device_draft_chain) {
+        stage_on_device = TryGreedyTokensToDevice(
+            mtp_model_, chain_logits,
+            device_drafts.subspan(
+                draft_index * feeds.size(), active_feed_indices.size()));
+      }
+      std::vector<int32_t> chain_drafts;
+      if (stage_on_device) {
+        device_stage_feed_indices.push_back(active_feed_indices);
+      } else {
+        if (device_draft_chain) {
+          materialize_device_drafts();
+          pending_device_requests.clear();
+          device_draft_chain = false;
+        }
+        chain_drafts = GreedyTokens(mtp_model_, chain_logits);
+      }
       for (size_t row = 0; row < active_feed_indices.size(); ++row) {
         const size_t feed_index = active_feed_indices[row];
-        step->drafts[feed_index].push_back(chain_drafts[row]);
+        if (!device_draft_chain) {
+          step->drafts[feed_index].push_back(chain_drafts[row]);
+        }
         feeds[feed_index].shadow->CommitAuxiliaryDecoderStep();
+        previous_stage_rows[feed_index] = row;
       }
 
       std::vector<size_t> next_active_feed_indices;
@@ -387,7 +520,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
         }
       }
       if (!next_active_feed_indices.empty()) {
-        Tensor* head_hidden = chain_requests.HiddenStates();
+        Tensor* head_hidden = chain_requests->HiddenStates();
         if (!head_hidden ||
             head_hidden->GetShape() !=
                 std::vector<int64_t>{static_cast<int64_t>(active_feed_indices.size()),
@@ -397,7 +530,14 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
         }
         feedback_hidden = copy_hidden_rows(*head_hidden, next_feedback_rows);
       }
+      if (device_draft_chain) {
+        pending_device_requests.push_back(std::move(chain_requests));
+      }
       active_feed_indices = std::move(next_active_feed_indices);
+    }
+
+    if (device_draft_chain) {
+      materialize_device_drafts();
     }
 
     for (size_t i = 0; i < feeds.size(); ++i) {

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "engine.h"
+#include "../search.h"
 
 namespace Generators {
 
@@ -19,6 +20,37 @@ std::string AddExceptionCause(std::string message, std::exception_ptr error) {
   return message;
 }
 
+std::vector<int32_t> GreedyTokens(
+    const std::shared_ptr<DecoderOnly_Model>& model,
+    std::vector<DeviceSpan<float>>& logits) {
+  std::vector<int32_t> tokens(logits.size());
+  auto device_tokens = model->p_device_->Allocate<int32_t>(logits.size());
+  (void)device_tokens.CpuSpan();
+  bool device_argmax = true;
+  for (size_t i = 0; i < logits.size(); ++i) {
+    device_argmax &= model->p_device_->ArgMaxDevice(
+        logits[i].Span().data(), Ort::TypeToTensorType<float>, 1,
+        model->config_->model.vocab_size, device_tokens.subspan(i, 1));
+  }
+  if (device_argmax) {
+    device_tokens.CopyDeviceToCpu();
+    std::copy(device_tokens.CpuSpan().begin(), device_tokens.CpuSpan().end(),
+              tokens.begin());
+    return tokens;
+  }
+
+  for (size_t i = 0; i < logits.size(); ++i) {
+    if (!model->p_device_->ArgMax(
+            logits[i].Span().data(), Ort::TypeToTensorType<float>, 1,
+            model->config_->model.vocab_size, &tokens[i])) {
+      const auto values = logits[i].CopyDeviceToCpu();
+      tokens[i] = static_cast<int32_t>(
+          std::max_element(values.begin(), values.end()) - values.begin());
+    }
+  }
+  return tokens;
+}
+
 }  // namespace
 
 Engine::Engine(std::shared_ptr<Model> model)
@@ -28,7 +60,10 @@ Engine::Engine(std::shared_ptr<Model> model, EngineDependencies dependencies)
     : model_{std::move(model)},
       cache_manager_{std::move(dependencies.cache_manager)},
       scheduler_{std::move(dependencies.scheduler)},
-      model_executor_{std::move(dependencies.model_executor)} {
+      model_executor_{std::move(dependencies.model_executor)},
+      mtp_model_{std::move(dependencies.mtp_model)},
+      mtp_cache_manager_{std::move(dependencies.mtp_cache_manager)},
+      mtp_model_executor_{std::move(dependencies.mtp_model_executor)} {
   // Fail fast on a missing collaborator rather than crashing later on first use.
   if (!cache_manager_) {
     throw std::runtime_error("Engine requires a non-null cache manager.");
@@ -45,13 +80,384 @@ Engine::Engine(std::shared_ptr<Model> model, EngineDependencies dependencies)
   step_results_.reserve(max_batch_size);
   ready_requests_.reserve(max_batch_size);
   staged_ready_requests_.reserve(max_batch_size);
+  mtp_requests_.reserve(max_batch_size);
 }
 
 EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
-  std::shared_ptr<CacheManager> cache_manager = CacheManager::Create(model);
+  std::shared_ptr<DecoderOnly_Model> mtp_model;
+  size_t mtp_bytes_per_block = 0;
+  if (!model->config_->model.mtp.filename.empty()) {
+    if (!model->config_->engine.dynamic_batching) {
+      throw std::runtime_error("An Engine-hosted MTP head requires dynamic batching.");
+    }
+    mtp_model = std::make_shared<DecoderOnly_Model>(
+        CreateMtpDecoderConfig(*model->config_), GetOrtEnv());
+    mtp_bytes_per_block = PagedKeyValueCacheBytesPerBlock(mtp_model);
+  }
+
+  std::shared_ptr<CacheManager> cache_manager =
+      CacheManager::Create(model, mtp_bytes_per_block);
   auto scheduler = Scheduler::Create(model, cache_manager);
   auto model_executor = ModelExecutor::Create(model, cache_manager);
-  return EngineDependencies{std::move(cache_manager), std::move(scheduler), std::move(model_executor)};
+
+  std::shared_ptr<CacheManager> mtp_cache_manager;
+  std::unique_ptr<ModelExecutor> mtp_model_executor;
+  if (mtp_model) {
+    // Both decoders cover the same resident request set. Fixing the head to the main pool's block
+    // count makes the auxiliary bytes included above exact rather than letting it independently
+    // consume another gpu_utilization_factor share of currently free memory.
+    mtp_model->config_->engine.dynamic_batching->num_blocks =
+        cache_manager->Snapshot().total_blocks;
+    mtp_cache_manager = CacheManager::Create(mtp_model);
+    mtp_model_executor = ModelExecutor::Create(mtp_model, mtp_cache_manager);
+  }
+
+  return EngineDependencies{
+      std::move(cache_manager), std::move(scheduler), std::move(model_executor),
+      std::move(mtp_model), std::move(mtp_cache_manager), std::move(mtp_model_executor)};
+}
+
+std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
+    const StepPlan& target_plan,
+    const std::vector<RequestStepResult>& target_results,
+    ScheduledRequests& target_requests) {
+  if (!mtp_model_ || MaxDraftTokensPerStep() == 0) {
+    return nullptr;
+  }
+  if (target_results.size() != target_plan.requests.size()) {
+    throw std::logic_error("MTP preparation requires one target result per planned request.");
+  }
+
+  Tensor* target_hidden_states = target_requests.HiddenStates();
+  if (!target_hidden_states) {
+    throw std::logic_error("The main decoder did not expose hidden states for its MTP head.");
+  }
+  const auto target_hidden_shape = target_hidden_states->GetShape();
+  const int64_t hidden_size = model_->config_->model.decoder.hidden_size;
+  if (target_hidden_shape !=
+      std::vector<int64_t>{static_cast<int64_t>(target_plan.token_count), hidden_size}) {
+    throw std::logic_error("The main decoder hidden-state shape does not match its packed step plan.");
+  }
+  const auto hidden_type = target_hidden_states->GetType();
+  const auto& mtp_hidden_name = mtp_model_->config_->model.decoder.inputs.hidden_states;
+  if (hidden_type != mtp_model_->session_info_.GetInputDataType(mtp_hidden_name)) {
+    throw std::logic_error("The main and MTP hidden-state element types do not match.");
+  }
+
+  struct Feed {
+    std::shared_ptr<Request> target;
+    std::shared_ptr<Request> shadow;
+    std::vector<int32_t> tokens;
+    size_t target_hidden_row{};
+    size_t max_draft_tokens{};
+    bool newly_created{};
+  };
+  std::vector<Feed> feeds;
+  feeds.reserve(target_plan.requests.size());
+  std::vector<std::shared_ptr<Request>> checkpointed_shadows;
+  checkpointed_shadows.reserve(target_plan.requests.size());
+  size_t total_rows = 0;
+  try {
+    for (size_t i = 0; i < target_plan.requests.size(); ++i) {
+      const auto& entry = target_plan.requests[i];
+      const auto& result = target_results[i];
+      const auto& search = entry.request->SearchOptions();
+      const bool greedy = !search.do_sample || search.top_k == 1 || search.temperature == 0;
+      const int64_t committed_length_after_step =
+          entry.request->CurrentSequenceLength() + (result.token_appended ? 1 : 0);
+      const size_t max_draft_tokens = std::min({MaxDraftTokensPerStep(),
+                                                static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
+                                                committed_length_after_step + 1 < search.max_length
+                                                    ? static_cast<size_t>(search.max_length - committed_length_after_step - 1)
+                                                    : size_t{0}});
+      if (!result.token_appended || result.done || !greedy ||
+          search.repetition_penalty != 1.0f || search.no_repeat_ngram_size > 0 ||
+          search.min_length > entry.request->CurrentSequenceLength() ||
+          max_draft_tokens == 0) {
+        continue;
+      }
+
+      Feed feed;
+      feed.target = entry.request;
+      const size_t accepted = entry.request->AcceptedDraftTokenCount();
+      if (accepted > entry.draft_token_count) {
+        throw std::logic_error("MTP preparation observed more accepted drafts than the target planned.");
+      }
+      const auto staged_drafts = entry.request->StagedDraftTokens();
+      feed.tokens.insert(feed.tokens.end(), staged_drafts.begin(),
+                         staged_drafts.begin() + static_cast<ptrdiff_t>(accepted));
+      feed.tokens.push_back(result.token);
+      feed.target_hidden_row = entry.packed_token_offset +
+                               (entry.draft_token_count == 0
+                                    ? entry.unprocessed_token_count - 1
+                                    : 0);
+      feed.max_draft_tokens = max_draft_tokens;
+
+      const auto existing = mtp_requests_.find(entry.request.get());
+      if (existing != mtp_requests_.end()) {
+        feed.shadow = existing->second;
+        feed.shadow->SaveStateForTransaction();
+        checkpointed_shadows.push_back(feed.shadow);
+        feed.shadow->AppendTokensForAuxiliaryDecoder(feed.tokens);
+      } else {
+        auto params = CreateGeneratorParams(*mtp_model_);
+        params->search = search;
+        feed.shadow = std::make_shared<Request>(std::move(params));
+        feed.shadow->AddTokens(feed.tokens);
+        feed.shadow->Assign(shared_from_this());
+        feed.shadow->Schedule();
+        feed.newly_created = true;
+      }
+      total_rows += feed.tokens.size();
+      feeds.push_back(std::move(feed));
+    }
+  } catch (...) {
+    const auto setup_error = std::current_exception();
+    for (auto it = checkpointed_shadows.rbegin(); it != checkpointed_shadows.rend(); ++it) {
+      try {
+        (*it)->RestoreStateForTransaction();
+      } catch (...) {
+      }
+    }
+    std::rethrow_exception(setup_error);
+  }
+  if (feeds.empty()) {
+    return nullptr;
+  }
+
+  auto step = std::make_unique<MtpStep>();
+  step->plan.transaction_id = target_plan.transaction_id;
+  step->plan.scheduled_request_limit = feeds.size();
+  step->plan.token_count = total_rows;
+  step->target_requests.reserve(feeds.size());
+  step->newly_created.reserve(feeds.size());
+  step->drafts.resize(feeds.size());
+
+  size_t packed_offset = 0;
+  for (const auto& feed : feeds) {
+    const size_t token_count = feed.tokens.size();
+    const size_t processed = static_cast<size_t>(feed.shadow->ProcessedSequenceLength());
+    step->plan.requests.push_back(RequestStepPlan{
+        feed.shadow,
+        feed.shadow.get(),
+        feed.shadow->CurrentSequenceLength(),
+        token_count,
+        0,
+        packed_offset,
+        packed_offset + token_count - 1,
+        processed + token_count,
+        static_cast<size_t>(feed.shadow->CurrentSequenceLength()) +
+            feed.max_draft_tokens - 1,
+        feed.shadow->IsPrefill(),
+        feed.newly_created,
+    });
+    step->target_requests.push_back(feed.target);
+    step->newly_created.push_back(feed.newly_created);
+    packed_offset += token_count;
+  }
+  step->plan.graph_capture_eligible = std::all_of(
+      step->plan.requests.begin(), step->plan.requests.end(),
+      [](const RequestStepPlan& entry) {
+        return !entry.is_prefill && entry.unprocessed_token_count == 1;
+      });
+
+  try {
+    const auto planning = mtp_cache_manager_->PlanStepResources(step->plan);
+    if (!planning.executable || step->plan.requests.size() != feeds.size()) {
+      throw std::runtime_error("The MTP cache could not reserve every target-committed suffix.");
+    }
+    step->reservation = mtp_cache_manager_->ReserveStep(step->plan);
+
+    Tensor packed_hidden_states{mtp_model_->p_device_inputs_, hidden_type};
+    const std::array<int64_t, 2> packed_hidden_shape{
+        static_cast<int64_t>(total_rows), hidden_size};
+    packed_hidden_states.CreateTensor(packed_hidden_shape);
+    const size_t row_bytes = static_cast<size_t>(hidden_size) * Ort::SizeOf(hidden_type);
+    auto source_bytes = target_hidden_states->GetByteSpan();
+    auto destination_bytes = packed_hidden_states.GetByteSpan();
+    size_t destination_row = 0;
+    for (const auto& feed : feeds) {
+      const size_t row_count = feed.tokens.size();
+      destination_bytes.subspan(destination_row * row_bytes, row_count * row_bytes)
+          .CopyFrom(source_bytes.subspan(feed.target_hidden_row * row_bytes,
+                                         row_count * row_bytes));
+      destination_row += row_count;
+    }
+
+    ScheduledRequests mtp_requests{step->plan, mtp_model_, nullptr, nullptr};
+    ExecutionContext context{&step->plan};
+    context.cache_reservation = step->reservation->PagedReservation();
+    context.hidden_states_input = packed_hidden_states.GetOrtTensor();
+    mtp_model_executor_->Decode(mtp_requests, context);
+    auto logits = mtp_requests.ProcessLogits();
+    const auto first_drafts = GreedyTokens(mtp_model_, logits);
+    for (size_t i = 0; i < first_drafts.size(); ++i) {
+      step->drafts[i].reserve(feeds[i].max_draft_tokens);
+      step->drafts[i].push_back(first_drafts[i]);
+      step->plan.requests[i].request->CommitAuxiliaryDecoderStep();
+    }
+
+    const auto copy_hidden_rows = [&](Tensor& source,
+                                      std::span<const size_t> source_rows) {
+      auto destination = std::make_unique<Tensor>(mtp_model_->p_device_inputs_, hidden_type);
+      const std::array<int64_t, 2> shape{
+          static_cast<int64_t>(source_rows.size()), hidden_size};
+      destination->CreateTensor(shape);
+      const size_t row_bytes = static_cast<size_t>(hidden_size) * Ort::SizeOf(hidden_type);
+      auto source_bytes = source.GetByteSpan();
+      auto destination_bytes = destination->GetByteSpan();
+      for (size_t row = 0; row < source_rows.size(); ++row) {
+        destination_bytes.subspan(row * row_bytes, row_bytes)
+            .CopyFrom(source_bytes.subspan(source_rows[row] * row_bytes, row_bytes));
+      }
+      return destination;
+    };
+
+    std::vector<size_t> active_feed_indices;
+    std::vector<size_t> feedback_rows;
+    for (size_t i = 0; i < feeds.size(); ++i) {
+      if (feeds[i].max_draft_tokens > 1) {
+        active_feed_indices.push_back(i);
+        feedback_rows.push_back(step->plan.requests[i].logits_row_index);
+      }
+    }
+    std::unique_ptr<Tensor> feedback_hidden;
+    if (!active_feed_indices.empty()) {
+      Tensor* head_hidden = mtp_requests.HiddenStates();
+      if (!head_hidden ||
+          head_hidden->GetShape() !=
+              std::vector<int64_t>{static_cast<int64_t>(total_rows), hidden_size}) {
+        throw std::runtime_error(
+            "Chained MTP drafts require one configured head hidden-state output row per input token.");
+      }
+      feedback_hidden = copy_hidden_rows(*head_hidden, feedback_rows);
+    }
+
+    for (size_t draft_index = 1; !active_feed_indices.empty(); ++draft_index) {
+      StepPlan chain_plan;
+      chain_plan.transaction_id = target_plan.transaction_id;
+      chain_plan.scheduled_request_limit = active_feed_indices.size();
+      chain_plan.token_count = active_feed_indices.size();
+      chain_plan.proposed_block_table_columns = step->plan.proposed_block_table_columns;
+      chain_plan.graph_capture_eligible = true;
+      chain_plan.requests.reserve(active_feed_indices.size());
+      for (size_t feed_index : active_feed_indices) {
+        auto& shadow = feeds[feed_index].shadow;
+        const std::array<int32_t, 1> token{step->drafts[feed_index].back()};
+        shadow->AppendTokensForAuxiliaryDecoder(token);
+        const size_t processed = static_cast<size_t>(shadow->ProcessedSequenceLength());
+        chain_plan.requests.push_back(RequestStepPlan{
+            shadow,
+            shadow.get(),
+            shadow->CurrentSequenceLength(),
+            1,
+            0,
+            chain_plan.requests.size(),
+            chain_plan.requests.size(),
+            processed + 1,
+            step->plan.requests[feed_index].whole_sequence_cache_slots,
+            false,
+            false,
+        });
+      }
+
+      ScheduledRequests chain_requests{chain_plan, mtp_model_, nullptr, nullptr};
+      ExecutionContext chain_context{&chain_plan};
+      chain_context.cache_reservation = step->reservation->PagedReservation();
+      chain_context.hidden_states_input = feedback_hidden->GetOrtTensor();
+      mtp_model_executor_->Decode(chain_requests, chain_context);
+      auto chain_logits = chain_requests.ProcessLogits();
+      const auto chain_drafts = GreedyTokens(mtp_model_, chain_logits);
+      for (size_t row = 0; row < active_feed_indices.size(); ++row) {
+        const size_t feed_index = active_feed_indices[row];
+        step->drafts[feed_index].push_back(chain_drafts[row]);
+        feeds[feed_index].shadow->CommitAuxiliaryDecoderStep();
+      }
+
+      std::vector<size_t> next_active_feed_indices;
+      std::vector<size_t> next_feedback_rows;
+      for (size_t row = 0; row < active_feed_indices.size(); ++row) {
+        if (feeds[active_feed_indices[row]].max_draft_tokens > draft_index + 1) {
+          next_active_feed_indices.push_back(active_feed_indices[row]);
+          next_feedback_rows.push_back(row);
+        }
+      }
+      if (!next_active_feed_indices.empty()) {
+        Tensor* head_hidden = chain_requests.HiddenStates();
+        if (!head_hidden ||
+            head_hidden->GetShape() !=
+                std::vector<int64_t>{static_cast<int64_t>(active_feed_indices.size()),
+                                     hidden_size}) {
+          throw std::runtime_error(
+              "Chained MTP hidden-state output does not match the active request batch.");
+        }
+        feedback_hidden = copy_hidden_rows(*head_hidden, next_feedback_rows);
+      }
+      active_feed_indices = std::move(next_active_feed_indices);
+    }
+
+    for (size_t i = 0; i < feeds.size(); ++i) {
+      feeds[i].shadow->RewindAuxiliaryDecoderTo(
+          static_cast<size_t>(step->plan.requests[i].target_cache_slots));
+    }
+    for (size_t i = 0; i < step->plan.requests.size(); ++i) {
+      if (step->newly_created[i]) {
+        mtp_requests_.emplace(step->target_requests[i].get(),
+                              step->plan.requests[i].request);
+      }
+    }
+  } catch (...) {
+    RollbackMtpStep(*step);
+    throw;
+  }
+  return step;
+}
+
+void Engine::RollbackMtpStep(MtpStep& step) {
+  std::exception_ptr rollback_error;
+  if (step.reservation) {
+    try {
+      step.reservation->Release();
+    } catch (...) {
+      rollback_error = std::current_exception();
+    }
+    step.reservation.reset();
+  }
+  for (size_t i = 0; i < step.plan.requests.size(); ++i) {
+    if (step.newly_created[i]) {
+      mtp_requests_.erase(step.target_requests[i].get());
+      continue;
+    }
+    try {
+      step.plan.requests[i].request->RestoreStateForTransaction();
+    } catch (...) {
+      if (!rollback_error) {
+        rollback_error = std::current_exception();
+      }
+    }
+  }
+  if (rollback_error) {
+    std::rethrow_exception(rollback_error);
+  }
+}
+
+void Engine::CommitMtpStep(MtpStep& step) {
+  for (size_t i = 0; i < step.plan.requests.size(); ++i) {
+    if (!step.newly_created[i]) {
+      step.plan.requests[i].request->CommitStateForTransaction();
+    }
+  }
+  step.reservation->Commit();
+  step.reservation.reset();
+  for (size_t i = 0; i < step.plan.requests.size(); ++i) {
+    step.plan.requests[i].request->CommitAuxiliaryDecoderStep();
+  }
+}
+
+void Engine::PublishMtpDrafts(MtpStep& step) {
+  for (size_t i = 0; i < step.plan.requests.size(); ++i) {
+    step.target_requests[i]->SetDraftTokens(step.drafts[i]);
+  }
 }
 
 void Engine::AddRequest(std::shared_ptr<Request> request) {
@@ -82,6 +488,14 @@ void Engine::RemoveRequest(std::shared_ptr<Request> request) {
   }
 
   scheduler_->RemoveRequest(request);
+
+  if (const auto mtp_it = mtp_requests_.find(request.get());
+      mtp_it != mtp_requests_.end()) {
+    std::vector<std::shared_ptr<Request>> mtp_requests{mtp_it->second};
+    mtp_cache_manager_->Deallocate(mtp_requests);
+    mtp_it->second->CompleteClose();
+    mtp_requests_.erase(mtp_it);
+  }
 
   ready_requests_.erase(
       ready_requests_.begin(),
@@ -348,12 +762,21 @@ std::shared_ptr<Request> Engine::StepDynamic() {
     context.fixed_state_staging_bytes = reservation->FixedStateStagingBytes();
 
     bool request_transaction_active = false;
+    std::unique_ptr<MtpStep> mtp_step;
     const auto rollback_transaction = [&]() {
       // Request/search state and composite cache state are checkpointed separately. Both must be
       // restored so a retry observes exactly the state that existed before this Step() call. The
       // reservation's Release() discards fixed provisional slots and staged banks as well as the
       // reserved paged blocks.
       std::exception_ptr rollback_error;
+      if (mtp_step) {
+        try {
+          RollbackMtpStep(*mtp_step);
+        } catch (...) {
+          rollback_error = std::current_exception();
+        }
+        mtp_step.reset();
+      }
       if (request_transaction_active) {
         try {
           scheduled_requests.RestoreStateForTransaction();
@@ -454,6 +877,7 @@ std::shared_ptr<Request> Engine::StepDynamic() {
             entry.unprocessed_token_count - entry.draft_token_count +
                 entry.request->AcceptedDraftTokenCount());
       }
+      mtp_step = PrepareMtpStep(step_plan_, step_results_, scheduled_requests);
       staged_ready_requests_.clear();
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         auto& request = step_plan_.requests[i].request;
@@ -482,6 +906,9 @@ std::shared_ptr<Request> Engine::StepDynamic() {
       // publishing anything. A failure here is fatal even though committed state is intact: the
       // fixed inactive banks may be partly written and cannot be proven consistent for a retry.
       reservation->PrepareCommit();
+      if (mtp_step) {
+        mtp_step->reservation->PrepareCommit();
+      }
       // Everything below crosses the commit boundary and is never retried. Make staged search state
       // durable, publish paged occupancy and the fixed bank flip, then advance the lightweight
       // Request bookkeeping that readers observe. Any failure after this point is fatal because a
@@ -489,9 +916,15 @@ std::shared_ptr<Request> Engine::StepDynamic() {
       scheduled_requests.CommitStateForTransaction();
       request_transaction_active = false;
       reservation->Commit();
+      if (mtp_step) {
+        CommitMtpStep(*mtp_step);
+      }
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         step_plan_.requests[i].request->CommitStep(
             step_plan_.requests[i], step_results_[i]);
+      }
+      if (mtp_step) {
+        PublishMtpDrafts(*mtp_step);
       }
     } catch (...) {
       MarkUnhealthyAndThrow(

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -6,6 +6,8 @@
 
 namespace Generators {
 
+static_assert(kMaxDraftTokensPerStep < kSpeculativeAcceptanceLengthBins);
+
 namespace {
 
 std::string AddExceptionCause(std::string message, std::exception_ptr error) {
@@ -289,6 +291,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     context.cache_reservation = step->reservation->PagedReservation();
     context.hidden_states_input = packed_hidden_states.GetOrtTensor();
     mtp_model_executor_->Decode(mtp_requests, context);
+    ++speculative_stats_.draft_forward_passes;
     auto logits = mtp_requests.ProcessLogits();
     const auto first_drafts = GreedyTokens(mtp_model_, logits);
     for (size_t i = 0; i < first_drafts.size(); ++i) {
@@ -366,6 +369,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       chain_context.cache_reservation = step->reservation->PagedReservation();
       chain_context.hidden_states_input = feedback_hidden->GetOrtTensor();
       mtp_model_executor_->Decode(chain_requests, chain_context);
+      ++speculative_stats_.draft_forward_passes;
       auto chain_logits = chain_requests.ProcessLogits();
       const auto chain_drafts = GreedyTokens(mtp_model_, chain_logits);
       for (size_t row = 0; row < active_feed_indices.size(); ++row) {
@@ -457,6 +461,30 @@ void Engine::CommitMtpStep(MtpStep& step) {
 void Engine::PublishMtpDrafts(MtpStep& step) {
   for (size_t i = 0; i < step.plan.requests.size(); ++i) {
     step.target_requests[i]->SetDraftTokens(step.drafts[i]);
+  }
+}
+
+void Engine::RecordSpeculativeCommit(const StepPlan& plan) noexcept {
+  for (const auto& entry : plan.requests) {
+    if (entry.draft_token_count == 0) {
+      continue;
+    }
+
+    const size_t accepted = entry.request->AcceptedDraftTokenCount();
+    ++speculative_stats_.rounds;
+    ++speculative_stats_.completed_rounds;
+    speculative_stats_.draft_tokens_proposed += entry.draft_token_count;
+    speculative_stats_.draft_tokens_evaluated +=
+        std::min(accepted + 1, entry.draft_token_count);
+    speculative_stats_.draft_tokens_accepted += accepted;
+    ++speculative_stats_.acceptance_length_histogram[accepted];
+    if (accepted == 0) {
+      ++speculative_stats_.zero_accept_rounds;
+    } else if (accepted == entry.draft_token_count) {
+      ++speculative_stats_.full_accept_rounds;
+    } else {
+      ++speculative_stats_.partial_accept_rounds;
+    }
   }
 }
 
@@ -619,6 +647,7 @@ std::shared_ptr<Request> Engine::StepStatic() {
     }
 
     model_executor_->Decode(scheduled_requests);
+    ++speculative_stats_.target_forward_passes;
     scheduled_requests.GenerateNextTokens();
 
     for (size_t i = 0; i < scheduled_requests.size(); ++i) {
@@ -828,6 +857,7 @@ std::shared_ptr<Request> Engine::StepDynamic() {
       scheduled_requests.BeginTransaction();
       request_transaction_active = true;
       model_executor_->Decode(scheduled_requests, context);
+      ++speculative_stats_.target_forward_passes;
     } catch (const ModelExecutionError& error) {
       const auto execution_error = std::current_exception();
       rollback_transaction();
@@ -919,6 +949,7 @@ std::shared_ptr<Request> Engine::StepDynamic() {
       if (mtp_step) {
         CommitMtpStep(*mtp_step);
       }
+      RecordSpeculativeCommit(step_plan_);
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         step_plan_.requests[i].request->CommitStep(
             step_plan_.requests[i], step_results_[i]);
@@ -983,6 +1014,20 @@ size_t Engine::MaxDraftTokensPerStep() const {
   return cache_manager_->SupportsDynamicBatching()
              ? cache_manager_->MaxDraftTokensPerStep()
              : 0;
+}
+
+SpeculativeStats Engine::GetSpeculativeStats() const noexcept {
+  auto stats = speculative_stats_;
+  if (stats.draft_tokens_evaluated != 0) {
+    stats.acceptance_rate = static_cast<float>(stats.draft_tokens_accepted) /
+                            static_cast<float>(stats.draft_tokens_evaluated);
+  }
+  if (stats.rounds != 0) {
+    stats.avg_draft_tokens_per_round =
+        static_cast<float>(stats.draft_tokens_proposed) /
+        static_cast<float>(stats.rounds);
+  }
+  return stats;
 }
 
 }  // namespace Generators

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -37,6 +37,9 @@ struct EngineDependencies {
   std::shared_ptr<CacheManager> cache_manager;
   std::unique_ptr<Scheduler> scheduler;
   std::unique_ptr<ModelExecutor> model_executor;
+  std::shared_ptr<DecoderOnly_Model> mtp_model;
+  std::shared_ptr<CacheManager> mtp_cache_manager;
+  std::unique_ptr<ModelExecutor> mtp_model_executor;
 };
 
 struct EngineTransactionMetrics {
@@ -125,10 +128,25 @@ struct Engine : std::enable_shared_from_this<Engine>,
   size_t MaxDraftTokensPerStep() const;
 
  private:
+  struct MtpStep {
+    StepPlan plan;
+    std::vector<std::shared_ptr<Request>> target_requests;
+    std::vector<bool> newly_created;
+    std::vector<std::vector<int32_t>> drafts;
+    std::unique_ptr<CacheStepReservation> reservation;
+  };
+
   void ReclaimAbandonedRequests();
   std::shared_ptr<Request> DrainReadyRequest();
   std::shared_ptr<Request> StepDynamic();
   std::shared_ptr<Request> StepStatic();
+  std::unique_ptr<MtpStep> PrepareMtpStep(
+      const StepPlan& target_plan,
+      const std::vector<RequestStepResult>& target_results,
+      ScheduledRequests& target_requests);
+  void RollbackMtpStep(MtpStep& step);
+  void CommitMtpStep(MtpStep& step);
+  void PublishMtpDrafts(MtpStep& step);
   void ValidateRequestCanContinue(const std::shared_ptr<Request>& request) const;
   [[noreturn]] void HandleContinuationRestoreFailure(
       const std::shared_ptr<Request>& request,
@@ -144,6 +162,12 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::shared_ptr<CacheManager> cache_manager_;    // The cache manager for handling cached data.
   std::unique_ptr<Scheduler> scheduler_;           // The scheduler responsible for managing execution order.
   std::unique_ptr<ModelExecutor> model_executor_;  // The executor responsible for running the model.
+  // Present only when model.mtp names an auxiliary paged draft head. These are constructed with
+  // the Engine so both cache pools share one memory budget; draft orchestration is added separately.
+  std::shared_ptr<DecoderOnly_Model> mtp_model_;
+  std::shared_ptr<CacheManager> mtp_cache_manager_;
+  std::unique_ptr<ModelExecutor> mtp_model_executor_;
+  std::unordered_map<const Request*, std::shared_ptr<Request>> mtp_requests_;
   EngineHealth health_{EngineHealth::Healthy};
   std::exception_ptr fatal_error_;
   StepTransactionId next_transaction_id_{1};

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -6,6 +6,7 @@
 #include "request.h"
 #include "model_executor.h"
 #include "scheduler.h"
+#include "../speculative_stats.h"
 
 /**
  * @file engine.h
@@ -127,6 +128,11 @@ struct Engine : std::enable_shared_from_this<Engine>,
    */
   size_t MaxDraftTokensPerStep() const;
 
+  /**
+   * @brief Returns cumulative speculative-decoding work and acceptance statistics.
+   */
+  SpeculativeStats GetSpeculativeStats() const noexcept;
+
  private:
   struct MtpStep {
     StepPlan plan;
@@ -147,6 +153,7 @@ struct Engine : std::enable_shared_from_this<Engine>,
   void RollbackMtpStep(MtpStep& step);
   void CommitMtpStep(MtpStep& step);
   void PublishMtpDrafts(MtpStep& step);
+  void RecordSpeculativeCommit(const StepPlan& plan) noexcept;
   void ValidateRequestCanContinue(const std::shared_ptr<Request>& request) const;
   [[noreturn]] void HandleContinuationRestoreFailure(
       const std::shared_ptr<Request>& request,
@@ -172,6 +179,7 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::exception_ptr fatal_error_;
   StepTransactionId next_transaction_id_{1};
   EngineTransactionMetrics transaction_metrics_;
+  SpeculativeStats speculative_stats_;
   StepPlan step_plan_;
   std::vector<RequestStepResult> step_results_;
   std::vector<std::weak_ptr<Request>> tracked_requests_;

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -175,6 +175,8 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::shared_ptr<CacheManager> mtp_cache_manager_;
   std::unique_ptr<ModelExecutor> mtp_model_executor_;
   std::unordered_map<const Request*, std::shared_ptr<Request>> mtp_requests_;
+  DeviceSpan<int32_t> mtp_device_drafts_;
+  DeviceSpan<int32_t> mtp_device_chain_inputs_;
   EngineHealth health_{EngineHealth::Healthy};
   std::exception_ptr fatal_error_;
   StepTransactionId next_transaction_id_{1};

--- a/src/engine/execution_context.h
+++ b/src/engine/execution_context.h
@@ -24,6 +24,9 @@ struct ExecutionContext {
   std::span<const FixedStateSlotHandle> fixed_state_slots;
   std::span<const FixedStateBinding> fixed_state_bindings;
   size_t fixed_state_staging_bytes{};
+  // Optional packed [token_count, hidden_size] input supplied by an auxiliary decoder driver.
+  // Ordinary decoder steps leave this null.
+  OrtValue* hidden_states_input{};
   std::unique_ptr<OrtRunOptions> run_options;
   size_t block_table_columns{};
 };

--- a/src/engine/execution_context.h
+++ b/src/engine/execution_context.h
@@ -24,6 +24,9 @@ struct ExecutionContext {
   std::span<const FixedStateSlotHandle> fixed_state_slots;
   std::span<const FixedStateBinding> fixed_state_bindings;
   size_t fixed_state_staging_bytes{};
+  // Optional packed int32 token ids already resident on the model device. VarlenDecoderIO casts
+  // these directly into its int64 input tensor without reading a request's host token mirror.
+  DeviceSpan<int32_t> input_ids;
   // Optional packed [token_count, hidden_size] input supplied by an auxiliary decoder driver.
   // Ordinary decoder steps leave this null.
   OrtValue* hidden_states_input{};

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -169,7 +169,7 @@ void PagedCacheReservation::FillBlockTable(std::span<const void* const> request_
   if (state_ != PagedCacheReservationState::Reserved) {
     throw std::logic_error("Paged cache block table is only available while the reservation is active.");
   }
-  if (request_ids.size() != deltas_.size() ||
+  if (request_ids.size() > deltas_.size() ||
       columns < RequiredBlockTableColumns() ||
       output.size() != request_ids.size() * columns) {
     throw std::runtime_error("Paged cache block table output has an invalid shape.");
@@ -203,7 +203,7 @@ void PagedCacheReservation::FillWindowBlockTable(
   if (state_ != PagedCacheReservationState::Reserved || !window_block_pool_) {
     throw std::logic_error("Paged cache window block table is unavailable.");
   }
-  if (request_ids.size() != deltas_.size() ||
+  if (request_ids.size() > deltas_.size() ||
       output.size() != request_ids.size() * columns) {
     throw std::runtime_error("Paged cache window block table output has an invalid shape.");
   }
@@ -223,8 +223,8 @@ void PagedCacheReservation::FillWindowBlockTable(
 }
 
 void PagedCacheReservation::CommitPrefix(const void* request_id,
-                                        size_t step_slots,
-                                        size_t kept_slots) {
+                                         size_t step_slots,
+                                         size_t kept_slots) {
   if (state_ != PagedCacheReservationState::Reserved) {
     throw std::logic_error("Paged cache reservation is no longer accepting prefix commits.");
   }

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -113,7 +113,8 @@ size_t BytesPerBlock(const std::shared_ptr<Model>& model,
 size_t ComputeNumBlocks(std::shared_ptr<Model> model,
                         size_t full_layer_count,
                         size_t windowed_bytes,
-                        ONNXTensorElementDataType dtype) {
+                        ONNXTensorElementDataType dtype,
+                        size_t auxiliary_bytes_per_block) {
   if (model->config_->engine.dynamic_batching->num_blocks.has_value()) {
     return *model->config_->engine.dynamic_batching->num_blocks;
   }
@@ -129,7 +130,8 @@ size_t ComputeNumBlocks(std::shared_ptr<Model> model,
       model->config_->model.decoder.num_key_value_heads,
       model->config_->model.decoder.head_size,
       full_layer_count,
-      Ort::SizeOf(dtype));
+      Ort::SizeOf(dtype),
+      auxiliary_bytes_per_block);
 }
 
 size_t UsedSlots(const std::vector<std::shared_ptr<Block>>& blocks) {
@@ -153,7 +155,8 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
                                  size_t num_key_value_heads,
                                  size_t head_size,
                                  size_t full_layer_count,
-                                 size_t element_size) {
+                                 size_t element_size,
+                                 size_t auxiliary_bytes_per_block) {
   if (block_size == 0 || num_key_value_heads == 0 || head_size == 0 ||
       full_layer_count == 0 || element_size == 0) {
     throw std::invalid_argument(
@@ -168,16 +171,23 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
   }
 
   constexpr size_t num_caches_per_layer = 2;
+  const size_t primary_bytes_per_block =
+      block_size * num_key_value_heads * head_size * full_layer_count *
+      element_size * num_caches_per_layer;
   return (budget - reserved_memory_bytes) /
-         (block_size *
-          num_key_value_heads *
-          head_size *
-          full_layer_count *
-          element_size *
-          num_caches_per_layer);
+         (primary_bytes_per_block + auxiliary_bytes_per_block);
 }
 
-PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
+size_t PagedKeyValueCacheBytesPerBlock(const std::shared_ptr<Model>& model) {
+  const auto paged_group = ResolvePagedKeyValueGroup(model->config_->model.decoder);
+  const auto dtype = KeyValueCacheType(model, paged_group);
+  const auto windowed = WindowedLayers(model, paged_group);
+  const size_t full_layer_count = paged_group.layer_ids.size() - windowed.size();
+  return full_layer_count * BytesPerBlock(model, dtype);
+}
+
+PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model,
+                                       size_t auxiliary_bytes_per_block)
     : model_(model) {
   const auto& decoder = model->config_->model.decoder;
   const size_t block_size = model->config_->engine.dynamic_batching->block_size;
@@ -216,7 +226,8 @@ PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
   const auto num_blocks = ComputeNumBlocks(model_, num_full_layers,
                                            num_window_blocks * windowed.size() *
                                                BytesPerBlock(model, dtype),
-                                           dtype);
+                                           dtype,
+                                           auxiliary_bytes_per_block);
 
   for (const int layer_id : paged_group.layer_ids) {
     const auto blocks = windowed.count(layer_id) != 0 ? num_window_blocks : num_blocks;

--- a/src/engine/paged_key_value_cache.h
+++ b/src/engine/paged_key_value_cache.h
@@ -41,7 +41,10 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
                                  size_t num_key_value_heads,
                                  size_t head_size,
                                  size_t full_layer_count,
-                                 size_t element_size);
+                                 size_t element_size,
+                                 size_t auxiliary_bytes_per_block = 0);
+
+size_t PagedKeyValueCacheBytesPerBlock(const std::shared_ptr<Model>& model);
 
 /*
  * PagedKeyValueCache manages a paged key-value cache for models that use the PagedAttention operator.
@@ -55,7 +58,8 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
  */
 struct PagedKeyValueCache {
  public:
-  explicit PagedKeyValueCache(std::shared_ptr<Model> model);
+  explicit PagedKeyValueCache(std::shared_ptr<Model> model,
+                              size_t auxiliary_bytes_per_block = 0);
 
   bool CanAdd(std::shared_ptr<Request> request) const;
 

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -38,6 +38,7 @@ Request::Request(std::shared_ptr<GeneratorParams> params)
     : params_{params},
       rng_{CreateRandomGenerator(params->search.random_seed)},
       search_{CreateSearch(*params)} {
+  draft_tokens_.reserve(kMaxDraftTokensPerStep);
   // A request is one sequence: the engine batches requests, not rows within a request. Several
   // places here read row 0 only (UnprocessedTokens, CurrentSequenceLength) or take the tail of the
   // next-token span, so a wider search would silently mirror the wrong row's tokens.
@@ -375,6 +376,36 @@ void Request::AdvanceChunk() {
   processed_sequence_length_ += static_cast<int64_t>(ScheduledTokenCount());
 }
 
+void Request::AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens) {
+  if (status_ != RequestStatus::Active || tokens.empty() ||
+      processed_sequence_length_ != CurrentSequenceLength()) {
+    throw std::logic_error(
+        "Auxiliary decoder tokens require an active request with no pending rows.");
+  }
+  ValidateAppendLength(*params_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+  auto device_tokens = AllocateOnDevice(*params_, tokens);
+  search_->AppendTokens(device_tokens);
+  tokens_host_.insert(tokens_host_.end(), tokens.begin(), tokens.end());
+}
+
+void Request::RewindAuxiliaryDecoderTo(size_t sequence_length) {
+  if (status_ != RequestStatus::Active ||
+      processed_sequence_length_ != CurrentSequenceLength() ||
+      sequence_length > static_cast<size_t>(processed_sequence_length_)) {
+    throw std::logic_error(
+        "Auxiliary decoder rewind requires an active request at a processed sequence boundary.");
+  }
+  search_->RewindTo(sequence_length);
+  tokens_host_.resize(sequence_length);
+  processed_sequence_length_ = static_cast<int64_t>(sequence_length);
+  scheduled_token_count_ = 0;
+}
+
+void Request::CommitAuxiliaryDecoderStep() noexcept {
+  processed_sequence_length_ += static_cast<int64_t>(ScheduledTokenCount());
+  scheduled_token_count_ = 0;
+}
+
 int32_t Request::UnseenToken() {
   if (next_unseen_token_index_ >= unseen_token_indices_.size())
     throw std::runtime_error("All tokens have been seen.");
@@ -462,11 +493,15 @@ void Request::ValidateEngineCompatibility() const {
 void Request::SaveStateForTransaction() {
   search_->SaveStateForTransaction();
   transaction_rng_ = rng_;
+  transaction_processed_sequence_length_ = processed_sequence_length_;
+  transaction_tokens_host_size_ = tokens_host_.size();
 }
 
 void Request::SaveStateForExternalSamplingTransaction() {
   search_->SaveStateForExternalSamplingTransaction();
   transaction_rng_ = rng_;
+  transaction_processed_sequence_length_ = processed_sequence_length_;
+  transaction_tokens_host_size_ = tokens_host_.size();
 }
 
 RequestStepResult Request::ApplyLogitsForTransaction(DeviceSpan<float> logits) {
@@ -489,13 +524,21 @@ RequestStepResult Request::StageGenerationForTransaction() {
 void Request::RestoreStateForTransaction() {
   search_->RestoreStateForTransaction();
   rng_ = transaction_rng_;
-  DiscardStagedDrafts();
+  processed_sequence_length_ = transaction_processed_sequence_length_;
+  tokens_host_.resize(transaction_tokens_host_size_);
+  staged_draft_count_ = 0;
+  accepted_draft_count_ = 0;
+  scheduled_token_count_ = 0;
 }
 
 void Request::QueueStateRestoreForTransaction() {
   search_->QueueStateRestoreForTransaction();
   rng_ = transaction_rng_;
-  DiscardStagedDrafts();
+  processed_sequence_length_ = transaction_processed_sequence_length_;
+  tokens_host_.resize(transaction_tokens_host_size_);
+  staged_draft_count_ = 0;
+  accepted_draft_count_ = 0;
+  scheduled_token_count_ = 0;
 }
 
 void Request::CompleteStateRestoreForTransaction() {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -388,6 +388,18 @@ void Request::AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens) {
   tokens_host_.insert(tokens_host_.end(), tokens.begin(), tokens.end());
 }
 
+void Request::AppendTokensForAuxiliaryDecoder(DeviceSpan<int32_t> tokens) {
+  if (status_ != RequestStatus::Active || tokens.empty() ||
+      processed_sequence_length_ != CurrentSequenceLength()) {
+    throw std::logic_error(
+        "Auxiliary decoder tokens require an active request with no pending rows.");
+  }
+  ValidateAppendLength(*params_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+  search_->AppendTokens(tokens);
+  const int32_t non_pad = params_->config.model.pad_token_id == 0 ? 1 : 0;
+  tokens_host_.insert(tokens_host_.end(), tokens.size(), non_pad);
+}
+
 void Request::RewindAuxiliaryDecoderTo(size_t sequence_length) {
   if (status_ != RequestStatus::Active ||
       processed_sequence_length_ != CurrentSequenceLength() ||

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -361,6 +361,7 @@ struct Request : std::enable_shared_from_this<Request>,
   // never samples from this request; these helpers append decided tokens and advance its processed
   // boundary only after the auxiliary cache transaction commits.
   void AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens);
+  void AppendTokensForAuxiliaryDecoder(DeviceSpan<int32_t> tokens);
   void RewindAuxiliaryDecoderTo(size_t sequence_length);
   void CommitAuxiliaryDecoderStep() noexcept;
 

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -357,6 +357,12 @@ struct Request : std::enable_shared_from_this<Request>,
   // Drops whatever the step in flight staged past the committed sequence, leaving the host mirror
   // exactly as long as the search after its own transaction rewind.
   void DiscardStagedDrafts() noexcept;
+  // The Engine-hosted MTP head mirrors target-committed tokens in a scheduler-private request. It
+  // never samples from this request; these helpers append decided tokens and advance its processed
+  // boundary only after the auxiliary cache transaction commits.
+  void AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens);
+  void RewindAuxiliaryDecoderTo(size_t sequence_length);
+  void CommitAuxiliaryDecoderStep() noexcept;
 
   int64_t processed_sequence_length_{};
   // Sequence length the application's tokens reach up to. Everything below it is prompt, so the
@@ -371,6 +377,8 @@ struct Request : std::enable_shared_from_this<Request>,
   std::shared_ptr<GeneratorParams> params_;
   std::mt19937 rng_;
   std::mt19937 transaction_rng_;
+  int64_t transaction_processed_sequence_length_{};
+  size_t transaction_tokens_host_size_{};
   std::unique_ptr<Search> search_;
   std::unique_ptr<BatchedSamplerState> batched_sampler_state_;
   std::weak_ptr<Engine> engine_;

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -199,6 +199,10 @@ std::vector<DeviceSpan<float>> ScheduledRequests::ProcessLogits() {
   return logits;
 }
 
+Tensor* ScheduledRequests::HiddenStates() const {
+  return decoder_state_ ? decoder_state_->HiddenStates() : nullptr;
+}
+
 std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
     std::vector<DeviceSpan<float>>& verify_rows) {
   std::vector<DeviceSpan<float>> sampled_rows;

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -70,6 +70,7 @@ struct ScheduledRequests {
   void AddDecoderState(std::unique_ptr<DecoderIO> decoder_state);
 
   std::vector<DeviceSpan<float>> ProcessLogits();
+  Tensor* HiddenStates() const;
 
   void GenerateNextTokens();
   void BeginTransaction();

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -72,6 +72,19 @@ struct OgaSpeculativeStats : OgaAbstract {
     return value;
   }
 
+  uint64_t GetAcceptanceLengthCount(size_t accepted_length) const {
+    uint64_t value{};
+    OgaCheckResult(OgaSpeculativeStatsGetAcceptanceLengthCount(
+        this, accepted_length, &value));
+    return value;
+  }
+
+  size_t GetAcceptanceLengthHistogramSize() const {
+    size_t value{};
+    OgaCheckResult(OgaSpeculativeStatsGetAcceptanceLengthHistogramSize(this, &value));
+    return value;
+  }
+
   double GetNumber(const char* name) const {
     double value;
     OgaCheckResult(OgaSpeculativeStatsGetNumber(this, name, &value));
@@ -978,6 +991,15 @@ struct OgaEngine : OgaAbstract {
     size_t count{};
     OgaCheckResult(OgaEngineMaxDraftTokensPerStep(this, &count));
     return count;
+  }
+
+  /**
+   * \brief Cumulative target/head work and committed draft acceptance statistics.
+   */
+  std::unique_ptr<OgaSpeculativeStats> GetSpeculativeStats() const {
+    OgaSpeculativeStats* stats;
+    OgaCheckResult(OgaEngineGetSpeculativeStats(this, &stats));
+    return std::unique_ptr<OgaSpeculativeStats>(stats);
   }
 
   /**

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -871,6 +871,28 @@ OgaResult* OGA_API_CALL OgaSpeculativeStatsGetCount(
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaSpeculativeStatsGetAcceptanceLengthCount(
+    const OgaSpeculativeStats* stats, size_t accepted_length, uint64_t* value) {
+  OGA_TRY
+  if (!stats || !value)
+    throw std::invalid_argument("stats and value must not be null.");
+  if (accepted_length >= stats->acceptance_length_histogram.size())
+    throw std::out_of_range("accepted_length is outside the statistics histogram.");
+  *value = stats->acceptance_length_histogram[accepted_length];
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OGA_API_CALL OgaSpeculativeStatsGetAcceptanceLengthHistogramSize(
+    const OgaSpeculativeStats* stats, size_t* value) {
+  OGA_TRY
+  if (!stats || !value)
+    throw std::invalid_argument("stats and value must not be null.");
+  *value = stats->acceptance_length_histogram.size();
+  return nullptr;
+  OGA_CATCH
+}
+
 OgaResult* OGA_API_CALL OgaSpeculativeStatsGetNumber(
     const OgaSpeculativeStats* stats, const char* name, double* value) {
   OGA_TRY
@@ -1383,6 +1405,17 @@ OgaResult* OgaEngineHasPendingRequests(OgaEngine* engine, bool* out) {
 OgaResult* OgaEngineMaxDraftTokensPerStep(const OgaEngine* engine, size_t* out) {
   OGA_TRY
   *out = engine->MaxDraftTokensPerStep();
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OgaEngineGetSpeculativeStats(
+    const OgaEngine* engine, OgaSpeculativeStats** out) {
+  OGA_TRY
+  if (!engine || !out)
+    throw std::invalid_argument("engine and out must not be null.");
+  *out = ReturnUnique<OgaSpeculativeStats>(
+      std::make_unique<Generators::SpeculativeStats>(engine->GetSpeculativeStats()));
   return nullptr;
   OGA_CATCH
 }

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -779,6 +779,14 @@ OGA_EXPORT void OGA_API_CALL OgaDestroySpeculativeStats(OgaSpeculativeStats* sta
 OGA_EXPORT OgaResult* OGA_API_CALL OgaSpeculativeStatsGetCount(
     const OgaSpeculativeStats* stats, const char* name, uint64_t* value);
 
+/** \brief Gets the number of rounds that accepted exactly the requested number of draft tokens. */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaSpeculativeStatsGetAcceptanceLengthCount(
+    const OgaSpeculativeStats* stats, size_t accepted_length, uint64_t* value);
+
+/** \brief Gets the number of bins in the acceptance-length histogram. */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaSpeculativeStatsGetAcceptanceLengthHistogramSize(
+    const OgaSpeculativeStats* stats, size_t* value);
+
 /** \brief Gets a timing, rate, ratio, average, or speedup value from a statistics snapshot. */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaSpeculativeStatsGetNumber(
     const OgaSpeculativeStats* stats, const char* name, double* value);
@@ -1310,6 +1318,20 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaRequestSetDraftTokens(OgaRequest* request,
  * \return OgaResult containing the error message on failure, or nullptr on success.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaEngineMaxDraftTokensPerStep(const OgaEngine* engine, size_t* out);
+
+/**
+ * \brief Returns a cumulative snapshot of Engine speculative-decoding statistics.
+ *
+ * Target and draft forward-pass counters include successful model executions even if a later
+ * transaction phase rolls back. Proposal, acceptance, and acceptance-length counters include only
+ * committed speculative steps.
+ *
+ * \param[in] engine The engine to query.
+ * \param[out] out The newly allocated statistics snapshot. Destroy it with OgaDestroySpeculativeStats.
+ * \return OgaResult containing the error message on failure, or nullptr on success.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaEngineGetSpeculativeStats(
+    const OgaEngine* engine, OgaSpeculativeStats** out);
 
 /**
  * \brief Destroys the given request.

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -272,6 +272,14 @@ pybind11::dict ToSpeculativeStatsDict(const OgaSpeculativeStats& stats) {
                           "target_overhead_ratio", "estimated_speedup", "observed_speedup",
                           "adaptive_k_throughput"})
     d[key] = stats.GetNumber(key);
+  pybind11::list acceptance_length_histogram;
+  for (size_t accepted_length = 0;
+       accepted_length < stats.GetAcceptanceLengthHistogramSize();
+       ++accepted_length) {
+    acceptance_length_histogram.append(
+        stats.GetAcceptanceLengthCount(accepted_length));
+  }
+  d["acceptance_length_histogram"] = std::move(acceptance_length_histogram);
   return d;
 }
 
@@ -776,7 +784,10 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
            "Remove a request. Repeated calls after it is closed are successful no-ops.")
       .def("has_pending_requests", &OgaEngine::HasPendingRequests)
       .def("max_draft_tokens_per_step", &OgaEngine::MaxDraftTokensPerStep,
-           "Speculative draft tokens a request may attach to one step; zero when unsupported.");
+           "Speculative draft tokens a request may attach to one step; zero when unsupported.")
+      .def("get_speculative_stats", [](const OgaEngine& engine) {
+        return ToSpeculativeStatsDict(*engine.GetSpeculativeStats());
+      }, "Return cumulative speculative-decoding telemetry.");
 
   pybind11::class_<OgaStreamingProcessor>(m, "StreamingProcessor")
       .def(pybind11::init([](OgaModel& model) { return OgaStreamingProcessor::Create(model); }),

--- a/src/speculative_stats.h
+++ b/src/speculative_stats.h
@@ -2,9 +2,12 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <array>
 #include <cstddef>
 
 namespace Generators {
+
+inline constexpr size_t kSpeculativeAcceptanceLengthBins = 8;
 
 // Separates draft work from output delivery and exposes the speedup formula terms.
 // Target-dependent formula fields are zero without a baseline or when guidance is active.
@@ -46,6 +49,7 @@ struct SpeculativeStats {
   size_t ngram_grammar_candidate_rejections{};
   size_t ngram_history_syncs{};
   size_t ngram_history_tokens_synced{};
+  std::array<size_t, kSpeculativeAcceptanceLengthBins> acceptance_length_histogram{};
   size_t formula_supported{};
   float total_draft_ms{};
   float total_target_ms{};

--- a/test/engine/engine_step_tests.cpp
+++ b/test/engine/engine_step_tests.cpp
@@ -1143,7 +1143,7 @@ TEST_F(EngineStepTest, CompositePostProcessingFailurePreservesResidentState) {
   });
 
   ASSERT_EQ(engine.engine->Step(), request);  // prefill commits: state_gen 1, committed 3, bank = 5
-  expected_input = 5.0f;                       // the decode step gathers the published value
+  expected_input = 5.0f;                      // the decode step gathers the published value
   staged_output = 99.0f;
   engine.executor->SetNextFailure(ScriptedExecutionFailure::PostProcessing);
   try {
@@ -1479,6 +1479,48 @@ TEST_F(EngineStepTest, SpeculativeStepAcceptingEveryDraftAlsoTakesTheBonusToken)
   EXPECT_EQ(request->ProcessedSequenceLength(), length_after_prefill + 3);
 }
 
+TEST_F(EngineStepTest, SpeculativeTelemetryAggregatesAcceptanceLengths) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 12, 21, 22});
+  ASSERT_EQ(engine.engine->Step(), request);
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{14, 15});
+  engine.executor->SetVerifyRowTokens({24, 25, 26});
+  ASSERT_EQ(engine.engine->Step(), request);
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{16});
+  engine.executor->SetVerifyRowTokens({16, 26});
+  ASSERT_EQ(engine.engine->Step(), request);
+
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.target_forward_passes, 4u);
+  EXPECT_EQ(stats.draft_forward_passes, 0u);
+  EXPECT_EQ(stats.rounds, 3u);
+  EXPECT_EQ(stats.draft_tokens_proposed, 6u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 5u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 3u);
+  EXPECT_EQ(stats.zero_accept_rounds, 1u);
+  EXPECT_EQ(stats.partial_accept_rounds, 1u);
+  EXPECT_EQ(stats.full_accept_rounds, 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[0], 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[1], 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[2], 1u);
+  EXPECT_FLOAT_EQ(stats.acceptance_rate, 3.0f / 5.0f);
+  EXPECT_FLOAT_EQ(stats.avg_draft_tokens_per_round, 2.0f);
+}
+
 TEST_F(EngineStepTest, RolledBackSpeculativeStepLeavesTheProposalPendingAndRetryable) {
   const int32_t eos = EosToken(*model_);
   const int32_t filler = eos == 5 ? 6 : 5;
@@ -1499,12 +1541,23 @@ TEST_F(EngineStepTest, RolledBackSpeculativeStepLeavesTheProposalPendingAndRetry
   EXPECT_EQ(request->PendingDraftTokenCount(), 2u);
   EXPECT_EQ(request->AcceptedDraftTokenCount(), 0u);
   EXPECT_TRUE(engine.cache->prefix_commits.empty());
+  auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.target_forward_passes, 2u);
+  EXPECT_EQ(stats.rounds, 0u);
+  EXPECT_EQ(stats.draft_tokens_proposed, 0u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 0u);
 
   engine.executor->SetVerifyRowTokens({11, 12, 25});
   ASSERT_EQ(engine.engine->Step(), request);
   std::vector<int32_t> produced;
   while (request->HasUnseenTokens()) produced.push_back(request->UnseenToken());
   EXPECT_EQ(produced, (std::vector<int32_t>{11, 12, 25}));
+  stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.target_forward_passes, 3u);
+  EXPECT_EQ(stats.rounds, 1u);
+  EXPECT_EQ(stats.draft_tokens_proposed, 2u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 2u);
+  EXPECT_EQ(stats.acceptance_length_histogram[2], 1u);
 }
 
 TEST_F(EngineStepTest, DraftsAreRejectedWhenTheCacheCannotRollThemBack) {

--- a/test/engine/engine_step_tests.cpp
+++ b/test/engine/engine_step_tests.cpp
@@ -111,6 +111,61 @@ class EngineStepTest : public ::testing::Test {
   std::shared_ptr<Model> model_;
 };
 
+MtpDoublesEngine MakeMtpDoublesEngine(
+    std::shared_ptr<Model> model, size_t capacity,
+    int32_t target_token, int32_t draft_token) {
+  auto mtp_model = std::dynamic_pointer_cast<DecoderOnly_Model>(LoadSyntheticPagedModel());
+  if (!mtp_model) {
+    throw std::logic_error("MTP Engine tests require a decoder-only auxiliary model.");
+  }
+  mtp_model->config_->engine.dynamic_batching = Config::Engine::DynamicBatching{};
+  mtp_model->config_->model.decoder.inputs.hidden_states = "past_key_values.1.key";
+
+  auto device = std::make_unique<CountingCudaDevice>();
+  auto device_state = device->state;
+  mtp_model->p_device_ = device.get();
+  mtp_model->p_device_scoring_ = device.get();
+
+  auto cache = std::make_shared<RecordingCacheManager>(model, capacity);
+  cache->SetMaxDraftTokensPerStep(3);
+  auto scheduler = Scheduler::Create(model, cache);
+  auto executor = std::make_unique<RecordingModelExecutor>(model, cache, target_token);
+  executor->EnableHiddenStatesOutput(model->config_->model.decoder.hidden_size);
+
+  auto mtp_cache = std::make_shared<RecordingCacheManager>(mtp_model, capacity);
+  auto mtp_executor = std::make_unique<RecordingModelExecutor>(
+      mtp_model, mtp_cache, draft_token);
+  mtp_executor->EnableHiddenStatesOutput(model->config_->model.decoder.hidden_size);
+
+  auto* cache_observer = cache.get();
+  auto* executor_observer = executor.get();
+  auto* mtp_cache_observer = mtp_cache.get();
+  auto* mtp_executor_observer = mtp_executor.get();
+
+  EngineDependencies dependencies{
+      std::move(cache), std::move(scheduler), std::move(executor),
+      std::move(mtp_model), std::move(mtp_cache), std::move(mtp_executor)};
+  auto engine = std::make_shared<Engine>(std::move(model), std::move(dependencies));
+  return MtpDoublesEngine{
+      std::move(device), std::move(engine), cache_observer, executor_observer,
+      mtp_cache_observer, mtp_executor_observer, std::move(device_state)};
+}
+
+void AdvanceUntilTargetDecodeCount(MtpDoublesEngine& engine, int decode_calls) {
+  while (engine.executor->decode_calls < decode_calls) {
+    ASSERT_TRUE(engine.engine->HasPendingRequests());
+    static_cast<void>(engine.engine->Step());
+  }
+}
+
+std::vector<int32_t> DrainTokens(const std::shared_ptr<Request>& request) {
+  std::vector<int32_t> tokens;
+  while (request->HasUnseenTokens()) {
+    tokens.push_back(request->UnseenToken());
+  }
+  return tokens;
+}
+
 // One request: Step decodes the proposed batch exactly once, commits its cache allocation, and
 // returns the request.
 TEST_F(EngineStepTest, SingleRequestSchedulesThenDecodesThenReturns) {
@@ -1389,6 +1444,173 @@ TEST_F(EngineStepTest, CompositeAggregateAdmissionCommitsEveryNewTable) {
 // Speculative decoding: a request proposes drafts, the step runs 1 + drafts rows, and the Engine
 // keeps the prefix the target model would have produced on its own.
 // ---------------------------------------------------------------------------------------------
+
+TEST_F(EngineStepTest, MtpCoordinatorCompactsMixedDraftLengthsWithoutIntermediateReadback) {
+  constexpr int32_t target_token = 5;
+  constexpr int32_t draft_token = 11;
+  auto engine = MakeMtpDoublesEngine(
+      model_, /*capacity=*/8, target_token, draft_token);
+
+  std::vector<std::shared_ptr<Request>> requests;
+  for (size_t draft_count : {size_t{1}, size_t{2}, size_t{3}}) {
+    auto request = MintRequest(*model_, Prompt(static_cast<int32_t>(draft_count * 10)));
+    request->Params()->speculative.max_draft_tokens = static_cast<int>(draft_count);
+    engine.engine->AddRequest(request);
+    requests.push_back(std::move(request));
+  }
+
+  ASSERT_NE(engine.engine->Step(), nullptr);
+
+  ASSERT_EQ(engine.mtp_executor->decoded_batch_sizes,
+            (std::vector<size_t>{3, 2, 1}));
+  ASSERT_EQ(engine.mtp_executor->used_device_input_ids,
+            (std::vector<bool>{false, true, true}));
+  ASSERT_EQ(engine.device_state->argmax_rows,
+            (std::vector<int>{3, 2, 1}));
+  EXPECT_EQ(engine.device_state->device_to_host_copies, 1u);
+  EXPECT_EQ(engine.device_state->synchronize_calls, 0u);
+  for (size_t i = 0; i < requests.size(); ++i) {
+    EXPECT_EQ(requests[i]->PendingDraftTokenCount(), i + 1);
+  }
+}
+
+TEST_F(EngineStepTest, MtpCoordinatorRecordsFullPartialAndZeroAcceptance) {
+  constexpr int32_t draft_token = 11;
+  auto engine = MakeMtpDoublesEngine(
+      model_, /*capacity=*/8, /*target_token=*/5, draft_token);
+
+  std::vector<std::shared_ptr<Request>> requests;
+  for (int32_t seed : {10, 20, 30}) {
+    auto request = MintRequest(*model_, Prompt(seed));
+    request->Params()->speculative.max_draft_tokens = 3;
+    engine.engine->AddRequest(request);
+    requests.push_back(std::move(request));
+  }
+  ASSERT_NE(engine.engine->Step(), nullptr);
+  for (const auto& request : requests) {
+    ASSERT_EQ(request->PendingDraftTokenCount(), 3u);
+    static_cast<void>(DrainTokens(request));
+  }
+
+  engine.executor->SetVerifyRowTokens({
+      draft_token,
+      draft_token,
+      draft_token,
+      14,
+      draft_token,
+      12,
+      13,
+      14,
+      12,
+      13,
+      14,
+      15,
+  });
+  AdvanceUntilTargetDecodeCount(engine, 2);
+
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.rounds, 3u);
+  EXPECT_EQ(stats.draft_tokens_proposed, 9u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 6u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 4u);
+  EXPECT_EQ(stats.full_accept_rounds, 1u);
+  EXPECT_EQ(stats.partial_accept_rounds, 1u);
+  EXPECT_EQ(stats.zero_accept_rounds, 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[0], 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[1], 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[3], 1u);
+}
+
+TEST_F(EngineStepTest, MtpHeadFailureRollsBackTargetAndAuxiliaryTransactions) {
+  constexpr int32_t draft_token = 11;
+  auto engine = MakeMtpDoublesEngine(
+      model_, /*capacity=*/8, /*target_token=*/5, draft_token);
+  auto request = MintRequest(*model_, Prompt(10));
+  request->Params()->speculative.max_draft_tokens = 3;
+  engine.engine->AddRequest(request);
+
+  ASSERT_EQ(engine.engine->Step(), request);
+  static_cast<void>(DrainTokens(request));
+  const auto before = request->Snapshot();
+  ASSERT_EQ(request->PendingDraftTokenCount(), 3u);
+  const int target_releases_before = engine.cache->reservation_release_calls;
+  const int releases_before = engine.mtp_cache->reservation_release_calls;
+
+  engine.executor->SetVerifyRowTokens(
+      {draft_token, draft_token, draft_token, 14});
+  engine.mtp_executor->SetNextFailure(
+      ScriptedExecutionFailure::RetryableDuringExecution);
+  EXPECT_THROW(static_cast<void>(engine.engine->Step()), EngineStepError);
+
+  const auto after_failure = request->Snapshot();
+  EXPECT_EQ(after_failure.current_sequence_length, before.current_sequence_length);
+  EXPECT_EQ(after_failure.processed_sequence_length, before.processed_sequence_length);
+  EXPECT_EQ(request->PendingDraftTokenCount(), 3u);
+  EXPECT_EQ(engine.cache->reservation_release_calls, target_releases_before + 1);
+  EXPECT_EQ(engine.mtp_cache->reservation_release_calls, releases_before + 1);
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+  EXPECT_EQ(engine.engine->GetSpeculativeStats().rounds, 0u);
+
+  ASSERT_EQ(engine.engine->Step(), request);
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.rounds, 1u);
+  EXPECT_EQ(stats.full_accept_rounds, 1u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 3u);
+}
+
+TEST_F(EngineStepTest, MtpCoordinatorClampsDraftsAtMaxLength) {
+  constexpr int32_t draft_token = 11;
+  const auto prompt = Prompt(10);
+  auto engine = MakeMtpDoublesEngine(
+      model_, /*capacity=*/8, /*target_token=*/5, draft_token);
+  auto request = MintRequest(*model_, prompt);
+  request->Params()->speculative.max_draft_tokens = 3;
+  request->Params()->search.max_length = static_cast<int>(prompt.size() + 4);
+  engine.engine->AddRequest(request);
+
+  ASSERT_EQ(engine.engine->Step(), request);
+  EXPECT_EQ(request->PendingDraftTokenCount(), 2u);
+  EXPECT_EQ(engine.mtp_executor->decoded_batch_sizes,
+            (std::vector<size_t>{1, 1}));
+  static_cast<void>(DrainTokens(request));
+
+  engine.executor->SetVerifyRowTokens({draft_token, draft_token, 12});
+  ASSERT_EQ(engine.engine->Step(), request);
+  EXPECT_TRUE(request->IsTurnComplete());
+  EXPECT_EQ(request->CurrentSequenceLength(), request->Params()->search.max_length);
+  EXPECT_EQ(engine.mtp_executor->decode_calls, 2);
+  EXPECT_EQ(engine.engine->GetSpeculativeStats().full_accept_rounds, 1u);
+}
+
+TEST_F(EngineStepTest, MtpCoordinatorReusesCacheAfterDiscardingSpeculativeRows) {
+  constexpr int32_t draft_token = 11;
+  auto engine = MakeMtpDoublesEngine(
+      model_, /*capacity=*/8, /*target_token=*/5, draft_token);
+  auto request = MintRequest(*model_, Prompt(10));
+  request->Params()->speculative.max_draft_tokens = 3;
+  engine.engine->AddRequest(request);
+
+  ASSERT_EQ(engine.engine->Step(), request);
+  static_cast<void>(DrainTokens(request));
+  for (int round = 0; round < 2; ++round) {
+    engine.executor->SetVerifyRowTokens({12, 13, 14, 15});
+    ASSERT_EQ(engine.engine->Step(), request);
+    static_cast<void>(DrainTokens(request));
+  }
+
+  ASSERT_EQ(engine.mtp_cache->reserved_new_request_counts,
+            (std::vector<size_t>{1, 0, 0}));
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+  EXPECT_EQ(engine.mtp_cache->deallocate_calls, 0);
+  ASSERT_EQ(engine.mtp_executor->decoded_sequence_lengths_before.size(), 9u);
+  EXPECT_EQ(engine.mtp_executor->decoded_sequence_lengths_before[0],
+            (std::vector<int64_t>{1}));
+  EXPECT_EQ(engine.mtp_executor->decoded_sequence_lengths_before[3],
+            (std::vector<int64_t>{2}));
+  EXPECT_EQ(engine.mtp_executor->decoded_sequence_lengths_before[6],
+            (std::vector<int64_t>{3}));
+  EXPECT_EQ(engine.device_state->device_to_host_copies, 3u);
+}
 
 TEST_F(EngineStepTest, SpeculativeStepKeepsTheAcceptedPrefixAndReplacesTheRejectedDraft) {
   const int32_t eos = EosToken(*model_);

--- a/test/engine/engine_step_tests.cpp
+++ b/test/engine/engine_step_tests.cpp
@@ -1946,6 +1946,44 @@ TEST_F(EngineStepTest, CompositeSpeculativeStepPublishesTheAcceptedCheckpoint) {
   EXPECT_EQ(engine.engine->Step(), request);
 }
 
+TEST_F(EngineStepTest, CompositeDefersDraftsWhilePrefillSharesTheStep) {
+  model_ = LoadSyntheticCompositeModel();
+  auto engine = MakeCompositeDoublesEngine(model_, /*forced_token=*/5);
+  auto decode = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(decode);
+  engine.executor->SetExecutionCallback([](ExecutionContext& context) {
+    for (const auto& binding : context.fixed_state_bindings) {
+      FillFixedOutputRow(binding, 0, 10.0f);
+    }
+  });
+  ASSERT_EQ(engine.engine->Step(), decode);
+  while (decode->HasUnseenTokens()) decode->UnseenToken();
+
+  decode->SetDraftTokens(std::array<int32_t, 3>{11, 12, 13});
+  auto prefill = MintRequest(*model_, Prompt(20));
+  engine.engine->AddRequest(prefill);
+  engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
+    ASSERT_EQ(context.plan->requests.size(), 2u);
+    EXPECT_EQ(context.plan->requests[0].request, decode);
+    EXPECT_EQ(context.plan->requests[0].draft_token_count, 0u);
+    EXPECT_EQ(context.plan->requests[0].unprocessed_token_count, 1u);
+    EXPECT_EQ(context.plan->requests[1].request, prefill);
+    EXPECT_TRUE(context.plan->requests[1].is_prefill);
+    EXPECT_FALSE(context.plan->fixed_state.capture_checkpoints);
+    for (size_t row = 0; row < context.fixed_state_slots.size(); ++row) {
+      for (const auto& binding : context.fixed_state_bindings) {
+        EXPECT_EQ(binding.checkpoints, nullptr);
+        FillFixedOutputRow(binding, row, 20.0f + static_cast<float>(row));
+      }
+    }
+  });
+
+  ASSERT_EQ(engine.engine->Step(), decode);
+  EXPECT_EQ(decode->PendingDraftTokenCount(), 0u);
+  EXPECT_TRUE(decode->HasUnseenTokens());
+  EXPECT_TRUE(prefill->HasUnseenTokens());
+}
+
 TEST_F(EngineStepTest, CompositeCompletionRemovalFreesSlotForReadmission) {
   model_ = LoadSyntheticCompositeModel();
   auto engine = MakeCompositeDoublesEngine(model_, EosToken(*model_));  // force EOS to complete

--- a/test/engine/engine_test_doubles.h
+++ b/test/engine/engine_test_doubles.h
@@ -5,6 +5,8 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
+#include <deque>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -13,6 +15,7 @@
 #include <vector>
 
 #include "generators.h"
+#include "search.h"
 #include "engine/cache_manager.h"
 #include "engine/model_executor.h"
 #include "engine/scheduler.h"
@@ -167,6 +170,7 @@ struct RecordingCacheManager : CacheManager {
   }
 
   std::unique_ptr<CacheStepReservation> ReserveStep(const StepPlan& plan) override {
+    reserve_calls++;
     struct Reservation final : CacheStepReservation {
       Reservation(RecordingCacheManager& cache, const StepPlan& plan)
           : cache_{cache} {
@@ -202,6 +206,7 @@ struct RecordingCacheManager : CacheManager {
           throw std::logic_error("Recording cache reservation can only commit once.");
         }
         cache_.Allocate(newly_admitted_);
+        cache_.reservation_commit_calls++;
         committed_ = true;
       }
 
@@ -209,6 +214,7 @@ struct RecordingCacheManager : CacheManager {
         if (committed_) {
           throw std::logic_error("Cannot release a committed recording cache reservation.");
         }
+        cache_.reservation_release_calls++;
         released_ = true;
       }
 
@@ -220,6 +226,11 @@ struct RecordingCacheManager : CacheManager {
       bool released_{};
     };
 
+    size_t newly_admitted = 0;
+    for (const auto& entry : plan.requests) {
+      newly_admitted += entry.newly_admitted ? 1 : 0;
+    }
+    reserved_new_request_counts.push_back(newly_admitted);
     return std::make_unique<Reservation>(*this, plan);
   }
 
@@ -263,6 +274,10 @@ struct RecordingCacheManager : CacheManager {
   int allocate_calls{0};
   int deallocate_calls{0};
   int step_calls{0};
+  int reserve_calls{0};
+  int reservation_commit_calls{0};
+  int reservation_release_calls{0};
+  std::vector<size_t> reserved_new_request_counts;
 
  private:
   size_t capacity_;
@@ -292,7 +307,9 @@ struct ScriptedDecoderIO : DecoderIO {
                     std::shared_ptr<CacheManager> cache_manager, int32_t forced_token,
                     bool fail_process_logits = false,
                     const StepPlan* plan = nullptr,
-                    std::span<const int32_t> row_tokens = {})
+                    std::span<const int32_t> row_tokens = {},
+                    int64_t hidden_size = 0,
+                    ONNXTensorElementDataType hidden_type = Ort::TypeToTensorType<float>)
       : DecoderIO(model, scheduled_requests, cache_manager),
         vocab_size_{static_cast<int64_t>(model->config_->model.vocab_size)},
         fail_process_logits_{fail_process_logits} {
@@ -323,6 +340,15 @@ struct ScriptedDecoderIO : DecoderIO {
       cpu_span[static_cast<int64_t>(row) * vocab_size_ + token] = 100.0f;
     }
     device_span.CopyCpuToDevice();
+
+    if (hidden_size > 0) {
+      hidden_states_ = std::make_unique<Tensor>(model->p_device_inputs_, hidden_type);
+      const size_t hidden_rows = plan ? plan->token_count : scheduled_requests.size();
+      const std::array<int64_t, 2> hidden_shape{
+          static_cast<int64_t>(hidden_rows), hidden_size};
+      hidden_states_->CreateTensor(hidden_shape);
+      hidden_states_->GetByteSpan().Zero();
+    }
   }
 
   std::vector<DeviceSpan<float>> ProcessLogits() override {
@@ -337,10 +363,13 @@ struct ScriptedDecoderIO : DecoderIO {
     return rows;
   }
 
+  Tensor* HiddenStates() const override { return hidden_states_.get(); }
+
  private:
   int64_t vocab_size_;
   size_t row_count_{};
   bool fail_process_logits_{};
+  std::unique_ptr<Tensor> hidden_states_;
 };
 
 enum class ScriptedExecutionFailure {
@@ -374,7 +403,13 @@ struct RecordingModelExecutor : ModelExecutor {
       for (const auto& entry : context.plan->requests)
         request_ids.push_back(entry.request_id);
       decoded_request_ids.push_back(std::move(request_ids));
+      std::vector<int64_t> sequence_lengths;
+      sequence_lengths.reserve(context.plan->requests.size());
+      for (const auto& entry : context.plan->requests)
+        sequence_lengths.push_back(entry.sequence_length_before);
+      decoded_sequence_lengths_before.push_back(std::move(sequence_lengths));
     }
+    used_device_input_ids.push_back(!context.input_ids.empty());
     if (trace_) trace_->Record("Decode");
     const auto failure = std::exchange(next_failure_, ScriptedExecutionFailure::None);
     if (failure == ScriptedExecutionFailure::RetryableBeforeExecution) {
@@ -398,11 +433,17 @@ struct RecordingModelExecutor : ModelExecutor {
     if (failure == ScriptedExecutionFailure::Fatal) {
       throw std::runtime_error("Injected fatal execution failure.");
     }
+    std::vector<int32_t> row_tokens;
+    if (!queued_row_tokens_.empty()) {
+      row_tokens = std::move(queued_row_tokens_.front());
+      queued_row_tokens_.pop_front();
+    }
+    const auto& active_row_tokens = row_tokens.empty() ? verify_row_tokens_ : row_tokens;
     scheduled_requests.AddDecoderState(
         std::make_unique<ScriptedDecoderIO>(
             model_, scheduled_requests, cache_manager_, forced_token_,
             failure == ScriptedExecutionFailure::PostProcessing,
-            context.plan, verify_row_tokens_));
+            context.plan, active_row_tokens, hidden_size_, hidden_type_));
     static_cast<void>(context);
   }
 
@@ -413,6 +454,15 @@ struct RecordingModelExecutor : ModelExecutor {
   void SetVerifyRowTokens(std::vector<int32_t> tokens) {
     verify_row_tokens_ = std::move(tokens);
   }
+  void QueueRowTokens(std::vector<int32_t> tokens) {
+    queued_row_tokens_.push_back(std::move(tokens));
+  }
+  void EnableHiddenStatesOutput(
+      int64_t hidden_size,
+      ONNXTensorElementDataType hidden_type = Ort::TypeToTensorType<float>) {
+    hidden_size_ = hidden_size;
+    hidden_type_ = hidden_type;
+  }
   void SetExecutionCallback(std::function<void(ExecutionContext&)> callback) {
     on_execute_ = std::move(callback);
   }
@@ -421,6 +471,8 @@ struct RecordingModelExecutor : ModelExecutor {
   std::vector<size_t> decoded_batch_sizes;
   std::vector<size_t> decoded_token_counts;
   std::vector<std::vector<const void*>> decoded_request_ids;
+  std::vector<std::vector<int64_t>> decoded_sequence_lengths_before;
+  std::vector<bool> used_device_input_ids;
 
  private:
   std::shared_ptr<Model> model_;
@@ -429,7 +481,90 @@ struct RecordingModelExecutor : ModelExecutor {
   std::shared_ptr<CallTrace> trace_;
   ScriptedExecutionFailure next_failure_{ScriptedExecutionFailure::None};
   std::vector<int32_t> verify_row_tokens_;
+  std::deque<std::vector<int32_t>> queued_row_tokens_;
   std::function<void(ExecutionContext&)> on_execute_;
+  int64_t hidden_size_{};
+  ONNXTensorElementDataType hidden_type_{Ort::TypeToTensorType<float>};
+};
+
+struct CountingCudaDeviceState {
+  size_t device_to_host_copies{};
+  size_t synchronize_calls{};
+  std::vector<int> argmax_rows;
+};
+
+struct CountingCudaMemory final : DeviceBuffer {
+  CountingCudaMemory(size_t size, std::shared_ptr<CountingCudaDeviceState> state)
+      : storage_{std::make_unique<uint8_t[]>(size)}, state_{std::move(state)} {
+    size_in_bytes_ = size;
+    p_cpu_ = p_device_ = storage_.get();
+  }
+
+  CountingCudaMemory(void* memory, size_t size,
+                     std::shared_ptr<CountingCudaDeviceState> state)
+      : state_{std::move(state)} {
+    size_in_bytes_ = size;
+    p_cpu_ = p_device_ = static_cast<uint8_t*>(memory);
+  }
+
+  const char* GetType() const override { return "test_cuda"; }
+  void AllocateCpu() override {}
+  void CopyDeviceToCpu() override { ++state_->device_to_host_copies; }
+  void CopyCpuToDevice() override {}
+  void CopyFrom(size_t begin_dest, DeviceBuffer& source,
+                size_t begin_source, size_t size_in_bytes) override {
+    std::memmove(p_device_ + begin_dest, source.p_device_ + begin_source, size_in_bytes);
+  }
+  void Zero() override { std::memset(p_device_, 0, size_in_bytes_); }
+
+ private:
+  std::unique_ptr<uint8_t[]> storage_;
+  std::shared_ptr<CountingCudaDeviceState> state_;
+};
+
+struct CountingCudaDevice final : DeviceInterface {
+  CountingCudaDevice()
+      : state{std::make_shared<CountingCudaDeviceState>()} {}
+
+  DeviceType GetType() const override { return DeviceType::CUDA; }
+  void InitOrt(const OrtApi&, Ort::Allocator&) override {}
+  Ort::Allocator& GetAllocator() override {
+    return GetDeviceInterface(DeviceType::CPU)->GetAllocator();
+  }
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override { return {}; }
+  std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
+    return std::make_shared<CountingCudaMemory>(size, state);
+  }
+  std::shared_ptr<DeviceBuffer> WrapMemoryBase(void* memory, size_t size) override {
+    return std::make_shared<CountingCudaMemory>(memory, size, state);
+  }
+  std::unique_ptr<Search> CreateGreedy(const GeneratorParams& params) override {
+    return std::make_unique<GreedySearch_Cpu>(params);
+  }
+  std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override {
+    return std::make_unique<BeamSearch_Cpu>(params);
+  }
+  void Synchronize() override { ++state->synchronize_calls; }
+
+  bool ArgMaxDevice(const void* logits, ONNXTensorElementDataType logits_type,
+                    int num_rows, int vocab_size,
+                    DeviceSpan<int32_t> out_tokens) override {
+    if (logits_type != Ort::TypeToTensorType<float> ||
+        out_tokens.size() < static_cast<size_t>(num_rows)) {
+      return false;
+    }
+    state->argmax_rows.push_back(num_rows);
+    const auto* values = static_cast<const float*>(logits);
+    auto output = out_tokens.Span();
+    for (int row = 0; row < num_rows; ++row) {
+      const auto* begin = values + static_cast<size_t>(row) * vocab_size;
+      output[row] = static_cast<int32_t>(
+          std::max_element(begin, begin + vocab_size) - begin);
+    }
+    return true;
+  }
+
+  std::shared_ptr<CountingCudaDeviceState> state;
 };
 
 // An Engine wired with the recording doubles above, together with non-owning observers of those
@@ -440,6 +575,16 @@ struct DoublesEngine {
   RecordingCacheManager* cache;
   RecordingModelExecutor* executor;
   std::shared_ptr<CallTrace> trace;
+};
+
+struct MtpDoublesEngine {
+  std::unique_ptr<CountingCudaDevice> device;
+  std::shared_ptr<Engine> engine;
+  RecordingCacheManager* cache;
+  RecordingModelExecutor* executor;
+  RecordingCacheManager* mtp_cache;
+  RecordingModelExecutor* mtp_executor;
+  std::shared_ptr<CountingCudaDeviceState> device_state;
 };
 
 // A composite Engine wired over the *real* PagedCacheManager (so a real PagedKeyValueCache and, when

--- a/test/engine/paged_cache_reservation_tests.cpp
+++ b/test/engine/paged_cache_reservation_tests.cpp
@@ -131,6 +131,22 @@ TEST(PagedCacheReservationTest, ProposedBlockTableIncludesReservationsAndPadding
   EXPECT_EQ(block_table[5], -1);
 }
 
+TEST(PagedCacheReservationTest, ProposedBlockTableAllowsRequestSubset) {
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables;
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 2, true},
+      PagedCacheReservationRequest{kRequestB, 2, true},
+  };
+  PagedCacheReservation reservation{pool, tables, requests};
+  const std::array request_ids{kRequestB};
+  std::array<int32_t, 1> block_table;
+
+  reservation.FillBlockTable(request_ids, 1, block_table);
+
+  EXPECT_EQ(block_table[0], 1);
+}
+
 TEST(PagedCacheReservationTest, ReleaseIsIdempotentAndBlocksCanBeReused) {
   BlockPool pool{kBlockSize, 1};
   std::vector<PagedCacheBlockTable> tables;

--- a/test/engine/paged_key_value_cache_tests.cpp
+++ b/test/engine/paged_key_value_cache_tests.cpp
@@ -383,6 +383,21 @@ TEST(PagedKeyValueCacheManifestTest, BlockCapacityUsesParticipatingLayerCount) {
           /*element_size=*/2),
       48u);
 
+  // One auxiliary layer with the same geometry adds 32 bytes to the primary model's 64 bytes per
+  // block, so both pools together fit 96 blocks in the same 90%-adjusted memory budget.
+  EXPECT_EQ(
+      ComputePagedBlockCapacity(
+          /*available_memory_bytes=*/10240,
+          /*gpu_utilization_factor=*/1.0f,
+          /*reserved_memory_bytes=*/0,
+          /*block_size=*/4,
+          /*num_key_value_heads=*/1,
+          /*head_size=*/2,
+          /*full_layer_count=*/2,
+          /*element_size=*/2,
+          /*auxiliary_bytes_per_block=*/32),
+      96u);
+
   EXPECT_EQ(
       ComputePagedBlockCapacity(
           /*available_memory_bytes=*/10240,


### PR DESCRIPTION
## Summary
- run the auxiliary MTP decoder transactionally beside the target decoder
- support per-request draft lengths and compact active requests between head stages
- keep chained draft IDs on device and perform one final host materialization
- expose cumulative Engine speculative telemetry through C, C++, and Python
- defer drafts for a selected transaction that mixes prefill and speculative rows, then resume MTP on decode-only transactions

## Stack
PR 6/6. Depends on `tlwu/20260823/gdn-paged-mtp-config`.

## Correctness fix
Packed recurrent operators choose one execution plan for the whole ragged batch. A long prefill can select chunked GatedDeltaNet, which publishes final state but not the intermediate recurrent checkpoints required to reject drafts. The Engine previously treated those checkpoint outputs as valid, so a rejected request could publish an uninitialized checkpoint and diverge on its next target call.

After paged selection, the composite cache planner now clears draft counts only when the selected transaction contains both prefill and draft rows. Decode requests still advance by one token, prefills continue, and K=3 resumes when the selected transaction is decode-only.

## Validation
- `engine_unit_tests`: 323/323 passed
- focused `CompositeDefersDraftsWhilePrefillSharesTheStep` regression passed
- clang-format dry run and `git diff --check` passed
- post-fix layer tracing is exact for 2,048/2,048 rows in transaction 1 and 1,803/1,803 rows in transaction 2
- batch-1 token parity: 438/438; 49.02 to 91.93 tok/s (1.88x)
- sustained concurrency-16 token parity: 2,004/2,004; 288.55 to 316.00 tok/s (+9.5%)
- seven-shard MMLU-Pro: true plain 664/800 (83.00%), post-fix K=3 666/800 (83.25%), zero unextracted
- seven-shard GPQA: true plain 147/198 (74.24%), post-fix K=3 151/198 (76.26%), zero unextracted
- weighted accepted/evaluated draft rate: 84.98% MMLU-Pro and 84.73% GPQA

## Release disposition
K=3 MTP is quality-safe for continuous batching with this safeguard. The prior batch-1-only disposition and numerical-shape explanation are superseded by the recurrent-checkpoint rollback root cause above. Keep the stack in draft pending CI.