### PR TITLE
Verify speculative drafts in dynamic Engine steps

### DIFF
--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -50,12 +50,11 @@ class CompositeCacheStepReservation final : public CacheStepReservation {
       if (fixed_state_pool) {
         // Fixed and paged track the same per-request cache-slot boundary: the fixed target_tokens
         // mirror the paged target so both commit at one token boundary. The pool infers resident
-        // vs. new ownership itself, so no newly_admitted flag is passed. capture_count stays 0
-        // until MTP scheduling requests compact state_update captures, so no step currently
-        // reaches FixedStateReservation::CommitPrefix.
+        // vs. new ownership itself, so no newly_admitted flag is passed.
         fixed_requests.push_back(FixedStateReservationRequest{
             entry.request_id,
             entry.target_cache_slots,
+          entry.draft_token_count,
         });
       }
       if (entry.newly_admitted) {
@@ -75,6 +74,10 @@ class CompositeCacheStepReservation final : public CacheStepReservation {
 
   PagedCacheReservation* PagedReservation() override {
     return &*paged_reservation_;
+  }
+
+  FixedStateReservation* FixedReservation() override {
+    return fixed_reservation_ ? &*fixed_reservation_ : nullptr;
   }
 
   std::span<const FixedStateSlotHandle> FixedStateSlots() const override {
@@ -500,12 +503,19 @@ StepPlanningResult PagedCacheManager::PlanStepResources(StepPlan& plan) const {
     throw StepPlanningConsistencyError(
         "Paged planning selected more admissions than fixed state can reserve.");
   }
-
+  const bool capture_state_updates = std::any_of(
+      plan.requests.begin(), plan.requests.end(),
+      [](const RequestStepPlan& entry) { return entry.draft_token_count != 0; });
+  if (capture_state_updates && !fixed_state_pool_->SupportsStateUpdates()) {
+    throw std::logic_error(
+        "Planned draft verification on a model whose fixed state declares no compact updates.");
+  }
   plan.fixed_state = FixedStateResourcePlan{
       true,
       plan.requests.size(),
       new_slot_count,
-      fixed_state_pool_->PlannedStagingBytes(plan.requests.size()),
+      fixed_state_pool_->PlannedStagingBytes(
+          plan.requests.size(), capture_state_updates),
   };
   return result;
 }

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -54,7 +54,7 @@ class CompositeCacheStepReservation final : public CacheStepReservation {
         fixed_requests.push_back(FixedStateReservationRequest{
             entry.request_id,
             entry.target_cache_slots,
-          entry.draft_token_count,
+            entry.draft_token_count,
         });
       }
       if (entry.newly_admitted) {

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -98,6 +98,20 @@ class CompositeCacheStepReservation final : public CacheStepReservation {
     return fixed_reservation_ ? fixed_reservation_->NewSlotCount() : 0;
   }
 
+  void CommitPrefix(size_t row, const void* request_id,
+                    size_t step_tokens, size_t kept_tokens) override {
+    if (prepared_ || committed_) {
+      throw std::logic_error(
+          "Composite cache step reservation no longer accepts prefix commits.");
+    }
+    // Fixed first: it is the only one of the two that can reject the request (no checkpoints, or a
+    // step longer than the checkpoint window), so the paged boundary is never lowered on its own.
+    if (fixed_reservation_) {
+      fixed_reservation_->CommitPrefix(row, step_tokens, kept_tokens);
+    }
+    paged_reservation_->CommitPrefix(request_id, step_tokens, kept_tokens);
+  }
+
   void ValidateCommit() const override {
     if (committed_) {
       throw std::logic_error(
@@ -438,6 +452,20 @@ void PagedCacheManager::Deallocate(std::vector<std::shared_ptr<Request>>& reques
 }
 
 bool PagedCacheManager::SupportsDynamicBatching() const { return true; }
+
+size_t PagedCacheManager::MaxDraftTokensPerStep() const {
+  // Recurrent state can only be replayed through the compact transitions the operators captured.
+  // Without fixed state the paged KV boundary alone decides, and any tail slot can be left
+  // uncommitted.
+  size_t limit = kMaxDraftTokensPerStep;
+  if (fixed_state_pool_) {
+    limit = std::min(limit, fixed_state_pool_->StateUpdateCapacity());
+  }
+  if (const size_t query_cap = MaxQueryTokensPerRequest(); query_cap != 0) {
+    limit = std::min(limit, query_cap - 1);
+  }
+  return limit;
+}
 
 std::vector<std::shared_ptr<Request>> PagedCacheManager::AllocatedRequests() const {
   return cache_allocated_requests_;

--- a/src/engine/cache_manager.h
+++ b/src/engine/cache_manager.h
@@ -18,6 +18,7 @@ struct CacheStepReservation {
   virtual PagedCacheReservation* PagedReservation() { return nullptr; }
   // Fixed decoder-state resources this reservation owns, in scheduled request row order. Empty for
   // a paged-only reservation.
+  virtual FixedStateReservation* FixedReservation() { return nullptr; }
   virtual std::span<const FixedStateSlotHandle> FixedStateSlots() const { return {}; }
   virtual std::span<const FixedStateBinding> FixedStateBindings() const { return {}; }
   virtual size_t FixedStateStagingBytes() const { return 0; }

--- a/src/engine/cache_manager.h
+++ b/src/engine/cache_manager.h
@@ -26,6 +26,13 @@ struct CacheStepReservation {
   // Validate every ownership and capacity precondition of the whole reservation without publishing
   // or performing device work. PrepareCommit additionally performs all fallible device work (fixed
   // staging into inactive banks) so the subsequent Commit() crosses the boundary without retry.
+  // Narrows one scheduled row's step to the accepted prefix of a speculative verify, moving the
+  // paged KV boundary and the fixed decoder state to the same token together. Must be called
+  // before PrepareCommit.
+  virtual void CommitPrefix(size_t /*row*/, const void* /*request_id*/,
+                            size_t /*step_tokens*/, size_t /*kept_tokens*/) {
+    throw std::logic_error("Cache step reservation cannot commit a partial step.");
+  }
   virtual void ValidateCommit() const {}
   virtual void PrepareCommit() { ValidateCommit(); }
   virtual void Commit() = 0;
@@ -81,6 +88,11 @@ struct CacheManager {
   // Maximum query tokens one request can contribute to a step, or 0 when the cache imposes no
   // per-request limit. Sliding-window rings use this to prevent a step from overwriting live KV.
   virtual size_t MaxQueryTokensPerRequest() const { return 0; }
+
+  // Speculative draft tokens one request may attach to a decode step, or 0 when this cache cannot
+  // roll a rejected draft back. A verify step runs 1 + drafts tokens, so a model with recurrent
+  // state is capped by its checkpoint window.
+  virtual size_t MaxDraftTokensPerStep() const { return 0; }
 
   // Immutable snapshot of the cache's block accounting for invariant validation and state
   // inspection. Caches that do not use paged blocks return an empty snapshot.
@@ -167,6 +179,8 @@ struct PagedCacheManager : CacheManager {
   size_t MaxQueryTokensPerRequest() const override {
     return key_value_cache_->MaxQueryTokensPerRequest();
   }
+
+  size_t MaxDraftTokensPerStep() const override;
 
   PagedCacheSnapshot Snapshot() const override { return key_value_cache_->Snapshot(); }
 

--- a/src/engine/decode_first_scheduler_policy.cpp
+++ b/src/engine/decode_first_scheduler_policy.cpp
@@ -45,6 +45,16 @@ std::vector<size_t> AllocateDecodeFirstTokenBudget(
     const auto& candidate = selected_candidates[i];
     if (candidate.pending_token_count == 0)
       throw std::invalid_argument("A scheduling candidate must have pending tokens.");
+    if (candidate.is_prefill)
+      continue;
+
+    const size_t additional_tokens =
+        std::min(candidate.decode_extra_token_count, remaining_budget);
+    token_counts[i] += additional_tokens;
+    remaining_budget -= additional_tokens;
+  }
+  for (size_t i = 0; i < selected_candidates.size(); ++i) {
+    const auto& candidate = selected_candidates[i];
     if (!candidate.is_prefill)
       continue;
 

--- a/src/engine/decode_first_scheduler_policy.h
+++ b/src/engine/decode_first_scheduler_policy.h
@@ -15,6 +15,7 @@ struct DecodeFirstBudgetCandidate {
   bool is_prefill{};
   size_t pending_token_count{};
   std::optional<size_t> prefill_token_cap;
+    size_t decode_extra_token_count{};
 };
 
 std::vector<size_t> DecodeFirstCandidateOrder(

--- a/src/engine/decode_first_scheduler_policy.h
+++ b/src/engine/decode_first_scheduler_policy.h
@@ -15,7 +15,7 @@ struct DecodeFirstBudgetCandidate {
   bool is_prefill{};
   size_t pending_token_count{};
   std::optional<size_t> prefill_token_cap;
-    size_t decode_extra_token_count{};
+  size_t decode_extra_token_count{};
 };
 
 std::vector<size_t> DecodeFirstCandidateOrder(

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -261,7 +261,9 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
     // The operator writes token j at past_sequence_lengths[i] + j. The processed cursor is the
     // number of tokens already in the cache and therefore the base position for this step.
     const int64_t processed_sequence_length = request->ProcessedSequenceLength();
-    if (entry && (request->CurrentSequenceLength() != entry->sequence_length_before ||
+    if (entry && (request->CurrentSequenceLength() !=
+                      entry->sequence_length_before +
+                          static_cast<int64_t>(entry->draft_token_count) ||
                   SlotsAfterStep(processed_sequence_length, entry->unprocessed_token_count) !=
                       entry->target_cache_slots)) {
       throw std::runtime_error("Step plan processed sequence length does not match the request.");
@@ -436,7 +438,10 @@ void VarlenDecoderIO::PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, Sc
 }
 
 std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {
-  std::vector<size_t> valid_token_indices(scheduled_requests_.size());
+  // One row per request, plus the extra rows a speculative step needs to verify its drafts: the
+  // request's whole packed range ends with the row that predicts the token after the last draft.
+  std::vector<size_t> valid_token_indices;
+  valid_token_indices.reserve(scheduled_requests_.size());
   if (logits_are_per_token_) {
     if (plan_) {
       const auto& plan = *plan_;
@@ -447,17 +452,29 @@ std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {
         if (plan.requests[i].request != scheduled_requests_[i]) {
           throw std::runtime_error("Step plan order does not match logits batch order.");
         }
-        valid_token_indices[i] = plan.requests[i].logits_row_index;
+        const auto& entry = plan.requests[i];
+        for (size_t draft = entry.draft_token_count; draft > 0; --draft) {
+          valid_token_indices.push_back(entry.logits_row_index - draft);
+        }
+        valid_token_indices.push_back(entry.logits_row_index);
       }
     } else {
       for (size_t i = 0, running_length = 0; i < scheduled_requests_.size(); ++i) {
-        valid_token_indices[i] = running_length + scheduled_requests_[i]->ScheduledTokenCount() - 1;
+        valid_token_indices.push_back(running_length + scheduled_requests_[i]->ScheduledTokenCount() - 1);
         running_length += scheduled_requests_[i]->ScheduledTokenCount();
       }
     }
   } else {
+    const auto* plan = plan_;
+    if (plan && std::any_of(plan->requests.begin(), plan->requests.end(),
+                            [](const RequestStepPlan& entry) {
+                              return entry.draft_token_count != 0;
+                            })) {
+      throw std::runtime_error(
+          "Verifying draft tokens requires a model whose logits have one row per token.");
+    }
     for (size_t i = 0; i < scheduled_requests_.size(); ++i) {
-      valid_token_indices[i] = i;
+      valid_token_indices.push_back(i);
     }
   }
 
@@ -474,7 +491,7 @@ std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {
   }
 
   std::vector<DeviceSpan<float>> logits_vector;
-  const std::vector<int64_t> logits_shape{static_cast<int64_t>(scheduled_requests_.size()),
+  const std::vector<int64_t> logits_shape{static_cast<int64_t>(valid_token_indices.size()),
                                           vocab_size};
 
   const bool requires_cast = active_logits_->GetType() != Ort::TypeToTensorType<float>;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -576,7 +576,8 @@ bool Engine::HasPendingRequests() const {
 }
 
 size_t Engine::MaxDraftTokensPerStep() const {
-  return cache_manager_->SupportsDynamicBatching()
+  return cache_manager_->SupportsDynamicBatching() &&
+                 model_executor_->SupportsDraftVerification()
              ? cache_manager_->MaxDraftTokensPerStep()
              : 0;
 }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -444,6 +444,18 @@ std::shared_ptr<Request> Engine::StepDynamic() {
       // counters, host token mirrors, and completion status still remain unchanged in this phase.
       scheduled_requests.GenerateNextTokensForTransaction(
           step_plan_, step_results_);
+      // A verify step planned cache slots for every draft. Narrow the reservation to the accepted
+      // prefix before anything is staged, so the paged and fixed states commit at one boundary.
+      for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
+        const auto& entry = step_plan_.requests[i];
+        if (entry.draft_token_count == 0) {
+          continue;
+        }
+        reservation->CommitPrefix(
+            i, entry.request_id, entry.unprocessed_token_count,
+            entry.unprocessed_token_count - entry.draft_token_count +
+                entry.request->AcceptedDraftTokenCount());
+      }
       staged_ready_requests_.clear();
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         auto& request = step_plan_.requests[i].request;
@@ -561,6 +573,12 @@ std::shared_ptr<Request> Engine::DrainReadyRequest() {
 bool Engine::HasPendingRequests() const {
   return ready_request_index_ < ready_requests_.size() ||
          scheduler_->HasPendingRequests();
+}
+
+size_t Engine::MaxDraftTokensPerStep() const {
+  return cache_manager_->SupportsDynamicBatching()
+             ? cache_manager_->MaxDraftTokensPerStep()
+             : 0;
 }
 
 }  // namespace Generators

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -118,6 +118,12 @@ struct Engine : std::enable_shared_from_this<Engine>,
    */
   bool HasPendingRequests() const;
 
+  /**
+   * @brief Speculative draft tokens a request may attach to one decode step.
+   * @return Zero when this Engine cannot roll a rejected draft back.
+   */
+  size_t MaxDraftTokensPerStep() const;
+
  private:
   void ReclaimAbandonedRequests();
   std::shared_ptr<Request> DrainReadyRequest();

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -120,7 +120,7 @@ struct Engine : std::enable_shared_from_this<Engine>,
 
   /**
    * @brief Speculative draft tokens a request may attach to one decode step.
-   * @return Zero when this Engine cannot roll a rejected draft back.
+    * @return Zero when this Engine cannot verify and roll back draft tokens.
    */
   size_t MaxDraftTokensPerStep() const;
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -120,7 +120,7 @@ struct Engine : std::enable_shared_from_this<Engine>,
 
   /**
    * @brief Speculative draft tokens a request may attach to one decode step.
-    * @return Zero when this Engine cannot verify and roll back draft tokens.
+   * @return Zero when this Engine cannot verify and roll back draft tokens.
    */
   size_t MaxDraftTokensPerStep() const;
 

--- a/src/engine/fixed_state_pool.h
+++ b/src/engine/fixed_state_pool.h
@@ -139,6 +139,10 @@ class FixedStateReservation {
   bool CapturesStateUpdates() const;
   // True when model inputs and outputs view the active and inactive persistent banks directly.
   bool UsesDirectBindings() const;
+
+  // Commits only the first `kept_tokens` of the `step_tokens` this row's request contributed,
+  // by replaying the captured compact updates through the accepted transition and lowering the
+  // row's committed token boundary by the rejected tokens. Must be called before PrepareCommit.
   void CommitPrefix(size_t row, size_t step_tokens, size_t kept_tokens);
 
   // Commit is split into three phases so a composite Engine transaction can validate and stage all

--- a/src/engine/model_executor.cpp
+++ b/src/engine/model_executor.cpp
@@ -70,4 +70,13 @@ void DecoderModelExecutor::Decode(ScheduledRequests& scheduled_requests,
   }
 }
 
+bool DecoderModelExecutor::SupportsDraftVerification() const {
+  const auto logits_symbolic_shape =
+      model_->session_info_.GetOutputSymbolicShape(
+          model_->config_->model.decoder.outputs.logits);
+  return logits_symbolic_shape.empty() ||
+         logits_symbolic_shape[0] == nullptr ||
+         std::string_view(logits_symbolic_shape[0]) != "batch_size";
+}
+
 }  // namespace Generators

--- a/src/engine/model_executor.h
+++ b/src/engine/model_executor.h
@@ -52,6 +52,8 @@ struct ModelExecutor {
   virtual void Decode(ScheduledRequests& scheduled_requests,
                       ExecutionContext& context) = 0;
 
+  virtual bool SupportsDraftVerification() const { return false; }
+
   virtual ~ModelExecutor() = default;
 };
 
@@ -70,6 +72,8 @@ struct DecoderModelExecutor : ModelExecutor {
 
   void Decode(ScheduledRequests& scheduled_requests,
               ExecutionContext& context) override;
+
+  bool SupportsDraftVerification() const override;
 
  private:
   std::shared_ptr<Model> model_;

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -460,8 +460,8 @@ void PagedCacheReservation::FillWindowBlockTable(
 }
 
 void PagedCacheReservation::CommitPrefix(const void* request_id,
-                                        size_t step_slots,
-                                        size_t kept_slots) {
+                                         size_t step_slots,
+                                         size_t kept_slots) {
   if (state_ != PagedCacheReservationState::Reserved) {
     throw std::logic_error("Paged cache reservation is no longer accepting prefix commits.");
   }

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -459,11 +459,33 @@ void PagedCacheReservation::FillWindowBlockTable(
   }
 }
 
+void PagedCacheReservation::CommitPrefix(const void* request_id,
+                                        size_t step_slots,
+                                        size_t kept_slots) {
+  if (state_ != PagedCacheReservationState::Reserved) {
+    throw std::logic_error("Paged cache reservation is no longer accepting prefix commits.");
+  }
+  const auto delta = std::find_if(deltas_.begin(), deltas_.end(),
+                                  [request_id](const PagedCacheReservationDelta& candidate) {
+                                    return candidate.request_id == request_id;
+                                  });
+  if (delta == deltas_.end()) {
+    throw std::runtime_error("Request is not part of the paged cache reservation.");
+  }
+  if (kept_slots == 0 || kept_slots > step_slots ||
+      step_slots != delta->target_slots - delta->committed_slots) {
+    throw std::runtime_error(
+        "Paged cache prefix commit must keep between one and step_slots of the slots this step "
+        "planned.");
+  }
+
+  delta->target_slots = delta->committed_slots + kept_slots;
+}
+
 void PagedCacheReservation::Commit() {
   ValidateCommit();
   CommitValidated();
 }
-
 void PagedCacheReservation::ValidateCommit() const {
   if (state_ != PagedCacheReservationState::Reserved) {
     throw std::logic_error("Paged cache reservation can only be committed once.");

--- a/src/engine/paged_cache_reservation.h
+++ b/src/engine/paged_cache_reservation.h
@@ -129,6 +129,11 @@ class PagedCacheReservation {
   void FillWindowBlockTable(std::span<const void* const> request_ids,
                             size_t columns,
                             std::span<int32_t> output) const;
+  // Commits only the first `kept_slots` of the `step_slots` this request's step planned, leaving
+  // the rejected tail slots reserved-but-unwritten inside the blocks the request already owns. The
+  // speculative counterpart of FixedStateReservation::CommitPrefix; both have to be called with the
+  // same accepted prefix so the two states commit at one token boundary.
+  void CommitPrefix(const void* request_id, size_t step_slots, size_t kept_slots);
   // Validates every precondition this reservation's own CommitValidated relies on, without
   // mutating any state. For a reservation that still satisfies the publish contract it is the only
   // part of committing expected to fail under the Engine's serialized transaction contract.

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -269,6 +269,9 @@ void Request::SetDraftTokens(std::span<const int32_t> tokens) {
   if (tokens.empty()) {
     return;
   }
+  if (guidance_logits_processor_) {
+    throw std::runtime_error("Speculative draft tokens are not supported with guidance.");
+  }
 
   const auto& search = params_->search;
   // Verification compares the target model's argmax against each draft, which only reproduces the

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -254,8 +254,100 @@ int64_t Request::CurrentSequenceLength() const {
   return search_->GetSequenceLength();
 }
 
+int64_t Request::CommittedSequenceLength() const {
+  return CurrentSequenceLength() - static_cast<int64_t>(staged_draft_count_);
+}
+
+void Request::SetDraftTokens(std::span<const int32_t> tokens) {
+  if (staged_draft_count_ != 0) {
+    throw std::runtime_error("Cannot replace draft tokens while a step is in flight.");
+  }
+  if (IsClosed(status_)) {
+    throw std::runtime_error("Cannot propose draft tokens for a closed request.");
+  }
+  draft_tokens_.clear();
+  if (tokens.empty()) {
+    return;
+  }
+
+  const auto& search = params_->search;
+  // Verification compares the target model's argmax against each draft, which only reproduces the
+  // request's own token stream when that stream is greedy.
+  if (search.do_sample && search.top_k != 1 && search.temperature != 0) {
+    throw std::runtime_error("Speculative draft tokens require a greedy request.");
+  }
+  // The draft rows are read before any logits processor runs, so a processor that would change a
+  // row's argmax has to be inactive for every position this step verifies.
+  if (search.repetition_penalty != 1.0f || search.no_repeat_ngram_size > 0 ||
+      search.min_length > CurrentSequenceLength()) {
+    throw std::runtime_error(
+        "Speculative draft tokens require repetition_penalty 1, no_repeat_ngram_size 0, and a "
+        "sequence already past min_length.");
+  }
+  auto engine = engine_.lock();
+  if (!engine) {
+    throw std::runtime_error("Cannot propose draft tokens before the request is added to an engine.");
+  }
+  const size_t max_drafts = engine->MaxDraftTokensPerStep();
+  if (max_drafts == 0) {
+    throw std::runtime_error("This engine cannot roll back a rejected draft token.");
+  }
+  if (tokens.size() > max_drafts) {
+    throw std::runtime_error(
+        "A step accepts at most " + std::to_string(max_drafts) + " draft tokens.");
+  }
+  ValidateAppendLength(*params_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+  if (tokens_host_.capacity() < tokens_host_.size() + tokens.size()) {
+    throw std::logic_error("The request host token mirror does not have reserved draft capacity.");
+  }
+  draft_tokens_.assign(tokens.begin(), tokens.end());
+}
+
+std::span<const int32_t> Request::StagedDraftTokens() const {
+  return std::span<const int32_t>{draft_tokens_}.subspan(0, staged_draft_count_);
+}
+
+void Request::AppendDraftsForTransaction(size_t draft_count) {
+  if (draft_count == 0) {
+    return;
+  }
+  if (staged_draft_count_ != 0 || draft_count > draft_tokens_.size()) {
+    throw std::logic_error("The step staged more draft tokens than the request proposed.");
+  }
+
+  const std::span<const int32_t> drafts{draft_tokens_.data(), draft_count};
+  auto device_tokens = AllocateOnDevice(*params_, drafts);
+  search_->AppendTokens(device_tokens);
+  tokens_host_.insert(tokens_host_.end(), drafts.begin(), drafts.end());
+  staged_draft_count_ = draft_count;
+  accepted_draft_count_ = 0;
+}
+
+void Request::RewindDraftsForTransaction(size_t accepted_count) {
+  if (accepted_count > staged_draft_count_) {
+    throw std::logic_error("The step accepted more draft tokens than it staged.");
+  }
+  const size_t rejected_count = staged_draft_count_ - accepted_count;
+  accepted_draft_count_ = accepted_count;
+  if (rejected_count == 0) {
+    return;
+  }
+
+  staged_draft_count_ = accepted_count;
+  tokens_host_.resize(tokens_host_.size() - rejected_count);
+  search_->RewindTo(static_cast<size_t>(CurrentSequenceLength()) - rejected_count);
+}
+
+void Request::DiscardStagedDrafts() noexcept {
+  if (staged_draft_count_ != 0) {
+    tokens_host_.resize(tokens_host_.size() - staged_draft_count_);
+    staged_draft_count_ = 0;
+  }
+  accepted_draft_count_ = 0;
+}
+
 RequestStateSnapshot Request::Snapshot() const {
-  const int64_t current = CurrentSequenceLength();
+  const int64_t current = CommittedSequenceLength();
   RequestStateSnapshot snapshot;
   snapshot.request_id = this;
   snapshot.status = status_;
@@ -281,7 +373,9 @@ void Request::ScheduleTokens() {
 }
 
 void Request::BindScheduledTokenCount(size_t token_count) {
-  const int64_t remaining = CurrentSequenceLength() - processed_sequence_length_;
+  // A speculative step also sends the drafts the transaction is about to stage onto the sequence.
+  const int64_t remaining = CurrentSequenceLength() - processed_sequence_length_ +
+                            static_cast<int64_t>(draft_tokens_.size() - staged_draft_count_);
   if (remaining <= 0 || token_count == 0 ||
       token_count > static_cast<size_t>(remaining)) {
     throw std::runtime_error(
@@ -417,6 +511,7 @@ RequestStepResult Request::StageGenerationForTransaction(
 void Request::RestoreStateForTransaction() {
   search_->RestoreStateForTransaction();
   rng_ = transaction_rng_;
+  DiscardStagedDrafts();
   if (guidance_transaction_checkpoint_) {
     guidance_logits_processor_ = std::move(guidance_transaction_checkpoint_);
   }
@@ -425,6 +520,7 @@ void Request::RestoreStateForTransaction() {
 void Request::QueueStateRestoreForTransaction() {
   search_->QueueStateRestoreForTransaction();
   rng_ = transaction_rng_;
+  DiscardStagedDrafts();
 }
 
 void Request::CompleteStateRestoreForTransaction() {
@@ -441,15 +537,25 @@ void Request::CommitStateForTransaction() {
 
 void Request::CommitStep(const RequestStepPlan& plan,
                          const RequestStepResult& result) noexcept {
+  // ScheduledRequests reserved every append below before model execution. tokens_host_ retains its
+  // existing max-length reservation, so nothing at this commit boundary allocates.
+  const size_t accepted_drafts = accepted_draft_count_;
+  const size_t first_accepted_index = tokens_host_.size() - accepted_drafts;
+  for (size_t offset = 0; offset < accepted_drafts; ++offset) {
+    unseen_token_indices_.push_back(first_accepted_index + offset);
+  }
   if (result.token_appended) {
-    // ScheduledRequests reserved this append before model execution. tokens_host_ retains its
-    // existing max-length reservation, so neither push allocates at this commit boundary.
     const size_t token_index = tokens_host_.size();
     tokens_host_.push_back(result.token);
     unseen_token_indices_.push_back(token_index);
   }
-  processed_sequence_length_ = static_cast<int64_t>(plan.target_cache_slots);
+  // A verify step reserved cache slots for every draft; the rejected ones were never committed.
+  processed_sequence_length_ =
+      static_cast<int64_t>(plan.target_cache_slots - (plan.draft_token_count - accepted_drafts));
   status_ = result.done ? RequestStatus::TurnComplete : RequestStatus::Active;
+  draft_tokens_.clear();
+  staged_draft_count_ = 0;
+  accepted_draft_count_ = 0;
 }
 
 void Request::ApplyLogitsProcessors(DeviceSpan<float> logits) {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -293,7 +293,7 @@ void Request::SetDraftTokens(std::span<const int32_t> tokens) {
   }
   const size_t max_drafts = engine->MaxDraftTokensPerStep();
   if (max_drafts == 0) {
-    throw std::runtime_error("This engine cannot roll back a rejected draft token.");
+    throw std::runtime_error("This engine does not support speculative draft verification.");
   }
   if (tokens.size() > max_drafts) {
     throw std::runtime_error(
@@ -324,21 +324,41 @@ void Request::AppendDraftsForTransaction(size_t draft_count) {
   tokens_host_.insert(tokens_host_.end(), drafts.begin(), drafts.end());
   staged_draft_count_ = draft_count;
   accepted_draft_count_ = 0;
+  draft_verification_completed_generation_ = false;
 }
 
-void Request::RewindDraftsForTransaction(size_t accepted_count) {
+void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
   if (accepted_count > staged_draft_count_) {
     throw std::logic_error("The step accepted more draft tokens than it staged.");
   }
-  const size_t rejected_count = staged_draft_count_ - accepted_count;
-  accepted_draft_count_ = accepted_count;
-  if (rejected_count == 0) {
-    return;
-  }
+  const size_t proposed_count = staged_draft_count_;
+  const size_t committed_length =
+      static_cast<size_t>(CurrentSequenceLength()) - proposed_count;
+  tokens_host_.resize(tokens_host_.size() - proposed_count);
+  search_->RewindTo(committed_length);
+  staged_draft_count_ = 0;
+  accepted_draft_count_ = 0;
+  draft_verification_completed_generation_ = false;
 
-  staged_draft_count_ = accepted_count;
-  tokens_host_.resize(tokens_host_.size() - rejected_count);
-  search_->RewindTo(static_cast<size_t>(CurrentSequenceLength()) - rejected_count);
+  for (size_t offset = 0; offset < accepted_count; ++offset) {
+    const int32_t token = draft_tokens_[offset];
+    const int64_t sequence_length_before = CurrentSequenceLength();
+    search_->CommitToken(token);
+    const int64_t sequence_length_after = CurrentSequenceLength();
+    if (sequence_length_after == sequence_length_before + 1) {
+      tokens_host_.push_back(token);
+      ++staged_draft_count_;
+      ++accepted_draft_count_;
+    } else if (sequence_length_after != sequence_length_before ||
+               !search_->IsDone()) {
+      throw std::logic_error(
+          "Committing an accepted draft produced an invalid sequence transition.");
+    }
+    if (search_->IsDone()) {
+      draft_verification_completed_generation_ = true;
+      break;
+    }
+  }
 }
 
 void Request::DiscardStagedDrafts() noexcept {
@@ -347,6 +367,7 @@ void Request::DiscardStagedDrafts() noexcept {
     staged_draft_count_ = 0;
   }
   accepted_draft_count_ = 0;
+  draft_verification_completed_generation_ = false;
 }
 
 RequestStateSnapshot Request::Snapshot() const {
@@ -559,6 +580,7 @@ void Request::CommitStep(const RequestStepPlan& plan,
   draft_tokens_.clear();
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
+  draft_verification_completed_generation_ = false;
 }
 
 void Request::ApplyLogitsProcessors(DeviceSpan<float> logits) {

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -169,7 +169,10 @@ struct Request : std::enable_shared_from_this<Request>,
 
   void AppendDraftsForTransaction(size_t draft_count);
   std::span<const int32_t> StagedDraftTokens() const;
-  void RewindDraftsForTransaction(size_t accepted_count);
+  void CommitAcceptedDraftsForTransaction(size_t accepted_count);
+  bool DraftVerificationCompletedGeneration() const noexcept {
+    return draft_verification_completed_generation_;
+  }
 
   void ValidateEngineCompatibility() const;
   void SaveStateForTransaction();
@@ -369,6 +372,7 @@ struct Request : std::enable_shared_from_this<Request>,
   std::vector<int32_t> draft_tokens_;
   size_t staged_draft_count_{};
   size_t accepted_draft_count_{};
+  bool draft_verification_completed_generation_{};
   std::shared_ptr<GeneratorParams> params_;
   std::mt19937 rng_;
   std::mt19937 transaction_rng_;

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -139,6 +139,38 @@ struct Request : std::enable_shared_from_this<Request>,
    */
   void GenerateNextTokens(DeviceSpan<float> logits);
 
+  /**
+   * @brief Proposes speculative draft tokens for this request's next step.
+   * @param tokens Draft continuation of the sequence, in order. An empty span clears the proposal.
+   *
+   * The next decode step then runs 1 + tokens.size() rows, verifies each draft against the target
+   * model's own prediction, and keeps the accepted prefix. Only greedy requests may propose drafts,
+   * because verification compares argmax tokens rather than sampling probabilities.
+   *
+   * The proposal applies to the next step only. A committed step consumes it even when it could not
+   * verify it (a prefill chunk, for one); a rolled back step leaves it pending.
+   */
+  void SetDraftTokens(std::span<const int32_t> tokens);
+
+  /**
+   * @brief Draft tokens proposed for the next step but not yet sent through the model.
+   */
+  size_t PendingDraftTokenCount() const noexcept { return draft_tokens_.size(); }
+
+  /**
+   * @brief Drafts of the step in flight that the target model accepted.
+   */
+  size_t AcceptedDraftTokenCount() const noexcept { return accepted_draft_count_; }
+
+  /**
+   * @brief Sequence length excluding any drafts staged by the step in flight.
+   */
+  int64_t CommittedSequenceLength() const;
+
+  void AppendDraftsForTransaction(size_t draft_count);
+  std::span<const int32_t> StagedDraftTokens() const;
+  void RewindDraftsForTransaction(size_t accepted_count);
+
   void ValidateEngineCompatibility() const;
   void SaveStateForTransaction();
   void SaveStateForExternalSamplingTransaction();
@@ -323,12 +355,20 @@ struct Request : std::enable_shared_from_this<Request>,
   // Runs before a scheduled step can execute. It keeps only useful consumed-prefix storage and
   // reserves every unseen-index append that the step can perform, so CommitStep stays noexcept.
   void PrepareForStep(size_t max_generated_token_indices);
+  // Drops whatever the step in flight staged past the committed sequence, leaving the host mirror
+  // exactly as long as the search after its own transaction rewind.
+  void DiscardStagedDrafts() noexcept;
 
   int64_t processed_sequence_length_{};
   // Sequence length the application's tokens reach up to. Everything below it is prompt, so the
   // request is still prefilling while processed_sequence_length_ has not caught up with it.
   int64_t prompt_sequence_length_{};
   size_t scheduled_token_count_{};
+  // Drafts proposed for the next step, the ones the step in flight staged onto the sequence, and
+  // the leading part of those the target model accepted.
+  std::vector<int32_t> draft_tokens_;
+  size_t staged_draft_count_{};
+  size_t accepted_draft_count_{};
   std::shared_ptr<GeneratorParams> params_;
   std::mt19937 rng_;
   std::mt19937 transaction_rng_;

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -168,7 +168,9 @@ std::vector<DeviceSpan<float>> ScheduledRequests::ProcessLogits() {
 
   std::vector<DeviceSpan<float>> logits = decoder_state_->ProcessLogits();
   if (logits.size() != expected_rows) {
-    throw std::runtime_error("Logits size does not match the number of requests.");
+    throw std::runtime_error(
+        "Logits row count does not match the packed step: expected " +
+        std::to_string(expected_rows) + ", got " + std::to_string(logits.size()) + ".");
   }
 
   return logits;

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -49,6 +49,7 @@ ScheduledRequests::ScheduledRequests(const StepPlan& plan,
                                      BatchedSamplingPlan* sampling_plan)
     : model_{std::move(model)}, batched_sampler_{batched_sampler}, sampling_plan_{sampling_plan} {
   requests_.reserve(plan.requests.size());
+  draft_token_counts_.reserve(plan.requests.size());
   RequestIndex request_ids{plan.requests.size()};
   for (const auto& entry : plan.requests) {
     if (!entry.request || entry.request_id != entry.request.get() ||
@@ -58,9 +59,15 @@ ScheduledRequests::ScheduledRequests(const StepPlan& plan,
     if (!IsExecutable(entry.request->status_)) {
       throw std::runtime_error("The dynamic step plan contains a request that is not executable.");
     }
+    if (entry.draft_token_count > entry.request->PendingDraftTokenCount()) {
+      throw std::runtime_error("The dynamic step plan verifies drafts the request never proposed.");
+    }
+    // A verify step sends the request's last committed token plus every draft, so the drafts the
+    // transaction is about to stage count towards what this step is allowed to schedule.
     const int64_t remaining =
         entry.request->CurrentSequenceLength() -
-        entry.request->ProcessedSequenceLength();
+        entry.request->ProcessedSequenceLength() +
+        static_cast<int64_t>(entry.draft_token_count);
     if (remaining <= 0 || entry.unprocessed_token_count == 0 ||
         entry.unprocessed_token_count > static_cast<size_t>(remaining)) {
       throw std::runtime_error(
@@ -69,19 +76,22 @@ ScheduledRequests::ScheduledRequests(const StepPlan& plan,
   }
   // Complete every potentially allocating output-bookkeeping operation before binding the plan or
   // executing the model. A partial prefill cannot sample, while a chunk-complete single-sequence
-  // request can append at most one generated index.
+  // request can append its accepted drafts plus one generated token.
   for (const auto& entry : plan.requests) {
     const auto remaining =
         static_cast<size_t>(entry.request->CurrentSequenceLength() -
-                            entry.request->ProcessedSequenceLength());
+                            entry.request->ProcessedSequenceLength()) +
+        entry.draft_token_count;
     if (entry.unprocessed_token_count == remaining) {
-      entry.request->PrepareForStep(kMaxGeneratedTokenIndicesPerStep);
+      entry.request->PrepareForStep(kMaxGeneratedTokenIndicesPerStep +
+                                    entry.draft_token_count);
     }
   }
   for (const auto& entry : plan.requests) {
     entry.request->BindScheduledTokenCount(
         entry.unprocessed_token_count);
     requests_.push_back(entry.request);
+    draft_token_counts_.push_back(entry.draft_token_count);
   }
 }
 
@@ -150,12 +160,52 @@ std::vector<DeviceSpan<float>> ScheduledRequests::ProcessLogits() {
     throw std::runtime_error("Cannot process logits without the decoder state.");
   }
 
+  // A verify step gets one row per draft on top of the row that predicts the request's next token.
+  size_t expected_rows = requests_.size();
+  for (size_t draft_count : draft_token_counts_) {
+    expected_rows += draft_count;
+  }
+
   std::vector<DeviceSpan<float>> logits = decoder_state_->ProcessLogits();
-  if (logits.size() != requests_.size()) {
+  if (logits.size() != expected_rows) {
     throw std::runtime_error("Logits size does not match the number of requests.");
   }
 
   return logits;
+}
+
+std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
+    std::vector<DeviceSpan<float>>& verify_rows) {
+  std::vector<DeviceSpan<float>> sampled_rows;
+  sampled_rows.reserve(requests_.size());
+  size_t row = 0;
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    const size_t draft_count =
+        i < draft_token_counts_.size() ? draft_token_counts_[i] : 0;
+    if (draft_count == 0) {
+      sampled_rows.push_back(verify_rows[row++]);
+      continue;
+    }
+
+    // Row j predicts the token at committed_length + j, which is exactly where draft j sits. Accept
+    // the longest prefix of the proposal the target model would have produced on its own; the row
+    // after it holds the token that replaces the first rejected draft, or the bonus token.
+    const auto drafts = requests_[i]->StagedDraftTokens();
+    size_t accepted_count = 0;
+    while (accepted_count < draft_count) {
+      auto row_values = verify_rows[row + accepted_count].CopyDeviceToCpu();
+      const auto predicted = static_cast<int32_t>(
+          std::max_element(row_values.begin(), row_values.end()) - row_values.begin());
+      if (predicted != drafts[accepted_count]) {
+        break;
+      }
+      ++accepted_count;
+    }
+    requests_[i]->RewindDraftsForTransaction(accepted_count);
+    sampled_rows.push_back(verify_rows[row + accepted_count]);
+    row += draft_count + 1;
+  }
+  return sampled_rows;
 }
 
 // Samples all active requests through the scheduler-owned sampler. It owns the reusable workspace
@@ -244,6 +294,11 @@ void ScheduledRequests::BeginTransaction() {
         request->SaveStateForTransaction();
       ++transaction_checkpoint_count_;
     }
+    // Drafts join the sequence only after every checkpoint exists, so an abort rewinds them for
+    // free through the same restore path as a sampled token.
+    for (size_t i = 0; i < draft_token_counts_.size(); ++i) {
+      requests_[i]->AppendDraftsForTransaction(draft_token_counts_[i]);
+    }
     if (transaction_uses_batched_sampler_) {
       batched_sampler_->SaveStateForTransaction(sampling_plan_->states);
       sampler_checkpoint_active_ = true;
@@ -266,7 +321,8 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
     throw std::logic_error("Scheduled request transaction does not match the step plan.");
   }
 
-  auto logits = ProcessLogits();
+  auto verify_rows = ProcessLogits();
+  auto logits = SelectSampledRows(verify_rows);
   results.assign(requests_.size(), RequestStepResult{});
   if (transaction_uses_batched_sampler_) {
     sampling_plan_->logits.clear();

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -178,6 +178,49 @@ std::vector<DeviceSpan<float>> ScheduledRequests::ProcessLogits() {
 
 std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
     std::vector<DeviceSpan<float>>& verify_rows) {
+  if (!sampling_plan_) {
+    throw std::logic_error("Draft verification requires scheduler-owned argmax storage.");
+  }
+  auto& predicted_tokens = sampling_plan_->verification_tokens;
+  predicted_tokens.resize(verify_rows.size());
+
+  bool rows_are_contiguous = !verify_rows.empty();
+  const size_t vocab_size = static_cast<size_t>(model_->config_->model.vocab_size);
+  const float* first_row = rows_are_contiguous
+                               ? verify_rows.front().Span().data()
+                               : nullptr;
+  for (size_t row = 0; row < verify_rows.size() && rows_are_contiguous; ++row) {
+    rows_are_contiguous =
+        verify_rows[row].size() == vocab_size &&
+        verify_rows[row].Span().data() == first_row + row * vocab_size;
+  }
+
+  const bool used_device_argmax =
+      rows_are_contiguous &&
+      model_->p_device_scoring_->ArgMax(
+          first_row, Ort::TypeToTensorType<float>,
+          static_cast<int>(verify_rows.size()),
+          model_->config_->model.vocab_size, predicted_tokens.data());
+  if (!used_device_argmax) {
+    const bool rows_share_buffer =
+        !verify_rows.empty() &&
+        std::all_of(verify_rows.begin() + 1, verify_rows.end(),
+                    [&verify_rows](const DeviceSpan<float>& row) {
+                      return row.SameBufferAs(verify_rows.front());
+                    });
+    if (rows_share_buffer) {
+      verify_rows.front().CopyDeviceToCpu();
+    }
+    for (size_t row = 0; row < verify_rows.size(); ++row) {
+      auto row_values = rows_share_buffer
+                            ? verify_rows[row].CpuSpan()
+                            : verify_rows[row].CopyDeviceToCpu();
+      predicted_tokens[row] = static_cast<int32_t>(
+          std::max_element(row_values.begin(), row_values.end()) -
+          row_values.begin());
+    }
+  }
+
   std::vector<DeviceSpan<float>> sampled_rows;
   sampled_rows.reserve(requests_.size());
   size_t row = 0;
@@ -195,15 +238,12 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
     const auto drafts = requests_[i]->StagedDraftTokens();
     size_t accepted_count = 0;
     while (accepted_count < draft_count) {
-      auto row_values = verify_rows[row + accepted_count].CopyDeviceToCpu();
-      const auto predicted = static_cast<int32_t>(
-          std::max_element(row_values.begin(), row_values.end()) - row_values.begin());
-      if (predicted != drafts[accepted_count]) {
+      if (predicted_tokens[row + accepted_count] != drafts[accepted_count]) {
         break;
       }
       ++accepted_count;
     }
-    requests_[i]->RewindDraftsForTransaction(accepted_count);
+    requests_[i]->CommitAcceptedDraftsForTransaction(accepted_count);
     sampled_rows.push_back(verify_rows[row + accepted_count]);
     row += draft_count + 1;
   }
@@ -328,20 +368,41 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
   results.assign(requests_.size(), RequestStepResult{});
   if (transaction_uses_batched_sampler_) {
     sampling_plan_->logits.clear();
-    size_t sampling_index = 0;
+    const size_t original_sampling_count = sampling_plan_->requests.size();
+    size_t source_sampling_index = 0;
+    size_t active_sampling_count = 0;
     for (size_t i = 0; i < requests_.size(); ++i) {
       if (!requests_[i]->IsChunkComplete())
         continue;
-      if (sampling_index >= sampling_plan_->requests.size() ||
-          sampling_plan_->requests[sampling_index] != requests_[i].get()) {
+      if (source_sampling_index >= original_sampling_count ||
+          sampling_plan_->requests[source_sampling_index] != requests_[i].get()) {
         throw std::logic_error("Batched sampling plan does not match the scheduled requests.");
       }
-      sampling_plan_->logits.push_back(logits[i]);
-      requests_[i]->PrepareGenerationForTransaction(logits[i]);
-      ++sampling_index;
+      if (requests_[i]->DraftVerificationCompletedGeneration()) {
+        results[i].done = true;
+      } else {
+        if (active_sampling_count != source_sampling_index) {
+          sampling_plan_->requests[active_sampling_count] =
+              sampling_plan_->requests[source_sampling_index];
+          sampling_plan_->params[active_sampling_count] =
+              sampling_plan_->params[source_sampling_index];
+          sampling_plan_->states[active_sampling_count] =
+              sampling_plan_->states[source_sampling_index];
+        }
+        sampling_plan_->logits.push_back(logits[i]);
+        requests_[i]->PrepareGenerationForTransaction(logits[i]);
+        ++active_sampling_count;
+      }
+      ++source_sampling_index;
     }
-    if (sampling_index != sampling_plan_->requests.size())
+    if (source_sampling_index != original_sampling_count)
       throw std::logic_error("Batched sampling plan does not match the scheduled requests.");
+    sampling_plan_->requests.resize(active_sampling_count);
+    sampling_plan_->params.resize(active_sampling_count);
+    sampling_plan_->states.resize(active_sampling_count);
+
+    if (active_sampling_count == 0)
+      return;
 
     auto next_tokens = batched_sampler_->Sample(
         sampling_plan_->logits, sampling_plan_->params,
@@ -352,19 +413,21 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
       sampling_plan_->requests[i]->OnNextTokensSampled();
     }
     next_tokens.CopyDeviceToCpu();
-    sampling_index = 0;
     for (size_t i = 0; i < requests_.size(); ++i) {
-      if (!requests_[i]->IsChunkComplete())
+      if (!requests_[i]->IsChunkComplete() ||
+          requests_[i]->DraftVerificationCompletedGeneration())
         continue;
       results[i] = requests_[i]->StageGenerationForTransaction(plan.requests[i]);
-      ++sampling_index;
     }
     return;
   }
 
   for (size_t i = 0; i < requests_.size(); ++i) {
-    if (requests_[i]->IsChunkComplete())
+    if (requests_[i]->DraftVerificationCompletedGeneration()) {
+      results[i].done = true;
+    } else if (requests_[i]->IsChunkComplete()) {
       results[i] = requests_[i]->ApplyLogitsForTransaction(logits[i]);
+    }
   }
 }
 

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -82,8 +82,15 @@ struct ScheduledRequests {
  private:
   bool PrepareBatchedSamplingPlan(bool require_transaction_support);
   bool TryGenerateNextTokensBatched(std::vector<DeviceSpan<float>>& logits);
+  // Verifies each drafted request's proposal against the target model's own rows, rewinds the
+  // rejected tail, and returns the one row per request that the sampler must select from.
+  std::vector<DeviceSpan<float>> SelectSampledRows(
+      std::vector<DeviceSpan<float>>& verify_rows);
 
   std::vector<std::shared_ptr<Request>> requests_;
+  // Drafts the transaction stages onto each request's sequence, in scheduled row order. Empty
+  // outside a dynamic step plan.
+  std::vector<size_t> draft_token_counts_;
   std::shared_ptr<Model> model_;
   std::unique_ptr<DecoderIO> decoder_state_;
   std::unique_ptr<ExecutionContext> execution_context_;

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -11,11 +11,12 @@ namespace Generators {
 struct DecoderIO;
 
 struct BatchedSamplingPlan {
-  void Reserve(size_t capacity) {
+  void Reserve(size_t capacity, size_t verification_capacity) {
     requests.reserve(capacity);
     logits.reserve(capacity);
     params.reserve(capacity);
     states.reserve(capacity);
+    verification_tokens.reserve(verification_capacity);
   }
 
   void Clear() {
@@ -29,6 +30,7 @@ struct BatchedSamplingPlan {
   std::vector<DeviceSpan<float>> logits;
   std::vector<BatchedSamplingParams> params;
   std::vector<BatchedSamplerState*> states;
+  std::vector<int32_t> verification_tokens;
 };
 
 struct ScheduledRequests {

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -298,14 +298,15 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
   plan.graph_capture_eligible = true;
   for (size_t i = 0; i < plan.requests.size(); ++i) {
     auto& entry = plan.requests[i];
+    const size_t scheduling_index = entry.scheduling_order;
     // The budget only distributes committed tokens. A step that stops short of the sequence tail
     // has no row that predicts the first draft, so it cannot verify one.
-    if (token_counts[i] != selected_remaining_lengths[i]) {
+    if (token_counts[scheduling_index] != selected_remaining_lengths[scheduling_index]) {
       entry.draft_token_count = 0;
     }
-    entry.unprocessed_token_count = token_counts[i] + entry.draft_token_count;
+    entry.unprocessed_token_count = token_counts[scheduling_index] + entry.draft_token_count;
     entry.target_cache_slots = RequiredSlots(
-        selected_processed_lengths[i],
+        selected_processed_lengths[scheduling_index],
         entry.unprocessed_token_count);
     entry.packed_token_offset = packed_token_offset;
     entry.logits_row_index =

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -155,13 +155,15 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     RequestStepPlan entry;
     DecodeFirstBudgetCandidate budget;
     size_t processed_sequence_length{};
+    size_t remaining_token_count{};
   };
   const auto allocated_requests = cache_manager_->AllocatedRequests();
   std::vector<Candidate> candidates;
   candidates.reserve(allocated_requests.size() + requests_pool_.size());
   const size_t cache_query_token_cap = cache_manager_->MaxQueryTokensPerRequest();
+  const size_t max_draft_token_count = cache_manager_->MaxDraftTokensPerStep();
 
-  const auto add_candidate = [&candidates, cache_query_token_cap](
+  const auto add_candidate = [&candidates, cache_query_token_cap, max_draft_token_count](
                                  const std::shared_ptr<Request>& request,
                                  bool newly_admitted) {
     const auto snapshot = request->Snapshot();
@@ -183,6 +185,12 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     candidate.entry.request_id = request.get();
     candidate.entry.sequence_length_before = snapshot.current_sequence_length;
     candidate.entry.unprocessed_token_count = 1;
+    // Drafts extend a decode step, which by definition ends at the sequence tail. A prefill chunk
+    // has committed tokens of its own left to push through, so it can never verify one.
+    candidate.entry.draft_token_count =
+        snapshot.is_prefill
+            ? 0
+            : std::min(request->PendingDraftTokenCount(), max_draft_token_count);
     candidate.entry.target_cache_slots = RequiredSlots(
         static_cast<size_t>(snapshot.processed_sequence_length), 1);
     candidate.entry.whole_sequence_cache_slots =
@@ -201,6 +209,7 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     };
     candidate.processed_sequence_length =
         static_cast<size_t>(snapshot.processed_sequence_length);
+    candidate.remaining_token_count = static_cast<size_t>(remaining_token_count);
     candidates.push_back(std::move(candidate));
   };
 
@@ -247,8 +256,10 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
   }
   std::vector<DecodeFirstBudgetCandidate> selected_candidates;
   std::vector<size_t> selected_processed_lengths;
+  std::vector<size_t> selected_remaining_lengths;
   selected_candidates.reserve(plan.requests.size());
   selected_processed_lengths.reserve(plan.requests.size());
+  selected_remaining_lengths.reserve(plan.requests.size());
   for (const auto& entry : plan.requests) {
     const auto candidate_index_value =
         candidate_index.Find(entry.request_id);
@@ -259,6 +270,8 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     selected_candidates.push_back(candidate.budget);
     selected_processed_lengths.push_back(
         candidate.processed_sequence_length);
+    selected_remaining_lengths.push_back(
+      candidate.remaining_token_count);
   }
   std::vector<size_t> token_counts;
   try {
@@ -283,7 +296,17 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
   // used to sample its next token.
   size_t packed_token_offset = 0;
   plan.graph_capture_eligible = true;
-  for (auto& entry : plan.requests) {
+  for (size_t i = 0; i < plan.requests.size(); ++i) {
+    auto& entry = plan.requests[i];
+    // The budget only distributes committed tokens. A step that stops short of the sequence tail
+    // has no row that predicts the first draft, so it cannot verify one.
+    if (token_counts[i] != selected_remaining_lengths[i]) {
+      entry.draft_token_count = 0;
+    }
+    entry.unprocessed_token_count = token_counts[i] + entry.draft_token_count;
+    entry.target_cache_slots = RequiredSlots(
+        selected_processed_lengths[i],
+        entry.unprocessed_token_count);
     entry.packed_token_offset = packed_token_offset;
     entry.logits_row_index =
         packed_token_offset + entry.unprocessed_token_count - 1;

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -198,8 +198,8 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
             : std::min(request->PendingDraftTokenCount(), max_draft_token_count);
     candidate.entry.unprocessed_token_count = 1 + candidate.entry.draft_token_count;
     candidate.entry.target_cache_slots = RequiredSlots(
-      static_cast<size_t>(snapshot.processed_sequence_length),
-      candidate.entry.unprocessed_token_count);
+        static_cast<size_t>(snapshot.processed_sequence_length),
+        candidate.entry.unprocessed_token_count);
     candidate.entry.whole_sequence_cache_slots =
         SlotsForWholeSequence(snapshot.current_sequence_length);
     candidate.entry.is_prefill = snapshot.is_prefill;
@@ -213,7 +213,7 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
         snapshot.is_prefill,
         static_cast<size_t>(remaining_token_count),
         prefill_token_cap,
-      candidate.entry.draft_token_count,
+        candidate.entry.draft_token_count,
     };
     candidate.processed_sequence_length =
         static_cast<size_t>(snapshot.processed_sequence_length);

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -271,7 +271,7 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     selected_processed_lengths.push_back(
         candidate.processed_sequence_length);
     selected_remaining_lengths.push_back(
-      candidate.remaining_token_count);
+        candidate.remaining_token_count);
   }
   std::vector<size_t> token_counts;
   try {

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -19,7 +19,13 @@ Scheduler::Scheduler(std::shared_ptr<Model> model)
   if (engine_config.static_batching)
     max_batch_size = std::max(max_batch_size, engine_config.static_batching->max_batch_size);
 
-  batched_sampling_plan_.Reserve(max_batch_size);
+  size_t max_verification_rows = max_batch_size;
+  if (engine_config.dynamic_batching) {
+    max_verification_rows = std::max(
+        max_verification_rows,
+        engine_config.dynamic_batching->max_scheduled_tokens);
+  }
+  batched_sampling_plan_.Reserve(max_batch_size, max_verification_rows);
   batched_sampler_ = model->p_device_scoring_->CreateBatchedSampler(
       max_batch_size, model->config_->model.vocab_size);
 }
@@ -184,15 +190,16 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     candidate.entry.request = request;
     candidate.entry.request_id = request.get();
     candidate.entry.sequence_length_before = snapshot.current_sequence_length;
-    candidate.entry.unprocessed_token_count = 1;
     // Drafts extend a decode step, which by definition ends at the sequence tail. A prefill chunk
     // has committed tokens of its own left to push through, so it can never verify one.
     candidate.entry.draft_token_count =
         snapshot.is_prefill
             ? 0
             : std::min(request->PendingDraftTokenCount(), max_draft_token_count);
+    candidate.entry.unprocessed_token_count = 1 + candidate.entry.draft_token_count;
     candidate.entry.target_cache_slots = RequiredSlots(
-        static_cast<size_t>(snapshot.processed_sequence_length), 1);
+      static_cast<size_t>(snapshot.processed_sequence_length),
+      candidate.entry.unprocessed_token_count);
     candidate.entry.whole_sequence_cache_slots =
         SlotsForWholeSequence(snapshot.current_sequence_length);
     candidate.entry.is_prefill = snapshot.is_prefill;
@@ -206,6 +213,7 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
         snapshot.is_prefill,
         static_cast<size_t>(remaining_token_count),
         prefill_token_cap,
+      candidate.entry.draft_token_count,
     };
     candidate.processed_sequence_length =
         static_cast<size_t>(snapshot.processed_sequence_length);
@@ -256,10 +264,8 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
   }
   std::vector<DecodeFirstBudgetCandidate> selected_candidates;
   std::vector<size_t> selected_processed_lengths;
-  std::vector<size_t> selected_remaining_lengths;
   selected_candidates.reserve(plan.requests.size());
   selected_processed_lengths.reserve(plan.requests.size());
-  selected_remaining_lengths.reserve(plan.requests.size());
   for (const auto& entry : plan.requests) {
     const auto candidate_index_value =
         candidate_index.Find(entry.request_id);
@@ -270,8 +276,6 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     selected_candidates.push_back(candidate.budget);
     selected_processed_lengths.push_back(
         candidate.processed_sequence_length);
-    selected_remaining_lengths.push_back(
-        candidate.remaining_token_count);
   }
   std::vector<size_t> token_counts;
   try {
@@ -285,6 +289,7 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     auto& entry = plan.requests[index];
     entry.scheduling_order = index;
     entry.unprocessed_token_count = token_counts[index];
+    entry.draft_token_count = entry.is_prefill ? 0 : token_counts[index] - 1;
     entry.target_cache_slots = RequiredSlots(
         selected_processed_lengths[index],
         entry.unprocessed_token_count);
@@ -299,12 +304,7 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
   for (size_t i = 0; i < plan.requests.size(); ++i) {
     auto& entry = plan.requests[i];
     const size_t scheduling_index = entry.scheduling_order;
-    // The budget only distributes committed tokens. A step that stops short of the sequence tail
-    // has no row that predicts the first draft, so it cannot verify one.
-    if (token_counts[scheduling_index] != selected_remaining_lengths[scheduling_index]) {
-      entry.draft_token_count = 0;
-    }
-    entry.unprocessed_token_count = token_counts[scheduling_index] + entry.draft_token_count;
+    entry.unprocessed_token_count = token_counts[scheduling_index];
     entry.target_cache_slots = RequiredSlots(
         selected_processed_lengths[scheduling_index],
         entry.unprocessed_token_count);

--- a/src/engine/step_plan.h
+++ b/src/engine/step_plan.h
@@ -21,6 +21,11 @@ struct StepPlanningConsistencyError : std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
+// Upper bound on the speculative drafts a single request may attach to one decode step. The
+// packed recurrent-state operators checkpoint at most eight tokens, so no cache can roll back
+// further than a step of that length.
+inline constexpr size_t kMaxDraftTokensPerStep = 7;
+
 enum class StepOutcomeKind {
   NoWork,
   CapacityDeferred,

--- a/src/engine/step_plan.h
+++ b/src/engine/step_plan.h
@@ -56,6 +56,7 @@ struct RequestStepPlan {
   const void* request_id{};
   int64_t sequence_length_before{};     // Search length before this transaction appends a token.
   size_t unprocessed_token_count{};     // Prompt chunk or single decode token sent to the model.
+  size_t draft_token_count{};           // Trailing speculative tokens of that count, verified this step.
   size_t packed_token_offset{};         // First row for this request in the flat varlen input.
   size_t logits_row_index{};            // Last packed row; its logits produce this request's next token.
   size_t target_cache_slots{};          // Committed KV slots required after the model run succeeds.

--- a/test/cpp/engine/decode_first_scheduler_policy_tests.cpp
+++ b/test/cpp/engine/decode_first_scheduler_policy_tests.cpp
@@ -48,6 +48,19 @@ TEST(DecodeFirstSchedulerPolicyTest, DecodeDemandExhaustsTheBudget) {
                std::invalid_argument);
 }
 
+TEST(DecodeFirstSchedulerPolicyTest, SpeculativeRowsConsumeBudgetAfterEveryRequestGetsOneToken) {
+  const std::array selected{
+      DecodeFirstBudgetCandidate{false, 1, std::nullopt, 3},
+      DecodeFirstBudgetCandidate{false, 1, std::nullopt, 2},
+      DecodeFirstBudgetCandidate{true, 8, std::nullopt},
+  };
+
+  EXPECT_EQ(AllocateDecodeFirstTokenBudget(selected, 5),
+            (std::vector<size_t>{3, 1, 1}));
+  EXPECT_EQ(AllocateDecodeFirstTokenBudget(selected, 8),
+            (std::vector<size_t>{4, 3, 1}));
+}
+
 TEST(DecodeFirstSchedulerPolicyTest, PrefillsRespectPendingCapAndGlobalBudget) {
   const std::array selected{
       DecodeFirstBudgetCandidate{true, 2, std::nullopt},

--- a/test/cpp/engine/engine_step_tests.cpp
+++ b/test/cpp/engine/engine_step_tests.cpp
@@ -1721,6 +1721,164 @@ TEST_F(EngineStepTest, SpeculativeStepAcceptingEveryDraftAlsoTakesTheBonusToken)
   EXPECT_EQ(request->ProcessedSequenceLength(), length_after_prefill + 3);
 }
 
+TEST_F(EngineStepTest, SpeculativeStepStopsWhenTheFirstDraftIsEos) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{eos, 12});
+  engine.executor->SetVerifyRowTokens({eos, 12, 25});
+
+  ASSERT_EQ(engine.engine->Step(), request);
+  EXPECT_EQ(request->Status(), RequestStatus::TurnComplete);
+  EXPECT_FALSE(request->HasUnseenTokens());
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill);
+  EXPECT_EQ(request->ProcessedSequenceLength(), length_after_prefill);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 1u);
+}
+
+TEST_F(EngineStepTest, SpeculativeStepStopsAtAnAcceptedMiddleEos) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, eos, 13});
+  engine.executor->SetVerifyRowTokens({11, eos, 13, 25});
+
+  ASSERT_EQ(engine.engine->Step(), request);
+  EXPECT_EQ(request->Status(), RequestStatus::TurnComplete);
+  ASSERT_TRUE(request->HasUnseenTokens());
+  EXPECT_EQ(request->UnseenToken(), 11);
+  EXPECT_FALSE(request->HasUnseenTokens());
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 1);
+  EXPECT_EQ(request->ProcessedSequenceLength(), length_after_prefill + 1);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 2u);
+}
+
+#if USE_CUDA
+TEST_F(EngineStepTest, CudaSpeculativeStepStopsWhenTheFirstDraftIsEos) {
+  model_ = LoadSyntheticPagedCudaModel();
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeCompositeDoublesEngine(model_, filler);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{eos, 12});
+  engine.executor->SetVerifyRowTokens({eos, 12, 25});
+
+  ASSERT_EQ(engine.engine->Step(), request);
+  EXPECT_EQ(request->Status(), RequestStatus::TurnComplete);
+  EXPECT_FALSE(request->HasUnseenTokens());
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill);
+  EXPECT_EQ(request->ProcessedSequenceLength(), length_after_prefill);
+}
+
+TEST_F(EngineStepTest, CudaSpeculativeStepStopsAtAnAcceptedMiddleEos) {
+  model_ = LoadSyntheticPagedCudaModel();
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeCompositeDoublesEngine(model_, filler);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, eos, 13});
+  engine.executor->SetVerifyRowTokens({11, eos, 13, 25});
+
+  ASSERT_EQ(engine.engine->Step(), request);
+  EXPECT_EQ(request->Status(), RequestStatus::TurnComplete);
+  ASSERT_TRUE(request->HasUnseenTokens());
+  EXPECT_EQ(request->UnseenToken(), 11);
+  EXPECT_FALSE(request->HasUnseenTokens());
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 1);
+  EXPECT_EQ(request->ProcessedSequenceLength(), length_after_prefill + 1);
+}
+#endif
+
+TEST_F(EngineStepTest, SpeculativeRowsStayWithinTheGlobalTokenBudget) {
+  model_->config_->engine.dynamic_batching->max_scheduled_tokens = 3;
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto first = MintRequest(*model_, Prompt(10));
+  auto second = MintRequest(*model_, Prompt(20));
+  engine.engine->AddRequest(first);
+  engine.engine->AddRequest(second);
+  ASSERT_EQ(engine.engine->Step(), first);
+  ASSERT_EQ(engine.engine->Step(), second);
+  while (first->HasUnseenTokens()) first->UnseenToken();
+  while (second->HasUnseenTokens()) second->UnseenToken();
+
+  first->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  second->SetDraftTokens(std::vector<int32_t>{21, 22, 23});
+  engine.executor->SetVerifyRowTokens({11, 12, 31});
+
+  ASSERT_EQ(engine.engine->Step(), first);
+  ASSERT_EQ(engine.executor->decoded_token_counts.size(), 3u);
+  EXPECT_EQ(engine.executor->decoded_token_counts[2], 3u);
+  ASSERT_EQ(engine.executor->decoded_request_ids[2].size(), 2u);
+  EXPECT_EQ(first->PendingDraftTokenCount(), 0u);
+  EXPECT_EQ(second->PendingDraftTokenCount(), 0u);
+}
+
+TEST_F(EngineStepTest, SpeculativePlanReservesThePagedBlockBeforeExecution) {
+  model_ = LoadSyntheticPagedModel();
+  model_->config_->engine.dynamic_batching->max_scheduled_tokens = 2;
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeCompositeDoublesEngine(model_, filler);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  while (request->HasUnseenTokens()) request->UnseenToken();
+  const size_t decode_calls_before = engine.executor->decoded_token_counts.size();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 21});
+  engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
+    ASSERT_NE(context.plan, nullptr);
+    ASSERT_EQ(context.plan->requests.size(), 1u);
+    EXPECT_EQ(context.plan->token_count, 2u);
+    EXPECT_EQ(context.plan->requests[0].draft_token_count, 1u);
+    EXPECT_EQ(context.plan->requests[0].target_cache_slots, 5u);
+  });
+
+  ASSERT_EQ(engine.engine->Step(), request);
+  ASSERT_EQ(engine.executor->decoded_token_counts.size(), decode_calls_before + 1);
+  EXPECT_EQ(engine.executor->decoded_token_counts.back(), 2u);
+  const auto committed = engine.cache->Snapshot();
+  ASSERT_EQ(committed.requests.size(), 1u);
+  EXPECT_EQ(committed.requests[0].used_slots, 5u);
+  EXPECT_EQ(committed.requests[0].block_ids.size(), 2u);
+}
+
 TEST_F(EngineStepTest, RolledBackSpeculativeStepLeavesTheProposalPendingAndRetryable) {
   const int32_t eos = EosToken(*model_);
   const int32_t filler = eos == 5 ? 6 : 5;
@@ -1751,6 +1909,17 @@ TEST_F(EngineStepTest, RolledBackSpeculativeStepLeavesTheProposalPendingAndRetry
 
 TEST_F(EngineStepTest, DraftsAreRejectedWhenTheCacheCannotRollThemBack) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+
+  EXPECT_EQ(engine.engine->MaxDraftTokensPerStep(), 0u);
+  EXPECT_THROW(request->SetDraftTokens(std::vector<int32_t>{11}), std::runtime_error);
+}
+
+TEST_F(EngineStepTest, DraftsAreRejectedWhenTheModelDoesNotExposePerTokenLogits) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  engine.executor->SetSupportsDraftVerification(false);
   auto request = MintRequest(*model_, Prompt(10));
   engine.engine->AddRequest(request);
 

--- a/test/cpp/engine/engine_step_tests.cpp
+++ b/test/cpp/engine/engine_step_tests.cpp
@@ -1635,6 +1635,168 @@ TEST_F(EngineStepTest, CompositeOrdersResidentRowsByFixedSlotAfterAdmission) {
   EXPECT_EQ(engine.engine->Step(), replacement);
 }
 
+TEST_F(EngineStepTest, SpeculativeStepKeepsTheAcceptedPrefixAndReplacesTheRejectedDraft) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  ASSERT_EQ(request->status_, RequestStatus::Active);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 12, 21, 22});
+
+  ASSERT_EQ(engine.engine->Step(), request);
+
+  ASSERT_EQ(engine.executor->decoded_token_counts.size(), 2u);
+  EXPECT_EQ(engine.executor->decoded_token_counts[1], 4u);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].row, 0u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].request_id, request.get());
+  EXPECT_EQ(engine.cache->prefix_commits[0].step_tokens, 4u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 3u);
+
+  std::vector<int32_t> produced;
+  while (request->HasUnseenTokens()) produced.push_back(request->UnseenToken());
+  EXPECT_EQ(produced, (std::vector<int32_t>{11, 12, 21}));
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 3);
+  EXPECT_EQ(request->ProcessedSequenceLength(), length_after_prefill + 2);
+  EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
+}
+
+TEST_F(EngineStepTest, SpeculativeStepRejectingTheFirstDraftAdvancesByOneToken) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12});
+  engine.executor->SetVerifyRowTokens({21, 22, 23});
+
+  ASSERT_EQ(engine.engine->Step(), request);
+
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].step_tokens, 3u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 1u);
+  std::vector<int32_t> produced;
+  while (request->HasUnseenTokens()) produced.push_back(request->UnseenToken());
+  EXPECT_EQ(produced, (std::vector<int32_t>{21}));
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 1);
+}
+
+TEST_F(EngineStepTest, SpeculativeStepAcceptingEveryDraftAlsoTakesTheBonusToken) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 12, 13, 25});
+
+  ASSERT_EQ(engine.engine->Step(), request);
+
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 4u);
+  std::vector<int32_t> produced;
+  while (request->HasUnseenTokens()) produced.push_back(request->UnseenToken());
+  EXPECT_EQ(produced, (std::vector<int32_t>{11, 12, 13, 25}));
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 4);
+  EXPECT_EQ(request->ProcessedSequenceLength(), length_after_prefill + 3);
+}
+
+TEST_F(EngineStepTest, RolledBackSpeculativeStepLeavesTheProposalPendingAndRetryable) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  ASSERT_EQ(engine.engine->Step(), request);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  while (request->HasUnseenTokens()) request->UnseenToken();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12});
+  engine.executor->SetNextFailure(ScriptedExecutionFailure::PostProcessing);
+  EXPECT_THROW(engine.engine->Step(), EngineStepError);
+
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill);
+  EXPECT_EQ(request->PendingDraftTokenCount(), 2u);
+  EXPECT_EQ(request->AcceptedDraftTokenCount(), 0u);
+  EXPECT_TRUE(engine.cache->prefix_commits.empty());
+
+  engine.executor->SetVerifyRowTokens({11, 12, 25});
+  ASSERT_EQ(engine.engine->Step(), request);
+  std::vector<int32_t> produced;
+  while (request->HasUnseenTokens()) produced.push_back(request->UnseenToken());
+  EXPECT_EQ(produced, (std::vector<int32_t>{11, 12, 25}));
+}
+
+TEST_F(EngineStepTest, DraftsAreRejectedWhenTheCacheCannotRollThemBack) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+
+  EXPECT_EQ(engine.engine->MaxDraftTokensPerStep(), 0u);
+  EXPECT_THROW(request->SetDraftTokens(std::vector<int32_t>{11}), std::runtime_error);
+}
+
+TEST_F(EngineStepTest, DraftsAreRejectedBeyondTheCacheWindowAndForSampledRequests) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  engine.cache->SetMaxDraftTokensPerStep(2);
+
+  auto request = MintRequest(*model_, Prompt(10));
+  engine.engine->AddRequest(request);
+  EXPECT_THROW(request->SetDraftTokens(std::vector<int32_t>{11, 12, 13}), std::runtime_error);
+
+  auto sampled_params = MakeGreedyParams(*model_);
+  sampled_params->search.do_sample = true;
+  sampled_params->search.top_k = 40;
+  sampled_params->search.temperature = 1.0f;
+  auto sampled = std::make_shared<Request>(sampled_params);
+  sampled->AddTokens(Prompt(20));
+  engine.engine->AddRequest(sampled);
+  EXPECT_THROW(sampled->SetDraftTokens(std::vector<int32_t>{11}), std::runtime_error);
+}
+
+TEST_F(EngineStepTest, PrefillingRequestDoesNotVerifyDrafts) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto params = MakeGreedyParams(*model_);
+  params->search.chunk_size = 2;
+  auto request = std::make_shared<Request>(params);
+  request->AddTokens(Prompt(10));
+  engine.engine->AddRequest(request);
+  request->SetDraftTokens(std::vector<int32_t>{11, 12});
+
+  ASSERT_NE(engine.engine->Step(), nullptr);
+  ASSERT_EQ(engine.executor->decoded_token_counts.size(), 2u);
+  EXPECT_EQ(engine.executor->decoded_token_counts[0], 2u);
+  EXPECT_EQ(engine.executor->decoded_token_counts[1], 1u);
+  EXPECT_TRUE(engine.cache->prefix_commits.empty());
+  EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace Generators

--- a/test/cpp/engine/engine_test_doubles.h
+++ b/test/cpp/engine/engine_test_doubles.h
@@ -443,8 +443,8 @@ struct RecordingModelExecutor : ModelExecutor {
     scheduled_requests.AddDecoderState(
         std::make_unique<ScriptedDecoderIO>(
             model_, scheduled_requests, cache_manager_, forced_token_,
-        failure == ScriptedExecutionFailure::PostProcessing,
-        context.plan, verify_row_tokens_));
+            failure == ScriptedExecutionFailure::PostProcessing,
+            context.plan, verify_row_tokens_));
     static_cast<void>(context);
   }
 

--- a/test/cpp/engine/engine_test_doubles.h
+++ b/test/cpp/engine/engine_test_doubles.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -80,6 +81,8 @@ struct RecordingCacheManager : CacheManager {
   size_t MaxBatchSize() const override { return capacity_; }
 
   size_t MaxQueryTokensPerRequest() const override { return max_query_tokens_per_request_; }
+
+  size_t MaxDraftTokensPerStep() const override { return max_draft_tokens_per_step_; }
 
   std::vector<std::shared_ptr<Request>> AllocatedRequests() const override { return allocated_; }
 
@@ -213,6 +216,14 @@ struct RecordingCacheManager : CacheManager {
         }
       }
 
+      void CommitPrefix(size_t row, const void* request_id,
+                        size_t step_tokens, size_t kept_tokens) override {
+        if (committed_) {
+          throw std::logic_error("Recording cache reservation is already committed.");
+        }
+        cache_.prefix_commits.push_back({row, request_id, step_tokens, kept_tokens});
+      }
+
       void Commit() override {
         if (committed_) {
           throw std::logic_error("Recording cache reservation can only commit once.");
@@ -252,6 +263,9 @@ struct RecordingCacheManager : CacheManager {
   void SetMaxQueryTokensPerRequest(size_t token_count) {
     max_query_tokens_per_request_ = token_count;
   }
+  void SetMaxDraftTokensPerStep(size_t token_count) {
+    max_draft_tokens_per_step_ = token_count;
+  }
   void ThrowPlanningBadAllocOnce() { throw_planning_bad_alloc_ = true; }
   void ThrowPlanningConsistencyOnce() {
     throw_planning_consistency_ = true;
@@ -276,6 +290,14 @@ struct RecordingCacheManager : CacheManager {
   }
   size_t AllocatedCount() const { return allocated_.size(); }
 
+  struct PrefixCommit {
+    size_t row{};
+    const void* request_id{};
+    size_t step_tokens{};
+    size_t kept_tokens{};
+  };
+  std::vector<PrefixCommit> prefix_commits;
+
   // Recorded call counts.
   mutable int can_allocate_calls{0};
   int allocate_calls{0};
@@ -285,6 +307,7 @@ struct RecordingCacheManager : CacheManager {
  private:
   size_t capacity_;
   size_t max_query_tokens_per_request_{};
+  size_t max_draft_tokens_per_step_{};
   mutable bool throw_planning_bad_alloc_{};
   mutable bool throw_planning_consistency_{};
   mutable bool overselect_planning_once_{};
@@ -304,26 +327,42 @@ struct RecordingCacheManager : CacheManager {
 // A DecoderIO that fabricates logits instead of running the model: for each scheduled request it
 // returns a vocab-sized logits row whose maximum is at `forced_token`, so the request's real greedy
 // search deterministically selects that token. Using the model's end-of-stream token drives requests
-// to completion in one step.
+// to completion in one step. A speculative step needs one row per draft in addition to the
+// request's ordinary row; `row_tokens` scripts the argmax of every row in packed order.
 struct ScriptedDecoderIO : DecoderIO {
   ScriptedDecoderIO(std::shared_ptr<Model> model, ScheduledRequests& scheduled_requests,
                     std::shared_ptr<CacheManager> cache_manager, int32_t forced_token,
-                    bool fail_process_logits = false)
+                    bool fail_process_logits = false,
+                    const StepPlan* plan = nullptr,
+                    std::span<const int32_t> row_tokens = {})
       : DecoderIO(model, scheduled_requests, cache_manager),
         vocab_size_{static_cast<int64_t>(model->config_->model.vocab_size)},
         fail_process_logits_{fail_process_logits} {
     if (forced_token < 0 || forced_token >= vocab_size_) {
       throw std::runtime_error("ScriptedDecoderIO: forced_token out of vocabulary range");
     }
-    const int64_t batch_size = static_cast<int64_t>(scheduled_requests.size());
+    size_t rows = scheduled_requests.size();
+    if (plan) {
+      for (const auto& entry : plan->requests) {
+        rows += entry.draft_token_count;
+      }
+    }
+    if (!row_tokens.empty() && row_tokens.size() != rows) {
+      throw std::runtime_error("ScriptedDecoderIO: row token script does not cover every row.");
+    }
+    row_count_ = rows;
     logits_ = std::make_unique<Tensor>(model->p_device_inputs_, Ort::TypeToTensorType<float>);
-    const std::array<int64_t, 2> shape{batch_size, vocab_size_};
+    const std::array<int64_t, 2> shape{static_cast<int64_t>(rows), vocab_size_};
     logits_->CreateTensor(shape);
     auto device_span = logits_->GetDeviceSpan<float>();
     auto cpu_span = device_span.CpuSpan();
     std::fill(cpu_span.begin(), cpu_span.end(), 0.0f);
-    for (int64_t row = 0; row < batch_size; ++row) {
-      cpu_span[row * vocab_size_ + forced_token] = 100.0f;
+    for (size_t row = 0; row < rows; ++row) {
+      const int32_t token = row_tokens.empty() ? forced_token : row_tokens[row];
+      if (token < 0 || token >= vocab_size_) {
+        throw std::runtime_error("ScriptedDecoderIO: scripted row token out of vocabulary range");
+      }
+      cpu_span[static_cast<int64_t>(row) * vocab_size_ + token] = 100.0f;
     }
     device_span.CopyCpuToDevice();
   }
@@ -334,7 +373,7 @@ struct ScriptedDecoderIO : DecoderIO {
     }
     std::vector<DeviceSpan<float>> rows;
     auto all = logits_->GetDeviceSpan<float>();
-    for (size_t i = 0; i < scheduled_requests_.size(); ++i) {
+    for (size_t i = 0; i < row_count_; ++i) {
       rows.push_back(all.subspan(i * vocab_size_, vocab_size_));
     }
     return rows;
@@ -342,6 +381,7 @@ struct ScriptedDecoderIO : DecoderIO {
 
  private:
   int64_t vocab_size_;
+  size_t row_count_{};
   bool fail_process_logits_{};
 };
 
@@ -403,7 +443,8 @@ struct RecordingModelExecutor : ModelExecutor {
     scheduled_requests.AddDecoderState(
         std::make_unique<ScriptedDecoderIO>(
             model_, scheduled_requests, cache_manager_, forced_token_,
-            failure == ScriptedExecutionFailure::PostProcessing));
+        failure == ScriptedExecutionFailure::PostProcessing,
+        context.plan, verify_row_tokens_));
     static_cast<void>(context);
   }
 
@@ -411,6 +452,9 @@ struct RecordingModelExecutor : ModelExecutor {
   void SetForcedToken(int32_t token) { forced_token_ = token; }
   void SetExecutionCallback(std::function<void(ExecutionContext&)> callback) {
     on_execute_ = std::move(callback);
+  }
+  void SetVerifyRowTokens(std::vector<int32_t> tokens) {
+    verify_row_tokens_ = std::move(tokens);
   }
 
   int decode_calls{0};
@@ -425,6 +469,7 @@ struct RecordingModelExecutor : ModelExecutor {
   std::shared_ptr<CallTrace> trace_;
   ScriptedExecutionFailure next_failure_{ScriptedExecutionFailure::None};
   std::function<void(ExecutionContext&)> on_execute_;
+  std::vector<int32_t> verify_row_tokens_;
 };
 
 // An Engine wired with the recording doubles above, together with non-owning observers of those

--- a/test/cpp/engine/engine_test_doubles.h
+++ b/test/cpp/engine/engine_test_doubles.h
@@ -456,6 +456,12 @@ struct RecordingModelExecutor : ModelExecutor {
   void SetVerifyRowTokens(std::vector<int32_t> tokens) {
     verify_row_tokens_ = std::move(tokens);
   }
+  bool SupportsDraftVerification() const override {
+    return supports_draft_verification_;
+  }
+  void SetSupportsDraftVerification(bool supported) {
+    supports_draft_verification_ = supported;
+  }
 
   int decode_calls{0};
   std::vector<size_t> decoded_batch_sizes;
@@ -470,6 +476,7 @@ struct RecordingModelExecutor : ModelExecutor {
   ScriptedExecutionFailure next_failure_{ScriptedExecutionFailure::None};
   std::function<void(ExecutionContext&)> on_execute_;
   std::vector<int32_t> verify_row_tokens_;
+  bool supports_draft_verification_{true};
 };
 
 // An Engine wired with the recording doubles above, together with non-owning observers of those

--- a/test/cpp/engine/engine_test_helpers.h
+++ b/test/cpp/engine/engine_test_helpers.h
@@ -29,6 +29,15 @@ inline std::shared_ptr<Model> LoadSyntheticPagedModel() {
   return CreateModel(GetOrtEnv(), MODEL_PATH "engine/synthetic-paged");
 }
 
+#if USE_CUDA
+inline std::shared_ptr<Model> LoadSyntheticPagedCudaModel() {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/synthetic-paged");
+  ClearProviders(*config);
+  SetProviderOption(*config, "cuda", {}, {});
+  return CreateModel(GetOrtEnv(), std::move(config));
+}
+#endif
+
 // Loads the tiny checked-in hybrid decoder used by the fixed-state-pool tests. Its config declares
 // two fixed decoder state groups (convolution layers [0, 3] and recurrent layers [2, 5]) whose
 // bindings resolve to real session inputs/outputs, so FixedStatePool can validate the manifest and

--- a/test/cpp/engine/paged_cache_reservation_tests.cpp
+++ b/test/cpp/engine/paged_cache_reservation_tests.cpp
@@ -105,6 +105,46 @@ TEST(PagedCacheReservationTest, CommitConsumesExistingTailWithoutNewBlock) {
   EXPECT_TRUE(tables[0].Blocks()[0]->IsFull());
 }
 
+TEST(PagedCacheReservationTest, CommitPrefixCommitsOnlyTheAcceptedSlots) {
+    BlockPool pool{kBlockSize, 4};
+    std::vector<PagedCacheBlockTable> tables{
+            PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+    };
+    const std::array requests{
+            PagedCacheReservationRequest{kRequestA, 8, false},
+    };
+
+    PagedCacheReservation reservation{pool, tables, requests};
+    ASSERT_EQ(reservation.ReservedBlockCount(), 1u);
+    reservation.CommitPrefix(kRequestA, /*step_slots=*/4, /*kept_slots=*/2);
+    ASSERT_EQ(reservation.Deltas().size(), 1u);
+    EXPECT_EQ(reservation.Deltas()[0].target_slots, 6u);
+
+    reservation.Commit();
+
+    EXPECT_EQ(tables[0].CommittedSlots(), 6u);
+    EXPECT_EQ(tables[0].Blocks().size(), 2u);
+    EXPECT_EQ(tables[0].Blocks()[1]->EmptySlots(), 2u);
+}
+
+TEST(PagedCacheReservationTest, CommitPrefixRejectsArgumentsOutsideThePlannedStep) {
+    BlockPool pool{kBlockSize, 4};
+    std::vector<PagedCacheBlockTable> tables{
+            PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+    };
+    const std::array requests{
+            PagedCacheReservationRequest{kRequestA, 8, false},
+    };
+
+    PagedCacheReservation reservation{pool, tables, requests};
+    EXPECT_THROW(reservation.CommitPrefix(kRequestB, 4, 2), std::runtime_error);
+    EXPECT_THROW(reservation.CommitPrefix(kRequestA, 4, 0), std::runtime_error);
+    EXPECT_THROW(reservation.CommitPrefix(kRequestA, 4, 5), std::runtime_error);
+    EXPECT_THROW(reservation.CommitPrefix(kRequestA, 3, 2), std::runtime_error);
+    reservation.Commit();
+    EXPECT_THROW(reservation.CommitPrefix(kRequestA, 4, 2), std::logic_error);
+}
+
 TEST(PagedCacheReservationTest, ProposedBlockTableIncludesReservationsAndPadding) {
   BlockPool pool{kBlockSize, 4};
   std::vector<PagedCacheBlockTable> tables{

--- a/test/cpp/engine/paged_cache_reservation_tests.cpp
+++ b/test/cpp/engine/paged_cache_reservation_tests.cpp
@@ -106,43 +106,43 @@ TEST(PagedCacheReservationTest, CommitConsumesExistingTailWithoutNewBlock) {
 }
 
 TEST(PagedCacheReservationTest, CommitPrefixCommitsOnlyTheAcceptedSlots) {
-    BlockPool pool{kBlockSize, 4};
-    std::vector<PagedCacheBlockTable> tables{
-            PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
-    };
-    const std::array requests{
-            PagedCacheReservationRequest{kRequestA, 8, false},
-    };
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 8, false},
+  };
 
-    PagedCacheReservation reservation{pool, tables, requests};
-    ASSERT_EQ(reservation.ReservedBlockCount(), 1u);
-    reservation.CommitPrefix(kRequestA, /*step_slots=*/4, /*kept_slots=*/2);
-    ASSERT_EQ(reservation.Deltas().size(), 1u);
-    EXPECT_EQ(reservation.Deltas()[0].target_slots, 6u);
+  PagedCacheReservation reservation{pool, tables, requests};
+  ASSERT_EQ(reservation.ReservedBlockCount(), 1u);
+  reservation.CommitPrefix(kRequestA, /*step_slots=*/4, /*kept_slots=*/2);
+  ASSERT_EQ(reservation.Deltas().size(), 1u);
+  EXPECT_EQ(reservation.Deltas()[0].target_slots, 6u);
 
-    reservation.Commit();
+  reservation.Commit();
 
-    EXPECT_EQ(tables[0].CommittedSlots(), 6u);
-    EXPECT_EQ(tables[0].Blocks().size(), 2u);
-    EXPECT_EQ(tables[0].Blocks()[1]->EmptySlots(), 2u);
+  EXPECT_EQ(tables[0].CommittedSlots(), 6u);
+  EXPECT_EQ(tables[0].Blocks().size(), 2u);
+  EXPECT_EQ(tables[0].Blocks()[1]->EmptySlots(), 2u);
 }
 
 TEST(PagedCacheReservationTest, CommitPrefixRejectsArgumentsOutsideThePlannedStep) {
-    BlockPool pool{kBlockSize, 4};
-    std::vector<PagedCacheBlockTable> tables{
-            PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
-    };
-    const std::array requests{
-            PagedCacheReservationRequest{kRequestA, 8, false},
-    };
+  BlockPool pool{kBlockSize, 4};
+  std::vector<PagedCacheBlockTable> tables{
+      PagedCacheBlockTable{kRequestA, 4, pool.AllocateBlocks(4)},
+  };
+  const std::array requests{
+      PagedCacheReservationRequest{kRequestA, 8, false},
+  };
 
-    PagedCacheReservation reservation{pool, tables, requests};
-    EXPECT_THROW(reservation.CommitPrefix(kRequestB, 4, 2), std::runtime_error);
-    EXPECT_THROW(reservation.CommitPrefix(kRequestA, 4, 0), std::runtime_error);
-    EXPECT_THROW(reservation.CommitPrefix(kRequestA, 4, 5), std::runtime_error);
-    EXPECT_THROW(reservation.CommitPrefix(kRequestA, 3, 2), std::runtime_error);
-    reservation.Commit();
-    EXPECT_THROW(reservation.CommitPrefix(kRequestA, 4, 2), std::logic_error);
+  PagedCacheReservation reservation{pool, tables, requests};
+  EXPECT_THROW(reservation.CommitPrefix(kRequestB, 4, 2), std::runtime_error);
+  EXPECT_THROW(reservation.CommitPrefix(kRequestA, 4, 0), std::runtime_error);
+  EXPECT_THROW(reservation.CommitPrefix(kRequestA, 4, 5), std::runtime_error);
+  EXPECT_THROW(reservation.CommitPrefix(kRequestA, 3, 2), std::runtime_error);
+  reservation.Commit();
+  EXPECT_THROW(reservation.CommitPrefix(kRequestA, 4, 2), std::logic_error);
 }
 
 TEST(PagedCacheReservationTest, ProposedBlockTableIncludesReservationsAndPadding) {

--- a/test/cpp/engine/request_lifecycle_tests.cpp
+++ b/test/cpp/engine/request_lifecycle_tests.cpp
@@ -670,6 +670,23 @@ TEST_F(RequestLifecycleTest, RequestRejectsIncompleteGuidanceConfiguration) {
 }
 
 #if USE_GUIDANCE
+TEST_F(RequestLifecycleTest, RequestRejectsDraftTokensWithGuidance) {
+  auto guidance_model = CreateModel(
+      GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto guidance_engine = MakeDoublesEngine(guidance_model, /*capacity=*/8,
+                                           EosToken(*guidance_model));
+  guidance_engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto params = MakeGreedyParams(*guidance_model);
+  params->SetGuidance("regex", "!!", false);
+  auto request = std::make_shared<Request>(params);
+  request->AddTokens(Prompt());
+  guidance_engine.engine->AddRequest(request);
+
+  EXPECT_THROW(request->SetDraftTokens(std::array<int32_t, 1>{11}),
+               std::runtime_error);
+}
+
 TEST_F(RequestLifecycleTest, GuidanceMasksTokensAndRollsBackWithSearchState) {
   auto guidance_model = CreateModel(
       GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");

--- a/test/cpp/search_checkpoint_tests.cpp
+++ b/test/cpp/search_checkpoint_tests.cpp
@@ -300,6 +300,41 @@ TEST_F(CudaSearchCheckpointTest, ExternalSamplingRollbackRestoresSearchTailState
   EXPECT_EQ(external_search->GetSequenceLengths().CopyDeviceToCpu()[0], 5);
 }
 
+TEST_F(CudaSearchCheckpointTest, CommitTokenStopsAtFirstEosWithoutAppendingIt) {
+  auto single_params = CreateGeneratorParams(*model);
+  single_params->search.batch_size = 1;
+  single_params->search.max_length = 8;
+  auto single_search = CreateSearch(*single_params);
+  auto input = single_params->p_device->Allocate<int32_t>(1);
+  input.CpuSpan()[0] = 1;
+  input.CopyCpuToDevice();
+  single_search->AppendTokens(input);
+
+  single_search->CommitToken(3);
+
+  EXPECT_TRUE(single_search->IsDone());
+  EXPECT_EQ(single_search->GetSequenceLength(), 1);
+}
+
+TEST_F(CudaSearchCheckpointTest, CommitTokenStopsAtMiddleEosWithoutAppendingIt) {
+  auto single_params = CreateGeneratorParams(*model);
+  single_params->search.batch_size = 1;
+  single_params->search.max_length = 8;
+  auto single_search = CreateSearch(*single_params);
+  auto input = single_params->p_device->Allocate<int32_t>(1);
+  input.CpuSpan()[0] = 1;
+  input.CopyCpuToDevice();
+  single_search->AppendTokens(input);
+
+  single_search->CommitToken(2);
+  ASSERT_FALSE(single_search->IsDone());
+  ASSERT_EQ(single_search->GetSequenceLength(), 2);
+  single_search->CommitToken(3);
+
+  EXPECT_TRUE(single_search->IsDone());
+  EXPECT_EQ(single_search->GetSequenceLength(), 2);
+}
+
 TEST_F(CudaSearchCheckpointTest, RollbackRestoresDoneEosAndLengthState) {
   auto input = Tokens({1, 2});
   search->AppendTokens(input);


### PR DESCRIPTION
## Summary
- Thread draft proposals through Request/Scheduler/Engine and verify them inside a dynamic step.
- Narrow paged KV and compact fixed-state transactions to the accepted prefix.
- Defer or reject unsafe draft rows based on cache and state-update capacity.
- Use compact state-update replay without restoring dense recurrent checkpoints.

## Testing
- `engine_unit_tests`: 285 passed.

## Dependency
- Stacked on #2454 only.
- No ONNX Runtime dependency or version bump.
