### PR TITLE
Fix dockerfile netiso

### DIFF
--- a/tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_aarch64
+++ b/tools/ci_build/github/linux/docker/manylinux/Dockerfile.manylinux2_28_cpu_aarch64
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 FROM onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cpu_aarch64_almalinux8_gcc14:20251017.1
 
 ADD scripts /tmp/scripts


### PR DESCRIPTION
The pin to a frontend version for docker required reaching out to the internet. This gets blocked by netiso. The bundled docker buildkit should be sufficient for the feature level supplied in the dockerfile.