### PR TITLE
Add Gemma 4 text model builder support (dense gemma-4-12b-it + 26B-A4B MoE)

### DIFF
--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -22,6 +22,7 @@ from builders import (
     ErnieModel,
     Gemma2Model,
     Gemma3Model,
+    Gemma4Model,
     GemmaModel,
     GPTOSSModel,
     GraniteModel,
@@ -484,6 +485,15 @@ def create_model(
         onnx_model = Gemma3Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
         if not onnx_model.exclude_embeds:
             onnx_model.model_type = "gemma3_vl_text"
+    elif config.architectures[0] == "Gemma4UnifiedForConditionalGeneration":
+        text_config = config.text_config
+        for key in text_config:
+            if not hasattr(config, key):
+                setattr(config, key, getattr(text_config, key))
+        print("WARNING: This model loses accuracy with float16 precision. It is recommended to set `--precision bf16` or `--precision int4 --extra_options use_cuda_bf16=true` by default.")
+        print("WARNING: This is only generating the text component of the model. The vision and audio components are not supported.")
+        onnx_model = Gemma4Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
+        onnx_model.model_type = "gemma4_text"
     elif config.architectures[0] == "GptOssForCausalLM":
         print("WARNING: This model only supports symmetric quantization for `QMoE`.")
         if hasattr(config, "quantization_config") and config.quantization_config.get("quant_method") != "quark":

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -22,6 +22,7 @@ from builders import (
     ErnieModel,
     Gemma2Model,
     Gemma3Model,
+    Gemma4MoEModel,
     Gemma4Model,
     GemmaModel,
     GPTOSSModel,
@@ -485,6 +486,15 @@ def create_model(
         onnx_model = Gemma3Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
         if not onnx_model.exclude_embeds:
             onnx_model.model_type = "gemma3_vl_text"
+    elif config.architectures[0] == "Gemma4ForConditionalGeneration":
+        text_config = config.text_config
+        for key in text_config:
+            if not hasattr(config, key):
+                setattr(config, key, getattr(text_config, key))
+        print("WARNING: This model loses accuracy with float16 precision. It is recommended to set `--precision bf16` or `--precision int4 --extra_options use_cuda_bf16=true` by default.")
+        print("WARNING: This is only generating the text component of the model. The vision and audio components are not supported.")
+        onnx_model = Gemma4MoEModel(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
+        onnx_model.model_type = "gemma4_text"
     elif config.architectures[0] == "Gemma4UnifiedForConditionalGeneration":
         text_config = config.text_config
         for key in text_config:

--- a/src/python/py/models/builders/__init__.py
+++ b/src/python/py/models/builders/__init__.py
@@ -9,7 +9,7 @@
 from .base import Model
 from .chatglm import ChatGLMModel
 from .ernie import ErnieModel
-from .gemma import Gemma2Model, Gemma3Model, GemmaModel
+from .gemma import Gemma2Model, Gemma3Model, Gemma4Model, GemmaModel
 from .gptoss import GPTOSSModel
 from .granite import GraniteModel, GraniteMoEHybridModel
 from .hunyuan import HunyuanDenseV1Model
@@ -52,6 +52,7 @@ __all__ = [
     "GPTOSSModel",
     "Gemma2Model",
     "Gemma3Model",
+    "Gemma4Model",
     "GemmaModel",
     "GraniteMoEHybridModel",
     "GraniteModel",

--- a/src/python/py/models/builders/__init__.py
+++ b/src/python/py/models/builders/__init__.py
@@ -9,7 +9,7 @@
 from .base import Model
 from .chatglm import ChatGLMModel
 from .ernie import ErnieModel
-from .gemma import Gemma2Model, Gemma3Model, Gemma4Model, GemmaModel
+from .gemma import Gemma2Model, Gemma3Model, Gemma4MoEModel, Gemma4Model, GemmaModel
 from .gptoss import GPTOSSModel
 from .granite import GraniteModel, GraniteMoEHybridModel
 from .hunyuan import HunyuanDenseV1Model
@@ -52,6 +52,7 @@ __all__ = [
     "GPTOSSModel",
     "Gemma2Model",
     "Gemma3Model",
+    "Gemma4MoEModel",
     "Gemma4Model",
     "GemmaModel",
     "GraniteMoEHybridModel",

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -951,7 +951,12 @@ class Model:
 
         # MXFP4 and NVFP4 both resolve to the "mx" kind; the QMoE op tells them apart by dtype name
         # ("mxfp4" -> op "fp4", "nvfp4" -> op "nvfp4"). Integer dtypes use the plain "int" QMoE path.
-        self.moe_attrs["moe_op_type"] = "QMoE" if moe_descriptor.is_quantized else "MoE"
+        # Both keys carry the resolved op: the shared emitters (make_moe_expert_initializers /
+        # make_moe_op) read "op_type", while the gemma parallel-FFN path reads "moe_op_type". Setting
+        # only one left quantized experts on the float "MoE" op, which rejects uint8 weights.
+        moe_op_type = "QMoE" if moe_descriptor.is_quantized else "MoE"
+        self.moe_attrs["op_type"] = moe_op_type
+        self.moe_attrs["moe_op_type"] = moe_op_type
         if moe_descriptor.kind == "mx":
             self.moe_attrs["qmoe_quant_type"] = "nvfp4" if moe_descriptor.name == "nvfp4" else "fp4"
         else:

--- a/src/python/py/models/builders/gemma.py
+++ b/src/python/py/models/builders/gemma.py
@@ -3,7 +3,11 @@
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import os
+
 import numpy as np
+import torch
+from onnx_ir.tensor_adapters import to_torch_dtype
 
 from .mistral import MistralModel
 
@@ -144,3 +148,286 @@ class Gemma3Model(Gemma2Model):
             "sin_cache_name", self.sin_cache_global_name if self.window_size == -1 else self.sin_cache_local_name
         )
         return super().make_rotary_embedding_caches(cos_cache_name=cos_cache_name, sin_cache_name=sin_cache_name)
+
+
+class Gemma4Model(Gemma3Model):
+    """Builder for the text decoder of Gemma4Unified (gemma4-12b-it).
+
+    Differs from Gemma3 in several structural ways (see below). Only the text
+    component is built; vision/audio configs are ignored.
+    """
+
+    def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
+        # Per-layer-type geometry. Sliding layers are the base profile; full
+        # ("global") layers swap in their own head_dim / kv_heads per layer.
+        self.layer_types = list(config.layer_types)
+        self.sliding_head_dim = config.head_dim
+        self.global_head_dim = config.global_head_dim
+        self.sliding_num_kv_heads = config.num_key_value_heads
+        self.global_num_kv_heads = config.num_global_key_value_heads
+        self.attention_k_eq_v = getattr(config, "attention_k_eq_v", False)
+
+        # RoPE parameters differ per layer type (nested dict in the HF config).
+        rope_params = config.rope_parameters
+        self.global_rope_theta = rope_params["full_attention"]["rope_theta"]
+        self.global_partial_rotary_factor = rope_params["full_attention"]["partial_rotary_factor"]
+        self.local_rope_theta = rope_params["sliding_attention"]["rope_theta"]
+
+        # Base __init__ reads config.head_dim (= sliding) for self.head_size and
+        # config.num_key_value_heads (= sliding) for self.num_kv_heads, which is
+        # the default (sliding) profile. It also builds the RoPE caches via the
+        # Gemma3 multi-cache path, so set rope_local_base_freq for that.
+        config.rope_local_base_freq = self.local_rope_theta
+        # Gemma2Model.__init__ derives its attention scale from
+        # query_pre_attn_scalar, which Gemma4 does not have (its Q/K are
+        # RMS-normed, so the scale is 1.0). Provide a placeholder so the parent
+        # chain runs; the scale is overridden to 1.0 below.
+        if not hasattr(config, "query_pre_attn_scalar"):
+            config.query_pre_attn_scalar = config.head_dim
+        super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
+
+        # Gemma4 RMSNorm uses the weight directly (no `1 + weight` offset that
+        # Gemma1/2/3 apply). This also governs q_norm/k_norm weights.
+        self.layernorm_attrs["add_offset"] = 0
+
+        # Q/K are RMS-normed, so HF sets attention scaling to 1.0 (not
+        # 1/sqrt(head_dim)).
+        self.attention_attrs["scale"] = 1.0
+
+        # Partial rotary on the global layers requires the standalone
+        # RotaryEmbedding op (GQA's fused rope has no rotary_embedding_dim
+        # attribute). Force external RoPE and keep position_ids as an input.
+        self.attention_attrs["use_rope_in_attn"] = False
+        if "position_ids" not in self.input_names:
+            self.input_names["position_ids"] = "position_ids"
+            self.input_types["position_ids"] = self.input_types.get("attention_mask")
+            self.input_shapes["position_ids"] = ["batch_size", "sequence_length"]
+
+        # Per-layer residual output multipliers (`layer_scalar`), read from the
+        # weights in make_layer.
+        self.layer_scalars = {}
+
+    def make_rope_init(self, config):
+        # Gemma4 stores rope_parameters as a per-layer-type nested dict
+        # ({"full_attention": {...}, "sliding_attention": {...}}) rather than the
+        # flat {"rope_type": ...} form the base reader expects. The per-type theta
+        # / partial_rotary_factor are applied directly in __init__ and via the
+        # Gemma3 multi-cache path, so skip the base initializer.
+        return
+
+    def load_weights(self, input_path):
+        # The checkpoint is a full multimodal Gemma4Unified model whose text
+        # weights live under the `model.language_model.` prefix. Loading the full
+        # ConditionalGeneration model (as the base does) also pulls in the vision
+        # and audio towers, which are out of scope and roughly double the memory.
+        # Instead, build the text-only CausalLM and load just the remapped text
+        # weights.
+        if self.quant_type is not None or input_path.endswith(".gguf"):
+            return super().load_weights(input_path)
+
+        import glob
+
+        from safetensors import safe_open
+        from transformers import AutoConfig
+        from transformers.models.gemma4_unified import Gemma4UnifiedForCausalLM
+
+        config = AutoConfig.from_pretrained(
+            self.model_name_or_path, token=self.hf_token, trust_remote_code=self.hf_remote
+        )
+        text_config = config.text_config
+        text_config.num_hidden_layers = self.num_layers
+        text_config.layer_types = text_config.layer_types[: self.num_layers]
+
+        with torch.device("meta"):
+            model = Gemma4UnifiedForCausalLM(text_config)
+
+        # Remap `model.language_model.*` -> `model.*` and drop layers beyond the
+        # (possibly truncated) layer count.
+        prefix = "model.language_model."
+        state_dict = {}
+        for shard in sorted(glob.glob(os.path.join(self.model_name_or_path, "*.safetensors"))):
+            with safe_open(shard, framework="pt") as f:
+                for key in f.keys():
+                    if not key.startswith(prefix):
+                        continue
+                    new_key = key[len(prefix) :]
+                    if new_key.startswith("layers."):
+                        if int(new_key.split(".")[1]) >= self.num_layers:
+                            continue
+                    state_dict["model." + new_key] = f.get_tensor(key)
+
+        if getattr(text_config, "tie_word_embeddings", False):
+            state_dict["lm_head.weight"] = state_dict["model.embed_tokens.weight"]
+
+        missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
+        if missing:
+            raise ValueError(f"Missing weights while loading Gemma4 text model: {missing}")
+        if unexpected:
+            raise ValueError(f"Unexpected weights while loading Gemma4 text model: {unexpected}")
+
+        return model
+
+    def is_local(self, layer_id):
+        return self.layer_types[layer_id] == "sliding_attention"
+
+    def layer_head_dim(self, layer_id):
+        return self.sliding_head_dim if self.is_local(layer_id) else self.global_head_dim
+
+    def layer_num_kv_heads(self, layer_id):
+        return self.sliding_num_kv_heads if self.is_local(layer_id) else self.global_num_kv_heads
+
+    def make_key_value_cache_shape(self, layer_id, shape):
+        # Emit concrete kv_heads (dim 1) and head_dim (dim 3) per layer so the
+        # runtime's DefaultKeyValueCache detects the per-layer variation.
+        shape = super().make_key_value_cache_shape(layer_id, shape)
+        return [shape[0], self.layer_num_kv_heads(layer_id), shape[2], self.layer_head_dim(layer_id)]
+
+    def make_attention(self, layer_id, attention, root_input, **kwargs):
+        # Swap in this layer's geometry (head_dim, kv_heads, q/kv sizes) around
+        # the base implementation, restoring afterward. Window handling is done
+        # by Gemma2Model.make_attention (super) via is_local.
+        original = (self.head_size, self.num_kv_heads, self.q_size, self.kv_size)
+        self.head_size = self.layer_head_dim(layer_id)
+        self.num_kv_heads = self.layer_num_kv_heads(layer_id)
+        self.q_size = self.num_attn_heads * self.head_size
+        self.kv_size = self.num_kv_heads * self.head_size
+        # RoPE uses a full split-half rotation (rotary_embedding_dim=0) for both
+        # layer types. The global layers' partial rotary is baked into the global
+        # cache as a zero-padded NoPE tail (see make_proportional_rope_caches), so
+        # the op rotates the full head_dim with that pre-zeroed cache — matching
+        # HF's proportional RoPE. The external RotaryEmbedding op needs position_ids.
+        super().make_attention(
+            layer_id, attention, root_input, position_ids=self.input_names["position_ids"], **kwargs
+        )
+        self.head_size, self.num_kv_heads, self.q_size, self.kv_size = original
+
+    def make_attention_input_proj(self, layer_id, attention, root_input, **kwargs):
+        if self.attention_k_eq_v and not self.is_local(layer_id):
+            # Full-attention layers share the K projection as V (no v_proj).
+            attention.v_proj = attention.k_proj
+        super().make_attention_input_proj(layer_id, attention, root_input, **kwargs)
+        # Insert the scaleless value RMSNorm (v_norm) on the V path.
+        self.make_v_norm(layer_id)
+
+    def make_v_norm(self, layer_id):
+        # Scaleless SimplifiedLayerNorm (weight = ones) applied per-head on V,
+        # matching HF's Gemma4UnifiedRMSNorm(with_scale=False) on value_states.
+        head_size = self.head_size
+        kv_size = self.kv_size
+
+        reshape_1_name = f"/model/layers.{layer_id}/attn/v_norm/Reshape_1"
+        reshape_1_inputs = [self.attention_attrs["v_path"], f"/model/constants/INT64/[0, -1, {head_size}]"]
+        self.make_reshape(
+            reshape_1_name,
+            reshape_1_inputs,
+            dtype=self.io_dtype,
+            shape=["batch_size", "sequence_length * num_key_value_heads", head_size],
+        )
+
+        weight_name = f"model.layers.{layer_id}.attn.v_norm.layernorm.weight"
+        self.make_initializer(torch.ones(head_size), weight_name, to=self.io_dtype)
+
+        layernorm_name = f"/model/layers.{layer_id}/attn/v_norm/SimplifiedLayerNormalization"
+        layernorm_output = f"{layernorm_name}/output_0"
+        self.make_node(
+            "SimplifiedLayerNormalization",
+            inputs=[f"{reshape_1_name}/output_0", weight_name],
+            outputs=[layernorm_output],
+            name=layernorm_name,
+            epsilon=self.layernorm_attrs["epsilon"],
+            axis=-1,
+            stash_type=1,
+        )
+        self.make_value(
+            layernorm_output,
+            dtype=self.io_dtype,
+            shape=["batch_size", "sequence_length * num_key_value_heads", head_size],
+        )
+
+        reshape_2_name = f"/model/layers.{layer_id}/attn/v_norm/Reshape_2"
+        reshape_2_inputs = [layernorm_output, f"/model/constants/INT64/[0, -1, {kv_size}]"]
+        self.make_reshape(
+            reshape_2_name,
+            reshape_2_inputs,
+            dtype=self.io_dtype,
+            shape=["batch_size", "sequence_length", kv_size],
+        )
+        self.attention_attrs["v_path"] = f"{reshape_2_name}/output_0"
+
+    def make_rotary_embedding_multi_cache(self):
+        # Build the global cache with the proportional RoPE variant and the
+        # local cache with default RoPE (theta = local_rope_theta on the sliding
+        # head_dim). Overrides Gemma3's default-both-caches behavior.
+        self.cos_cache_global_name, self.sin_cache_global_name = "cos_cache_global", "sin_cache_global"
+        cos_global, sin_global = self.make_proportional_rope_caches()
+        self.make_initializer(cos_global, self.cos_cache_global_name, to=self.io_dtype)
+        self.make_initializer(sin_global, self.sin_cache_global_name, to=self.io_dtype)
+
+        # Local (sliding) cache: default RoPE on the sliding head_dim.
+        original = (self.head_size, self.rope_attrs["theta"], self.rope_attrs["partial_rotary_factor"])
+        self.head_size = self.sliding_head_dim
+        self.rope_attrs["theta"] = self.local_rope_theta
+        self.rope_attrs["partial_rotary_factor"] = 1.0
+        self.rope_attrs["create_caches"] = True
+        self.cos_cache_local_name, self.sin_cache_local_name = "cos_cache_local", "sin_cache_local"
+        super(Gemma3Model, self).make_rotary_embedding_caches(
+            cos_cache_name=self.cos_cache_local_name, sin_cache_name=self.sin_cache_local_name
+        )
+        self.head_size, self.rope_attrs["theta"], self.rope_attrs["partial_rotary_factor"] = original
+
+    def make_proportional_rope_caches(self):
+        # Replicates transformers' _compute_proportional_rope_parameters:
+        # partial rotary applied on the *global* head_dim, with a zero-padded
+        # NoPE tail so the emitted rotary_embedding_dim spans the full head_dim.
+        head_dim = self.global_head_dim
+        base = self.global_rope_theta
+        rope_angles = int(self.global_partial_rotary_factor * head_dim // 2)
+        inv_freq_rotated = 1.0 / (
+            base ** (torch.arange(0, 2 * rope_angles, 2, dtype=torch.int64).float() / head_dim)
+        )
+        nope_angles = head_dim // 2 - rope_angles
+        if nope_angles > 0:
+            inv_freq = torch.cat((inv_freq_rotated, torch.zeros(nope_angles, dtype=torch.float32)), dim=0)
+        else:
+            inv_freq = inv_freq_rotated
+
+        t = torch.arange(self.context_length, dtype=torch.int64).float()
+        freqs = torch.outer(t, inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos_cache, sin_cache = emb.cos(), emb.sin()
+        cos_cache = cos_cache.squeeze().to(to_torch_dtype(self.io_dtype))
+        sin_cache = sin_cache.squeeze().to(to_torch_dtype(self.io_dtype))
+        # Halve to (M, head_dim/2) as the RotaryEmbedding kernel expects. The
+        # NoPE tail contributes zero-frequency (cos=1, sin=0) entries.
+        cos_cache = cos_cache[:, : (head_dim // 2)]
+        sin_cache = sin_cache[:, : (head_dim // 2)]
+        return cos_cache, sin_cache
+
+    def make_layer(self, layer_id, layer):
+        super().make_layer(layer_id, layer)
+
+        # Apply the per-layer residual multiplier (`layer_scalar`) to the whole
+        # layer output, matching HF's `hidden_states *= self.layer_scalar`.
+        #
+        # In the SkipLayerNorm design the layer output is carried as
+        # (root_input + skip_input), summed inside the next SkipLayerNorm (or the
+        # final norm). To scale the sum, scale both operands. `last_layernorm` is
+        # set by the super() call for the final layer; the final norm consumes the
+        # same (root_input, skip_input) pair, so scaling both is correct there too.
+        #
+        # Gemma2/3 keep the residual (root_input, via SkipLayerNorm output_3) in
+        # fp32 while skip_input is io_dtype, so each Mul must use its operand's own
+        # recorded dtype (and a matching scalar constant).
+        scalar = float(layer.layer_scalar.item())
+
+        for suffix, attr in (("skip", "skip_input"), ("root", "root_input")):
+            operand = self.layernorm_attrs[attr]
+            operand_dtype = self.values[operand].dtype
+            mul_name = f"/model/layers.{layer_id}/layer_scalar/Mul_{suffix}"
+            self.make_mul(
+                mul_name,
+                [operand, f"/model/constants/{self.to_str_dtype(operand_dtype)}/{scalar}"],
+                dtype=operand_dtype,
+                shape=["batch_size", "sequence_length", self.hidden_size],
+            )
+            self.layernorm_attrs[attr] = f"{mul_name}/output_0"

--- a/src/python/py/models/builders/gemma.py
+++ b/src/python/py/models/builders/gemma.py
@@ -463,14 +463,17 @@ class Gemma4MoEModel(Gemma4Model):
             config.num_local_experts = config.num_experts
         if not hasattr(config, "num_experts_per_tok"):
             config.num_experts_per_tok = config.top_k_experts
-        super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
 
-        # Base __init__ prefers config.moe_intermediate_size for self.intermediate_size
-        # when present. Gemma4 keeps a parallel DENSE MLP alongside the experts, so pin
-        # self.intermediate_size back to the dense size (config.intermediate_size) and
-        # track the expert size separately as moe_intermediate_size.
-        self.intermediate_size = config.intermediate_size
-        self.moe_intermediate_size = config.moe_intermediate_size
+        # Base __init__ prefers config.moe_intermediate_size when setting self.intermediate_size,
+        # but Gemma4 keeps a parallel DENSE MLP alongside the experts and needs self.intermediate_size
+        # to stay the dense size. Hide moe_intermediate_size across super().__init__ so base sets the
+        # dense value (config.intermediate_size) directly, then restore it and track the expert size
+        # separately. (Assigning self.intermediate_size after super() would overwrite the base value.)
+        moe_intermediate_size = config.moe_intermediate_size
+        del config.moe_intermediate_size
+        super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
+        config.moe_intermediate_size = moe_intermediate_size
+        self.moe_intermediate_size = moe_intermediate_size
 
         # Gemma4 experts use GeGLU (gelu_pytorch_tanh(gate) * up). This maps to the fused QMoE
         # op's "geglu" activation with swiglu_fusion=1 (interleaved gate|up), which applies the

--- a/src/python/py/models/builders/gemma.py
+++ b/src/python/py/models/builders/gemma.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 from onnx_ir.tensor_adapters import to_torch_dtype
 
+from .base import Model
 from .mistral import MistralModel
 
 
@@ -370,8 +371,12 @@ class Gemma4Model(Gemma3Model):
         self.rope_attrs["partial_rotary_factor"] = 1.0
         self.rope_attrs["create_caches"] = True
         self.cos_cache_local_name, self.sin_cache_local_name = "cos_cache_local", "sin_cache_local"
-        super(Gemma3Model, self).make_rotary_embedding_caches(
-            cos_cache_name=self.cos_cache_local_name, sin_cache_name=self.sin_cache_local_name
+        # Deliberately reach the base (Model) implementation, skipping Gemma3's
+        # multi-cache override, to build a single default RoPE cache. Called
+        # explicitly (rather than super()) because super() would resolve to
+        # Gemma3Model.make_rotary_embedding_caches and change behavior.
+        Model.make_rotary_embedding_caches(
+            self, cos_cache_name=self.cos_cache_local_name, sin_cache_name=self.sin_cache_local_name
         )
         self.head_size, self.rope_attrs["theta"], self.rope_attrs["partial_rotary_factor"] = original
 
@@ -482,7 +487,11 @@ class Gemma4MoEModel(Gemma4Model):
         # Same text-only remap as the dense model, but the MoE checkpoint is a
         # `Gemma4ForConditionalGeneration` whose text tower is `Gemma4ForCausalLM`.
         if self.quant_type is not None or input_path.endswith(".gguf"):
-            return super(Gemma4Model, self).load_weights(input_path)
+            # Deliberately skip Gemma4Model.load_weights (the dense text-only
+            # remap) and use the generic base loader for quantized/GGUF inputs.
+            # Called explicitly rather than via super() because super() would
+            # resolve to Gemma4Model.load_weights and change behavior.
+            return Model.load_weights(self, input_path)
 
         import glob
 
@@ -572,7 +581,7 @@ class Gemma4MoEModel(Gemma4Model):
         expert_input = self.make_gemma4_rmsnorm(
             f"layers.{layer_id}.pre_feedforward_layernorm_2", residual, layer.pre_feedforward_layernorm_2.weight
         )
-        moe_out = self.make_moe(layer_id, layer, router_input=residual, expert_input=expert_input)
+        moe_out = self.make_gemma4_moe(layer_id, layer, router_input=residual, expert_input=expert_input)
         h2 = self.make_gemma4_rmsnorm(
             f"layers.{layer_id}.post_feedforward_layernorm_2", moe_out, layer.post_feedforward_layernorm_2.weight
         )
@@ -584,7 +593,10 @@ class Gemma4MoEModel(Gemma4Model):
         )
         self.layernorm_attrs["skip_input"] = f"{combine_name}/output_0"
 
-    def make_moe(self, layer_id, layer, router_input, expert_input):
+    def make_gemma4_moe(self, layer_id, layer, router_input, expert_input):
+        # Bespoke Gemma4 MoE builder (distinct signature from base Model.make_moe,
+        # which it does not override): the dense+MoE parallel FFN is driven from
+        # make_mlp, so this takes the full layer plus separate router/expert inputs.
         # Router pre-projection (built as explicit nodes) feeds raw logits to the fused
         # MoE/QMoE op; the op runs the experts on `expert_input` and does topk+softmax
         # internally. Returns the MoE op output tensor name.

--- a/src/python/py/models/builders/gemma.py
+++ b/src/python/py/models/builders/gemma.py
@@ -431,3 +431,243 @@ class Gemma4Model(Gemma3Model):
                 shape=["batch_size", "sequence_length", self.hidden_size],
             )
             self.layernorm_attrs[attr] = f"{mul_name}/output_0"
+
+
+class Gemma4MoEModel(Gemma4Model):
+    """Builder for the text decoder of Gemma4 MoE (gemma-4-26B-A4B-it).
+
+    Inherits the entire attention / RoPE / per-layer-KV / layer_scalar stack from
+    the dense `Gemma4Model`. The only structural difference is the FFN: every layer
+    runs a dense MLP AND a top-k expert MoE block in parallel, then sums them:
+
+        residual = hidden                         # after attention + post_attn norm
+        h1 = post_ffn_norm_1(mlp(pre_ffn_norm(residual)))         # dense branch
+        h2 = post_ffn_norm_2(experts(pre_ffn_norm_2(residual)))   # MoE branch
+        h  = post_ffn_norm(h1 + h2)
+        hidden = residual + h
+        hidden *= layer_scalar
+
+    Only `make_mlp` is overridden: the parent's LayerNorm/residual threading (and
+    layer_scalar) then work unchanged, with `make_mlp` producing the combined
+    dense+MoE contribution as the FFN block's `skip_input`.
+    """
+
+    def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
+        # The base MoE init (base.Model) reads num_local_experts / num_experts_per_tok.
+        if not hasattr(config, "num_local_experts"):
+            config.num_local_experts = config.num_experts
+        if not hasattr(config, "num_experts_per_tok"):
+            config.num_experts_per_tok = config.top_k_experts
+        super().__init__(config, io_dtype, onnx_dtype, ep, cache_dir, extra_options)
+
+        # Base __init__ prefers config.moe_intermediate_size for self.intermediate_size
+        # when present. Gemma4 keeps a parallel DENSE MLP alongside the experts, so pin
+        # self.intermediate_size back to the dense size (config.intermediate_size) and
+        # track the expert size separately as moe_intermediate_size.
+        self.intermediate_size = config.intermediate_size
+        self.moe_intermediate_size = config.moe_intermediate_size
+
+        # Gemma4 experts use GeGLU (gelu_pytorch_tanh(gate) * up). This maps to the fused QMoE
+        # op's "geglu" activation with swiglu_fusion=1 (interleaved gate|up), which applies the
+        # gelu-tanh gate on the gate half. HF renormalizes the selected top-k weights to sum to 1.
+        self.moe_attrs["activation_type"] = "geglu"
+        self.moe_attrs["swiglu_fusion"] = 1
+        self.moe_attrs["normalize_routing_weights"] = True
+
+        # MoE layers emit MoE/QMoE ops instead of dense /mlp/ MatMuls for the experts, but
+        # the parallel DENSE mlp is still a normal MatMul path — keep its mixed-precision
+        # overrides. (No pruning needed here, unlike pure-MoE models.)
+
+    def load_weights(self, input_path):
+        # Same text-only remap as the dense model, but the MoE checkpoint is a
+        # `Gemma4ForConditionalGeneration` whose text tower is `Gemma4ForCausalLM`.
+        if self.quant_type is not None or input_path.endswith(".gguf"):
+            return super(Gemma4Model, self).load_weights(input_path)
+
+        import glob
+
+        from safetensors import safe_open
+        from transformers import AutoConfig
+        from transformers.models.gemma4 import Gemma4ForCausalLM
+
+        config = AutoConfig.from_pretrained(
+            self.model_name_or_path, token=self.hf_token, trust_remote_code=self.hf_remote
+        )
+        text_config = config.text_config
+        text_config.num_hidden_layers = self.num_layers
+        text_config.layer_types = text_config.layer_types[: self.num_layers]
+
+        with torch.device("meta"):
+            model = Gemma4ForCausalLM(text_config)
+
+        prefix = "model.language_model."
+        state_dict = {}
+        for shard in sorted(glob.glob(os.path.join(self.model_name_or_path, "*.safetensors"))):
+            with safe_open(shard, framework="pt") as f:
+                for key in f.keys():
+                    if not key.startswith(prefix):
+                        continue
+                    new_key = key[len(prefix) :]
+                    if new_key.startswith("layers."):
+                        if int(new_key.split(".")[1]) >= self.num_layers:
+                            continue
+                    state_dict["model." + new_key] = f.get_tensor(key)
+
+        if getattr(text_config, "tie_word_embeddings", False):
+            state_dict["lm_head.weight"] = state_dict["model.embed_tokens.weight"]
+
+        missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
+        if missing:
+            raise ValueError(f"Missing weights while loading Gemma4 MoE text model: {missing}")
+        if unexpected:
+            raise ValueError(f"Unexpected weights while loading Gemma4 MoE text model: {unexpected}")
+
+        return model
+
+    def make_layer(self, layer_id, layer):
+        # Stash the full layer so make_mlp can reach the router/experts/extra norms
+        # (the parent only passes layer.mlp to make_mlp).
+        self._current_layer = layer
+        super().make_layer(layer_id, layer)
+        self._current_layer = None
+
+    def make_gemma4_rmsnorm(self, name, root_input, weight, with_scale=True):
+        # Standalone Gemma4 RMSNorm (SimplifiedLayerNormalization, fp32 accumulation)
+        # on a [B, S, H] tensor. `weight` is the HF parameter (or None if scaleless).
+        weight_name = f"model.{name}.weight"
+        if with_scale:
+            self.make_initializer(weight + self.layernorm_attrs["add_offset"], weight_name, to=self.io_dtype)
+        else:
+            self.make_initializer(torch.ones(self.hidden_size), weight_name, to=self.io_dtype)
+        # Node paths use '/' separators (initializer names keep the '.'-joined form).
+        ln_name = f"/model/{name.replace('.', '/')}/SimplifiedLayerNormalization"
+        output = f"{ln_name}/output_0"
+        self.make_node(
+            "SimplifiedLayerNormalization",
+            inputs=[root_input, weight_name],
+            outputs=[output],
+            name=ln_name,
+            epsilon=self.layernorm_attrs["epsilon"],
+            axis=-1,
+            stash_type=1,
+        )
+        self.make_value(output, self.io_dtype, shape=["batch_size", "sequence_length", self.hidden_size])
+        return output
+
+    def make_mlp(self, layer_id, mlp, root_input):
+        # Build the parallel dense-MLP + MoE FFN. `root_input` is
+        # pre_feedforward_layernorm(residual); the pre-FFN residual itself is carried
+        # in layernorm_attrs["root_input"] (output_3 of the pre-FFN SkipLayerNorm).
+        layer = self._current_layer
+        residual = self.layernorm_attrs["root_input"]
+
+        # --- Dense branch: mlp(root_input) -> post_feedforward_layernorm_1 ---
+        super().make_mlp(layer_id, mlp, root_input)
+        dense_out = self.layernorm_attrs["skip_input"]
+        h1 = self.make_gemma4_rmsnorm(
+            f"layers.{layer_id}.post_feedforward_layernorm_1", dense_out, layer.post_feedforward_layernorm_1.weight
+        )
+
+        # --- MoE branch on the pre-FFN residual ---
+        expert_input = self.make_gemma4_rmsnorm(
+            f"layers.{layer_id}.pre_feedforward_layernorm_2", residual, layer.pre_feedforward_layernorm_2.weight
+        )
+        moe_out = self.make_moe(layer_id, layer, router_input=residual, expert_input=expert_input)
+        h2 = self.make_gemma4_rmsnorm(
+            f"layers.{layer_id}.post_feedforward_layernorm_2", moe_out, layer.post_feedforward_layernorm_2.weight
+        )
+
+        # --- Combine dense + MoE; the sum is the FFN block contribution ---
+        combine_name = f"/model/layers.{layer_id}/ffn_combine/Add"
+        self.make_add(
+            combine_name, [h1, h2], dtype=self.io_dtype, shape=["batch_size", "sequence_length", self.hidden_size]
+        )
+        self.layernorm_attrs["skip_input"] = f"{combine_name}/output_0"
+
+    def make_moe(self, layer_id, layer, router_input, expert_input):
+        # Router pre-projection (built as explicit nodes) feeds raw logits to the fused
+        # MoE/QMoE op; the op runs the experts on `expert_input` and does topk+softmax
+        # internally. Returns the MoE op output tensor name.
+        basename = f"/model/layers.{layer_id}/moe"
+        op_type = self.moe_attrs["moe_op_type"]
+        num_experts = self.moe_attrs["num_experts"]
+        router = layer.router
+
+        # scaleless RMSNorm(router_input) * router.scale * hidden^-0.5
+        router_norm = self.make_gemma4_rmsnorm(
+            f"layers.{layer_id}.moe.router.norm", router_input, None, with_scale=False
+        )
+        scale_vec = router.scale * (self.hidden_size**-0.5)
+        scale_name = f"model.layers.{layer_id}.moe.router.scale"
+        self.make_initializer(scale_vec, scale_name, to=self.io_dtype)
+        scale_mul_name = f"{basename}/router/scale/Mul"
+        self.make_mul(
+            scale_mul_name,
+            [router_norm, scale_name],
+            dtype=self.io_dtype,
+            shape=["batch_size", "sequence_length", self.hidden_size],
+        )
+
+        # Router projection -> logits, reshaped to [tokens, num_experts]
+        router_matmul_name = self.make_matmul(router.proj, f"{basename}/router/MatMul", f"{scale_mul_name}/output_0")
+        router_reshape_name = f"{basename}/router/Reshape"
+        self.make_reshape(
+            router_reshape_name,
+            [f"{router_matmul_name}/output_0", f"/model/constants/INT64/{[-1, num_experts]}"],
+            dtype=self.io_dtype,
+            shape=["batch_size * sequence_length", num_experts],
+        )
+
+        # Expert weights. HF: experts.gate_up_proj [E, 2*inter, hidden] (gate|up concat),
+        # experts.down_proj [E, hidden, inter]. Fold per_expert_scale into down_proj (a pure
+        # per-expert output constant, exactly equivalent to scaling each expert's output).
+        moe_weight_type = f"{'q' if op_type == 'QMoE' else ''}weight"
+        gate_up_proj_weight = f"model.layers.{layer_id}.moe.experts.gate_up_proj.{moe_weight_type}"
+        gate_up_proj_scales = f"model.layers.{layer_id}.moe.experts.gate_up_proj.scales"
+        gate_up_proj_bias = f"model.layers.{layer_id}.moe.experts.gate_up_proj.bias"
+        down_proj_weight = f"model.layers.{layer_id}.moe.experts.down_proj.{moe_weight_type}"
+        down_proj_scales = f"model.layers.{layer_id}.moe.experts.down_proj.scales"
+        down_proj_bias = f"model.layers.{layer_id}.moe.experts.down_proj.bias"
+
+        raw_gate_up = layer.experts.gate_up_proj
+        half = raw_gate_up.shape[1] // 2
+        # Interleave [gate|up] -> [g0,u0,g1,u1,...] for swiglu_fusion=1.
+        interleaved = torch.stack([raw_gate_up[:, :half, :], raw_gate_up[:, half:, :]], dim=2).reshape_as(raw_gate_up)
+        down_scaled = layer.experts.down_proj * layer.router.per_expert_scale.reshape(-1, 1, 1)
+
+        if op_type == "MoE":
+            self.make_initializer(interleaved, gate_up_proj_weight, to=self.io_dtype)
+            self.make_initializer(down_scaled, down_proj_weight, to=self.io_dtype)
+        else:
+            gate_up_qw, gate_up_sc, down_qw, down_sc = [], [], [], []
+            for i in range(num_experts):
+                qw1, sc1 = self.make_qmoe_weights(interleaved[i])
+                gate_up_qw.append(qw1)
+                gate_up_sc.append(sc1)
+                qw2, sc2 = self.make_qmoe_weights(down_scaled[i])
+                down_qw.append(qw2)
+                down_sc.append(sc2)
+            self.make_initializer(torch.stack(gate_up_qw, dim=0).to(torch.uint8), gate_up_proj_weight)
+            self.make_initializer(torch.stack(down_qw, dim=0).to(torch.uint8), down_proj_weight)
+            self.make_initializer(torch.stack(gate_up_sc, dim=0), gate_up_proj_scales, to=self.io_dtype)
+            self.make_initializer(torch.stack(down_sc, dim=0), down_proj_scales, to=self.io_dtype)
+
+        # Experts have no bias; the op still expects the (empty) bias inputs.
+        self.make_initializer(
+            torch.zeros(num_experts, 2 * self.moe_intermediate_size), gate_up_proj_bias, to=self.io_dtype
+        )
+        self.make_initializer(torch.zeros(num_experts, self.hidden_size), down_proj_bias, to=self.io_dtype)
+
+        moe_name = f"{basename}/{op_type}"
+        self.make_moe_op(
+            moe_name,
+            root_input=expert_input,
+            router_probs=f"{router_reshape_name}/output_0",
+            weight1=gate_up_proj_weight,
+            scales1=gate_up_proj_scales if op_type == "QMoE" else "",
+            bias1=gate_up_proj_bias,
+            weight2=down_proj_weight,
+            scales2=down_proj_scales if op_type == "QMoE" else "",
+            bias2=down_proj_bias,
+        )
+        return f"{moe_name}/output_0"

--- a/test/python/builder/test_qmoe_weights.py
+++ b/test/python/builder/test_qmoe_weights.py
@@ -200,6 +200,8 @@ def _load_builder_cli_module(monkeypatch):
         "ErnieModel",
         "Gemma2Model",
         "Gemma3Model",
+        "Gemma4MoEModel",
+        "Gemma4Model",
         "GemmaModel",
         "GPTOSSModel",
         "GraniteMoEHybridModel",

--- a/test/python/models/test_gemma4_builder.py
+++ b/test/python/models/test_gemma4_builder.py
@@ -1,0 +1,188 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""Unit tests for the Gemma4Model builder (gemma4-12b-it text component).
+
+These exercise the builder's structural deviations from Gemma3 without loading
+weights or running the full pipeline:
+  - RMSNorm uses the weight directly (add_offset == 0), unlike Gemma1/2/3.
+  - Attention scale is 1.0 (Q/K are RMS-normed), not 1/sqrt(head_dim).
+  - Per-layer geometry: sliding layers use head_dim/kv_heads distinct from the
+    full ("global") layers, emitted as concrete KV-cache I/O shapes.
+  - Proportional RoPE on the global layers (partial rotary on the global
+    head_dim with a zero-padded NoPE tail) matches the HF reference.
+  - Local (sliding) RoPE uses the sliding theta on the sliding head_dim.
+
+Run with:
+    python -m pytest test/python/models/test_gemma4_builder.py -v --test_models <any>
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import numpy as np
+import onnx_ir as ir
+import pytest
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src", "python", "py"))
+
+from models.builders.gemma import Gemma4Model
+
+
+# 6-layer synthetic config: 5 sliding + 1 full, mirroring the gemma4 pattern.
+LAYER_TYPES = ["sliding_attention"] * 5 + ["full_attention"] + ["sliding_attention"] * 4
+
+
+def _make_minimal_config(**overrides):
+    layer_types = overrides.pop("layer_types", LAYER_TYPES)
+    cfg = types.SimpleNamespace(
+        architectures=["Gemma4UnifiedForConditionalGeneration"],
+        model_type="gemma4_unified_text",
+        hidden_size=256,
+        num_attention_heads=8,
+        num_key_value_heads=4,          # sliding KV heads
+        num_global_key_value_heads=1,   # full KV heads
+        num_hidden_layers=len(layer_types),
+        intermediate_size=512,
+        vocab_size=128,
+        max_position_embeddings=64,
+        hidden_activation="gelu_pytorch_tanh",
+        head_dim=32,                    # sliding head dim
+        global_head_dim=64,             # full head dim
+        sliding_window=16,
+        rms_norm_eps=1e-6,
+        layer_types=layer_types,
+        attention_k_eq_v=True,
+        final_logit_softcapping=30.0,
+        tie_word_embeddings=True,
+        rope_parameters={
+            "full_attention": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1000000.0,
+                "rope_type": "proportional",
+            },
+            "sliding_attention": {"rope_theta": 10000.0, "rope_type": "default"},
+        },
+        _name_or_path="",
+    )
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _hf_proportional_cos_sin(head_dim, base, partial_rotary_factor, cache_length):
+    """HF _compute_proportional_rope_parameters reference (cos/sin, halved)."""
+    rope_angles = int(partial_rotary_factor * head_dim // 2)
+    inv_freq_rotated = 1.0 / (
+        base ** (torch.arange(0, 2 * rope_angles, 2, dtype=torch.int64).float() / head_dim)
+    )
+    nope_angles = head_dim // 2 - rope_angles
+    if nope_angles > 0:
+        inv_freq = torch.cat((inv_freq_rotated, torch.zeros(nope_angles, dtype=torch.float32)), dim=0)
+    else:
+        inv_freq = inv_freq_rotated
+    t = torch.arange(cache_length, dtype=torch.int64).float()
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos()[:, : head_dim // 2].numpy()
+    sin = emb.sin()[:, : head_dim // 2].numpy()
+    return cos, sin
+
+
+def _hf_default_cos_sin(head_dim, base, cache_length):
+    """HF default RoPE reference (cos/sin, halved)."""
+    inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, dtype=torch.int64).float() / head_dim))
+    t = torch.arange(cache_length, dtype=torch.int64).float()
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos()[:, : head_dim // 2].numpy()
+    sin = emb.sin()[:, : head_dim // 2].numpy()
+    return cos, sin
+
+
+class TestGemma4Model:
+    def _make_model(self, **overrides):
+        cfg = _make_minimal_config(**overrides)
+        return Gemma4Model(
+            cfg,
+            io_dtype=ir.DataType.FLOAT,
+            onnx_dtype=ir.DataType.FLOAT,
+            ep="cpu",
+            cache_dir=None,
+            extra_options={},
+        )
+
+    def test_layernorm_no_offset(self):
+        """Gemma4 RMSNorm uses the weight directly (add_offset == 0)."""
+        m = self._make_model()
+        assert m.layernorm_attrs["add_offset"] == 0
+
+    def test_attention_scale_is_one(self):
+        """Q/K are RMS-normed, so the attention scale is 1.0."""
+        m = self._make_model()
+        assert m.attention_attrs["scale"] == 1.0
+
+    def test_is_local_matches_layer_types(self):
+        """is_local reflects the config's per-layer attention type."""
+        m = self._make_model()
+        for i, lt in enumerate(LAYER_TYPES):
+            assert m.is_local(i) == (lt == "sliding_attention")
+
+    def test_per_layer_kv_cache_shape(self):
+        """Sliding vs full layers emit concrete, distinct KV-cache shapes."""
+        m = self._make_model()
+        template = ["batch_size", m.num_kv_heads, "past_sequence_length", "kv_cache_dim"]
+        sliding = m.make_key_value_cache_shape(0, list(template))
+        full = m.make_key_value_cache_shape(5, list(template))
+        # [batch, kv_heads, seq, head_dim]
+        assert sliding[1] == 4 and sliding[3] == 32
+        assert full[1] == 1 and full[3] == 64
+
+    def test_external_rope_and_position_ids(self):
+        """Partial rotary needs the standalone RotaryEmbedding op + position_ids."""
+        m = self._make_model()
+        assert m.attention_attrs["use_rope_in_attn"] is False
+        assert "position_ids" in m.input_names
+
+    def test_proportional_rope_cache_parity(self):
+        """Global cache matches HF proportional RoPE (partial rotary + NoPE tail)."""
+        m = self._make_model()
+        builder_cos = m.values["cos_cache_global"].const_value.numpy()
+        builder_sin = m.values["sin_cache_global"].const_value.numpy()
+        hf_cos, hf_sin = _hf_proportional_cos_sin(
+            head_dim=64, base=1000000.0, partial_rotary_factor=0.25, cache_length=64
+        )
+        np.testing.assert_allclose(builder_cos, hf_cos, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(builder_sin, hf_sin, rtol=1e-5, atol=1e-5)
+
+    def test_proportional_rope_nope_tail_is_identity(self):
+        """The NoPE tail (zero frequencies) yields cos=1, sin=0 (no rotation)."""
+        m = self._make_model()
+        cos = m.values["cos_cache_global"].const_value.numpy()
+        sin = m.values["sin_cache_global"].const_value.numpy()
+        rope_angles = int(0.25 * 64 // 2)  # = 8
+        assert np.allclose(cos[:, rope_angles:], 1.0)
+        assert np.allclose(sin[:, rope_angles:], 0.0)
+
+    def test_local_rope_cache_parity(self):
+        """Local cache uses the sliding theta (1e4) on the sliding head_dim."""
+        m = self._make_model()
+        builder_cos = m.values["cos_cache_local"].const_value.numpy()
+        builder_sin = m.values["sin_cache_local"].const_value.numpy()
+        hf_cos, hf_sin = _hf_default_cos_sin(head_dim=32, base=10000.0, cache_length=64)
+        np.testing.assert_allclose(builder_cos, hf_cos, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(builder_sin, hf_sin, rtol=1e-5, atol=1e-5)
+
+    def test_global_and_local_caches_differ(self):
+        """Global (proportional, 1e6) and local (default, 1e4) caches must differ."""
+        m = self._make_model()
+        # Compare on the overlapping rotary columns only (local head_dim/2 = 16).
+        gcos = m.values["cos_cache_global"].const_value.numpy()
+        lcos = m.values["cos_cache_local"].const_value.numpy()
+        assert not np.allclose(gcos[:, : lcos.shape[1]], lcos, rtol=1e-3, atol=1e-3)

--- a/test/python/models/test_gemma4_builder.py
+++ b/test/python/models/test_gemma4_builder.py
@@ -27,13 +27,11 @@ import types
 
 import numpy as np
 import onnx_ir as ir
-import pytest
 import torch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src", "python", "py"))
 
 from models.builders.gemma import Gemma4Model
-
 
 # 6-layer synthetic config: 5 sliding + 1 full, mirroring the gemma4 pattern.
 LAYER_TYPES = ["sliding_attention"] * 5 + ["full_attention"] + ["sliding_attention"] * 4
@@ -46,15 +44,15 @@ def _make_minimal_config(**overrides):
         model_type="gemma4_unified_text",
         hidden_size=256,
         num_attention_heads=8,
-        num_key_value_heads=4,          # sliding KV heads
-        num_global_key_value_heads=1,   # full KV heads
+        num_key_value_heads=4,  # sliding KV heads
+        num_global_key_value_heads=1,  # full KV heads
         num_hidden_layers=len(layer_types),
         intermediate_size=512,
         vocab_size=128,
         max_position_embeddings=64,
         hidden_activation="gelu_pytorch_tanh",
-        head_dim=32,                    # sliding head dim
-        global_head_dim=64,             # full head dim
+        head_dim=32,  # sliding head dim
+        global_head_dim=64,  # full head dim
         sliding_window=16,
         rms_norm_eps=1e-6,
         layer_types=layer_types,
@@ -79,9 +77,7 @@ def _make_minimal_config(**overrides):
 def _hf_proportional_cos_sin(head_dim, base, partial_rotary_factor, cache_length):
     """HF _compute_proportional_rope_parameters reference (cos/sin, halved)."""
     rope_angles = int(partial_rotary_factor * head_dim // 2)
-    inv_freq_rotated = 1.0 / (
-        base ** (torch.arange(0, 2 * rope_angles, 2, dtype=torch.int64).float() / head_dim)
-    )
+    inv_freq_rotated = 1.0 / (base ** (torch.arange(0, 2 * rope_angles, 2, dtype=torch.int64).float() / head_dim))
     nope_angles = head_dim // 2 - rope_angles
     if nope_angles > 0:
         inv_freq = torch.cat((inv_freq_rotated, torch.zeros(nope_angles, dtype=torch.float32)), dim=0)

--- a/test/python/models/test_gemma4moe_builder.py
+++ b/test/python/models/test_gemma4moe_builder.py
@@ -1,0 +1,180 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""Unit tests for the Gemma4MoEModel builder (gemma-4-26B-A4B-it text component).
+
+Gemma4MoEModel subclasses the dense Gemma4Model and adds only the MoE FFN, so
+these tests focus on the MoE-specific structure without loading weights:
+  - moe_attrs: experts/top_k mapped from config, QMoE under int4, geglu +
+    swiglu_fusion=1 + normalize_routing_weights (fused-path activation choice).
+  - Each layer builds a parallel dense-MLP + MoE FFN combined by an Add.
+  - The router pre-projection subgraph (scaleless RMSNorm -> scale -> proj) feeds
+    logits to the fused MoE op.
+  - per_expert_scale is folded into the expert down_proj initializer offline.
+
+Run with:
+    python -m pytest test/python/models/test_gemma4moe_builder.py -v --test_models <any>
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import numpy as np
+import onnx_ir as ir
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src", "python", "py"))
+
+from models.builders.gemma import Gemma4MoEModel
+
+LAYER_TYPES = ["sliding_attention", "full_attention"]
+
+
+def _make_minimal_config(**overrides):
+    layer_types = overrides.pop("layer_types", LAYER_TYPES)
+    cfg = types.SimpleNamespace(
+        architectures=["Gemma4ForConditionalGeneration"],
+        model_type="gemma4_text",
+        hidden_size=64,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        num_global_key_value_heads=2,
+        num_hidden_layers=len(layer_types),
+        intermediate_size=128,  # dense MLP intermediate
+        moe_intermediate_size=32,  # MoE expert intermediate
+        num_experts=8,
+        top_k_experts=2,
+        vocab_size=128,
+        max_position_embeddings=128,
+        hidden_activation="gelu_pytorch_tanh",
+        head_dim=16,
+        global_head_dim=32,
+        sliding_window=32,
+        rms_norm_eps=1e-6,
+        layer_types=layer_types,
+        attention_k_eq_v=True,
+        final_logit_softcapping=30.0,
+        tie_word_embeddings=True,
+        enable_moe_block=True,
+        rope_parameters={
+            "full_attention": {"partial_rotary_factor": 0.25, "rope_theta": 1000000.0, "rope_type": "proportional"},
+            "sliding_attention": {"rope_theta": 10000.0, "rope_type": "default"},
+        },
+        _name_or_path="",
+    )
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _make_model(onnx_dtype=ir.DataType.FLOAT, **overrides):
+    return Gemma4MoEModel(
+        _make_minimal_config(**overrides),
+        io_dtype=ir.DataType.FLOAT,
+        onnx_dtype=onnx_dtype,
+        ep="cpu",
+        cache_dir=None,
+        extra_options={},
+    )
+
+
+def _mock_moe_layer(hidden, num_experts, moe_inter, dense_inter):
+    def lin(o, i):
+        return types.SimpleNamespace(weight=torch.randn(o, i), bias=None)
+
+    def ln():
+        return types.SimpleNamespace(weight=torch.randn(hidden))
+
+    return types.SimpleNamespace(
+        router=types.SimpleNamespace(
+            proj=lin(num_experts, hidden),
+            scale=torch.randn(hidden),
+            per_expert_scale=torch.rand(num_experts) + 0.5,
+        ),
+        experts=types.SimpleNamespace(
+            gate_up_proj=torch.randn(num_experts, 2 * moe_inter, hidden),
+            down_proj=torch.randn(num_experts, hidden, moe_inter),
+        ),
+        post_feedforward_layernorm_1=ln(),
+        post_feedforward_layernorm_2=ln(),
+        pre_feedforward_layernorm_2=ln(),
+    ), types.SimpleNamespace(
+        gate_proj=lin(dense_inter, hidden), up_proj=lin(dense_inter, hidden), down_proj=lin(hidden, dense_inter)
+    )
+
+
+class TestGemma4MoEModel:
+    def test_moe_attrs_mapping(self):
+        """num_experts/top_k come from config; activation/fusion/normalize set for fused path."""
+        m = _make_model()
+        assert m.moe_attrs["num_experts"] == 8
+        assert m.moe_attrs["top_k"] == 2
+        assert m.moe_attrs["activation_type"] == "geglu"
+        assert m.moe_attrs["swiglu_fusion"] == 1
+        assert m.moe_attrs["normalize_routing_weights"] is True
+
+    def test_qmoe_under_int4(self):
+        """int4 build selects the fused QMoE op; float build uses MoE."""
+        assert _make_model(onnx_dtype=ir.DataType.INT4).moe_attrs["moe_op_type"] == "QMoE"
+        assert _make_model(onnx_dtype=ir.DataType.FLOAT).moe_attrs["moe_op_type"] == "MoE"
+
+    def test_dense_and_moe_intermediate_sizes(self):
+        """Dense MLP uses intermediate_size; MoE uses moe_intermediate_size."""
+        m = _make_model()
+        assert m.intermediate_size == 128
+        assert m.moe_intermediate_size == 32
+
+    def test_inherits_dense_attention(self):
+        """MoE model inherits the dense Gemma4 attention config (scale 1.0, no offset)."""
+        m = _make_model()
+        assert m.attention_attrs["scale"] == 1.0
+        assert m.layernorm_attrs["add_offset"] == 0
+        assert m.is_local(0) is True and m.is_local(1) is False
+
+    def _build_one_layer(self, m):
+        hidden = m.hidden_size
+        moe_layer, dense_mlp = _mock_moe_layer(
+            hidden, m.moe_attrs["num_experts"], m.moe_intermediate_size, m.intermediate_size
+        )
+        # Seed layernorm_attrs as if the pre-FFN SkipLayerNorm had run.
+        m.make_value("resid", ir.DataType.FLOAT, ["batch_size", "sequence_length", hidden])
+        m.make_value("normed", ir.DataType.FLOAT, ["batch_size", "sequence_length", hidden])
+        m.layernorm_attrs["root_input"] = "resid"
+        m.layernorm_attrs["output_0"] = "normed"
+        m.layernorm_attrs["skip_input"] = "normed"
+        m._current_layer = moe_layer
+        m.make_mlp(0, dense_mlp, "normed")
+        return moe_layer
+
+    def test_parallel_dense_moe_combine(self):
+        """make_mlp builds both branches, a MoE op, and combines them with an Add."""
+        m = _make_model()
+        self._build_one_layer(m)
+        names = {n.name for n in m.model.graph}
+        assert any("/model/layers.0/moe/MoE" in n for n in names)
+        assert any("/model/layers.0/ffn_combine/Add" in n for n in names)
+        assert any("/model/layers.0/moe/router/MatMul" in n for n in names)
+        # The FFN block contribution (skip_input) is the combine output.
+        assert m.layernorm_attrs["skip_input"] == "/model/layers.0/ffn_combine/Add/output_0"
+
+    def test_router_preprojection_subgraph(self):
+        """Router path: scaleless RMSNorm -> * (scale * hidden^-0.5) -> proj -> reshape."""
+        m = _make_model()
+        self._build_one_layer(m)
+        names = {n.name for n in m.model.graph}
+        assert any("moe/router/norm/SimplifiedLayerNormalization" in n for n in names)
+        assert any("moe/router/scale/Mul" in n for n in names)
+        assert any("moe/router/Reshape" in n for n in names)
+
+    def test_per_expert_scale_folded_into_down_proj(self):
+        """down_proj initializer must equal raw_down_proj * per_expert_scale (folded offline)."""
+        m = _make_model()
+        layer = self._build_one_layer(m)
+        expected = (layer.experts.down_proj * layer.router.per_expert_scale.reshape(-1, 1, 1)).numpy()
+        init = m.values["model.layers.0.moe.experts.down_proj.weight"].const_value.numpy()
+        np.testing.assert_allclose(init, expected, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Summary

Adds **model-builder** support for Google's Gemma 4 text models, producing GenAI-compatible ONNX:

- **Dense** `gemma-4-12b-it` (`Gemma4UnifiedForConditionalGeneration`) via a new `Gemma4Model`.
- **MoE** `gemma-4-26B-A4B-it` (`Gemma4ForConditionalGeneration`) via a new `Gemma4MoEModel`, including the parallel dense-MLP-alongside-experts topology and the float (`MoE`) / quantized (`QMoE`) op-type split.

Both inherit from the existing `Gemma3Model` and override only the hooks that differ:
- Per-layer-type nested RoPE parameters (`{"full_attention": {...}, "sliding_attention": {...}}`) instead of the flat `rope_parameters["rope_type"]` form — handled via a `make_rope_init` override.
- Gemma4 keeps a parallel dense MLP alongside the experts, so `intermediate_size` is pinned to the dense size while the expert size is tracked separately as `moe_intermediate_size`.

## Scope / relationship to prior work

This is the **text builder** layer. It complements the already-merged Gemma 4 C++ runtime / multimodal processor. It supersedes the non-functional scaffolding stub in #2088 (which prints "not yet end-to-end functional" and raises `NotImplementedError`) — here the dense and MoE text paths build end-to-end and are unit-tested. See #2062 for the architecture background.

## Tests

- `test/python/models/test_gemma4_builder.py` — dense Gemma4 builder.
- `test/python/models/test_gemma4moe_builder.py` — MoE builder incl. `moe_op_type` (MoE vs QMoE) and dense/expert intermediate-size wiring.

All 16 tests pass locally.

## Follow-ups (separate stacked PRs)

- 2-bit (uint2) QMoE support.
- 4-bit (Quark/AWQ int4) expert generalization.

_Draft: opening for early review while the stacked quantization PRs are prepared._