### PR TITLE
[benchmark] Add prompt token truncation and trim benchmark output

### DIFF
--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -218,7 +218,11 @@ void RunBenchmark(const benchmark::Options& opts) {
                   << " (-l/--prompt_length); using all " << encoded_count << " tokens.\n";
       }
     }
-    prompt_tokens.assign(encoded_data, encoded_data + effective_count);
+    if (effective_count > 0) {
+      prompt_tokens.assign(encoded_data, encoded_data + effective_count);
+    } else {
+      prompt_tokens.clear();
+    }
     num_prompt_tokens = effective_count;
     // Reflect the tokens actually used (after truncation) in the displayed prompt.
     prompt = std::string{tokenizer->Decode(prompt_tokens.data(), prompt_tokens.size())};
@@ -316,9 +320,12 @@ void RunBenchmark(const benchmark::Options& opts) {
       }
       // Print only the generated tokens, not the prompt echoed back.
       const auto total_len = gen->TokenCount();
-      const auto* output_sequence_data = gen->GetSequenceData(0);
       const size_t gen_len = total_len > num_prompt_tokens ? total_len - num_prompt_tokens : 0;
-      const auto output = tokenizer->Decode(output_sequence_data + num_prompt_tokens, gen_len);
+      std::string output;
+      if (gen_len > 0) {
+        const auto* output_sequence_data = gen->GetSequenceData(0);
+        output = std::string{tokenizer->Decode(output_sequence_data + num_prompt_tokens, gen_len)};
+      }
       std::cout << "[OUTPUT BEGIN]" << output << "[OUTPUT END]\n";
     }
   }

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -191,6 +191,9 @@ void RunBenchmark(const benchmark::Options& opts) {
   size_t num_prompt_tokens;
   bool need_generate_prompt = false;
   std::string prompt;
+  // Populated when an explicit set of prompt token IDs should be used verbatim
+  // (a text prompt from --prompt/--prompt_file, optionally truncated to -l tokens).
+  std::vector<int32_t> prompt_tokens;
 
   if (opts.use_random_tokens) {
     num_prompt_tokens = std::get<size_t>(opts.prompt_num_tokens_or_content);
@@ -202,7 +205,23 @@ void RunBenchmark(const benchmark::Options& opts) {
     prompt = std::get<std::string>(opts.prompt_num_tokens_or_content);
     auto temp_sequences = OgaSequences::Create();
     tokenizer->Encode(prompt.c_str(), *temp_sequences);
-    num_prompt_tokens = temp_sequences->SequenceCount(0);
+    const size_t encoded_count = temp_sequences->SequenceCount(0);
+    const int32_t* encoded_data = temp_sequences->SequenceData(0);
+    size_t effective_count = encoded_count;
+    if (opts.prompt_truncate_tokens.has_value()) {
+      const size_t requested = *opts.prompt_truncate_tokens;
+      if (encoded_count >= requested) {
+        effective_count = requested;
+      } else {
+        std::cerr << "Warning: prompt has " << encoded_count
+                  << " tokens, fewer than the requested " << requested
+                  << " (-l/--prompt_length); using all " << encoded_count << " tokens.\n";
+      }
+    }
+    prompt_tokens.assign(encoded_data, encoded_data + effective_count);
+    num_prompt_tokens = effective_count;
+    // Reflect the tokens actually used (after truncation) in the displayed prompt.
+    prompt = std::string{tokenizer->Decode(prompt_tokens.data(), prompt_tokens.size())};
   }
 
   const size_t num_tokens = num_prompt_tokens + opts.num_tokens_to_generate;
@@ -251,6 +270,11 @@ void RunBenchmark(const benchmark::Options& opts) {
       });
       prompt_sequences->Append(random_tokens.data(), random_tokens.size());
     }
+  } else if (!prompt_tokens.empty()) {
+    // Text prompt (possibly truncated to -l tokens): feed the exact token IDs.
+    for (size_t i = 0; i < opts.batch_size; ++i) {
+      prompt_sequences->Append(prompt_tokens.data(), prompt_tokens.size());
+    }
   } else {
     for (size_t i = 0; i < opts.batch_size; ++i) {
       tokenizer->Encode(prompt.c_str(), *prompt_sequences);
@@ -280,11 +304,21 @@ void RunBenchmark(const benchmark::Options& opts) {
         std::cout << "[PROMPT] random token IDs in [0, 99], batch_size=" << opts.batch_size
                   << ", tokens per sequence=" << num_prompt_tokens << "\n";
       } else {
-        std::cout << "[PROMPT BEGIN]" << prompt << "[PROMPT END]\n";
+        // Only show the tail of very large prompts to keep output readable.
+        constexpr size_t kPromptPrintLimit = 256;
+        std::string_view prompt_view{prompt};
+        std::string prefix;
+        if (prompt_view.size() > kPromptPrintLimit) {
+          prompt_view = prompt_view.substr(prompt_view.size() - kPromptPrintLimit);
+          prefix = "...";
+        }
+        std::cout << "[PROMPT BEGIN]" << prefix << prompt_view << "[PROMPT END]\n";
       }
-      const auto output_sequence_length = gen->TokenCount();
+      // Print only the generated tokens, not the prompt echoed back.
+      const auto total_len = gen->TokenCount();
       const auto* output_sequence_data = gen->GetSequenceData(0);
-      const auto output = tokenizer->Decode(output_sequence_data, output_sequence_length);
+      const size_t gen_len = total_len > num_prompt_tokens ? total_len - num_prompt_tokens : 0;
+      const auto output = tokenizer->Decode(output_sequence_data + num_prompt_tokens, gen_len);
       std::cout << "[OUTPUT BEGIN]" << output << "[OUTPUT END]\n";
     }
   }

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -259,7 +259,16 @@ void RunBenchmark(const benchmark::Options& opts) {
     }
     const auto output_sequence_length = gen->TokenCount();
     const auto* output_sequence_data = gen->GetSequenceData(0);
-    prompt = std::string{tokenizer->Decode(output_sequence_data, output_sequence_length)};
+    if (output_sequence_length < num_prompt_tokens) {
+      throw std::runtime_error(
+          "Generated prompt has fewer tokens than requested by -l/--prompt_length.");
+    }
+
+    // Keep the generated token IDs instead of decoding and re-encoding them.
+    // Tokenizer round trips are not token-count preserving, so re-encoding can
+    // produce more than the exact prompt length requested with -l.
+    prompt_tokens.assign(output_sequence_data, output_sequence_data + num_prompt_tokens);
+    prompt = std::string{tokenizer->Decode(prompt_tokens.data(), prompt_tokens.size())};
   }
 
   auto prompt_sequences = OgaSequences::Create();

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -220,12 +220,13 @@ void RunBenchmark(const benchmark::Options& opts) {
     }
     if (effective_count > 0) {
       prompt_tokens.assign(encoded_data, encoded_data + effective_count);
+      // Reflect the tokens actually used (after truncation) in the displayed prompt.
+      prompt = std::string{tokenizer->Decode(prompt_tokens.data(), prompt_tokens.size())};
     } else {
       prompt_tokens.clear();
+      prompt.clear();
     }
     num_prompt_tokens = effective_count;
-    // Reflect the tokens actually used (after truncation) in the displayed prompt.
-    prompt = std::string{tokenizer->Decode(prompt_tokens.data(), prompt_tokens.size())};
   }
 
   const size_t num_tokens = num_prompt_tokens + opts.num_tokens_to_generate;
@@ -269,10 +270,11 @@ void RunBenchmark(const benchmark::Options& opts) {
     // produce more than the exact prompt length requested with -l.
     if (num_prompt_tokens > 0) {
       prompt_tokens.assign(output_sequence_data, output_sequence_data + num_prompt_tokens);
+      prompt = std::string{tokenizer->Decode(prompt_tokens.data(), prompt_tokens.size())};
     } else {
       prompt_tokens.clear();
+      prompt.clear();
     }
-    prompt = std::string{tokenizer->Decode(prompt_tokens.data(), prompt_tokens.size())};
   }
 
   auto prompt_sequences = OgaSequences::Create();

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -267,7 +267,11 @@ void RunBenchmark(const benchmark::Options& opts) {
     // Keep the generated token IDs instead of decoding and re-encoding them.
     // Tokenizer round trips are not token-count preserving, so re-encoding can
     // produce more than the exact prompt length requested with -l.
-    prompt_tokens.assign(output_sequence_data, output_sequence_data + num_prompt_tokens);
+    if (num_prompt_tokens > 0) {
+      prompt_tokens.assign(output_sequence_data, output_sequence_data + num_prompt_tokens);
+    } else {
+      prompt_tokens.clear();
+    }
     prompt = std::string{tokenizer->Decode(prompt_tokens.data(), prompt_tokens.size())};
   }
 

--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -321,12 +321,12 @@ void RunBenchmark(const benchmark::Options& opts) {
         std::cout << "[PROMPT] random token IDs in [0, 99], batch_size=" << opts.batch_size
                   << ", tokens per sequence=" << num_prompt_tokens << "\n";
       } else {
-        // Only show the tail of very large prompts to keep output readable.
-        constexpr size_t kPromptPrintLimit = 256;
+        // Print the whole prompt by default; --prompt_print_chars N limits output
+        // to the last min(prompt_size, N) characters.
         std::string_view prompt_view{prompt};
         std::string prefix;
-        if (prompt_view.size() > kPromptPrintLimit) {
-          prompt_view = prompt_view.substr(prompt_view.size() - kPromptPrintLimit);
+        if (opts.prompt_print_chars.has_value() && prompt_view.size() > *opts.prompt_print_chars) {
+          prompt_view = prompt_view.substr(prompt_view.size() - *opts.prompt_print_chars);
           prefix = "...";
         }
         std::cout << "[PROMPT BEGIN]" << prefix << prompt_view << "[PROMPT END]\n";

--- a/benchmark/c/options.cpp
+++ b/benchmark/c/options.cpp
@@ -36,6 +36,8 @@ namespace {
     << "    Prompt options:\n"
     << "      -l,--prompt_length <number>\n"
     << "        Number of tokens in the generated prompt. Default: " << default_prompt_num_tokens << "\n"
+    << "        When combined with --prompt or --prompt_file, the encoded prompt is truncated\n"
+    << "        to this many tokens (or all tokens, with a warning, if the prompt is shorter).\n"
     << "      --prompt <prompt text>\n"
     << "        Prompt text to use. Default: See --prompt_length.\n"
     << "      --prompt_file <file containing prompt text>\n"
@@ -127,7 +129,10 @@ Options ParseOptionsFromCommandLine(int argc, const char* const* argv) {
       return std::string_view{argv[++idx]};
     };
 
-    std::optional<PromptNumberOfTokensOrContent> prompt_num_tokens_or_content{};
+    // -l/--prompt_length is parsed separately from --prompt/--prompt_file so the two
+    // can be combined (truncate a text prompt to a given number of tokens).
+    std::optional<size_t> prompt_length{};
+    std::optional<std::string> prompt_content{};
 
     for (int i = 1; i < argc; ++i) {
       std::string_view arg{argv[i]};
@@ -139,17 +144,15 @@ Options ParseOptionsFromCommandLine(int argc, const char* const* argv) {
       } else if (arg == "-b" || arg == "--batch_size") {
         opts.batch_size = ParseNumber<size_t>(next_arg(i));
       } else if (arg == "-l" || arg == "--prompt_length") {
-        if (prompt_num_tokens_or_content.has_value())
-          throw std::runtime_error("--prompt_length, --prompt, and --prompt_file are mutually exclusive.");
-        prompt_num_tokens_or_content = ParseNumber<size_t>(next_arg(i));
+        prompt_length = ParseNumber<size_t>(next_arg(i));
       } else if (arg == "--prompt") {
-        if (prompt_num_tokens_or_content.has_value())
-          throw std::runtime_error("--prompt_length, --prompt, and --prompt_file are mutually exclusive.");
-        prompt_num_tokens_or_content = std::string{next_arg(i)};
+        if (prompt_content.has_value())
+          throw std::runtime_error("--prompt and --prompt_file are mutually exclusive.");
+        prompt_content = std::string{next_arg(i)};
       } else if (arg == "--prompt_file") {
-        if (prompt_num_tokens_or_content.has_value())
-          throw std::runtime_error("--prompt_length, --prompt, and --prompt_file are mutually exclusive.");
-        prompt_num_tokens_or_content = ReadFileContent(next_arg(i));
+        if (prompt_content.has_value())
+          throw std::runtime_error("--prompt and --prompt_file are mutually exclusive.");
+        prompt_content = ReadFileContent(next_arg(i));
       } else if (arg == "-g" || arg == "--generation_length") {
         opts.num_tokens_to_generate = ParseNumber<size_t>(next_arg(i));
       } else if (arg == "-r" || arg == "--repetitions") {
@@ -175,16 +178,24 @@ Options ParseOptionsFromCommandLine(int argc, const char* const* argv) {
       }
     }
 
-    if (prompt_num_tokens_or_content.has_value()) {
-      opts.prompt_num_tokens_or_content = std::move(*prompt_num_tokens_or_content);
+    // Reconcile the prompt source. A text prompt takes precedence; if -l is also
+    // given it becomes a token-truncation length. Otherwise -l alone selects the
+    // synthetic (generated) prompt of that many tokens.
+    if (prompt_content.has_value()) {
+      opts.prompt_num_tokens_or_content = std::move(*prompt_content);
+      if (prompt_length.has_value()) {
+        opts.prompt_truncate_tokens = *prompt_length;
+      }
+    } else if (prompt_length.has_value()) {
+      opts.prompt_num_tokens_or_content = *prompt_length;
     }
 
     if (opts.use_random_tokens) {
-      if (!prompt_num_tokens_or_content.has_value() ||
-          !std::holds_alternative<size_t>(*prompt_num_tokens_or_content)) {
-        throw std::runtime_error(!prompt_num_tokens_or_content.has_value()
-                                     ? "--use_random_tokens requires -l/--prompt_length."
-                                     : "--use_random_tokens cannot be used with --prompt or --prompt_file.");
+      if (prompt_content.has_value()) {
+        throw std::runtime_error("--use_random_tokens cannot be used with --prompt or --prompt_file.");
+      }
+      if (!prompt_length.has_value()) {
+        throw std::runtime_error("--use_random_tokens requires -l/--prompt_length.");
       }
     }
 

--- a/benchmark/c/options.cpp
+++ b/benchmark/c/options.cpp
@@ -48,6 +48,9 @@ namespace {
     << "        --prompt_file).\n"
     << "      Note: --prompt, --prompt_file, and --use_random_tokens are mutually exclusive;\n"
     << "        --use_random_tokens requires --prompt_length.\n"
+    << "      --prompt_print_chars <number>\n"
+    << "        In verbose mode, print only the last min(prompt_size, number) characters of\n"
+    << "        the input prompt. Default: print the entire prompt.\n"
     << "    -g,--generation_length <number>\n"
     << "      Number of tokens to generate. Default: " << defaults.num_tokens_to_generate << "\n"
     << "    -r,--repetitions <number>\n"
@@ -153,6 +156,8 @@ Options ParseOptionsFromCommandLine(int argc, const char* const* argv) {
         if (prompt_content.has_value())
           throw std::runtime_error("--prompt and --prompt_file are mutually exclusive.");
         prompt_content = ReadFileContent(next_arg(i));
+      } else if (arg == "--prompt_print_chars") {
+        opts.prompt_print_chars = ParseNumber<size_t>(next_arg(i));
       } else if (arg == "-g" || arg == "--generation_length") {
         opts.num_tokens_to_generate = ParseNumber<size_t>(next_arg(i));
       } else if (arg == "-r" || arg == "--repetitions") {

--- a/benchmark/c/options.h
+++ b/benchmark/c/options.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -15,6 +16,9 @@ struct Options {
   std::string model_path;
   std::string execution_provider{"cpu"};
   PromptNumberOfTokensOrContent prompt_num_tokens_or_content{size_t{16}};
+  // When a text prompt (--prompt/--prompt_file) is combined with -l/--prompt_length,
+  // holds the number of tokens to truncate the encoded prompt to.
+  std::optional<size_t> prompt_truncate_tokens{};
   size_t num_tokens_to_generate{128};
   size_t batch_size{1};
   size_t num_iterations{5};

--- a/benchmark/c/options.h
+++ b/benchmark/c/options.h
@@ -19,6 +19,9 @@ struct Options {
   // When a text prompt (--prompt/--prompt_file) is combined with -l/--prompt_length,
   // holds the number of tokens to truncate the encoded prompt to.
   std::optional<size_t> prompt_truncate_tokens{};
+  // When set, verbose mode prints only the last min(prompt_size, value) characters
+  // of the input prompt; unset prints the entire prompt.
+  std::optional<size_t> prompt_print_chars{};
   size_t num_tokens_to_generate{128};
   size_t batch_size{1};
   size_t num_iterations{5};


### PR DESCRIPTION
## Benchmark (C): prompt token truncation and cleaner verbose output

Improves prompt handling and the verbose print output in the C `model_benchmark`.

### Changes

- **Truncate a text prompt to `-l` tokens.** `-l/--prompt_length` can now be combined with `--prompt` or `--prompt_file`. The prompt is encoded and truncated to the requested number of tokens. If the prompt has fewer tokens than requested, a warning is printed to `stderr` and all available tokens are used. Previously `-l`, `--prompt`, and `--prompt_file` were mutually exclusive (`--prompt` and `--prompt_file` still are, with each other).
- **Trim printed input prompt.** In verbose mode, add new option `--prompt_print_chars N` so that only the last N characters of a large prompt are printed (with a leading `...`), instead of dumping the entire prompt.
- **Print only generated tokens.** The verbose `[OUTPUT ...]` block now decodes only the newly generated tokens instead of the full prompt + output sequence.
- **Preserve exact generated prompt length.** Use prompt token IDs instead of decode/re-encoding them and fail clearly if prompt generation unexpectedly produces too few tokens.

### Implementation notes

- `Options` gains `std::optional<size_t> prompt_truncate_tokens`. Parsing now reads `-l` and the text prompt into separate locals and reconciles them afterward, so a text prompt can carry a truncation length while `-l` alone still selects the synthetic generated prompt.
- Truncation is done at the token level: the encoded prompt's token IDs are sliced to the requested count and fed verbatim via `OgaSequences::Append`, and the displayed prompt is re-derived from those exact tokens.

### Testing

- `--prompt_file big.txt -l 128` -> prompt truncated to 128 tokens.
- `--prompt_file small.txt -l 100000` -> warning printed, all available tokens used.
- Large prompt with `-v --prompt_print_chars 256` -> prompt shows only its last 256 chars with a leading `...`; `[OUTPUT ...]` shows only generated text.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>