### PR TITLE
Change sampling tests with low vocab_size to set top_k equal to vocab_size because default top_k exceeds vocab_size

### DIFF
--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -667,8 +667,6 @@ void Generator::InitializeSamplingMethod(const GeneratorParams& params) {
       throw std::runtime_error("top_p must be between 0.0 and 1.0");
     if (search.top_k < 0)
       throw std::runtime_error("top_k must be 0 or greater");
-    if (search.top_k > params.config.model.vocab_size)
-      throw std::runtime_error("top_k (" + std::to_string(search.top_k) + ") must be less than or equal to vocab_size (" + std::to_string(params.config.model.vocab_size) + ")");
     if (search.top_p > 0.0f && search.top_p < 1.0f && search.top_k > 1) {
       sampling_method_ = SamplingMethod::kTopKTopP;
     } else if (search.top_k > 1) {

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -667,6 +667,8 @@ void Generator::InitializeSamplingMethod(const GeneratorParams& params) {
       throw std::runtime_error("top_p must be between 0.0 and 1.0");
     if (search.top_k < 0)
       throw std::runtime_error("top_k must be 0 or greater");
+    if (search.top_k > params.config.model.vocab_size)
+      throw std::runtime_error("top_k (" + std::to_string(search.top_k) + ") must be less than or equal to vocab_size (" + std::to_string(params.config.model.vocab_size) + ")");
     if (search.top_p > 0.0f && search.top_p < 1.0f && search.top_k > 1) {
       sampling_method_ = SamplingMethod::kTopKTopP;
     } else if (search.top_k > 1) {

--- a/test/sampling_tests.cpp
+++ b/test/sampling_tests.cpp
@@ -823,6 +823,9 @@ TEST(SamplingTests, BatchedSamplingTopPNvTensorRtRtx) {
                                    0.1f, 0.1f, 0.1f, 0.1f, 0.6f};
 
   setup.params->SetSearchOption("top_p", 0.25f);
+  // top_k defaults to 50, which exceeds this test's overlaid vocab_size and is rejected as an
+  // invalid request. Set top_k = vocab_size to express "consider all tokens" for pure top-p.
+  setup.params->SetSearchOption("top_k", vocab_size);
 
   auto generator = OgaGenerator::Create(*setup.model, *setup.params);
   generator->SetLogits(*OgaTensor::Create(logits_cpu.data(), std::array<int64_t, 2>{batch_size, vocab_size}));
@@ -901,6 +904,9 @@ TEST(SamplingTests, RandomizedSamplingTopPNvTensorRtRtx) {
   }
 
   setup.params->SetSearchOption("top_p", p);
+  // top_k defaults to 50, which exceeds this test's overlaid vocab_size and is rejected as an
+  // invalid request. Set top_k = vocab_size to express "consider all tokens" for pure top-p.
+  setup.params->SetSearchOption("top_k", vocab_size);
 
   std::random_device rd;
   std::mt19937 engine(rd());


### PR DESCRIPTION
## Set top_k to vocab_size in pure top-p tests

Two pure top-p tests failed at generator creation:

```
C++ exception with description "top_k (50) must be less than or equal to vocab_size (5)" // BatchedSamplingTopP 
C++ exception with description "top_k (50) must be less than or equal to vocab_size (21)" // RandomizedSamplingTopP
```


Both overlay a tiny vocabulary (5 and 21 tokens) but leave `top_k` at its default
of 50, so `Generator::InitializeSamplingMethod` rejected the request before
sampling ever ran. Neither test intends any top-k truncation; both exercise the
pure top-p path.

Fix: set `top_k = vocab_size` in the two tests, which expresses "consider all
tokens" without tripping the validation. No product code changes.
