### PR TITLE
Run chained MTP drafting in the batch engine

### DIFF
--- a/docs/engine_c_api_spec.md
+++ b/docs/engine_c_api_spec.md
@@ -452,12 +452,11 @@ At Engine construction:
 pending_events_.reserve(cache_manager_->MaxBatchSize());
 ```
 
-`reserve` allocates capacity without constructing events. A committed step produces at most one
-combined event per affected Request, so normal retained output is bounded by the scheduled batch
-size. Request creation grows the retained-event capacity to the tracked Request count because fatal
-handling publishes a terminal event for every executable Turn, including Requests outside the
-failed batch. This keeps event publication allocation-free after model/cache commit and after the
-Engine becomes unhealthy.
+`reserve` allocates capacity without constructing events. A speculative transaction can produce up
+to `max_draft_tokens_per_step + 1` token events per affected Request. Request creation grows the
+retained-event capacity for the tracked Request count because fatal handling publishes a terminal
+event for every executable Turn, including Requests outside the failed batch. This keeps event
+publication allocation-free after model/cache commit and after the Engine becomes unhealthy.
 
 Conceptual positive-capacity `Run` flow:
 
@@ -529,10 +528,11 @@ OgaRequestGetUnseenToken
 
 and remove their internal unseen-index FIFO bookkeeping.
 
-At successful step commit, the Engine already knows the Request, Turn ID, selected token, terminal
-state, finish reason, and usage. It captures those values in `PendingEngineEvent`. One committed
-step produces at most one combined event per affected Request. `OgaEngineRun` moves the available
-FIFO prefix into the reusable Buffer storage and retains overflow.
+At successful step commit, the Engine already knows the Request, Turn ID, visible tokens, terminal
+state, finish reason, and usage. It captures those values in `PendingEngineEvent`. A speculative
+transaction emits accepted drafts followed by its correction or bonus token; only the final event
+carries terminal state when the Turn finishes. `OgaEngineRun` moves the available FIFO prefix into
+the reusable Buffer storage and retains overflow.
 
 `tokens_host_` and the Search sequence remain authoritative resident conversation state. Event
 delivery does not remove tokens from that state. Because token and Turn ID are captured together at

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -363,12 +363,13 @@ borrowed. A Buffer event holds the Request internally for the lifetime of that v
 returned `const OgaRequest*` is never an independently owned handle and is invalidated with the
 event.
 
-A committed step emits a token event, a terminal event, or one combined
-`Token | TurnFinished` event. EOS can emit terminal completion without a visible token. Event
-delivery does not mutate the Request's retained logical sequence. One successful committed step
-produces at most one combined event per affected Request. If speculative verification accepts a
-visible draft immediately before an accepted EOS ends the Turn, the accepted visible token and
-terminal completion share that combined event; the EOS itself is never emitted as a token.
+A committed step emits zero or more token events and may emit a terminal event. The final visible
+token can carry `Token | TurnFinished`; EOS can emit terminal completion without a visible token.
+Speculative verification emits each accepted draft and its correction or bonus as a separate token
+event in sequence order. If verification accepts a visible draft immediately before an accepted EOS
+ends the Turn, the accepted visible token and terminal completion share that combined event; the EOS
+itself is never emitted as a token. Event delivery does not mutate the Request's retained logical
+sequence.
 
 A chunked partial-prefill transaction can commit cache and Request progress without producing an
 event. `Run()` then returns count zero while `HasPendingRequests()` remains true. It does not loop
@@ -386,12 +387,13 @@ This distinction is important:
 If the engine has previously encountered a fatal transaction or execution failure, `Run()` rethrows
 the stored error instead of attempting more work.
 
-## Caller-supplied speculative drafts
+## Speculative drafts
 
-The dynamic Engine can verify a caller-supplied continuation together with a request's next decode
-token. This is separate from the `Generator` API's draft-model and n-gram strategies: the Engine
-does not create a proposer. The caller proposes tokens for one request before the next step with
-`Request::SetDraftTokens` (`OgaRequestSetDraftTokens` in C or `Request.set_draft_tokens` in Python).
+The dynamic Engine can verify a continuation together with a request's next decode token. A caller
+can propose tokens before the next step with `Request::SetDraftTokens` (`OgaRequestSetDraftTokens`
+in C or `Request.set_draft_tokens` in Python). When `model.mtp` names an auxiliary draft head, the
+Engine also maintains an internal shadow Request and automatically proposes a chained greedy
+continuation after each committed target step.
 
 Query the internal `Engine::MaxDraftTokensPerStep` capability through
 `OgaEngineMaxDraftTokensPerProposal`, `OgaEngine::MaxDraftTokensPerProposal`, or
@@ -401,16 +403,18 @@ The reported value is a capability limit, not a guarantee that every proposed to
 step's global token budget or current cache capacity.
 
 The request must already belong to the Engine, have completed prefill, and be ready to decode.
-Verification currently supports only requests whose resolved search mode is greedy (`do_sample` is
-false, `top_k` is 1, or `temperature` is zero), with no guidance, repetition penalty,
-no-repeat-ngram processing, or active minimum-length processing. Passing an empty sequence clears a
-pending proposal.
+Verification supports greedy target selection and random target sampling with a positive `top_k`;
+proposals remain deterministic. Guidance,
+repetition penalty, no-repeat-ngram processing, and active minimum-length processing are not
+supported. Passing an empty sequence clears a pending proposal.
 
 For a decode with K scheduled drafts, the packed input is the request's one unprocessed token
 followed by the K drafts. The decoder must return K+1 logits rows for that request. Row `i` predicts
 draft `i`; verification accepts the longest prefix whose tokens equal the target argmax. The first
 nonmatching row supplies the replacement token, or row K supplies a bonus token when every draft is
-accepted. Accepted drafts and the replacement or bonus are published together, so one model run can
+accepted. Under random target sampling, each target row is sampled and the deterministic draft is
+accepted when it matches that sample; the first mismatch is the correction token. Accepted drafts
+and the correction or bonus are published together, so one model run can
 publish several ordered token events. If the caller's event buffer cannot hold all of them, `Run()`
 retains the overflow and drains it on subsequent calls before executing the model again. Callers
 must process all returned events before reusing the buffer.
@@ -544,7 +548,7 @@ The fixed sub-reservation, when present, admits the same rows in the same order.
 Physical execution ordering does not change event ordering. Each row retains its logical scheduler
 rank, and the Engine restores that order when it publishes the transaction's events after commit.
 
-The fixed `target_tokens` mirror the paged `target_cache_slots`, so both states commit at one token boundary. `StepPlan::fixed_state` records the fixed row count, new-slot count, and binding footprint; `Engine::StepDynamic()` then proves the reservation matches that plan exactly -- required flag, row count, new-slot count, bytes, and per-row request identity -- and fails fatally on any mismatch. A composite reservation wraps exactly one paged reservation and the Engine holds at most one at a time, so the paged split-commit contract (its constructor reserves its own `committed_tables_` headroom, and the pool permits a single live reservation) holds without any cross-reservation aggregate check.
+The fixed `target_tokens` mirror the paged `target_cache_slots`, so both states commit at one token boundary. `StepPlan::fixed_state` records the fixed row count, new-slot count, and binding footprint; `Engine::RunDynamic()` then proves the reservation matches that plan exactly -- required flag, row count, new-slot count, bytes, and per-row request identity -- and fails fatally on any mismatch. A composite reservation wraps exactly one paged reservation and the Engine holds at most one at a time, so the paged split-commit contract (its constructor reserves its own `committed_tables_` headroom, and the pool permits a single live reservation) holds without any cross-reservation aggregate check.
 
 While the reservation is active, decoder input preparation can view a combined block table containing:
 

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -429,6 +429,46 @@ retryable rollback restores the request and leaves the proposal pending for retr
 the cache reservation is narrowed from the scheduled K+1 slots to the accepted prefix plus the
 request's mandatory token; paged KV and fixed recurrent state publish at that same boundary.
 
+### Engine-hosted MTP head: operational contract
+
+`model.mtp` turns the head on automatically for every request the dynamic Engine decodes. Server
+authors should size capacity and handle failures against the following behaviors.
+
+**Auxiliary memory accounting.** The head is a second paged pool that always holds the same block
+count as the target pool, so both are sized from one budget. With
+`engine.dynamic_batching.gpu_utilization_factor`, the auxiliary bytes per block are folded into the
+capacity computation. With an explicit `engine.dynamic_batching.num_blocks`, that value is the
+combined budget: the target pool is scaled down so target plus head together cost what the
+configured block count would have cost without a head. A `num_blocks` too small to leave at least
+one block for each pool is rejected at Engine construction.
+
+**Failure isolation.** The target decode is mandatory; MTP drafting is optional acceleration. A
+recoverable head failure (cache pressure, shape mismatch, binding or session error) releases only
+MTP state, and the target step still commits — without drafts for that step — and increments
+`standard_fallback_steps` in the speculative statistics. Only a contract violation, or a failure to
+roll MTP state back, marks the Engine unhealthy. A persistent head failure therefore degrades to
+ordinary decoding instead of stalling the request.
+
+**Shadow lifecycle.** The head's shadow Request mirrors only the suffix the target committed during
+the current turn. Beginning a continuation and canceling a turn both drop the shadow and release its
+auxiliary blocks, so the next drafted step rebuilds it from the new turn's suffix. Closing the
+request releases it as well.
+
+**Mixed prefill batches.** Drafts are proposed only for requests that committed a decode token in
+the step. A request that was prefilling, finished its turn, or has a proposal the Engine cannot
+verify is skipped for that step and picks drafting back up on its next decode step.
+
+**Seeded sampling.** `search.random_seed` reproduces output for a given decode path, not across
+decode paths. A verified drafted step draws its target tokens from the Request's own host random
+stream because acceptance is sequential, while an ordinary batched step draws from the device
+sampler state. Whether drafts are admitted depends on batch composition and cache pressure, so a
+seeded run is only bit-reproducible against another run scheduled the same way. Disable `model.mtp`
+when exact cross-scheduling reproducibility is required.
+
+**Telemetry thread ownership.** `Engine::GetSpeculativeStats` (`OgaEngineGetSpeculativeStats`,
+`Engine.get_speculative_stats`) reads counters that `Run()` mutates without synchronization. Like
+every other Engine query, it must be called from the Engine's owner thread and throws otherwise.
+
 ## One dynamic step in detail
 
 `Engine::RunDynamic()` coordinates the complete transaction.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -140,6 +140,9 @@ std::unique_ptr<Config> CreateMtpDecoderConfig(const Config& config) {
   decoder.sliding_window.reset();
   decoder.state_groups.reset();
   decoder.pipeline.clear();
+  // A chained draft feeds every stage the previous stage's hidden states, so the head must emit its
+  // own hidden states. Record that before clearing the MTP section the demand was inferred from.
+  projected->engine.hidden_states_output_required = true;
   projected->model.mtp = {};
   return projected;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -598,7 +598,13 @@ struct Config {
       size_t max_batch_size{4};  // Maximum batch size for static batching
     };
     std::optional<StaticBatching> static_batching;  // Static batching settings
-  } engine;                                         // Engine settings
+
+    // Runtime-only capability flag, never parsed from genai_config.json. The Engine sets it on
+    // every decoder whose packed hidden states it consumes: the target decoder feeds the MTP head,
+    // and the head feeds the next link of a chained draft. Models that merely export hidden states
+    // leave it false so an ordinary step does not pay for the extra output.
+    bool hidden_states_output_required{};
+  } engine;  // Engine settings
 
   void AddMapping(const std::string& nominal_name, const std::string& graph_name);
   // Returns graph name and true if the nominal name is found in the mapping

--- a/src/decoding/speculative_stats.h
+++ b/src/decoding/speculative_stats.h
@@ -2,9 +2,12 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <array>
 #include <cstddef>
 
 namespace Generators {
+
+inline constexpr size_t kSpeculativeAcceptanceLengthBins = 8;
 
 // Separates draft work from output delivery and exposes the speedup formula terms.
 // Target-dependent formula fields are zero without a baseline or when guidance is active.
@@ -46,6 +49,7 @@ struct SpeculativeStats {
   size_t ngram_grammar_candidate_rejections{};
   size_t ngram_history_syncs{};
   size_t ngram_history_tokens_synced{};
+  std::array<size_t, kSpeculativeAcceptanceLengthBins> acceptance_length_histogram{};
   size_t formula_supported{};
   float total_draft_ms{};
   float total_target_ms{};

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -510,6 +510,25 @@ bool PagedCacheManager::IsResident(const std::shared_ptr<Request>& request) cons
 
 StepPlanningResult PagedCacheManager::PlanStepResources(StepPlan& plan) const {
   plan.fixed_state = {};
+  if (fixed_state_pool_) {
+    const bool has_prefill = std::any_of(
+        plan.requests.begin(), plan.requests.end(),
+        [](const RequestStepPlan& entry) { return entry.is_prefill; });
+    const bool has_drafts = std::any_of(
+        plan.requests.begin(), plan.requests.end(),
+        [](const RequestStepPlan& entry) { return entry.draft_token_count != 0; });
+    if (has_prefill && has_drafts) {
+      // Packed recurrent operators cannot capture intermediate draft checkpoints while a prefill
+      // shares the step. Remove those optional rows before paged capacity planning so they cannot
+      // displace a request that the actual mixed step has room to execute.
+      for (auto& entry : plan.requests) {
+        entry.unprocessed_token_count -= entry.draft_token_count;
+        entry.target_cache_slots -= entry.draft_token_count;
+        entry.whole_sequence_cache_slots -= entry.draft_token_count;
+        entry.draft_token_count = 0;
+      }
+    }
+  }
   auto result = key_value_cache_->PlanStepResources(plan);
   if (!fixed_state_pool_) {
     return result;
@@ -543,21 +562,6 @@ StepPlanningResult PagedCacheManager::PlanStepResources(StepPlan& plan) const {
     return result;
   }
 
-  const bool has_prefill = std::any_of(
-      plan.requests.begin(), plan.requests.end(),
-      [](const RequestStepPlan& entry) { return entry.is_prefill; });
-  const bool has_drafts = std::any_of(
-      plan.requests.begin(), plan.requests.end(),
-      [](const RequestStepPlan& entry) { return entry.draft_token_count != 0; });
-  if (has_prefill && has_drafts) {
-    // Packed recurrent operators choose one execution plan for the whole batch. A long prefill
-    // selects the chunked GDN path, which only publishes final state and cannot provide the
-    // intermediate checkpoints needed to reject a draft. Keep every selected request progressing
-    // in this mixed step, but verify drafts only once the selected batch is decode-only.
-    for (auto& entry : plan.requests) {
-      entry.draft_token_count = 0;
-    }
-  }
   size_t new_slot_count = 0;
   for (const auto& entry : plan.requests) {
     // Cross-check per-request ownership against the fixed pool: a resident must own a committed

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -200,11 +200,12 @@ class CompositeCacheStepReservation final : public CacheStepReservation {
 
 }  // namespace
 
-std::unique_ptr<CacheManager> CacheManager::Create(std::shared_ptr<Model> model) {
+std::unique_ptr<CacheManager> CacheManager::Create(std::shared_ptr<Model> model,
+                                                   size_t auxiliary_bytes_per_block) {
   const ModelStateManifest manifest{model->config_->model.decoder};
   if (model->config_->engine.dynamic_batching) {
     ModelStateManifest::ValidateDynamicEngineCompatibility(model->config_->model.decoder);
-    return std::make_unique<PagedCacheManager>(model);
+    return std::make_unique<PagedCacheManager>(model, auxiliary_bytes_per_block);
   }
   if (manifest.HasFixedStateGroups()) {
     throw std::runtime_error(
@@ -327,7 +328,8 @@ bool StaticCacheManager::IsResident(const std::shared_ptr<Request>& request) con
          cache_allocated_requests_.end();
 }
 
-PagedCacheManager::PagedCacheManager(std::shared_ptr<Model> model)
+PagedCacheManager::PagedCacheManager(std::shared_ptr<Model> model,
+                                     size_t auxiliary_bytes_per_block)
     : CacheManager(model),
       params_(std::make_shared<GeneratorParams>(*model_)) {
   // The paged cache resolves its own paged_kv group. The fixed pool is created only when the
@@ -340,10 +342,9 @@ PagedCacheManager::PagedCacheManager(std::shared_ptr<Model> model)
         model, model_->config_->engine.dynamic_batching->max_batch_size);
     fixed_state_pool_ = std::move(fixed_state_pool);
   }
-  // Allocate fixed banks before auto-sizing paged KV. ComputeNumBlocks queries current device free
-  // memory, so the fixed pool's complete persistent footprint is already excluded without
-  // duplicating its geometry/accounting in the paged cache.
-  key_value_cache_ = std::make_unique<PagedKeyValueCache>(model);
+  // Size the primary and auxiliary paged caches from one memory budget. The fixed pool above is
+  // already reflected in the free-memory query used by the paged cache.
+  key_value_cache_ = std::make_unique<PagedKeyValueCache>(model, auxiliary_bytes_per_block);
   key_value_cache_state_ = std::make_unique<KeyValueCacheState>(*params_, *model_);
 }
 

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -543,6 +543,21 @@ StepPlanningResult PagedCacheManager::PlanStepResources(StepPlan& plan) const {
     return result;
   }
 
+  const bool has_prefill = std::any_of(
+      plan.requests.begin(), plan.requests.end(),
+      [](const RequestStepPlan& entry) { return entry.is_prefill; });
+  const bool has_drafts = std::any_of(
+      plan.requests.begin(), plan.requests.end(),
+      [](const RequestStepPlan& entry) { return entry.draft_token_count != 0; });
+  if (has_prefill && has_drafts) {
+    // Packed recurrent operators choose one execution plan for the whole batch. A long prefill
+    // selects the chunked GDN path, which only publishes final state and cannot provide the
+    // intermediate checkpoints needed to reject a draft. Keep every selected request progressing
+    // in this mixed step, but verify drafts only once the selected batch is decode-only.
+    for (auto& entry : plan.requests) {
+      entry.draft_token_count = 0;
+    }
+  }
   size_t new_slot_count = 0;
   for (const auto& entry : plan.requests) {
     // Cross-check per-request ownership against the fixed pool: a resident must own a committed

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -524,7 +524,6 @@ StepPlanningResult PagedCacheManager::PlanStepResources(StepPlan& plan) const {
       for (auto& entry : plan.requests) {
         entry.unprocessed_token_count -= entry.draft_token_count;
         entry.target_cache_slots -= entry.draft_token_count;
-        entry.whole_sequence_cache_slots -= entry.draft_token_count;
         entry.draft_token_count = 0;
       }
     }

--- a/src/engine/cache_manager.h
+++ b/src/engine/cache_manager.h
@@ -53,7 +53,8 @@ struct KeyValueCacheState : State {
 struct CacheManager {
   CacheManager(std::shared_ptr<Model> model) : model_{model} {}
 
-  static std::unique_ptr<CacheManager> Create(std::shared_ptr<Model> model);
+  static std::unique_ptr<CacheManager> Create(std::shared_ptr<Model> model,
+                                              size_t auxiliary_bytes_per_block = 0);
 
   virtual bool CanAllocate(const std::vector<std::shared_ptr<Request>>& requests) const = 0;
 
@@ -158,7 +159,8 @@ struct StaticCacheManager : CacheManager {
 };
 
 struct PagedCacheManager : CacheManager {
-  PagedCacheManager(std::shared_ptr<Model> model);
+  PagedCacheManager(std::shared_ptr<Model> model,
+                    size_t auxiliary_bytes_per_block = 0);
 
   bool CanAllocate(const std::vector<std::shared_ptr<Request>>& requests) const override;
 

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -309,16 +309,32 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
   auto sequence_lengths_span = sequence_lengths_tensor->GetDeviceSpan<int32_t>();
   auto sequence_lengths_cpu_span = sequence_lengths_span.CpuSpan();
 
+  DeviceSpan<int32_t> device_input_ids =
+      execution_context_ ? execution_context_->input_ids : DeviceSpan<int32_t>{};
+  if (!device_input_ids.empty()) {
+    if (device_input_ids.size() != num_tokens) {
+      throw std::runtime_error("Packed device input IDs do not match the step token count.");
+    }
+    if (!model->p_device_inputs_->Cast(
+            device_input_ids.Span().data(), device_span.Span().data(),
+            Ort::TypeToTensorType<int32_t>, Ort::TypeToTensorType<int64_t>, num_tokens)) {
+      throw std::runtime_error("The model device cannot cast packed input IDs to int64.");
+    }
+  }
+
   for (size_t i = 0, running_length = 0; i < scheduled_requests.size(); ++i) {
     auto request = scheduled_requests[i];
-    auto input_ids = request->UnprocessedTokensCpu();
+    const size_t input_id_count = request->ScheduledTokenCount();
     const RequestStepPlan* entry = plan ? &plan->requests[i] : nullptr;
     if (entry && (entry->request != request ||
-                  entry->unprocessed_token_count != input_ids.size() ||
+                  entry->unprocessed_token_count != input_id_count ||
                   entry->packed_token_offset != running_length)) {
       throw std::runtime_error("Step plan token layout does not match the scheduled request.");
     }
-    std::copy(input_ids.begin(), input_ids.end(), cpu_span.begin() + running_length);
+    if (device_input_ids.empty()) {
+      auto input_ids = request->UnprocessedTokensCpu();
+      std::copy(input_ids.begin(), input_ids.end(), cpu_span.begin() + running_length);
+    }
 
     // The batch is represented as three coordinated arrays:
     //   input_ids                  = all pending tokens concatenated
@@ -336,11 +352,13 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
     }
     sequence_lengths_cpu_span[i] = static_cast<int32_t>(processed_sequence_length);
 
-    running_length += input_ids.size();
+    running_length += input_id_count;
     cumulative_sequence_lengths_cpu_span[i + 1] = static_cast<int32_t>(running_length);
   }
 
-  device_span.CopyCpuToDevice();
+  if (device_input_ids.empty()) {
+    device_span.CopyCpuToDevice();
+  }
   cumulative_sequence_lengths_span.CopyCpuToDevice();
   sequence_lengths_span.CopyCpuToDevice();
 

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -150,6 +150,16 @@ VarlenGraphBuffers::VarlenGraphBuffers(DecoderOnly_Model& model) {
                                             static_cast<int64_t>(model.config_->model.vocab_size)},
                        /*make_static=*/true);
 
+  const auto& hidden_states_input_name = model.config_->model.decoder.inputs.hidden_states;
+  if (!hidden_states_input_name.empty() && model.session_info_.HasInput(hidden_states_input_name)) {
+    hidden_states_input = std::make_unique<Tensor>(
+        model.p_device_inputs_, model.session_info_.GetInputDataType(hidden_states_input_name));
+    hidden_states_input->CreateTensor(
+        std::vector<int64_t>{static_cast<int64_t>(max_batch_size),
+                             static_cast<int64_t>(model.config_->model.decoder.hidden_size)},
+        /*make_static=*/true);
+  }
+
   const auto& hidden_states_name = model.config_->model.decoder.outputs.hidden_states;
   if (!model.config_->model.mtp.filename.empty() &&
       !hidden_states_name.empty() && model.session_info_.HasOutput(hidden_states_name)) {
@@ -182,6 +192,8 @@ VarlenDecoderIO::VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
       plan_{execution_context ? execution_context->plan : nullptr},
       block_table_columns_{
           execution_context ? execution_context->block_table_columns : 0},
+        hidden_states_input_{
+          execution_context ? execution_context->hidden_states_input : nullptr},
       position_planes_{position_planes} {
   // Logits with a symbolic batch_size first dimension contain one row per request. Any other first
   // dimension is treated as one row per packed token.
@@ -194,6 +206,7 @@ VarlenDecoderIO::VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
   PrepareInputIds(model, scheduled_requests);
   PreparePositionIds(model, scheduled_requests);
   PrepareAttentionMetadata(model, scheduled_requests);
+  PrepareHiddenStatesInput(model, scheduled_requests);
   PrepareLogits(model, scheduled_requests);
   PrepareHiddenStates(model, scheduled_requests);
 
@@ -207,6 +220,48 @@ VarlenDecoderIO::VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
     output_names_.push_back(cache->output_names_[i]);
     outputs_.push_back(cache->outputs_[i]);
   }
+}
+
+void VarlenDecoderIO::PrepareHiddenStatesInput(
+    std::shared_ptr<DecoderOnly_Model> model,
+    ScheduledRequests& scheduled_requests) {
+  const auto& hidden_states_name = model->config_->model.decoder.inputs.hidden_states;
+  if (hidden_states_name.empty() || !model->session_info_.HasInput(hidden_states_name)) {
+    return;
+  }
+  if (!hidden_states_input_) {
+    throw std::runtime_error(
+        "The decoder requires a packed hidden_states input, but the execution context did not provide one.");
+  }
+
+  const auto info = hidden_states_input_->GetTensorTypeAndShapeInfo();
+  const auto shape = info->GetShape();
+  const std::vector<int64_t> expected_shape = {
+      static_cast<int64_t>(TokenCount(scheduled_requests)),
+      static_cast<int64_t>(model->config_->model.decoder.hidden_size)};
+  if (shape != expected_shape) {
+    throw std::runtime_error(
+        "The packed hidden_states input shape does not match the scheduled token rows.");
+  }
+  if (info->GetElementType() != model->session_info_.GetInputDataType(hidden_states_name)) {
+    throw std::runtime_error(
+        "The packed hidden_states input type does not match the decoder input type.");
+  }
+
+  OrtValue* active_hidden_states_input = hidden_states_input_;
+  if (graph_buffers_ != nullptr) {
+    if (!graph_buffers_->hidden_states_input) {
+      throw std::runtime_error(
+          "Captured decoder step has no persistent hidden_states input buffer.");
+    }
+    graph_buffers_->hidden_states_input->CreateTensor(expected_shape, /*make_static=*/true);
+    graph_buffers_->hidden_states_input->GetByteSpan().CopyFrom(
+      ByteWrapTensor(*model->p_device_inputs_, *hidden_states_input_));
+    active_hidden_states_input = graph_buffers_->hidden_states_input->GetOrtTensor();
+  }
+
+  input_names_.push_back(hidden_states_name.c_str());
+  inputs_.push_back(active_hidden_states_input);
 }
 
 void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests) {

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -161,7 +161,7 @@ VarlenGraphBuffers::VarlenGraphBuffers(DecoderOnly_Model& model) {
   }
 
   const auto& hidden_states_name = model.config_->model.decoder.outputs.hidden_states;
-  if (!model.config_->model.mtp.filename.empty() &&
+  if (model.config_->engine.hidden_states_output_required &&
       !hidden_states_name.empty() && model.session_info_.HasOutput(hidden_states_name)) {
     hidden_states = std::make_unique<Tensor>(model.p_device_inputs_,
                                              model.session_info_.GetOutputDataType(hidden_states_name));
@@ -525,10 +525,11 @@ void VarlenDecoderIO::PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, Sc
 
 void VarlenDecoderIO::PrepareHiddenStates(std::shared_ptr<DecoderOnly_Model> model,
                                           ScheduledRequests& scheduled_requests) {
-  // Bind this optional output only when an MTP head is configured to consume it. A model may
-  // expose hidden states for other clients without requiring the Engine to produce them each step.
+  // Bind this optional output only when the Engine declared that it consumes these hidden states.
+  // A model may expose hidden states for other clients without requiring the Engine to produce them
+  // each step.
   const auto& hidden_states_name = model->config_->model.decoder.outputs.hidden_states;
-  if (model->config_->model.mtp.filename.empty() ||
+  if (!model->config_->engine.hidden_states_output_required ||
       hidden_states_name.empty() || !model->session_info_.HasOutput(hidden_states_name)) {
     return;
   }

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -192,7 +192,8 @@ VarlenDecoderIO::VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
       plan_{execution_context ? execution_context->plan : nullptr},
       block_table_columns_{
           execution_context ? execution_context->block_table_columns : 0},
-        hidden_states_input_{
+      input_ids_{execution_context ? execution_context->input_ids : DeviceSpan<int32_t>{}},
+      hidden_states_input_{
           execution_context ? execution_context->hidden_states_input : nullptr},
       position_planes_{position_planes} {
   // Logits with a symbolic batch_size first dimension contain one row per request. Any other first
@@ -309,8 +310,7 @@ void VarlenDecoderIO::PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, 
   auto sequence_lengths_span = sequence_lengths_tensor->GetDeviceSpan<int32_t>();
   auto sequence_lengths_cpu_span = sequence_lengths_span.CpuSpan();
 
-  DeviceSpan<int32_t> device_input_ids =
-      execution_context_ ? execution_context_->input_ids : DeviceSpan<int32_t>{};
+  DeviceSpan<int32_t> device_input_ids = input_ids_;
   if (!device_input_ids.empty()) {
     if (device_input_ids.size() != num_tokens) {
       throw std::runtime_error("Packed device input IDs do not match the step token count.");

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -257,7 +257,7 @@ void VarlenDecoderIO::PrepareHiddenStatesInput(
     }
     graph_buffers_->hidden_states_input->CreateTensor(expected_shape, /*make_static=*/true);
     graph_buffers_->hidden_states_input->GetByteSpan().CopyFrom(
-      ByteWrapTensor(*model->p_device_inputs_, *hidden_states_input_));
+        ByteWrapTensor(*model->p_device_inputs_, *hidden_states_input_));
     active_hidden_states_input = graph_buffers_->hidden_states_input->GetOrtTensor();
   }
 

--- a/src/engine/decoders/varlen_decoder_io.h
+++ b/src/engine/decoders/varlen_decoder_io.h
@@ -57,6 +57,8 @@ struct VarlenGraphBuffers {
   std::unique_ptr<Tensor> cumulative_sequence_lengths;
   std::unique_ptr<Tensor> past_sequence_lengths;
   std::unique_ptr<Tensor> logits;
+  // Null unless the model consumes hidden_states (for example, an MTP head).
+  std::unique_ptr<Tensor> hidden_states_input;
   // Null unless the model was exported with include_hidden_states.
   std::unique_ptr<Tensor> hidden_states;
   size_t max_batch_size{};
@@ -101,6 +103,7 @@ struct VarlenDecoderIO : DecoderIO {
   void PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PreparePositionIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareAttentionMetadata(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
+  void PrepareHiddenStatesInput(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareHiddenStates(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
 
@@ -113,6 +116,8 @@ struct VarlenDecoderIO : DecoderIO {
   VarlenGraphBuffers* graph_buffers_{};
   const StepPlan* plan_{};
   size_t block_table_columns_{};
+  // Borrowed from the MTP coordinator, which owns the tensor through synchronous model execution.
+  OrtValue* hidden_states_input_{};
   size_t position_planes_{};
   std::vector<std::unique_ptr<Tensor>> owned_inputs_;
   std::unique_ptr<Tensor> logits_;

--- a/src/engine/decoders/varlen_decoder_io.h
+++ b/src/engine/decoders/varlen_decoder_io.h
@@ -116,7 +116,8 @@ struct VarlenDecoderIO : DecoderIO {
   VarlenGraphBuffers* graph_buffers_{};
   const StepPlan* plan_{};
   size_t block_table_columns_{};
-  // Borrowed from the MTP coordinator, which owns the tensor through synchronous model execution.
+  // Borrowed spans/pointers whose backing storage is owned through synchronous model execution.
+  DeviceSpan<int32_t> input_ids_;
   OrtValue* hidden_states_input_{};
   size_t position_planes_{};
   std::vector<std::unique_ptr<Tensor>> owned_inputs_;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "engine.h"
+#include "../search.h"
 
 #include <limits>
 
@@ -40,6 +41,37 @@ std::string AddExceptionCause(std::string message, std::exception_ptr error) {
   return message;
 }
 
+std::vector<int32_t> GreedyTokens(
+    const std::shared_ptr<DecoderOnly_Model>& model,
+    std::vector<DeviceSpan<float>>& logits) {
+  std::vector<int32_t> tokens(logits.size());
+  auto device_tokens = model->p_device_->Allocate<int32_t>(logits.size());
+  (void)device_tokens.CpuSpan();
+  bool device_argmax = true;
+  for (size_t i = 0; i < logits.size(); ++i) {
+    device_argmax &= model->p_device_->ArgMaxDevice(
+        logits[i].Span().data(), Ort::TypeToTensorType<float>, 1,
+        model->config_->model.vocab_size, device_tokens.subspan(i, 1));
+  }
+  if (device_argmax) {
+    device_tokens.CopyDeviceToCpu();
+    std::copy(device_tokens.CpuSpan().begin(), device_tokens.CpuSpan().end(),
+              tokens.begin());
+    return tokens;
+  }
+
+  for (size_t i = 0; i < logits.size(); ++i) {
+    if (!model->p_device_->ArgMax(
+            logits[i].Span().data(), Ort::TypeToTensorType<float>, 1,
+            model->config_->model.vocab_size, &tokens[i])) {
+      const auto values = logits[i].CopyDeviceToCpu();
+      tokens[i] = static_cast<int32_t>(
+          std::max_element(values.begin(), values.end()) - values.begin());
+    }
+  }
+  return tokens;
+}
+
 }  // namespace
 
 Engine::Engine(std::shared_ptr<Model> model)
@@ -49,7 +81,10 @@ Engine::Engine(std::shared_ptr<Model> model, EngineDependencies dependencies)
     : model_{std::move(model)},
       cache_manager_{std::move(dependencies.cache_manager)},
       scheduler_{std::move(dependencies.scheduler)},
-      model_executor_{std::move(dependencies.model_executor)} {
+      model_executor_{std::move(dependencies.model_executor)},
+      mtp_model_{std::move(dependencies.mtp_model)},
+      mtp_cache_manager_{std::move(dependencies.mtp_cache_manager)},
+      mtp_model_executor_{std::move(dependencies.mtp_model_executor)} {
   // Fail fast on a missing collaborator rather than crashing later on first use.
   if (!cache_manager_) {
     throw std::runtime_error("Engine requires a non-null cache manager.");
@@ -74,6 +109,7 @@ Engine::Engine(std::shared_ptr<Model> model, EngineDependencies dependencies)
   staged_event_order_.reserve(max_batch_size);
   pending_events_.reserve(max_step_events);
   staged_events_.reserve(max_step_events);
+  mtp_requests_.reserve(max_batch_size);
 }
 
 Engine::~Engine() {
@@ -85,10 +121,382 @@ Engine::~Engine() {
 }
 
 EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
-  std::shared_ptr<CacheManager> cache_manager = CacheManager::Create(model);
+  std::shared_ptr<DecoderOnly_Model> mtp_model;
+  size_t mtp_bytes_per_block = 0;
+  if (!model->config_->model.mtp.filename.empty()) {
+    if (!model->config_->engine.dynamic_batching) {
+      throw std::runtime_error("An Engine-hosted MTP head requires dynamic batching.");
+    }
+    mtp_model = std::make_shared<DecoderOnly_Model>(
+        CreateMtpDecoderConfig(*model->config_), GetOrtEnv());
+    mtp_bytes_per_block = PagedKeyValueCacheBytesPerBlock(mtp_model);
+  }
+
+  std::shared_ptr<CacheManager> cache_manager =
+      CacheManager::Create(model, mtp_bytes_per_block);
   auto scheduler = Scheduler::Create(model, cache_manager);
   auto model_executor = ModelExecutor::Create(model, cache_manager);
-  return EngineDependencies{std::move(cache_manager), std::move(scheduler), std::move(model_executor)};
+
+  std::shared_ptr<CacheManager> mtp_cache_manager;
+  std::unique_ptr<ModelExecutor> mtp_model_executor;
+  if (mtp_model) {
+    // Both decoders cover the same resident request set. Fixing the head to the main pool's block
+    // count makes the auxiliary bytes included above exact rather than letting it independently
+    // consume another gpu_utilization_factor share of currently free memory.
+    mtp_model->config_->engine.dynamic_batching->num_blocks =
+        cache_manager->Snapshot().total_blocks;
+    mtp_cache_manager = CacheManager::Create(mtp_model);
+    mtp_model_executor = ModelExecutor::Create(mtp_model, mtp_cache_manager);
+  }
+
+  return EngineDependencies{
+      std::move(cache_manager), std::move(scheduler), std::move(model_executor),
+      std::move(mtp_model), std::move(mtp_cache_manager), std::move(mtp_model_executor)};
+}
+
+std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
+    const StepPlan& target_plan,
+    const std::vector<RequestStepResult>& target_results,
+    ScheduledRequests& target_requests) {
+  if (!mtp_model_ || MaxDraftTokensPerStep() == 0) {
+    return nullptr;
+  }
+  if (target_results.size() != target_plan.requests.size()) {
+    throw std::logic_error("MTP preparation requires one target result per planned request.");
+  }
+
+  Tensor* target_hidden_states = target_requests.HiddenStates();
+  if (!target_hidden_states) {
+    throw std::logic_error("The main decoder did not expose hidden states for its MTP head.");
+  }
+  const auto target_hidden_shape = target_hidden_states->GetShape();
+  const int64_t hidden_size = model_->config_->model.decoder.hidden_size;
+  if (target_hidden_shape !=
+      std::vector<int64_t>{static_cast<int64_t>(target_plan.token_count), hidden_size}) {
+    throw std::logic_error("The main decoder hidden-state shape does not match its packed step plan.");
+  }
+  const auto hidden_type = target_hidden_states->GetType();
+  const auto& mtp_hidden_name = mtp_model_->config_->model.decoder.inputs.hidden_states;
+  if (hidden_type != mtp_model_->session_info_.GetInputDataType(mtp_hidden_name)) {
+    throw std::logic_error("The main and MTP hidden-state element types do not match.");
+  }
+
+  struct Feed {
+    std::shared_ptr<Request> target;
+    std::shared_ptr<Request> shadow;
+    std::vector<int32_t> tokens;
+    size_t target_hidden_row{};
+    size_t max_draft_tokens{};
+    bool newly_created{};
+  };
+  std::vector<Feed> feeds;
+  feeds.reserve(target_plan.requests.size());
+  std::vector<std::shared_ptr<Request>> checkpointed_shadows;
+  checkpointed_shadows.reserve(target_plan.requests.size());
+  size_t total_rows = 0;
+  try {
+    for (size_t i = 0; i < target_plan.requests.size(); ++i) {
+      const auto& entry = target_plan.requests[i];
+      const auto& result = target_results[i];
+      const auto& search = entry.request->SearchOptions();
+      const bool greedy = !search.do_sample || search.top_k == 1 || search.temperature == 0;
+      const int64_t committed_length_after_step =
+          entry.request->CurrentSequenceLength() + (result.token_appended ? 1 : 0);
+      const size_t max_draft_tokens = std::min({MaxDraftTokensPerStep(),
+                                                static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
+                                                committed_length_after_step + 1 < search.max_length
+                                                    ? static_cast<size_t>(search.max_length - committed_length_after_step - 1)
+                                                    : size_t{0}});
+      if (!result.token_appended || result.done || !greedy ||
+          search.repetition_penalty != 1.0f || search.no_repeat_ngram_size > 0 ||
+          search.min_length > entry.request->CurrentSequenceLength() ||
+          max_draft_tokens == 0) {
+        continue;
+      }
+
+      Feed feed;
+      feed.target = entry.request;
+      const size_t accepted = entry.request->AcceptedDraftTokenCount();
+      if (accepted > entry.draft_token_count) {
+        throw std::logic_error("MTP preparation observed more accepted drafts than the target planned.");
+      }
+      const auto staged_drafts = entry.request->StagedDraftTokens();
+      feed.tokens.insert(feed.tokens.end(), staged_drafts.begin(),
+                         staged_drafts.begin() + static_cast<ptrdiff_t>(accepted));
+      feed.tokens.push_back(result.token);
+      feed.target_hidden_row = entry.packed_token_offset +
+                               (entry.draft_token_count == 0
+                                    ? entry.unprocessed_token_count - 1
+                                    : 0);
+      feed.max_draft_tokens = max_draft_tokens;
+
+      const auto existing = mtp_requests_.find(entry.request.get());
+      if (existing != mtp_requests_.end()) {
+        feed.shadow = existing->second;
+        feed.shadow->SaveStateForTransaction();
+        checkpointed_shadows.push_back(feed.shadow);
+        feed.shadow->AppendTokensForAuxiliaryDecoder(feed.tokens);
+      } else {
+        auto params = CreateGeneratorParams(*mtp_model_);
+        params->search = search;
+        feed.shadow = std::make_shared<Request>(
+            std::move(params), entry.request->max_total_tokens_, abandonment_pending_);
+        feed.shadow->engine_ = shared_from_this();
+        feed.shadow->status_ = RequestStatus::Active;
+        feed.shadow->AppendTokensForAuxiliaryDecoder(feed.tokens);
+        feed.shadow->prompt_sequence_length_ = feed.shadow->CurrentSequenceLength();
+        feed.newly_created = true;
+      }
+      total_rows += feed.tokens.size();
+      feeds.push_back(std::move(feed));
+    }
+  } catch (...) {
+    const auto setup_error = std::current_exception();
+    for (auto it = checkpointed_shadows.rbegin(); it != checkpointed_shadows.rend(); ++it) {
+      try {
+        (*it)->RestoreStateForTransaction();
+      } catch (...) {
+      }
+    }
+    std::rethrow_exception(setup_error);
+  }
+  if (feeds.empty()) {
+    return nullptr;
+  }
+
+  auto step = std::make_unique<MtpStep>();
+  step->plan.transaction_id = target_plan.transaction_id;
+  step->plan.scheduled_request_limit = feeds.size();
+  step->plan.token_count = total_rows;
+  step->target_requests.reserve(feeds.size());
+  step->newly_created.reserve(feeds.size());
+  step->drafts.resize(feeds.size());
+
+  size_t packed_offset = 0;
+  for (const auto& feed : feeds) {
+    const size_t token_count = feed.tokens.size();
+    const size_t processed = static_cast<size_t>(feed.shadow->ProcessedSequenceLength());
+    step->plan.requests.push_back(RequestStepPlan{
+        feed.shadow,
+        feed.shadow.get(),
+        feed.shadow->CurrentSequenceLength(),
+        token_count,
+        0,
+        packed_offset,
+        packed_offset + token_count - 1,
+        processed + token_count,
+        static_cast<size_t>(feed.shadow->CurrentSequenceLength()) +
+            feed.max_draft_tokens - 1,
+        feed.shadow->IsPrefill(),
+        feed.newly_created,
+    });
+    step->target_requests.push_back(feed.target);
+    step->newly_created.push_back(feed.newly_created);
+    packed_offset += token_count;
+  }
+  step->plan.graph_capture_eligible = std::all_of(
+      step->plan.requests.begin(), step->plan.requests.end(),
+      [](const RequestStepPlan& entry) {
+        return !entry.is_prefill && entry.unprocessed_token_count == 1;
+      });
+
+  try {
+    const auto planning = mtp_cache_manager_->PlanStepResources(step->plan);
+    if (!planning.executable || step->plan.requests.size() != feeds.size()) {
+      throw std::runtime_error("The MTP cache could not reserve every target-committed suffix.");
+    }
+    step->reservation = mtp_cache_manager_->ReserveStep(step->plan);
+
+    Tensor packed_hidden_states{mtp_model_->p_device_inputs_, hidden_type};
+    const std::array<int64_t, 2> packed_hidden_shape{
+        static_cast<int64_t>(total_rows), hidden_size};
+    packed_hidden_states.CreateTensor(packed_hidden_shape);
+    const size_t row_bytes = static_cast<size_t>(hidden_size) * Ort::SizeOf(hidden_type);
+    auto source_bytes = target_hidden_states->GetByteSpan();
+    auto destination_bytes = packed_hidden_states.GetByteSpan();
+    size_t destination_row = 0;
+    for (const auto& feed : feeds) {
+      const size_t row_count = feed.tokens.size();
+      destination_bytes.subspan(destination_row * row_bytes, row_count * row_bytes)
+          .CopyFrom(source_bytes.subspan(feed.target_hidden_row * row_bytes,
+                                         row_count * row_bytes));
+      destination_row += row_count;
+    }
+
+    ScheduledRequests mtp_requests{step->plan, mtp_model_, nullptr, nullptr};
+    ExecutionContext context{&step->plan};
+    context.cache_reservation = step->reservation->PagedReservation();
+    context.hidden_states_input = packed_hidden_states.GetOrtTensor();
+    mtp_model_executor_->Decode(mtp_requests, context);
+    auto logits = mtp_requests.ProcessLogits();
+    const auto first_drafts = GreedyTokens(mtp_model_, logits);
+    for (size_t i = 0; i < first_drafts.size(); ++i) {
+      step->drafts[i].reserve(feeds[i].max_draft_tokens);
+      step->drafts[i].push_back(first_drafts[i]);
+      step->plan.requests[i].request->CommitAuxiliaryDecoderStep();
+    }
+
+    const auto copy_hidden_rows = [&](Tensor& source,
+                                      std::span<const size_t> source_rows) {
+      auto destination = std::make_unique<Tensor>(mtp_model_->p_device_inputs_, hidden_type);
+      const std::array<int64_t, 2> shape{
+          static_cast<int64_t>(source_rows.size()), hidden_size};
+      destination->CreateTensor(shape);
+      const size_t row_bytes = static_cast<size_t>(hidden_size) * Ort::SizeOf(hidden_type);
+      auto source_bytes = source.GetByteSpan();
+      auto destination_bytes = destination->GetByteSpan();
+      for (size_t row = 0; row < source_rows.size(); ++row) {
+        destination_bytes.subspan(row * row_bytes, row_bytes)
+            .CopyFrom(source_bytes.subspan(source_rows[row] * row_bytes, row_bytes));
+      }
+      return destination;
+    };
+
+    std::vector<size_t> active_feed_indices;
+    std::vector<size_t> feedback_rows;
+    for (size_t i = 0; i < feeds.size(); ++i) {
+      if (feeds[i].max_draft_tokens > 1) {
+        active_feed_indices.push_back(i);
+        feedback_rows.push_back(step->plan.requests[i].logits_row_index);
+      }
+    }
+    std::unique_ptr<Tensor> feedback_hidden;
+    if (!active_feed_indices.empty()) {
+      Tensor* head_hidden = mtp_requests.HiddenStates();
+      if (!head_hidden ||
+          head_hidden->GetShape() !=
+              std::vector<int64_t>{static_cast<int64_t>(total_rows), hidden_size}) {
+        throw std::runtime_error(
+            "Chained MTP drafts require one configured head hidden-state output row per input token.");
+      }
+      feedback_hidden = copy_hidden_rows(*head_hidden, feedback_rows);
+    }
+
+    for (size_t draft_index = 1; !active_feed_indices.empty(); ++draft_index) {
+      StepPlan chain_plan;
+      chain_plan.transaction_id = target_plan.transaction_id;
+      chain_plan.scheduled_request_limit = active_feed_indices.size();
+      chain_plan.token_count = active_feed_indices.size();
+      chain_plan.proposed_block_table_columns = step->plan.proposed_block_table_columns;
+      chain_plan.graph_capture_eligible = true;
+      chain_plan.requests.reserve(active_feed_indices.size());
+      for (size_t feed_index : active_feed_indices) {
+        auto& shadow = feeds[feed_index].shadow;
+        const std::array<int32_t, 1> token{step->drafts[feed_index].back()};
+        shadow->AppendTokensForAuxiliaryDecoder(token);
+        const size_t processed = static_cast<size_t>(shadow->ProcessedSequenceLength());
+        chain_plan.requests.push_back(RequestStepPlan{
+            shadow,
+            shadow.get(),
+            shadow->CurrentSequenceLength(),
+            1,
+            0,
+            chain_plan.requests.size(),
+            chain_plan.requests.size(),
+            processed + 1,
+            step->plan.requests[feed_index].whole_sequence_cache_slots,
+            false,
+            false,
+        });
+      }
+
+      ScheduledRequests chain_requests{chain_plan, mtp_model_, nullptr, nullptr};
+      ExecutionContext chain_context{&chain_plan};
+      chain_context.cache_reservation = step->reservation->PagedReservation();
+      chain_context.hidden_states_input = feedback_hidden->GetOrtTensor();
+      mtp_model_executor_->Decode(chain_requests, chain_context);
+      auto chain_logits = chain_requests.ProcessLogits();
+      const auto chain_drafts = GreedyTokens(mtp_model_, chain_logits);
+      for (size_t row = 0; row < active_feed_indices.size(); ++row) {
+        const size_t feed_index = active_feed_indices[row];
+        step->drafts[feed_index].push_back(chain_drafts[row]);
+        feeds[feed_index].shadow->CommitAuxiliaryDecoderStep();
+      }
+
+      std::vector<size_t> next_active_feed_indices;
+      std::vector<size_t> next_feedback_rows;
+      for (size_t row = 0; row < active_feed_indices.size(); ++row) {
+        if (feeds[active_feed_indices[row]].max_draft_tokens > draft_index + 1) {
+          next_active_feed_indices.push_back(active_feed_indices[row]);
+          next_feedback_rows.push_back(row);
+        }
+      }
+      if (!next_active_feed_indices.empty()) {
+        Tensor* head_hidden = chain_requests.HiddenStates();
+        if (!head_hidden ||
+            head_hidden->GetShape() !=
+                std::vector<int64_t>{static_cast<int64_t>(active_feed_indices.size()),
+                                     hidden_size}) {
+          throw std::runtime_error(
+              "Chained MTP hidden-state output does not match the active request batch.");
+        }
+        feedback_hidden = copy_hidden_rows(*head_hidden, next_feedback_rows);
+      }
+      active_feed_indices = std::move(next_active_feed_indices);
+    }
+
+    for (size_t i = 0; i < feeds.size(); ++i) {
+      feeds[i].shadow->RewindAuxiliaryDecoderTo(
+          static_cast<size_t>(step->plan.requests[i].target_cache_slots));
+    }
+    for (size_t i = 0; i < step->plan.requests.size(); ++i) {
+      if (step->newly_created[i]) {
+        mtp_requests_.emplace(step->target_requests[i].get(),
+                              step->plan.requests[i].request);
+      }
+    }
+  } catch (...) {
+    RollbackMtpStep(*step);
+    throw;
+  }
+  return step;
+}
+
+void Engine::RollbackMtpStep(MtpStep& step) {
+  std::exception_ptr rollback_error;
+  if (step.reservation) {
+    try {
+      step.reservation->Release();
+    } catch (...) {
+      rollback_error = std::current_exception();
+    }
+    step.reservation.reset();
+  }
+  for (size_t i = 0; i < step.plan.requests.size(); ++i) {
+    if (step.newly_created[i]) {
+      mtp_requests_.erase(step.target_requests[i].get());
+      continue;
+    }
+    try {
+      step.plan.requests[i].request->RestoreStateForTransaction();
+    } catch (...) {
+      if (!rollback_error) {
+        rollback_error = std::current_exception();
+      }
+    }
+  }
+  if (rollback_error) {
+    std::rethrow_exception(rollback_error);
+  }
+}
+
+void Engine::CommitMtpStep(MtpStep& step) {
+  for (size_t i = 0; i < step.plan.requests.size(); ++i) {
+    if (!step.newly_created[i]) {
+      step.plan.requests[i].request->CommitStateForTransaction();
+    }
+  }
+  step.reservation->Commit();
+  step.reservation.reset();
+  for (size_t i = 0; i < step.plan.requests.size(); ++i) {
+    step.plan.requests[i].request->CommitAuxiliaryDecoderStep();
+  }
+}
+
+void Engine::PublishMtpDrafts(MtpStep& step) {
+  for (size_t i = 0; i < step.plan.requests.size(); ++i) {
+    step.target_requests[i]->SetDraftTokens(step.drafts[i]);
+  }
 }
 
 void Engine::ValidateOwnerThread() const {
@@ -252,6 +660,14 @@ void Engine::CloseRequest(const std::shared_ptr<Request>& request) {
       !cache_manager_->SupportsDynamicBatching() &&
       cache_manager_->IsResident(request);
 
+  if (const auto mtp_it = mtp_requests_.find(request.get());
+      mtp_it != mtp_requests_.end()) {
+    std::vector<std::shared_ptr<Request>> mtp_requests{mtp_it->second};
+    mtp_cache_manager_->Deallocate(mtp_requests);
+    mtp_it->second->CompleteClose();
+    mtp_requests_.erase(mtp_it);
+  }
+
   pending_events_.erase(
       pending_events_.begin(),
       pending_events_.begin() + static_cast<ptrdiff_t>(pending_event_index_));
@@ -288,6 +704,16 @@ void Engine::DetachRequestForTeardown(
   }
 
   scheduler_->DetachRequestForTeardown(request);
+  if (const auto mtp_it = mtp_requests_.find(request.get());
+      mtp_it != mtp_requests_.end()) {
+    try {
+      std::vector<std::shared_ptr<Request>> mtp_requests{mtp_it->second};
+      mtp_cache_manager_->Deallocate(mtp_requests);
+    } catch (...) {
+    }
+    mtp_it->second->CompleteClose();
+    mtp_requests_.erase(mtp_it);
+  }
   pending_events_.erase(
       std::remove_if(
           pending_events_.begin(), pending_events_.end(),
@@ -614,12 +1040,21 @@ void Engine::RunDynamic() {
     context.fixed_state_staging_bytes = reservation->FixedStateStagingBytes();
 
     bool request_transaction_active = false;
+    std::unique_ptr<MtpStep> mtp_step;
     const auto rollback_transaction = [&]() {
       // Request/search state and composite cache state are checkpointed separately. Both must be
       // restored so a retry observes exactly the state that existed before this Run() call. The
       // reservation's Release() discards fixed provisional slots and staged banks as well as the
       // reserved paged blocks.
       std::exception_ptr rollback_error;
+      if (mtp_step) {
+        try {
+          RollbackMtpStep(*mtp_step);
+        } catch (...) {
+          rollback_error = std::current_exception();
+        }
+        mtp_step.reset();
+      }
       if (request_transaction_active) {
         try {
           scheduled_requests.RestoreStateForTransaction();
@@ -721,6 +1156,7 @@ void Engine::RunDynamic() {
             entry.unprocessed_token_count - entry.draft_token_count +
                 entry.request->AcceptedDraftTokenCount());
       }
+      mtp_step = PrepareMtpStep(step_plan_, step_results_, scheduled_requests);
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         if (step_results_[i].visible_token_count != 0 ||
             step_results_[i].done) {
@@ -762,6 +1198,9 @@ void Engine::RunDynamic() {
     // work into inactive banks without publishing anything.
     try {
       reservation->PrepareCommit();
+      if (mtp_step) {
+        mtp_step->reservation->PrepareCommit();
+      }
     } catch (...) {
       const auto preparation_error = std::current_exception();
       rollback_transaction();
@@ -781,9 +1220,15 @@ void Engine::RunDynamic() {
       scheduled_requests.CommitStateForTransaction();
       request_transaction_active = false;
       reservation->Commit();
+      if (mtp_step) {
+        CommitMtpStep(*mtp_step);
+      }
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         step_plan_.requests[i].request->CommitStep(
             step_plan_.requests[i], step_results_[i]);
+      }
+      if (mtp_step) {
+        PublishMtpDrafts(*mtp_step);
       }
     } catch (...) {
       MarkUnhealthyAndThrow(

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -238,10 +238,22 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       const auto& search = entry.request->SearchOptions();
       const int64_t committed_length_after_step =
           entry.request->CurrentSequenceLength();
+      const size_t sequence_limit =
+          std::min(static_cast<size_t>(search.max_length),
+                   entry.request->max_total_tokens_);
+      const size_t remaining_turn_tokens =
+          entry.request->RemainingTurnTokenBudget();
+      const size_t remaining_turn_tokens_after_step =
+          result.visible_token_count < remaining_turn_tokens
+              ? remaining_turn_tokens - result.visible_token_count
+              : 0;
       const size_t max_draft_tokens = std::min({MaxDraftTokensPerStep(),
                                                 static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
-                                                committed_length_after_step + 1 < search.max_length
-                                                    ? static_cast<size_t>(search.max_length - committed_length_after_step - 1)
+                                                static_cast<size_t>(committed_length_after_step) + 1 < sequence_limit
+                                                    ? sequence_limit - static_cast<size_t>(committed_length_after_step) - 1
+                                                    : size_t{0},
+                                                remaining_turn_tokens_after_step > 1
+                                                    ? remaining_turn_tokens_after_step - 1
                                                     : size_t{0}});
       if (!result.token_appended || result.done ||
           entry.request->DraftTokenValidationError() ||
@@ -468,6 +480,8 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     // ArgMax can still be reading its logits after Decode returns.
     std::vector<std::unique_ptr<ScheduledRequests>> pending_device_requests;
     pending_device_requests.reserve(max_draft_tokens - 1);
+    std::vector<std::unique_ptr<Tensor>> pending_device_inputs;
+    pending_device_inputs.reserve(max_draft_tokens - 1);
 
     for (size_t draft_index = 1; !active_feed_indices.empty(); ++draft_index) {
       StepPlan chain_plan;
@@ -536,6 +550,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
         if (device_draft_chain) {
           materialize_device_drafts();
           pending_device_requests.clear();
+          pending_device_inputs.clear();
           device_draft_chain = false;
         }
         chain_drafts = GreedyTokens(mtp_model_, chain_logits);
@@ -566,7 +581,12 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
           throw std::runtime_error(
               "Chained MTP hidden-state output does not match the active request batch.");
         }
-        feedback_hidden = copy_hidden_rows(*head_hidden, next_feedback_rows);
+        auto next_feedback_hidden =
+            copy_hidden_rows(*head_hidden, next_feedback_rows);
+        if (device_draft_chain) {
+          pending_device_inputs.push_back(std::move(feedback_hidden));
+        }
+        feedback_hidden = std::move(next_feedback_hidden);
       }
       if (device_draft_chain) {
         pending_device_requests.push_back(std::move(chain_requests));
@@ -834,13 +854,7 @@ void Engine::CloseRequest(const std::shared_ptr<Request>& request) {
       !cache_manager_->SupportsDynamicBatching() &&
       cache_manager_->IsResident(request);
 
-  if (const auto mtp_it = mtp_requests_.find(request.get());
-      mtp_it != mtp_requests_.end()) {
-    std::vector<std::shared_ptr<Request>> mtp_requests{mtp_it->second};
-    mtp_cache_manager_->Deallocate(mtp_requests);
-    mtp_it->second->CompleteClose();
-    mtp_requests_.erase(mtp_it);
-  }
+  CloseMtpRequest(request);
 
   pending_events_.erase(
       pending_events_.begin(),
@@ -869,6 +883,17 @@ void Engine::CloseRequest(const std::shared_ptr<Request>& request) {
             return tracked == request;
           }),
       tracked_requests_.end());
+}
+
+void Engine::CloseMtpRequest(const std::shared_ptr<Request>& request) {
+  const auto mtp_it = mtp_requests_.find(request.get());
+  if (mtp_it == mtp_requests_.end()) {
+    return;
+  }
+  std::vector<std::shared_ptr<Request>> mtp_requests{mtp_it->second};
+  mtp_cache_manager_->Deallocate(mtp_requests);
+  mtp_it->second->CompleteClose();
+  mtp_requests_.erase(mtp_it);
 }
 
 void Engine::DetachRequestForTeardown(
@@ -1506,6 +1531,7 @@ EngineEvent Engine::FailUnserviceableRequest(const void* request_id) {
             "Invalid unserviceable Request identity."}));
   }
   scheduler_->RemoveRequest(request);
+  CloseMtpRequest(request);
   request->CompleteFailedTurnFromEngine(*this);
 
   EngineEvent event;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -74,6 +74,41 @@ std::vector<int32_t> GreedyTokens(
   return tokens;
 }
 
+bool TryGreedyTokensToDevice(
+    const std::shared_ptr<DecoderOnly_Model>& model,
+    std::vector<DeviceSpan<float>>& logits,
+    DeviceSpan<int32_t> tokens) {
+  if (tokens.size() != logits.size()) {
+    return false;
+  }
+
+  const size_t vocab_size = static_cast<size_t>(model->config_->model.vocab_size);
+  const bool contiguous = !logits.empty() && std::all_of(
+                                                 logits.begin(), logits.end(),
+                                                 [&](DeviceSpan<float>& row) {
+                                                   const size_t index = &row - logits.data();
+                                                   return row.size() == vocab_size &&
+                                                          row.SameBufferAs(logits.front()) &&
+                                                          row.Span().data() ==
+                                                              logits.front().Span().data() +
+                                                                  index * vocab_size;
+                                                 });
+  if (contiguous) {
+    return model->p_device_->ArgMaxDevice(
+        logits.front().Span().data(), Ort::TypeToTensorType<float>,
+        static_cast<int>(logits.size()), model->config_->model.vocab_size, tokens);
+  }
+
+  for (size_t i = 0; i < logits.size(); ++i) {
+    if (!model->p_device_->ArgMaxDevice(
+            logits[i].Span().data(), Ort::TypeToTensorType<float>, 1,
+            model->config_->model.vocab_size, tokens.subspan(i, 1))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace
 
 Engine::Engine(std::shared_ptr<Model> model)
@@ -201,9 +236,10 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       const auto& entry = target_plan.requests[i];
       const auto& result = target_results[i];
       const auto& search = entry.request->SearchOptions();
-      const bool greedy = !search.do_sample || search.top_k == 1 || search.temperature == 0;
+      const bool greedy =
+          !search.do_sample || search.top_k == 1 || search.temperature == 0;
       const int64_t committed_length_after_step =
-          entry.request->CurrentSequenceLength() + (result.token_appended ? 1 : 0);
+          entry.request->CurrentSequenceLength();
       const size_t max_draft_tokens = std::min({MaxDraftTokensPerStep(),
                                                 static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
                                                 committed_length_after_step + 1 < search.max_length
@@ -309,6 +345,41 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     }
     step->reservation = mtp_cache_manager_->ReserveStep(step->plan);
 
+    const size_t max_draft_tokens = std::max_element(
+                                        feeds.begin(), feeds.end(),
+                                        [](const Feed& left, const Feed& right) {
+                                          return left.max_draft_tokens < right.max_draft_tokens;
+                                        })
+                                        ->max_draft_tokens;
+    bool device_draft_chain =
+        max_draft_tokens > 1 && mtp_model_->p_device_->GetType() == DeviceType::CUDA;
+    DeviceSpan<int32_t> device_drafts;
+    DeviceSpan<int32_t> device_chain_inputs;
+    if (device_draft_chain) {
+      const size_t draft_capacity = feeds.size() * max_draft_tokens;
+      if (mtp_device_drafts_.size() < draft_capacity) {
+        mtp_device_drafts_ = mtp_model_->p_device_->Allocate<int32_t>(draft_capacity);
+      }
+      if (mtp_device_chain_inputs_.size() < feeds.size()) {
+        mtp_device_chain_inputs_ = mtp_model_->p_device_->Allocate<int32_t>(feeds.size());
+      }
+      device_drafts = mtp_device_drafts_.subspan(0, draft_capacity);
+      device_chain_inputs = mtp_device_chain_inputs_.subspan(0, feeds.size());
+    }
+    std::vector<std::vector<size_t>> device_stage_feed_indices;
+    device_stage_feed_indices.reserve(max_draft_tokens);
+
+    const auto materialize_device_drafts = [&]() {
+      auto draft_ids = device_drafts.CopyDeviceToCpu();
+      for (size_t stage = 0; stage < device_stage_feed_indices.size(); ++stage) {
+        const auto& feed_indices = device_stage_feed_indices[stage];
+        for (size_t row = 0; row < feed_indices.size(); ++row) {
+          step->drafts[feed_indices[row]].push_back(
+              draft_ids[stage * feeds.size() + row]);
+        }
+      }
+    };
+
     Tensor packed_hidden_states{mtp_model_->p_device_inputs_, hidden_type};
     const std::array<int64_t, 2> packed_hidden_shape{
         static_cast<int64_t>(total_rows), hidden_size};
@@ -329,13 +400,32 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     ExecutionContext context{&step->plan};
     context.cache_reservation = step->reservation->PagedReservation();
     context.hidden_states_input = packed_hidden_states.GetOrtTensor();
+    if (device_draft_chain) {
+      context.run_options->AddConfigEntry("disable_synchronize_execution_providers", "1");
+    }
     mtp_model_executor_->Decode(mtp_requests, context);
     ++speculative_stats_.draft_forward_passes;
     auto logits = mtp_requests.ProcessLogits();
-    const auto first_drafts = GreedyTokens(mtp_model_, logits);
-    for (size_t i = 0; i < first_drafts.size(); ++i) {
+    device_draft_chain =
+        device_draft_chain &&
+        TryGreedyTokensToDevice(
+            mtp_model_, logits, device_drafts.subspan(0, feeds.size()));
+    std::vector<int32_t> first_drafts;
+    if (device_draft_chain) {
+      std::vector<size_t> first_stage_feed_indices;
+      first_stage_feed_indices.reserve(feeds.size());
+      for (size_t i = 0; i < feeds.size(); ++i) {
+        first_stage_feed_indices.push_back(i);
+      }
+      device_stage_feed_indices.push_back(std::move(first_stage_feed_indices));
+    } else {
+      first_drafts = GreedyTokens(mtp_model_, logits);
+    }
+    for (size_t i = 0; i < feeds.size(); ++i) {
       step->drafts[i].reserve(feeds[i].max_draft_tokens);
-      step->drafts[i].push_back(first_drafts[i]);
+      if (!device_draft_chain) {
+        step->drafts[i].push_back(first_drafts[i]);
+      }
       step->plan.requests[i].request->CommitAuxiliaryDecoderStep();
     }
 
@@ -356,8 +446,10 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     };
 
     std::vector<size_t> active_feed_indices;
+    std::vector<size_t> previous_stage_rows(feeds.size());
     std::vector<size_t> feedback_rows;
     for (size_t i = 0; i < feeds.size(); ++i) {
+      previous_stage_rows[i] = i;
       if (feeds[i].max_draft_tokens > 1) {
         active_feed_indices.push_back(i);
         feedback_rows.push_back(step->plan.requests[i].logits_row_index);
@@ -375,6 +467,9 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       feedback_hidden = copy_hidden_rows(*head_hidden, feedback_rows);
     }
 
+    std::vector<std::unique_ptr<ScheduledRequests>> pending_device_requests;
+    pending_device_requests.reserve(max_draft_tokens - 1);
+
     for (size_t draft_index = 1; !active_feed_indices.empty(); ++draft_index) {
       StepPlan chain_plan;
       chain_plan.transaction_id = target_plan.transaction_id;
@@ -383,10 +478,22 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       chain_plan.proposed_block_table_columns = step->plan.proposed_block_table_columns;
       chain_plan.graph_capture_eligible = true;
       chain_plan.requests.reserve(active_feed_indices.size());
-      for (size_t feed_index : active_feed_indices) {
+      DeviceSpan<int32_t> packed_device_inputs;
+      if (device_draft_chain) {
+        packed_device_inputs = device_chain_inputs.subspan(0, active_feed_indices.size());
+      }
+      for (size_t row = 0; row < active_feed_indices.size(); ++row) {
+        const size_t feed_index = active_feed_indices[row];
         auto& shadow = feeds[feed_index].shadow;
-        const std::array<int32_t, 1> token{step->drafts[feed_index].back()};
-        shadow->AppendTokensForAuxiliaryDecoder(token);
+        if (device_draft_chain) {
+          auto token = packed_device_inputs.subspan(row, 1);
+          token.CopyFrom(device_drafts.subspan(
+              (draft_index - 1) * feeds.size() + previous_stage_rows[feed_index], 1));
+          shadow->AppendTokensForAuxiliaryDecoder(token);
+        } else {
+          const std::array<int32_t, 1> token{step->drafts[feed_index].back()};
+          shadow->AppendTokensForAuxiliaryDecoder(token);
+        }
         const size_t processed = static_cast<size_t>(shadow->ProcessedSequenceLength());
         chain_plan.requests.push_back(RequestStepPlan{
             shadow,
@@ -403,18 +510,44 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
         });
       }
 
-      ScheduledRequests chain_requests{chain_plan, mtp_model_, nullptr, nullptr};
+      auto chain_requests = std::make_unique<ScheduledRequests>(
+          chain_plan, mtp_model_, nullptr, nullptr);
       ExecutionContext chain_context{&chain_plan};
       chain_context.cache_reservation = step->reservation->PagedReservation();
       chain_context.hidden_states_input = feedback_hidden->GetOrtTensor();
-      mtp_model_executor_->Decode(chain_requests, chain_context);
+      if (device_draft_chain) {
+        chain_context.input_ids = packed_device_inputs;
+        chain_context.run_options->AddConfigEntry(
+            "disable_synchronize_execution_providers", "1");
+      }
+      mtp_model_executor_->Decode(*chain_requests, chain_context);
       ++speculative_stats_.draft_forward_passes;
-      auto chain_logits = chain_requests.ProcessLogits();
-      const auto chain_drafts = GreedyTokens(mtp_model_, chain_logits);
+      auto chain_logits = chain_requests->ProcessLogits();
+      bool stage_on_device = false;
+      if (device_draft_chain) {
+        stage_on_device = TryGreedyTokensToDevice(
+            mtp_model_, chain_logits,
+            device_drafts.subspan(
+                draft_index * feeds.size(), active_feed_indices.size()));
+      }
+      std::vector<int32_t> chain_drafts;
+      if (stage_on_device) {
+        device_stage_feed_indices.push_back(active_feed_indices);
+      } else {
+        if (device_draft_chain) {
+          materialize_device_drafts();
+          pending_device_requests.clear();
+          device_draft_chain = false;
+        }
+        chain_drafts = GreedyTokens(mtp_model_, chain_logits);
+      }
       for (size_t row = 0; row < active_feed_indices.size(); ++row) {
         const size_t feed_index = active_feed_indices[row];
-        step->drafts[feed_index].push_back(chain_drafts[row]);
+        if (!device_draft_chain) {
+          step->drafts[feed_index].push_back(chain_drafts[row]);
+        }
         feeds[feed_index].shadow->CommitAuxiliaryDecoderStep();
+        previous_stage_rows[feed_index] = row;
       }
 
       std::vector<size_t> next_active_feed_indices;
@@ -426,7 +559,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
         }
       }
       if (!next_active_feed_indices.empty()) {
-        Tensor* head_hidden = chain_requests.HiddenStates();
+        Tensor* head_hidden = chain_requests->HiddenStates();
         if (!head_hidden ||
             head_hidden->GetShape() !=
                 std::vector<int64_t>{static_cast<int64_t>(active_feed_indices.size()),
@@ -436,7 +569,14 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
         }
         feedback_hidden = copy_hidden_rows(*head_hidden, next_feedback_rows);
       }
+      if (device_draft_chain) {
+        pending_device_requests.push_back(std::move(chain_requests));
+      }
       active_feed_indices = std::move(next_active_feed_indices);
+    }
+
+    if (device_draft_chain) {
+      materialize_device_drafts();
     }
 
     for (size_t i = 0; i < feeds.size(); ++i) {

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -10,6 +10,8 @@
 
 namespace Generators {
 
+static_assert(kMaxDraftTokensPerStep < kSpeculativeAcceptanceLengthBins);
+
 namespace {
 
 std::shared_ptr<GeneratorParams> CloneRequestParams(
@@ -328,6 +330,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     context.cache_reservation = step->reservation->PagedReservation();
     context.hidden_states_input = packed_hidden_states.GetOrtTensor();
     mtp_model_executor_->Decode(mtp_requests, context);
+    ++speculative_stats_.draft_forward_passes;
     auto logits = mtp_requests.ProcessLogits();
     const auto first_drafts = GreedyTokens(mtp_model_, logits);
     for (size_t i = 0; i < first_drafts.size(); ++i) {
@@ -405,6 +408,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       chain_context.cache_reservation = step->reservation->PagedReservation();
       chain_context.hidden_states_input = feedback_hidden->GetOrtTensor();
       mtp_model_executor_->Decode(chain_requests, chain_context);
+      ++speculative_stats_.draft_forward_passes;
       auto chain_logits = chain_requests.ProcessLogits();
       const auto chain_drafts = GreedyTokens(mtp_model_, chain_logits);
       for (size_t row = 0; row < active_feed_indices.size(); ++row) {
@@ -496,6 +500,30 @@ void Engine::CommitMtpStep(MtpStep& step) {
 void Engine::PublishMtpDrafts(MtpStep& step) {
   for (size_t i = 0; i < step.plan.requests.size(); ++i) {
     step.target_requests[i]->SetDraftTokens(step.drafts[i]);
+  }
+}
+
+void Engine::RecordSpeculativeCommit(const StepPlan& plan) noexcept {
+  for (const auto& entry : plan.requests) {
+    if (entry.draft_token_count == 0) {
+      continue;
+    }
+
+    const size_t accepted = entry.request->AcceptedDraftTokenCount();
+    ++speculative_stats_.rounds;
+    ++speculative_stats_.completed_rounds;
+    speculative_stats_.draft_tokens_proposed += entry.draft_token_count;
+    speculative_stats_.draft_tokens_evaluated +=
+        std::min(accepted + 1, entry.draft_token_count);
+    speculative_stats_.draft_tokens_accepted += accepted;
+    ++speculative_stats_.acceptance_length_histogram[accepted];
+    if (accepted == 0) {
+      ++speculative_stats_.zero_accept_rounds;
+    } else if (accepted == entry.draft_token_count) {
+      ++speculative_stats_.full_accept_rounds;
+    } else {
+      ++speculative_stats_.partial_accept_rounds;
+    }
   }
 }
 
@@ -890,6 +918,7 @@ void Engine::RunStatic() {
 
     try {
       model_executor_->Decode(scheduled_requests);
+      ++speculative_stats_.target_forward_passes;
       scheduled_requests.GenerateNextTokens(step_results_);
     } catch (...) {
       MarkUnhealthyAndThrow(
@@ -1106,6 +1135,7 @@ void Engine::RunDynamic() {
       scheduled_requests.BeginTransaction();
       request_transaction_active = true;
       model_executor_->Decode(scheduled_requests, context);
+      ++speculative_stats_.target_forward_passes;
     } catch (const ModelExecutionError& error) {
       const auto execution_error = std::current_exception();
       rollback_transaction();
@@ -1223,6 +1253,7 @@ void Engine::RunDynamic() {
       if (mtp_step) {
         CommitMtpStep(*mtp_step);
       }
+      RecordSpeculativeCommit(step_plan_);
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         step_plan_.requests[i].request->CommitStep(
             step_plan_.requests[i], step_results_[i]);
@@ -1465,6 +1496,20 @@ size_t Engine::MaxDraftTokensPerStep() const {
                  model_executor_->SupportsDraftVerification()
              ? cache_manager_->MaxDraftTokensPerStep()
              : 0;
+}
+
+SpeculativeStats Engine::GetSpeculativeStats() const noexcept {
+  auto stats = speculative_stats_;
+  if (stats.draft_tokens_evaluated != 0) {
+    stats.acceptance_rate = static_cast<float>(stats.draft_tokens_accepted) /
+                            static_cast<float>(stats.draft_tokens_evaluated);
+  }
+  if (stats.rounds != 0) {
+    stats.avg_draft_tokens_per_round =
+        static_cast<float>(stats.draft_tokens_proposed) /
+        static_cast<float>(stats.rounds);
+  }
+  return stats;
 }
 
 }  // namespace Generators

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -272,7 +272,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
           entry.request->CurrentSequenceLength();
       const size_t sequence_limit =
           std::min(static_cast<size_t>(search.max_length),
-                   entry.request->max_total_tokens_);
+                   entry.request->MaxTotalTokens());
       const size_t remaining_turn_tokens =
           entry.request->RemainingTurnTokenBudget();
       const size_t remaining_turn_tokens_after_step =
@@ -280,7 +280,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
               ? remaining_turn_tokens - result.visible_token_count
               : 0;
       const size_t max_draft_tokens = std::min({MaxDraftTokensPerStep(),
-                                                static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
+                                                static_cast<size_t>(entry.request->SpeculativeOptions().max_draft_tokens),
                                                 static_cast<size_t>(committed_length_after_step) + 1 < sequence_limit
                                                     ? sequence_limit - static_cast<size_t>(committed_length_after_step) - 1
                                                     : size_t{0},
@@ -318,12 +318,9 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       } else {
         auto params = CreateGeneratorParams(*mtp_model_);
         params->search = search;
-        feed.shadow = std::make_shared<Request>(
-            std::move(params), entry.request->max_total_tokens_, abandonment_pending_);
-        feed.shadow->engine_ = shared_from_this();
-        feed.shadow->status_ = RequestStatus::Active;
-        feed.shadow->AppendTokensForAuxiliaryDecoder(feed.tokens);
-        feed.shadow->prompt_sequence_length_ = feed.shadow->CurrentSequenceLength();
+        feed.shadow = Request::CreateAuxiliaryDecoderRequest(
+            std::move(params), entry.request->MaxTotalTokens(),
+            abandonment_pending_, shared_from_this(), feed.tokens);
         feed.newly_created = true;
       }
       total_rows += feed.tokens.size();
@@ -932,7 +929,7 @@ void Engine::CloseMtpRequest(const std::shared_ptr<Request>& request) {
   }
   std::vector<std::shared_ptr<Request>> mtp_requests{mtp_it->second};
   mtp_cache_manager_->Deallocate(mtp_requests);
-  mtp_it->second->CompleteClose();
+  mtp_it->second->CompleteCloseFromEngine(*this);
   mtp_requests_.erase(mtp_it);
 }
 
@@ -950,7 +947,7 @@ void Engine::DetachRequestForTeardown(
       mtp_cache_manager_->Deallocate(mtp_requests);
     } catch (...) {
     }
-    mtp_it->second->CompleteClose();
+    mtp_it->second->CompleteCloseFromEngine(*this);
     mtp_requests_.erase(mtp_it);
   }
   pending_events_.erase(

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -244,8 +244,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
                                                     ? static_cast<size_t>(search.max_length - committed_length_after_step - 1)
                                                     : size_t{0}});
       if (!result.token_appended || result.done ||
-          search.repetition_penalty != 1.0f || search.no_repeat_ngram_size > 0 ||
-          search.min_length > entry.request->CurrentSequenceLength() ||
+          entry.request->DraftTokenValidationError() ||
           max_draft_tokens == 0) {
         continue;
       }
@@ -465,6 +464,8 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       feedback_hidden = copy_hidden_rows(*head_hidden, feedback_rows);
     }
 
+    // Keep each stage's decoder I/O alive until the final device-to-host copy completes; device
+    // ArgMax can still be reading its logits after Decode returns.
     std::vector<std::unique_ptr<ScheduledRequests>> pending_device_requests;
     pending_device_requests.reserve(max_draft_tokens - 1);
 
@@ -596,11 +597,18 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
 
 void Engine::RollbackMtpStep(MtpStep& step) {
   std::exception_ptr rollback_error;
+  try {
+    mtp_model_->p_device_scoring_->Synchronize();
+  } catch (...) {
+    rollback_error = std::current_exception();
+  }
   if (step.reservation) {
     try {
       step.reservation->Release();
     } catch (...) {
-      rollback_error = std::current_exception();
+      if (!rollback_error) {
+        rollback_error = std::current_exception();
+      }
     }
     step.reservation.reset();
   }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -169,6 +169,8 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
     mtp_model = std::make_shared<DecoderOnly_Model>(
         CreateMtpDecoderConfig(*model->config_), GetOrtEnv());
     mtp_bytes_per_block = PagedKeyValueCacheBytesPerBlock(mtp_model);
+    // The head consumes the target decoder's packed hidden states, so the target must emit them.
+    model->config_->engine.hidden_states_output_required = true;
   }
 
   std::shared_ptr<CacheManager> cache_manager =
@@ -809,6 +811,12 @@ uint64_t Engine::BeginTurn(const std::shared_ptr<Request>& request,
   RequestTurnAdmission admission;
   bool added_to_scheduler = false;
 
+  // A continuation appends a prompt the MTP shadow never sees, so keeping the shadow would leave it
+  // a concatenation of generated tokens across turns with the intervening prompt missing. Drop it
+  // here so the next drafted step rebuilds a suffix-local shadow, matching fresh-turn semantics.
+  // Doing it before admission keeps a rolled back turn consistent: the shadow is simply rebuilt.
+  CloseMtpRequest(request);
+
   try {
     request->PrepareTurnAdmission(tokens, admission);
     if (first_turn) {
@@ -858,6 +866,9 @@ bool Engine::CancelRequest(const std::shared_ptr<Request>& request, uint64_t tur
 
   const auto counters =
       request->CompleteCancelFromEngine(*this, turn_id);
+  // The canceled turn's suffix is gone, so the shadow that mirrored it must not survive into the
+  // next turn.
+  CloseMtpRequest(request);
   EngineEvent terminal;
   terminal.request = request;
   terminal.turn_id = turn_id;
@@ -1394,7 +1405,21 @@ void Engine::RunDynamic() {
             entry.unprocessed_token_count - entry.draft_token_count +
                 entry.request->AcceptedDraftTokenCount());
       }
-      mtp_step = PrepareMtpStep(step_plan_, step_results_, scheduled_requests);
+      // MTP drafting is optional acceleration inside a mandatory target transaction. A recoverable
+      // head failure (cache pressure, shape mismatch, binding or session error) must not roll the
+      // committed target pass back, or a persistent failure would repeat forever with no progress.
+      // PrepareMtpStep restores every piece of MTP state before it rethrows, so the target step can
+      // commit without drafts. Contract violations and failed MTP rollback stay fatal below.
+      try {
+        mtp_step = PrepareMtpStep(step_plan_, step_results_, scheduled_requests);
+      } catch (const MtpRollbackError&) {
+        throw;
+      } catch (const std::logic_error&) {
+        throw;
+      } catch (...) {
+        mtp_step.reset();
+        ++speculative_stats_.standard_fallback_steps;
+      }
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         if (step_results_[i].visible_token_count != 0 ||
             step_results_[i].done) {
@@ -1717,7 +1742,10 @@ size_t Engine::MaxDraftTokensPerStep() const {
              : 0;
 }
 
-SpeculativeStats Engine::GetSpeculativeStats() const noexcept {
+SpeculativeStats Engine::GetSpeculativeStats() const {
+  // The counters are plain members mutated by Run(), so reading them from a monitoring thread
+  // would be a data race.
+  ValidateOwnerThread();
   auto stats = speculative_stats_;
   if (stats.draft_tokens_evaluated != 0) {
     stats.acceptance_rate = static_cast<float>(stats.draft_tokens_accepted) /

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -236,8 +236,6 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       const auto& entry = target_plan.requests[i];
       const auto& result = target_results[i];
       const auto& search = entry.request->SearchOptions();
-      const bool greedy =
-          !search.do_sample || search.top_k == 1 || search.temperature == 0;
       const int64_t committed_length_after_step =
           entry.request->CurrentSequenceLength();
       const size_t max_draft_tokens = std::min({MaxDraftTokensPerStep(),
@@ -245,7 +243,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
                                                 committed_length_after_step + 1 < search.max_length
                                                     ? static_cast<size_t>(search.max_length - committed_length_after_step - 1)
                                                     : size_t{0}});
-      if (!result.token_appended || result.done || !greedy ||
+      if (!result.token_appended || result.done ||
           search.repetition_penalty != 1.0f || search.no_repeat_ngram_size > 0 ||
           search.min_length > entry.request->CurrentSequenceLength() ||
           max_draft_tokens == 0) {

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -6,13 +6,15 @@
 
 #include <limits>
 
-#include "../search.h"
-
 namespace Generators {
 
 static_assert(kMaxDraftTokensPerStep < kSpeculativeAcceptanceLengthBins);
 
 namespace {
+
+struct MtpRollbackError : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
 
 std::shared_ptr<GeneratorParams> CloneRequestParams(
     const GeneratorParams& source,
@@ -230,6 +232,36 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
   feeds.reserve(target_plan.requests.size());
   std::vector<std::shared_ptr<Request>> checkpointed_shadows;
   checkpointed_shadows.reserve(target_plan.requests.size());
+  const auto restore_checkpointed_shadows = [&]() {
+    std::exception_ptr rollback_error;
+    for (auto it = checkpointed_shadows.rbegin();
+         it != checkpointed_shadows.rend(); ++it) {
+      try {
+        (*it)->RestoreStateForTransaction();
+      } catch (...) {
+        if (!rollback_error) {
+          rollback_error = std::current_exception();
+        }
+      }
+    }
+    if (rollback_error) {
+      std::rethrow_exception(rollback_error);
+    }
+  };
+  const auto rollback_setup_and_rethrow =
+      [&](std::exception_ptr setup_error) -> void {
+    try {
+      restore_checkpointed_shadows();
+    } catch (...) {
+      auto message = AddExceptionCause(
+          "MTP shadow setup failed.", setup_error);
+      message = AddExceptionCause(
+          std::move(message) + " Shadow rollback also failed.",
+          std::current_exception());
+      throw MtpRollbackError(std::move(message));
+    }
+    std::rethrow_exception(setup_error);
+  };
   size_t total_rows = 0;
   try {
     for (size_t i = 0; i < target_plan.requests.size(); ++i) {
@@ -298,54 +330,52 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       feeds.push_back(std::move(feed));
     }
   } catch (...) {
-    const auto setup_error = std::current_exception();
-    for (auto it = checkpointed_shadows.rbegin(); it != checkpointed_shadows.rend(); ++it) {
-      try {
-        (*it)->RestoreStateForTransaction();
-      } catch (...) {
-      }
-    }
-    std::rethrow_exception(setup_error);
+    rollback_setup_and_rethrow(std::current_exception());
   }
   if (feeds.empty()) {
     return nullptr;
   }
 
-  auto step = std::make_unique<MtpStep>();
-  step->plan.transaction_id = target_plan.transaction_id;
-  step->plan.scheduled_request_limit = feeds.size();
-  step->plan.token_count = total_rows;
-  step->target_requests.reserve(feeds.size());
-  step->newly_created.reserve(feeds.size());
-  step->drafts.resize(feeds.size());
+  std::unique_ptr<MtpStep> step;
+  try {
+    step = std::make_unique<MtpStep>();
+    step->plan.transaction_id = target_plan.transaction_id;
+    step->plan.scheduled_request_limit = feeds.size();
+    step->plan.token_count = total_rows;
+    step->target_requests.reserve(feeds.size());
+    step->newly_created.reserve(feeds.size());
+    step->drafts.resize(feeds.size());
 
-  size_t packed_offset = 0;
-  for (const auto& feed : feeds) {
-    const size_t token_count = feed.tokens.size();
-    const size_t processed = static_cast<size_t>(feed.shadow->ProcessedSequenceLength());
-    step->plan.requests.push_back(RequestStepPlan{
-        feed.shadow,
-        feed.shadow.get(),
-        feed.shadow->CurrentSequenceLength(),
-        token_count,
-        0,
-        packed_offset,
-        packed_offset + token_count - 1,
-        processed + token_count,
-        static_cast<size_t>(feed.shadow->CurrentSequenceLength()) +
-            feed.max_draft_tokens - 1,
-        feed.shadow->IsPrefill(),
-        feed.newly_created,
-    });
-    step->target_requests.push_back(feed.target);
-    step->newly_created.push_back(feed.newly_created);
-    packed_offset += token_count;
-  }
-  step->plan.graph_capture_eligible = std::all_of(
-      step->plan.requests.begin(), step->plan.requests.end(),
-      [](const RequestStepPlan& entry) {
-        return !entry.is_prefill && entry.unprocessed_token_count == 1;
+    size_t packed_offset = 0;
+    for (const auto& feed : feeds) {
+      const size_t token_count = feed.tokens.size();
+      const size_t processed = static_cast<size_t>(feed.shadow->ProcessedSequenceLength());
+      step->plan.requests.push_back(RequestStepPlan{
+          feed.shadow,
+          feed.shadow.get(),
+          feed.shadow->CurrentSequenceLength(),
+          token_count,
+          0,
+          packed_offset,
+          packed_offset + token_count - 1,
+          processed + token_count,
+          static_cast<size_t>(feed.shadow->CurrentSequenceLength()) +
+              feed.max_draft_tokens - 1,
+          feed.shadow->IsPrefill(),
+          feed.newly_created,
       });
+      step->target_requests.push_back(feed.target);
+      step->newly_created.push_back(feed.newly_created);
+      packed_offset += token_count;
+    }
+    step->plan.graph_capture_eligible = std::all_of(
+        step->plan.requests.begin(), step->plan.requests.end(),
+        [](const RequestStepPlan& entry) {
+          return !entry.is_prefill && entry.unprocessed_token_count == 1;
+        });
+  } catch (...) {
+    rollback_setup_and_rethrow(std::current_exception());
+  }
 
   try {
     const auto planning = mtp_cache_manager_->PlanStepResources(step->plan);
@@ -609,8 +639,18 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
       }
     }
   } catch (...) {
-    RollbackMtpStep(*step);
-    throw;
+    const auto preparation_error = std::current_exception();
+    try {
+      RollbackMtpStep(*step);
+    } catch (...) {
+      auto message = AddExceptionCause(
+          "MTP step preparation failed.", preparation_error);
+      message = AddExceptionCause(
+          std::move(message) + " MTP rollback also failed.",
+          std::current_exception());
+      throw MtpRollbackError(std::move(message));
+    }
+    std::rethrow_exception(preparation_error);
   }
   return step;
 }
@@ -1370,6 +1410,16 @@ void Engine::RunDynamic() {
             return step_plan_.requests[left].scheduling_order <
                    step_plan_.requests[right].scheduling_order;
           });
+    } catch (const MtpRollbackError&) {
+      const auto rollback_error = std::current_exception();
+      rollback_transaction();
+      ++transaction_metrics_.post_processing_aborts;
+      MarkUnhealthyAndThrow(
+          StepOutcomeKind::FatalExecutionFailure,
+          step_plan_.transaction_id,
+          nullptr,
+          "MTP rollback failed and the Engine is no longer healthy.",
+          rollback_error);
     } catch (const std::logic_error&) {
       const auto post_processing_error = std::current_exception();
       rollback_transaction();

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -74,6 +74,9 @@ struct EngineDependencies {
   std::shared_ptr<CacheManager> cache_manager;
   std::unique_ptr<Scheduler> scheduler;
   std::unique_ptr<ModelExecutor> model_executor;
+  std::shared_ptr<DecoderOnly_Model> mtp_model;
+  std::shared_ptr<CacheManager> mtp_cache_manager;
+  std::unique_ptr<ModelExecutor> mtp_model_executor;
 };
 
 struct EngineTransactionMetrics {
@@ -189,6 +192,26 @@ struct Engine : std::enable_shared_from_this<Engine>,
   void ValidateRequestCanContinue(
       const std::shared_ptr<Request>& request,
       bool allow_nonresident = false) const;
+
+  struct MtpStep {
+    StepPlan plan;
+    std::vector<std::shared_ptr<Request>> target_requests;
+    std::vector<bool> newly_created;
+    std::vector<std::vector<int32_t>> drafts;
+    std::unique_ptr<CacheStepReservation> reservation;
+  };
+
+  void ReclaimAbandonedRequests();
+  std::shared_ptr<Request> DrainReadyRequest();
+  std::shared_ptr<Request> StepDynamic();
+  std::shared_ptr<Request> StepStatic();
+  std::unique_ptr<MtpStep> PrepareMtpStep(
+      const StepPlan& target_plan,
+      const std::vector<RequestStepResult>& target_results,
+      ScheduledRequests& target_requests);
+  void RollbackMtpStep(MtpStep& step);
+  void CommitMtpStep(MtpStep& step);
+  void PublishMtpDrafts(MtpStep& step);
   [[noreturn]] void HandleContinuationRestoreFailure(
       const std::shared_ptr<Request>& request,
       std::exception_ptr append_error,
@@ -203,6 +226,12 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::shared_ptr<CacheManager> cache_manager_;    // The cache manager for handling cached data.
   std::unique_ptr<Scheduler> scheduler_;           // The scheduler responsible for managing execution order.
   std::unique_ptr<ModelExecutor> model_executor_;  // The executor responsible for running the model.
+  // Present only when model.mtp names an auxiliary paged draft head. These are constructed with
+  // the Engine so both cache pools share one memory budget; draft orchestration is added separately.
+  std::shared_ptr<DecoderOnly_Model> mtp_model_;
+  std::shared_ptr<CacheManager> mtp_cache_manager_;
+  std::unique_ptr<ModelExecutor> mtp_model_executor_;
+  std::unordered_map<const Request*, std::shared_ptr<Request>> mtp_requests_;
   const std::thread::id owner_thread_{std::this_thread::get_id()};
   EngineHealth health_{EngineHealth::Healthy};
   std::exception_ptr fatal_error_;

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -235,6 +235,8 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::shared_ptr<CacheManager> mtp_cache_manager_;
   std::unique_ptr<ModelExecutor> mtp_model_executor_;
   std::unordered_map<const Request*, std::shared_ptr<Request>> mtp_requests_;
+  DeviceSpan<int32_t> mtp_device_drafts_;
+  DeviceSpan<int32_t> mtp_device_chain_inputs_;
   const std::thread::id owner_thread_{std::this_thread::get_id()};
   EngineHealth health_{EngineHealth::Healthy};
   std::exception_ptr fatal_error_;

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -6,6 +6,7 @@
 #include "request.h"
 #include "model_executor.h"
 #include "scheduler.h"
+#include "../decoding/speculative_stats.h"
 
 #include <thread>
 
@@ -167,6 +168,11 @@ struct Engine : std::enable_shared_from_this<Engine>,
    */
   size_t MaxDraftTokensPerStep() const;
 
+  /**
+   * @brief Returns cumulative speculative-decoding work and acceptance statistics.
+   */
+  SpeculativeStats GetSpeculativeStats() const noexcept;
+
   uint64_t BeginTurn(const std::shared_ptr<Request>& request,
                      std::span<const int32_t> tokens,
                      std::optional<size_t> max_generated_tokens);
@@ -201,10 +207,6 @@ struct Engine : std::enable_shared_from_this<Engine>,
     std::unique_ptr<CacheStepReservation> reservation;
   };
 
-  void ReclaimAbandonedRequests();
-  std::shared_ptr<Request> DrainReadyRequest();
-  std::shared_ptr<Request> StepDynamic();
-  std::shared_ptr<Request> StepStatic();
   std::unique_ptr<MtpStep> PrepareMtpStep(
       const StepPlan& target_plan,
       const std::vector<RequestStepResult>& target_results,
@@ -212,6 +214,7 @@ struct Engine : std::enable_shared_from_this<Engine>,
   void RollbackMtpStep(MtpStep& step);
   void CommitMtpStep(MtpStep& step);
   void PublishMtpDrafts(MtpStep& step);
+  void RecordSpeculativeCommit(const StepPlan& plan) noexcept;
   [[noreturn]] void HandleContinuationRestoreFailure(
       const std::shared_ptr<Request>& request,
       std::exception_ptr append_error,
@@ -237,6 +240,7 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::exception_ptr fatal_error_;
   StepTransactionId next_transaction_id_{1};
   EngineTransactionMetrics transaction_metrics_;
+  SpeculativeStats speculative_stats_;
   StepPlan step_plan_;
   std::vector<RequestStepResult> step_results_;
   std::vector<size_t> staged_event_order_;

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -215,6 +215,7 @@ struct Engine : std::enable_shared_from_this<Engine>,
   void CommitMtpStep(MtpStep& step);
   void PublishMtpDrafts(MtpStep& step);
   void RecordSpeculativeCommit(const StepPlan& plan) noexcept;
+  void CloseMtpRequest(const std::shared_ptr<Request>& request);
   [[noreturn]] void HandleContinuationRestoreFailure(
       const std::shared_ptr<Request>& request,
       std::exception_ptr append_error,

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -170,8 +170,11 @@ struct Engine : std::enable_shared_from_this<Engine>,
 
   /**
    * @brief Returns cumulative speculative-decoding work and acceptance statistics.
+   *
+   * Must be called from the Engine owner thread: the counters are updated by Run() without
+   * synchronization.
    */
-  SpeculativeStats GetSpeculativeStats() const noexcept;
+  SpeculativeStats GetSpeculativeStats() const;
 
   uint64_t BeginTurn(const std::shared_ptr<Request>& request,
                      std::span<const int32_t> tokens,

--- a/src/engine/execution_context.h
+++ b/src/engine/execution_context.h
@@ -25,6 +25,9 @@ struct ExecutionContext {
   std::span<const FixedStateSlotHandle> fixed_state_slots;
   std::span<const FixedStateBinding> fixed_state_bindings;
   size_t fixed_state_staging_bytes{};
+  // Optional packed int32 token ids already resident on the model device. VarlenDecoderIO casts
+  // these directly into its int64 input tensor without reading a request's host token mirror.
+  DeviceSpan<int32_t> input_ids;
   // Optional packed [token_count, hidden_size] input supplied by an auxiliary decoder driver.
   // Ordinary decoder steps leave this null.
   OrtValue* hidden_states_input{};

--- a/src/engine/execution_context.h
+++ b/src/engine/execution_context.h
@@ -25,6 +25,9 @@ struct ExecutionContext {
   std::span<const FixedStateSlotHandle> fixed_state_slots;
   std::span<const FixedStateBinding> fixed_state_bindings;
   size_t fixed_state_staging_bytes{};
+  // Optional packed [token_count, hidden_size] input supplied by an auxiliary decoder driver.
+  // Ordinary decoder steps leave this null.
+  OrtValue* hidden_states_input{};
   std::unique_ptr<OrtRunOptions> run_options;
   size_t block_table_columns{};
 };

--- a/src/engine/paged_cache_reservation.cpp
+++ b/src/engine/paged_cache_reservation.cpp
@@ -407,7 +407,7 @@ void PagedCacheReservation::FillBlockTable(std::span<const void* const> request_
   if (state_ != PagedCacheReservationState::Reserved) {
     throw std::logic_error("Paged cache block table is only available while the reservation is active.");
   }
-  if (request_ids.size() != deltas_.size() ||
+  if (request_ids.size() > deltas_.size() ||
       columns < RequiredBlockTableColumns() ||
       output.size() != request_ids.size() * columns) {
     throw std::runtime_error("Paged cache block table output has an invalid shape.");
@@ -439,7 +439,7 @@ void PagedCacheReservation::FillWindowBlockTable(
   if (state_ != PagedCacheReservationState::Reserved || !window_block_pool_) {
     throw std::logic_error("Paged cache window block table is unavailable.");
   }
-  if (request_ids.size() != deltas_.size() ||
+  if (request_ids.size() > deltas_.size() ||
       output.size() != request_ids.size() * columns) {
     throw std::runtime_error("Paged cache window block table output has an invalid shape.");
   }

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -106,7 +106,8 @@ size_t BytesPerBlock(const std::shared_ptr<Model>& model,
 size_t ComputeNumBlocks(std::shared_ptr<Model> model,
                         size_t full_layer_count,
                         size_t windowed_bytes,
-                        ONNXTensorElementDataType dtype) {
+                        ONNXTensorElementDataType dtype,
+                        size_t auxiliary_bytes_per_block) {
   if (model->config_->engine.dynamic_batching->num_blocks.has_value()) {
     return *model->config_->engine.dynamic_batching->num_blocks;
   }
@@ -122,7 +123,8 @@ size_t ComputeNumBlocks(std::shared_ptr<Model> model,
       model->config_->model.decoder.num_key_value_heads,
       model->config_->model.decoder.head_size,
       full_layer_count,
-      Ort::SizeOf(dtype));
+      Ort::SizeOf(dtype),
+      auxiliary_bytes_per_block);
 }
 
 size_t UsedSlots(const std::vector<std::shared_ptr<Block>>& blocks) {
@@ -146,7 +148,8 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
                                  size_t num_key_value_heads,
                                  size_t head_size,
                                  size_t full_layer_count,
-                                 size_t element_size) {
+                                 size_t element_size,
+                                 size_t auxiliary_bytes_per_block) {
   if (block_size == 0 || num_key_value_heads == 0 || head_size == 0 ||
       full_layer_count == 0 || element_size == 0) {
     throw std::invalid_argument(
@@ -161,16 +164,23 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
   }
 
   constexpr size_t num_caches_per_layer = 2;
+  const size_t primary_bytes_per_block =
+      block_size * num_key_value_heads * head_size * full_layer_count *
+      element_size * num_caches_per_layer;
   return (budget - reserved_memory_bytes) /
-         (block_size *
-          num_key_value_heads *
-          head_size *
-          full_layer_count *
-          element_size *
-          num_caches_per_layer);
+         (primary_bytes_per_block + auxiliary_bytes_per_block);
 }
 
-PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
+size_t PagedKeyValueCacheBytesPerBlock(const std::shared_ptr<Model>& model) {
+  const auto paged_group = ResolvePagedKeyValueGroup(model->config_->model.decoder);
+  const auto dtype = KeyValueCacheType(model, paged_group);
+  const auto windowed = WindowedLayers(model, paged_group);
+  const size_t full_layer_count = paged_group.layer_ids.size() - windowed.size();
+  return full_layer_count * BytesPerBlock(model, dtype);
+}
+
+PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model,
+                                       size_t auxiliary_bytes_per_block)
     : model_(model) {
   const auto& decoder = model->config_->model.decoder;
   const size_t block_size = model->config_->engine.dynamic_batching->block_size;
@@ -209,7 +219,8 @@ PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
   const auto num_blocks = ComputeNumBlocks(model_, num_full_layers,
                                            num_window_blocks * windowed.size() *
                                                BytesPerBlock(model, dtype),
-                                           dtype);
+                                           dtype,
+                                           auxiliary_bytes_per_block);
 
   for (const int layer_id : paged_group.layer_ids) {
     const auto blocks = windowed.count(layer_id) != 0 ? num_window_blocks : num_blocks;

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -3,6 +3,7 @@
 
 #include "cache_manager.h"
 
+#include <limits>
 #include <numeric>
 #include <set>
 
@@ -109,7 +110,10 @@ size_t ComputeNumBlocks(std::shared_ptr<Model> model,
                         ONNXTensorElementDataType dtype,
                         size_t auxiliary_bytes_per_block) {
   if (model->config_->engine.dynamic_batching->num_blocks.has_value()) {
-    return *model->config_->engine.dynamic_batching->num_blocks;
+    return ResolveConfiguredPagedBlockCount(
+        *model->config_->engine.dynamic_batching->num_blocks,
+        BytesPerBlock(model, dtype) * full_layer_count,
+        auxiliary_bytes_per_block);
   }
 
   size_t free_bytes, total_bytes;
@@ -169,6 +173,32 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
       element_size * num_caches_per_layer;
   return (budget - reserved_memory_bytes) /
          (primary_bytes_per_block + auxiliary_bytes_per_block);
+}
+
+size_t ResolveConfiguredPagedBlockCount(size_t configured_num_blocks,
+                                        size_t primary_bytes_per_block,
+                                        size_t auxiliary_bytes_per_block) {
+  if (primary_bytes_per_block == 0) {
+    throw std::invalid_argument(
+        "Paged cache primary bytes per block must be greater than zero");
+  }
+  if (auxiliary_bytes_per_block == 0) {
+    return configured_num_blocks;
+  }
+  if (configured_num_blocks >
+      std::numeric_limits<size_t>::max() / primary_bytes_per_block) {
+    throw std::runtime_error(
+        "engine.dynamic_batching.num_blocks is too large for the paged key-value cache.");
+  }
+  const size_t blocks =
+      (configured_num_blocks * primary_bytes_per_block) /
+      (primary_bytes_per_block + auxiliary_bytes_per_block);
+  if (blocks == 0) {
+    throw std::runtime_error(
+        "engine.dynamic_batching.num_blocks is too small to hold both the target and the "
+        "MTP head key-value caches.");
+  }
+  return blocks;
 }
 
 size_t PagedKeyValueCacheBytesPerBlock(const std::shared_ptr<Model>& model) {

--- a/src/engine/paged_key_value_cache.h
+++ b/src/engine/paged_key_value_cache.h
@@ -44,6 +44,14 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
                                  size_t element_size,
                                  size_t auxiliary_bytes_per_block = 0);
 
+// Resolves an explicitly configured engine.dynamic_batching.num_blocks into the target pool's
+// block count. num_blocks is the whole paged budget: an Engine-hosted MTP head is given the same
+// block count as the target, so the target pool shrinks until both pools together cost what the
+// configured count would have cost on its own.
+size_t ResolveConfiguredPagedBlockCount(size_t configured_num_blocks,
+                                        size_t primary_bytes_per_block,
+                                        size_t auxiliary_bytes_per_block);
+
 size_t PagedKeyValueCacheBytesPerBlock(const std::shared_ptr<Model>& model);
 
 /*

--- a/src/engine/paged_key_value_cache.h
+++ b/src/engine/paged_key_value_cache.h
@@ -41,7 +41,10 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
                                  size_t num_key_value_heads,
                                  size_t head_size,
                                  size_t full_layer_count,
-                                 size_t element_size);
+                                 size_t element_size,
+                                 size_t auxiliary_bytes_per_block = 0);
+
+size_t PagedKeyValueCacheBytesPerBlock(const std::shared_ptr<Model>& model);
 
 /*
  * PagedKeyValueCache manages a paged key-value cache for models that use the PagedAttention operator.
@@ -55,7 +58,8 @@ size_t ComputePagedBlockCapacity(size_t available_memory_bytes,
  */
 struct PagedKeyValueCache {
  public:
-  explicit PagedKeyValueCache(std::shared_ptr<Model> model);
+  explicit PagedKeyValueCache(std::shared_ptr<Model> model,
+                              size_t auxiliary_bytes_per_block = 0);
 
   bool CanAdd(std::shared_ptr<Request> request) const;
 

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -68,6 +68,7 @@ Request::Request(
       params_{params},
       rng_{CreateRandomGenerator(params->search.random_seed)},
       search_{CreateSearch(*params)} {
+  draft_tokens_.reserve(kMaxDraftTokensPerStep);
   // A request is one sequence: the engine batches requests, not rows within a request. Several
   // places here read row 0 only (UnprocessedTokens, CurrentSequenceLength) or take the tail of the
   // next-token span, so a wider search would silently mirror the wrong row's tokens.
@@ -522,6 +523,36 @@ void Request::AdvanceChunk() {
   processed_sequence_length_ += static_cast<int64_t>(ScheduledTokenCount());
 }
 
+void Request::AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens) {
+  if (status_ != RequestStatus::Active || tokens.empty() ||
+      processed_sequence_length_ != CurrentSequenceLength()) {
+    throw std::logic_error(
+        "Auxiliary decoder tokens require an active request with no pending rows.");
+  }
+  ValidateAppendLength(*params_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+  auto device_tokens = AllocateOnDevice(*params_, tokens);
+  search_->AppendTokens(device_tokens);
+  tokens_host_.insert(tokens_host_.end(), tokens.begin(), tokens.end());
+}
+
+void Request::RewindAuxiliaryDecoderTo(size_t sequence_length) {
+  if (status_ != RequestStatus::Active ||
+      processed_sequence_length_ != CurrentSequenceLength() ||
+      sequence_length > static_cast<size_t>(processed_sequence_length_)) {
+    throw std::logic_error(
+        "Auxiliary decoder rewind requires an active request at a processed sequence boundary.");
+  }
+  search_->RewindTo(sequence_length);
+  tokens_host_.resize(sequence_length);
+  processed_sequence_length_ = static_cast<int64_t>(sequence_length);
+  scheduled_token_count_ = 0;
+}
+
+void Request::CommitAuxiliaryDecoderStep() noexcept {
+  processed_sequence_length_ += static_cast<int64_t>(ScheduledTokenCount());
+  scheduled_token_count_ = 0;
+}
+
 DeviceSpan<int32_t> Request::UnprocessedTokens() {
   auto sequence = search_->GetSequence(0);
   return sequence.subspan(processed_sequence_length_, ScheduledTokenCount());
@@ -603,6 +634,8 @@ void Request::SaveStateForTransaction() {
   search_->SaveStateForTransaction();
   guidance_transaction_checkpoint_ = std::move(guidance_checkpoint);
   transaction_rng_ = rng_;
+  transaction_processed_sequence_length_ = processed_sequence_length_;
+  transaction_tokens_host_size_ = tokens_host_.size();
 }
 
 void Request::SaveStateForExternalSamplingTransaction() {
@@ -612,6 +645,8 @@ void Request::SaveStateForExternalSamplingTransaction() {
   search_->SaveStateForExternalSamplingTransaction();
   guidance_transaction_checkpoint_ = std::move(guidance_checkpoint);
   transaction_rng_ = rng_;
+  transaction_processed_sequence_length_ = processed_sequence_length_;
+  transaction_tokens_host_size_ = tokens_host_.size();
 }
 
 RequestStepResult Request::ApplyLogitsForTransaction(DeviceSpan<float> logits,
@@ -669,7 +704,11 @@ RequestStepResult Request::StageDraftCompletionForTransaction() {
 void Request::RestoreStateForTransaction() {
   search_->RestoreStateForTransaction();
   rng_ = transaction_rng_;
-  DiscardStagedDrafts();
+  processed_sequence_length_ = transaction_processed_sequence_length_;
+  tokens_host_.resize(transaction_tokens_host_size_);
+  staged_draft_count_ = 0;
+  accepted_draft_count_ = 0;
+  scheduled_token_count_ = 0;
   if (guidance_transaction_checkpoint_) {
     guidance_logits_processor_ = std::move(guidance_transaction_checkpoint_);
   }
@@ -678,7 +717,11 @@ void Request::RestoreStateForTransaction() {
 void Request::QueueStateRestoreForTransaction() {
   search_->QueueStateRestoreForTransaction();
   rng_ = transaction_rng_;
-  DiscardStagedDrafts();
+  processed_sequence_length_ = transaction_processed_sequence_length_;
+  tokens_host_.resize(transaction_tokens_host_size_);
+  staged_draft_count_ = 0;
+  accepted_draft_count_ = 0;
+  scheduled_token_count_ = 0;
 }
 
 void Request::CompleteStateRestoreForTransaction() {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -560,7 +560,7 @@ void Request::AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens) {
     throw std::logic_error(
         "Auxiliary decoder tokens require an active request with no pending rows.");
   }
-  ValidateAppendLength(*params_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+  ValidateAppendLength(max_total_tokens_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
   auto device_tokens = AllocateOnDevice(*params_, tokens);
   search_->AppendTokens(device_tokens);
   tokens_host_.insert(tokens_host_.end(), tokens.begin(), tokens.end());
@@ -572,7 +572,7 @@ void Request::AppendTokensForAuxiliaryDecoder(DeviceSpan<int32_t> tokens) {
     throw std::logic_error(
         "Auxiliary decoder tokens require an active request with no pending rows.");
   }
-  ValidateAppendLength(*params_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+  ValidateAppendLength(max_total_tokens_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
   search_->AppendTokens(tokens);
   const int32_t non_pad = params_->config.model.pad_token_id == 0 ? 1 : 0;
   tokens_host_.insert(tokens_host_.end(), tokens.size(), non_pad);

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -372,10 +372,10 @@ void Request::SetDraftTokens(std::span<const int32_t> tokens) {
   }
 
   const auto& search = params_->search;
-  // Verification compares the target model's argmax against each draft, which only reproduces the
-  // request's own token stream when that stream is greedy.
-  if (search.do_sample && search.top_k != 1 && search.temperature != 0) {
-    throw std::runtime_error("Speculative draft tokens require a greedy request.");
+  // Sampled verification extracts a bounded target distribution for every row. Pure nucleus
+  // sampling has no bounded sparse support and stays on the standard path.
+  if (search.do_sample && search.top_k != 1 && search.temperature != 0 && search.top_k <= 0) {
+    throw std::runtime_error("Sampled speculative draft tokens require top_k greater than 1.");
   }
   // The draft rows are read before any logits processor runs, so a processor that would change a
   // row's argmax has to be inactive for every position this step verifies.
@@ -407,6 +407,11 @@ void Request::SetDraftTokens(std::span<const int32_t> tokens) {
 
 std::span<const int32_t> Request::StagedDraftTokens() const {
   return std::span<const int32_t>{draft_tokens_}.subspan(0, staged_draft_count_);
+}
+
+bool Request::IsStopToken(int32_t token) const {
+  const auto& stop_tokens = params_->config.model.eos_token_id;
+  return std::find(stop_tokens.begin(), stop_tokens.end(), token) != stop_tokens.end();
 }
 
 void Request::AppendDraftsForTransaction(size_t draft_count) {
@@ -462,6 +467,31 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
       break;
     }
   }
+}
+
+void Request::RewindDraftsForTransaction(size_t accepted_count) {
+  if (accepted_count > staged_draft_count_) {
+    throw std::logic_error("The step accepted more draft tokens than it staged.");
+  }
+  const size_t rejected_count = staged_draft_count_ - accepted_count;
+  accepted_draft_count_ = accepted_count;
+  if (rejected_count == 0) {
+    return;
+  }
+
+  staged_draft_count_ = accepted_count;
+  tokens_host_.resize(tokens_host_.size() - rejected_count);
+  search_->RewindTo(static_cast<size_t>(CurrentSequenceLength()) - rejected_count);
+}
+
+void Request::RecordSampledDraftAcceptance(size_t accepted_count) {
+  if (staged_draft_count_ != 0 || accepted_count > draft_tokens_.size()) {
+    throw std::logic_error("Sampled verification recorded an invalid accepted draft prefix.");
+  }
+  tokens_host_.insert(tokens_host_.end(), draft_tokens_.begin(),
+                      draft_tokens_.begin() + static_cast<ptrdiff_t>(accepted_count));
+  staged_draft_count_ = accepted_count;
+  accepted_draft_count_ = accepted_count;
 }
 
 void Request::DiscardStagedDrafts() noexcept {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -553,6 +553,23 @@ void Request::AdvanceChunk() {
   processed_sequence_length_ += static_cast<int64_t>(ScheduledTokenCount());
 }
 
+std::shared_ptr<Request> Request::CreateAuxiliaryDecoderRequest(
+    std::shared_ptr<GeneratorParams> params,
+    size_t max_total_tokens,
+    std::shared_ptr<std::atomic<bool>> abandonment_pending,
+    const std::shared_ptr<Engine>& engine,
+    std::span<const int32_t> tokens) {
+  auto request = std::make_shared<Request>(
+      std::move(params), max_total_tokens, std::move(abandonment_pending));
+  request->AttachToEngine(engine);
+  // The shadow is never admitted through BeginTurn, so it starts decoding directly and treats the
+  // tokens it mirrors from the target as its prompt.
+  request->status_ = RequestStatus::Active;
+  request->AppendTokensForAuxiliaryDecoder(tokens);
+  request->prompt_sequence_length_ = request->CurrentSequenceLength();
+  return request;
+}
+
 void Request::AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens) {
   if (status_ != RequestStatus::Active || tokens.empty() ||
       processed_sequence_length_ != CurrentSequenceLength()) {
@@ -924,6 +941,10 @@ std::span<const uint32_t> Request::GetReadyGuidanceMask() {
 
 const Config::Search& Request::SearchOptions() const {
   return search_->params_->search;
+}
+
+const Config::Speculative& Request::SpeculativeOptions() const {
+  return params_->speculative;
 }
 
 bool Request::BindNextTokensSlot(DeviceSpan<int32_t> slot) {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -174,9 +174,8 @@ void Request::PrepareTurnAdmission(
   admission.prompt_sequence_length = prompt_sequence_length_;
   admission.processed_sequence_length = processed_sequence_length_;
 
-  SaveStateForTransaction();
+  SaveStateForNewTurnTransaction();
   admission.transaction_started = true;
-  ResetGuidanceForNewTurn();
   search_->AppendTokens(device_tokens);
   tokens_host_.insert(tokens_host_.end(), tokens.begin(), tokens.end());
   prompt_sequence_length_ = CurrentSequenceLength();
@@ -681,6 +680,18 @@ void Request::SaveStateForTransaction() {
   transaction_tokens_host_size_ = tokens_host_.size();
 }
 
+void Request::SaveStateForNewTurnTransaction() {
+  auto new_turn_guidance = guidance_logits_processor_
+                               ? guidance_logits_processor_->CloneForNewTurn()
+                               : nullptr;
+  search_->SaveStateForTransaction();
+  guidance_transaction_checkpoint_ =
+      std::exchange(guidance_logits_processor_, std::move(new_turn_guidance));
+  transaction_rng_ = rng_;
+  transaction_processed_sequence_length_ = processed_sequence_length_;
+  transaction_tokens_host_size_ = tokens_host_.size();
+}
+
 void Request::SaveStateForExternalSamplingTransaction() {
   auto guidance_checkpoint = guidance_logits_processor_
                                  ? guidance_logits_processor_->Clone()
@@ -836,12 +847,6 @@ void Request::ApplyLogitsProcessors(DeviceSpan<float> logits,
   search_->ApplyMinLength(search_params.min_length);
   search_->ApplyRepetitionPenalty(search_params.repetition_penalty);
   search_->ApplyNoRepeatNgram(search_params.no_repeat_ngram_size);
-}
-
-void Request::ResetGuidanceForNewTurn() {
-  if (guidance_logits_processor_) {
-    guidance_logits_processor_->Reset();
-  }
 }
 
 void Request::SelectNextToken() {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -535,6 +535,18 @@ void Request::AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens) {
   tokens_host_.insert(tokens_host_.end(), tokens.begin(), tokens.end());
 }
 
+void Request::AppendTokensForAuxiliaryDecoder(DeviceSpan<int32_t> tokens) {
+  if (status_ != RequestStatus::Active || tokens.empty() ||
+      processed_sequence_length_ != CurrentSequenceLength()) {
+    throw std::logic_error(
+        "Auxiliary decoder tokens require an active request with no pending rows.");
+  }
+  ValidateAppendLength(*params_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+  search_->AppendTokens(tokens);
+  const int32_t non_pad = params_->config.model.pad_token_id == 0 ? 1 : 0;
+  tokens_host_.insert(tokens_host_.end(), tokens.size(), non_pad);
+}
+
 void Request::RewindAuxiliaryDecoderTo(size_t sequence_length) {
   if (status_ != RequestStatus::Active ||
       processed_sequence_length_ != CurrentSequenceLength() ||

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -752,6 +752,7 @@ void Request::RestoreStateForTransaction() {
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
   scheduled_token_count_ = 0;
+  draft_verification_completed_generation_ = false;
   if (guidance_transaction_checkpoint_) {
     guidance_logits_processor_ = std::move(guidance_transaction_checkpoint_);
   }
@@ -765,6 +766,7 @@ void Request::QueueStateRestoreForTransaction() {
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
   scheduled_token_count_ = 0;
+  draft_verification_completed_generation_ = false;
 }
 
 void Request::CompleteStateRestoreForTransaction() {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -352,6 +352,22 @@ int64_t Request::CommittedSequenceLength() const {
   return CurrentSequenceLength() - static_cast<int64_t>(staged_draft_count_);
 }
 
+const char* Request::DraftTokenValidationError() const noexcept {
+  if (guidance_logits_processor_) {
+    return "Speculative draft tokens are not supported with guidance.";
+  }
+  const auto& search = params_->search;
+  if (search.do_sample && search.top_k != 1 && search.temperature != 0 && search.top_k <= 0) {
+    return "Sampled speculative draft tokens require a positive top_k.";
+  }
+  if (search.repetition_penalty != 1.0f || search.no_repeat_ngram_size > 0 ||
+      search.min_length > CurrentSequenceLength()) {
+    return "Speculative draft tokens require repetition_penalty 1, no_repeat_ngram_size 0, and a "
+           "sequence already past min_length.";
+  }
+  return nullptr;
+}
+
 void Request::SetDraftTokens(std::span<const int32_t> tokens) {
   if (staged_draft_count_ != 0) {
     throw std::runtime_error("Cannot replace draft tokens while a step is in flight.");
@@ -367,23 +383,8 @@ void Request::SetDraftTokens(std::span<const int32_t> tokens) {
     throw std::runtime_error(
         "Speculative draft tokens may only be proposed when the request is ready to decode.");
   }
-  if (guidance_logits_processor_) {
-    throw std::runtime_error("Speculative draft tokens are not supported with guidance.");
-  }
-
-  const auto& search = params_->search;
-  // Sampled verification extracts a bounded target distribution for every row. Pure nucleus
-  // sampling has no bounded sparse support and stays on the standard path.
-  if (search.do_sample && search.top_k != 1 && search.temperature != 0 && search.top_k <= 0) {
-    throw std::runtime_error("Sampled speculative draft tokens require top_k greater than 1.");
-  }
-  // The draft rows are read before any logits processor runs, so a processor that would change a
-  // row's argmax has to be inactive for every position this step verifies.
-  if (search.repetition_penalty != 1.0f || search.no_repeat_ngram_size > 0 ||
-      search.min_length > CurrentSequenceLength()) {
-    throw std::runtime_error(
-        "Speculative draft tokens require repetition_penalty 1, no_repeat_ngram_size 0, and a "
-        "sequence already past min_length.");
+  if (const char* error = DraftTokenValidationError()) {
+    throw std::runtime_error(error);
   }
   auto engine = engine_.lock();
   if (!engine) {

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -120,6 +120,35 @@ struct Request : std::enable_shared_from_this<Request>,
   void MarkFailedFromEngine(const Engine& engine) noexcept;
   void CompleteFailedTurnFromEngine(const Engine& engine) noexcept;
 
+  // Engine-hosted MTP head requests mirror a target request's committed tokens in a
+  // scheduler-private shadow the Engine owns outright. They never sample and never enter the
+  // public turn API, so they are admitted through this factory instead of BeginTurn.
+  static std::shared_ptr<Request> CreateAuxiliaryDecoderRequest(
+      std::shared_ptr<GeneratorParams> params,
+      size_t max_total_tokens,
+      std::shared_ptr<std::atomic<bool>> abandonment_pending,
+      const std::shared_ptr<Engine>& engine,
+      std::span<const int32_t> tokens);
+  void AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens);
+  void AppendTokensForAuxiliaryDecoder(DeviceSpan<int32_t> tokens);
+  void RewindAuxiliaryDecoderTo(size_t sequence_length);
+  void CommitAuxiliaryDecoderStep() noexcept;
+
+  /**
+   * @brief Total tokens (prompt plus generated) this request may ever reach.
+   */
+  size_t MaxTotalTokens() const noexcept { return max_total_tokens_; }
+
+  /**
+   * @brief The speculative-decoding options this request was created with.
+   */
+  const Config::Speculative& SpeculativeOptions() const;
+
+  /**
+   * @brief Why the pending draft proposal cannot be verified, or nullptr when it can.
+   */
+  const char* DraftTokenValidationError() const noexcept;
+
   /**
    * @brief Returns a span of unprocessed tokens on the device.
    * @return DeviceSpan containing unprocessed token IDs.
@@ -362,13 +391,6 @@ struct Request : std::enable_shared_from_this<Request>,
   // Drops whatever the step in flight staged past the committed sequence, leaving the host mirror
   // exactly as long as the search after its own transaction rewind.
   void DiscardStagedDrafts() noexcept;
-  // The Engine-hosted MTP head mirrors target-committed tokens in a scheduler-private request. It
-  // never samples from this request; these helpers append decided tokens and advance its processed
-  // boundary only after the auxiliary cache transaction commits.
-  void AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens);
-  void AppendTokensForAuxiliaryDecoder(DeviceSpan<int32_t> tokens);
-  void RewindAuxiliaryDecoderTo(size_t sequence_length);
-  void CommitAuxiliaryDecoderStep() noexcept;
 
   int64_t processed_sequence_length_{};
   // Sequence length the application's tokens reach up to. Everything below it is prompt, so the
@@ -402,7 +424,6 @@ struct Request : std::enable_shared_from_this<Request>,
   std::weak_ptr<Engine> engine_;
   const Engine* engine_identity_{};
 
-  const char* DraftTokenValidationError() const noexcept;
   void ApplyLogitsProcessors(DeviceSpan<float> logits, bool guidance_applied);
   void SelectNextToken();
   void StageVisibleTokens(RequestStepResult& result,

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -353,6 +353,7 @@ struct Request : std::enable_shared_from_this<Request>,
   // never samples from this request; these helpers append decided tokens and advance its processed
   // boundary only after the auxiliary cache transaction commits.
   void AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens);
+  void AppendTokensForAuxiliaryDecoder(DeviceSpan<int32_t> tokens);
   void RewindAuxiliaryDecoderTo(size_t sequence_length);
   void CommitAuxiliaryDecoderStep() noexcept;
 

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <limits>
 
 #include "generator/generators.h"
 #include "request_status.h"
@@ -223,6 +224,14 @@ struct Request : std::enable_shared_from_this<Request>,
   GenerationFinishReason FinishReason() const noexcept { return finish_reason_; }
   size_t TurnPromptTokens() const noexcept { return turn_prompt_tokens_; }
   size_t TurnGeneratedTokens() const noexcept { return turn_generated_tokens_; }
+  size_t RemainingTurnTokenBudget() const noexcept {
+    if (!turn_max_generated_tokens_) {
+      return std::numeric_limits<size_t>::max();
+    }
+    return turn_generated_tokens_ < *turn_max_generated_tokens_
+               ? *turn_max_generated_tokens_ - turn_generated_tokens_
+               : 0;
+  }
 
   RequestStatus Status() const noexcept { return status_; }
 

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -392,6 +392,7 @@ struct Request : std::enable_shared_from_this<Request>,
   std::weak_ptr<Engine> engine_;
   const Engine* engine_identity_{};
 
+  const char* DraftTokenValidationError() const noexcept;
   void ApplyLogitsProcessors(DeviceSpan<float> logits, bool guidance_applied);
   void ResetGuidanceForNewTurn();
   void SelectNextToken();

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -192,6 +192,7 @@ struct Request : std::enable_shared_from_this<Request>,
 
   void ValidateEngineCompatibility() const;
   void SaveStateForTransaction();
+  void SaveStateForNewTurnTransaction();
   void SaveStateForExternalSamplingTransaction();
   RequestStepResult ApplyLogitsForTransaction(DeviceSpan<float> logits,
                                               bool guidance_applied = false);
@@ -403,7 +404,6 @@ struct Request : std::enable_shared_from_this<Request>,
 
   const char* DraftTokenValidationError() const noexcept;
   void ApplyLogitsProcessors(DeviceSpan<float> logits, bool guidance_applied);
-  void ResetGuidanceForNewTurn();
   void SelectNextToken();
   void StageVisibleTokens(RequestStepResult& result,
                           size_t committed_count,

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -154,10 +154,10 @@ struct Request : std::enable_shared_from_this<Request>,
    * @brief Proposes speculative draft tokens for this request's next step.
    * @param tokens Draft continuation of the sequence, in order. An empty span clears the proposal.
    *
-   * The request must be ready to decode. The next step then runs 1 + tokens.size() rows, verifies
-   * each draft against the target model's own prediction, and keeps the accepted prefix. Only
-   * greedy requests may propose drafts, because verification compares argmax tokens rather than
-   * sampling probabilities.
+  * The request must be ready to decode. The next step then runs 1 + tokens.size() rows, verifies
+  * each draft against the target model's own prediction, and keeps the accepted prefix. Greedy
+  * requests compare argmax tokens; sampled requests draw from each target row's bounded
+  * top-k/top-p distribution.
    *
    * The proposal applies to the current turn's next committed decode step. A rolled back step
    * leaves it pending, while canceling the turn discards it.
@@ -185,6 +185,9 @@ struct Request : std::enable_shared_from_this<Request>,
   bool DraftVerificationCompletedGeneration() const noexcept {
     return draft_verification_completed_generation_;
   }
+  bool IsStopToken(int32_t token) const;
+  void RewindDraftsForTransaction(size_t accepted_count);
+  void RecordSampledDraftAcceptance(size_t accepted_count);
 
   void ValidateEngineCompatibility() const;
   void SaveStateForTransaction();

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -349,6 +349,12 @@ struct Request : std::enable_shared_from_this<Request>,
   // Drops whatever the step in flight staged past the committed sequence, leaving the host mirror
   // exactly as long as the search after its own transaction rewind.
   void DiscardStagedDrafts() noexcept;
+  // The Engine-hosted MTP head mirrors target-committed tokens in a scheduler-private request. It
+  // never samples from this request; these helpers append decided tokens and advance its processed
+  // boundary only after the auxiliary cache transaction commits.
+  void AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens);
+  void RewindAuxiliaryDecoderTo(size_t sequence_length);
+  void CommitAuxiliaryDecoderStep() noexcept;
 
   int64_t processed_sequence_length_{};
   // Sequence length the application's tokens reach up to. Everything below it is prompt, so the
@@ -373,6 +379,8 @@ struct Request : std::enable_shared_from_this<Request>,
   std::shared_ptr<GeneratorParams> params_;
   std::mt19937 rng_;
   std::mt19937 transaction_rng_;
+  int64_t transaction_processed_sequence_length_{};
+  size_t transaction_tokens_host_size_{};
   std::unique_ptr<Search> search_;
   std::unique_ptr<ConstrainedLogitsProcessor> guidance_logits_processor_;
   std::unique_ptr<ConstrainedLogitsProcessor> guidance_transaction_checkpoint_;

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -155,10 +155,10 @@ struct Request : std::enable_shared_from_this<Request>,
    * @brief Proposes speculative draft tokens for this request's next step.
    * @param tokens Draft continuation of the sequence, in order. An empty span clears the proposal.
    *
-  * The request must be ready to decode. The next step then runs 1 + tokens.size() rows, verifies
-  * each draft against the target model's own prediction, and keeps the accepted prefix. Greedy
-  * requests compare argmax tokens; sampled requests draw from each target row's bounded
-  * top-k/top-p distribution.
+   * The request must be ready to decode. The next step then runs 1 + tokens.size() rows, verifies
+   * each draft against the target model's own prediction, and keeps the accepted prefix. Greedy
+   * requests compare argmax tokens; sampled requests draw from each target row's bounded
+   * top-k/top-p distribution.
    *
    * The proposal applies to the current turn's next committed decode step. A rolled back step
    * leaves it pending, while canceling the turn discards it.

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -6,7 +6,9 @@
 #include "engine.h"
 #include "request_index.h"
 #include "../constrained_logits_processor.h"
+#include "../decoding/speculative_sampling.h"
 #include "../search.h"
+#include <cmath>
 #include <cstdint>
 #include <exception>
 #include <limits>
@@ -31,6 +33,116 @@ std::optional<BatchedSamplingParams> ResolveSampleArgs(const Config::Search& sea
   if (search.top_k > 1)
     return BatchedSamplingParams{search.top_k, 1.0f, search.temperature};
   return BatchedSamplingParams{-1, search.top_p, search.temperature};
+}
+
+// Greedy token for every row, computed on the device so that the full vocabulary never crosses the
+// bus. Returns nothing when the rows are not one contiguous block (the decoder only guarantees that
+// when it converts the batch in a single launch) or when the device has no top-1 kernel, leaving the
+// caller on its host fallback.
+std::vector<int32_t> TryDeviceArgmaxPerRow(DeviceInterface& device,
+                                           std::vector<DeviceSpan<float>>& rows) {
+  if (rows.empty())
+    return {};
+
+  const size_t vocab_size = rows[0].size();
+  const float* base = rows[0].Span().data();
+  for (size_t i = 1; i < rows.size(); ++i) {
+    if (rows[i].size() != vocab_size || rows[i].Span().data() != base + i * vocab_size)
+      return {};
+  }
+
+  std::vector<int32_t> tokens(rows.size());
+  if (!device.ArgMax(base, Ort::TypeToTensorType<float>, static_cast<int>(rows.size()),
+                     static_cast<int>(vocab_size), tokens.data()))
+    return {};
+  return tokens;
+}
+
+bool UsesRandomSampling(const Config::Search& search) {
+  return search.do_sample && search.top_k != 1 && search.temperature != 0;
+}
+
+struct TopKScores {
+  int k{};
+  std::vector<int32_t> tokens;
+  std::vector<float> scores;
+};
+
+TopKScores TryDeviceTopKScoresPerRow(DeviceInterface& device,
+                                     std::vector<DeviceSpan<float>>& rows,
+                                     int k) {
+  if (rows.empty() || k <= 1)
+    return {};
+
+  const size_t vocab_size = rows[0].size();
+  const float* base = rows[0].Span().data();
+  for (size_t i = 1; i < rows.size(); ++i) {
+    if (rows[i].size() != vocab_size || rows[i].Span().data() != base + i * vocab_size)
+      return {};
+  }
+
+  TopKScores result;
+  result.k = std::min(k, static_cast<int>(vocab_size));
+  const size_t value_count = rows.size() * static_cast<size_t>(result.k);
+  result.tokens.resize(value_count);
+  result.scores.resize(value_count);
+  if (!device.TopKScores(base, Ort::TypeToTensorType<float>, static_cast<int>(rows.size()),
+                         static_cast<int>(vocab_size), result.k,
+                         result.tokens.data(), result.scores.data())) {
+    return {};
+  }
+  return result;
+}
+
+TargetTokenSelection BuildTargetSelection(
+    size_t row, DeviceSpan<float> logits, const Config::Search& search,
+    const TopKScores& topk, SampledCategorical& scratch) {
+  TargetTokenSelection selection;
+  if (topk.k == 0) {
+    const auto cpu_logits = logits.CopyDeviceToCpu();
+    ComputeSampledCategorical(cpu_logits, search.top_k, search.top_p,
+                              search.temperature, scratch);
+    selection.indices = scratch.indices;
+    selection.probs = scratch.probs;
+    return selection;
+  }
+
+  const int k = std::min(search.top_k, topk.k);
+  const size_t offset = row * static_cast<size_t>(topk.k);
+  const float max_score = topk.scores[offset];
+  const float inverse_temperature = 1.0f / search.temperature;
+  std::vector<float> probabilities(static_cast<size_t>(k));
+  float sum = 0.0f;
+  for (int i = 0; i < k; ++i) {
+    probabilities[static_cast<size_t>(i)] =
+        std::exp((topk.scores[offset + static_cast<size_t>(i)] - max_score) *
+                 inverse_temperature);
+    sum += probabilities[static_cast<size_t>(i)];
+  }
+  for (float& probability : probabilities)
+    probability /= sum;
+
+  int keep = k;
+  if (search.top_p > 0.0f && search.top_p < 1.0f) {
+    float cumulative = 0.0f;
+    for (int i = 0; i < k; ++i) {
+      cumulative += probabilities[static_cast<size_t>(i)];
+      if (cumulative >= search.top_p) {
+        keep = i + 1;
+        break;
+      }
+    }
+  }
+  float kept_sum = 0.0f;
+  for (int i = 0; i < keep; ++i)
+    kept_sum += probabilities[static_cast<size_t>(i)];
+  selection.indices.assign(
+      topk.tokens.begin() + static_cast<ptrdiff_t>(offset),
+      topk.tokens.begin() + static_cast<ptrdiff_t>(offset + static_cast<size_t>(keep)));
+  selection.probs.assign(probabilities.begin(), probabilities.begin() + keep);
+  for (float& probability : selection.probs)
+    probability /= kept_sum;
+  return selection;
 }
 
 }  // namespace
@@ -181,35 +293,24 @@ Tensor* ScheduledRequests::HiddenStates() const {
 }
 
 std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
-    std::vector<DeviceSpan<float>>& verify_rows) {
-  if (std::none_of(draft_token_counts_.begin(), draft_token_counts_.end(),
-                   [](size_t draft_count) { return draft_count != 0; })) {
-    return std::move(verify_rows);
-  }
-  if (!sampling_plan_) {
-    throw std::logic_error("Draft verification requires scheduler-owned argmax storage.");
-  }
-  auto& predicted_tokens = sampling_plan_->verification_tokens;
-  predicted_tokens.resize(verify_rows.size());
+    std::vector<DeviceSpan<float>>& verify_rows,
+    std::vector<std::vector<int32_t>>& selected_tokens,
+    std::vector<size_t>& accepted_draft_counts) {
+  std::vector<DeviceSpan<float>> sampled_rows;
+  sampled_rows.reserve(requests_.size());
+  selected_tokens.resize(requests_.size());
+  accepted_draft_counts.assign(requests_.size(), 0);
 
-  bool rows_are_contiguous = !verify_rows.empty();
-  const size_t vocab_size = static_cast<size_t>(model_->config_->model.vocab_size);
-  const float* first_row = rows_are_contiguous
-                               ? verify_rows.front().Span().data()
-                               : nullptr;
-  for (size_t row = 0; row < verify_rows.size() && rows_are_contiguous; ++row) {
-    rows_are_contiguous =
-        verify_rows[row].size() == vocab_size &&
-        verify_rows[row].Span().data() == first_row + row * vocab_size;
-  }
-
-  const bool used_device_argmax =
-      rows_are_contiguous &&
-      model_->p_device_scoring_->ArgMax(
-          first_row, Ort::TypeToTensorType<float>,
-          static_cast<int>(verify_rows.size()),
-          model_->config_->model.vocab_size, predicted_tokens.data());
-  if (!used_device_argmax) {
+  // Verification only needs each draft row's argmax. Reading a whole vocabulary row back to the host
+  // costs about a megabyte and a stream synchronization per draft, which on a large-vocabulary model
+  // is comparable to the step itself, so ask the device for the token ids in one launch instead.
+  const bool step_has_drafts = std::any_of(draft_token_counts_.begin(), draft_token_counts_.end(),
+                                           [](size_t count) { return count != 0; });
+  std::vector<int32_t> row_argmax =
+      step_has_drafts ? TryDeviceArgmaxPerRow(*model_->p_device_inputs_, verify_rows)
+                      : std::vector<int32_t>{};
+  if (step_has_drafts && row_argmax.empty()) {
+    row_argmax.resize(verify_rows.size());
     const bool rows_share_buffer =
         !verify_rows.empty() &&
         std::all_of(verify_rows.begin() + 1, verify_rows.end(),
@@ -220,17 +321,22 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
       verify_rows.front().CopyDeviceToCpu();
     }
     for (size_t row = 0; row < verify_rows.size(); ++row) {
-      auto row_values = rows_share_buffer
-                            ? verify_rows[row].CpuSpan()
-                            : verify_rows[row].CopyDeviceToCpu();
-      predicted_tokens[row] = static_cast<int32_t>(
+      const auto row_values = rows_share_buffer
+                                  ? verify_rows[row].CpuSpan()
+                                  : verify_rows[row].CopyDeviceToCpu();
+      row_argmax[row] = static_cast<int32_t>(
           std::max_element(row_values.begin(), row_values.end()) -
           row_values.begin());
     }
   }
-
-  std::vector<DeviceSpan<float>> sampled_rows;
-  sampled_rows.reserve(requests_.size());
+  int max_sampling_top_k = 0;
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    if (draft_token_counts_[i] != 0 && UsesRandomSampling(requests_[i]->SearchOptions()))
+      max_sampling_top_k = std::max(max_sampling_top_k, requests_[i]->SearchOptions().top_k);
+  }
+  const TopKScores topk = TryDeviceTopKScoresPerRow(
+      *model_->p_device_inputs_, verify_rows, max_sampling_top_k);
+  SampledCategorical sampling_scratch;
   size_t row = 0;
   for (size_t i = 0; i < requests_.size(); ++i) {
     const size_t draft_count =
@@ -240,13 +346,39 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
       continue;
     }
 
+    if (UsesRandomSampling(requests_[i]->SearchOptions())) {
+      const auto drafts = requests_[i]->StagedDraftTokens();
+      requests_[i]->RewindDraftsForTransaction(0);
+      size_t accepted_count = 0;
+      for (; accepted_count < draft_count; ++accepted_count) {
+        const auto selection = BuildTargetSelection(
+            row + accepted_count, verify_rows[row + accepted_count],
+            requests_[i]->SearchOptions(), topk, sampling_scratch);
+        const int32_t token = SampleTargetToken(selection, requests_[i]->rng_);
+        selected_tokens[i].push_back(token);
+        if (token != drafts[accepted_count] || requests_[i]->IsStopToken(token))
+          break;
+      }
+      if (accepted_count == draft_count) {
+        const auto selection = BuildTargetSelection(
+            row + draft_count, verify_rows[row + draft_count],
+            requests_[i]->SearchOptions(), topk, sampling_scratch);
+        selected_tokens[i].push_back(
+            SampleTargetToken(selection, requests_[i]->rng_));
+      }
+      accepted_draft_counts[i] = accepted_count;
+      sampled_rows.push_back({});
+      row += draft_count + 1;
+      continue;
+    }
+
     // Row j predicts the token at committed_length + j, which is exactly where draft j sits. Accept
     // the longest prefix of the proposal the target model would have produced on its own; the row
     // after it holds the token that replaces the first rejected draft, or the bonus token.
     const auto drafts = requests_[i]->StagedDraftTokens();
     size_t accepted_count = 0;
     while (accepted_count < draft_count) {
-      if (predicted_tokens[row + accepted_count] != drafts[accepted_count]) {
+      if (row_argmax[row + accepted_count] != drafts[accepted_count]) {
         break;
       }
       ++accepted_count;
@@ -452,7 +584,13 @@ void ScheduledRequests::BeginTransaction() {
   if (transaction_checkpoint_count_ != 0 || sampler_checkpoint_active_)
     throw std::logic_error("Scheduled request transaction is already active.");
 
-  transaction_uses_batched_sampler_ = PrepareBatchedSamplingPlan(true);
+  bool has_sampled_drafts = false;
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    has_sampled_drafts = has_sampled_drafts ||
+                         (draft_token_counts_[i] != 0 &&
+                          UsesRandomSampling(requests_[i]->SearchOptions()));
+  }
+  transaction_uses_batched_sampler_ = !has_sampled_drafts && PrepareBatchedSamplingPlan(true);
   try {
     for (const auto& request : requests_) {
       if (transaction_uses_batched_sampler_)
@@ -489,7 +627,9 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
   }
 
   auto verify_rows = ProcessLogits();
-  auto logits = SelectSampledRows(verify_rows);
+  std::vector<std::vector<int32_t>> selected_tokens;
+  std::vector<size_t> accepted_draft_counts;
+  auto logits = SelectSampledRows(verify_rows, selected_tokens, accepted_draft_counts);
   const bool guidance_applied = TryApplyBatchedGuidanceMasks(logits);
   results.assign(requests_.size(), RequestStepResult{});
   if (transaction_uses_batched_sampler_) {
@@ -549,11 +689,80 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
     return;
   }
 
+  size_t sampled_request_count = 0;
+  size_t max_selected_tokens = 0;
+  for (const auto& tokens : selected_tokens) {
+    if (!tokens.empty()) {
+      ++sampled_request_count;
+      max_selected_tokens = std::max(max_selected_tokens, tokens.size());
+    }
+  }
+  if (sampled_request_count != 0) {
+    bool can_batch_commits = true;
+    for (size_t i = 0; i < requests_.size(); ++i) {
+      if (!selected_tokens[i].empty() && !requests_[i]->SupportsBatchedSampling()) {
+        can_batch_commits = false;
+        break;
+      }
+    }
+    DeviceSpan<int32_t> committed_tokens;
+    if (can_batch_commits)
+      committed_tokens = model_->p_device_->Allocate<int32_t>(sampled_request_count);
+
+    for (size_t stage = 0; stage < max_selected_tokens; ++stage) {
+      std::vector<size_t> active;
+      active.reserve(sampled_request_count);
+      for (size_t i = 0; i < selected_tokens.size(); ++i) {
+        if (stage < selected_tokens[i].size())
+          active.push_back(i);
+      }
+
+      if (can_batch_commits) {
+        auto stage_tokens = committed_tokens.subspan(0, active.size());
+        auto cpu_tokens = stage_tokens.CpuSpan();
+        for (size_t row = 0; row < active.size(); ++row)
+          cpu_tokens[row] = selected_tokens[active[row]][stage];
+        stage_tokens.CopyCpuToDevice();
+        for (size_t row = 0; row < active.size(); ++row) {
+          auto& request = requests_[active[row]];
+          request->sequence_length_before_sampling_ = request->CurrentSequenceLength();
+          if (!request->BindNextTokensSlot(stage_tokens.subspan(row, 1)))
+            throw std::logic_error("Sampled draft commit lost batched-search support.");
+          request->OnNextTokensSampled();
+        }
+        stage_tokens.CopyDeviceToCpu();
+        for (size_t row = 0; row < active.size(); ++row) {
+          const size_t request_index = active[row];
+          const auto stage_result = requests_[request_index]->StageGenerationForTransaction();
+          if (stage + 1 == selected_tokens[request_index].size())
+            results[request_index] = stage_result;
+          else if (!stage_result.token_appended || stage_result.done)
+            throw std::logic_error("An accepted sampled draft unexpectedly ended the request.");
+        }
+      } else {
+        for (size_t request_index : active) {
+          auto& request = requests_[request_index];
+          request->sequence_length_before_sampling_ = request->CurrentSequenceLength();
+          request->search_->CommitToken(selected_tokens[request_index][stage]);
+          const auto stage_result = request->StageGenerationForTransaction();
+          if (stage + 1 == selected_tokens[request_index].size())
+            results[request_index] = stage_result;
+          else if (!stage_result.token_appended || stage_result.done)
+            throw std::logic_error("An accepted sampled draft unexpectedly ended the request.");
+        }
+      }
+    }
+    for (size_t i = 0; i < requests_.size(); ++i) {
+      if (!selected_tokens[i].empty())
+        requests_[i]->RecordSampledDraftAcceptance(accepted_draft_counts[i]);
+    }
+  }
+
   for (size_t i = 0; i < requests_.size(); ++i) {
     if (requests_[i]->DraftVerificationCompletedGeneration()) {
       results[i] =
           requests_[i]->StageDraftCompletionForTransaction();
-    } else if (requests_[i]->IsChunkComplete()) {
+    } else if (requests_[i]->IsChunkComplete() && selected_tokens[i].empty()) {
       results[i] = requests_[i]->ApplyLogitsForTransaction(logits[i], guidance_applied);
     }
   }

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -348,9 +348,11 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
 
     if (UsesRandomSampling(requests_[i]->SearchOptions())) {
       const auto drafts = requests_[i]->StagedDraftTokens();
+      const size_t token_budget = requests_[i]->RemainingTurnTokenBudget();
       requests_[i]->RewindDraftsForTransaction(0);
       size_t accepted_count = 0;
-      for (; accepted_count < draft_count; ++accepted_count) {
+      while (accepted_count < draft_count &&
+             selected_tokens[i].size() < token_budget) {
         const auto selection = BuildTargetSelection(
             row + accepted_count, verify_rows[row + accepted_count],
             requests_[i]->SearchOptions(), topk, sampling_scratch);
@@ -358,8 +360,10 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
         selected_tokens[i].push_back(token);
         if (token != drafts[accepted_count] || requests_[i]->IsStopToken(token))
           break;
+        ++accepted_count;
       }
-      if (accepted_count == draft_count) {
+      if (accepted_count == draft_count &&
+          selected_tokens[i].size() < token_budget) {
         const auto selection = BuildTargetSelection(
             row + draft_count, verify_rows[row + draft_count],
             requests_[i]->SearchOptions(), topk, sampling_scratch);
@@ -566,6 +570,10 @@ bool ScheduledRequests::PrepareBatchedSamplingPlan(
     if (!status_is_executable ||
         !request->IsChunkComplete())
       continue;
+    if (require_transaction_support && draft_token_counts_[request_index] != 0 &&
+        UsesRandomSampling(request->SearchOptions())) {
+      continue;
+    }
 
     const auto args = ResolveSampleArgs(request->SearchOptions());
     if (!args || !request->SupportsBatchedSampling()) {
@@ -584,16 +592,14 @@ void ScheduledRequests::BeginTransaction() {
   if (transaction_checkpoint_count_ != 0 || sampler_checkpoint_active_)
     throw std::logic_error("Scheduled request transaction is already active.");
 
-  bool has_sampled_drafts = false;
-  for (size_t i = 0; i < requests_.size(); ++i) {
-    has_sampled_drafts = has_sampled_drafts ||
-                         (draft_token_counts_[i] != 0 &&
-                          UsesRandomSampling(requests_[i]->SearchOptions()));
-  }
-  transaction_uses_batched_sampler_ = !has_sampled_drafts && PrepareBatchedSamplingPlan(true);
+  transaction_uses_batched_sampler_ = PrepareBatchedSamplingPlan(true);
   try {
     for (const auto& request : requests_) {
-      if (transaction_uses_batched_sampler_)
+      const bool uses_batched_sampler =
+          transaction_uses_batched_sampler_ &&
+          std::find(sampling_plan_->requests.begin(), sampling_plan_->requests.end(),
+                    request.get()) != sampling_plan_->requests.end();
+      if (uses_batched_sampler)
         request->SaveStateForExternalSamplingTransaction();
       else
         request->SaveStateForTransaction();
@@ -632,16 +638,18 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
   auto logits = SelectSampledRows(verify_rows, selected_tokens, accepted_draft_counts);
   const bool guidance_applied = TryApplyBatchedGuidanceMasks(logits);
   results.assign(requests_.size(), RequestStepResult{});
+  std::vector<bool> sampled_by_batched_sampler(requests_.size(), false);
   if (transaction_uses_batched_sampler_) {
     sampling_plan_->logits.clear();
     const size_t original_sampling_count = sampling_plan_->requests.size();
     size_t source_sampling_index = 0;
     size_t active_sampling_count = 0;
-    for (size_t i = 0; i < requests_.size(); ++i) {
-      if (!requests_[i]->IsChunkComplete())
-        continue;
-      if (source_sampling_index >= original_sampling_count ||
-          sampling_plan_->requests[source_sampling_index] != requests_[i].get()) {
+    for (; source_sampling_index < original_sampling_count;
+         ++source_sampling_index) {
+      const size_t i = sampling_plan_->result_indices[source_sampling_index];
+      if (i >= requests_.size() ||
+          sampling_plan_->requests[source_sampling_index] != requests_[i].get() ||
+          !requests_[i]->IsChunkComplete()) {
         throw std::logic_error("Batched sampling plan does not match the scheduled requests.");
       }
       if (requests_[i]->DraftVerificationCompletedGeneration()) {
@@ -655,38 +663,35 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
               sampling_plan_->params[source_sampling_index];
           sampling_plan_->states[active_sampling_count] =
               sampling_plan_->states[source_sampling_index];
+          sampling_plan_->result_indices[active_sampling_count] = i;
         }
         sampling_plan_->logits.push_back(logits[i]);
         requests_[i]->PrepareGenerationForTransaction(logits[i], guidance_applied);
+        sampled_by_batched_sampler[i] = true;
         ++active_sampling_count;
       }
-      ++source_sampling_index;
     }
-    if (source_sampling_index != original_sampling_count)
-      throw std::logic_error("Batched sampling plan does not match the scheduled requests.");
     sampling_plan_->requests.resize(active_sampling_count);
+    sampling_plan_->result_indices.resize(active_sampling_count);
     sampling_plan_->params.resize(active_sampling_count);
     sampling_plan_->states.resize(active_sampling_count);
 
-    if (active_sampling_count == 0)
-      return;
-
-    auto next_tokens = batched_sampler_->Sample(
-        sampling_plan_->logits, sampling_plan_->params,
-        sampling_plan_->states, model_->config_->model.vocab_size);
-    for (size_t i = 0; i < sampling_plan_->requests.size(); ++i) {
-      if (!sampling_plan_->requests[i]->BindNextTokensSlot(next_tokens.subspan(i, 1)))
-        throw std::runtime_error("The request search rejected the batched sampler output.");
-      sampling_plan_->requests[i]->OnNextTokensSampled();
+    if (active_sampling_count != 0) {
+      auto next_tokens = batched_sampler_->Sample(
+          sampling_plan_->logits, sampling_plan_->params,
+          sampling_plan_->states, model_->config_->model.vocab_size);
+      for (size_t i = 0; i < sampling_plan_->requests.size(); ++i) {
+        if (!sampling_plan_->requests[i]->BindNextTokensSlot(next_tokens.subspan(i, 1)))
+          throw std::runtime_error("The request search rejected the batched sampler output.");
+        sampling_plan_->requests[i]->OnNextTokensSampled();
+      }
+      next_tokens.CopyDeviceToCpu();
+      for (size_t i = 0; i < requests_.size(); ++i) {
+        if (sampled_by_batched_sampler[i]) {
+          results[i] = requests_[i]->StageGenerationForTransaction(plan.requests[i]);
+        }
+      }
     }
-    next_tokens.CopyDeviceToCpu();
-    for (size_t i = 0; i < requests_.size(); ++i) {
-      if (!requests_[i]->IsChunkComplete() ||
-          requests_[i]->DraftVerificationCompletedGeneration())
-        continue;
-      results[i] = requests_[i]->StageGenerationForTransaction(plan.requests[i]);
-    }
-    return;
   }
 
   size_t sampled_request_count = 0;
@@ -725,7 +730,6 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
         stage_tokens.CopyCpuToDevice();
         for (size_t row = 0; row < active.size(); ++row) {
           auto& request = requests_[active[row]];
-          request->sequence_length_before_sampling_ = request->CurrentSequenceLength();
           if (!request->BindNextTokensSlot(stage_tokens.subspan(row, 1)))
             throw std::logic_error("Sampled draft commit lost batched-search support.");
           request->OnNextTokensSampled();
@@ -733,28 +737,42 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
         stage_tokens.CopyDeviceToCpu();
         for (size_t row = 0; row < active.size(); ++row) {
           const size_t request_index = active[row];
-          const auto stage_result = requests_[request_index]->StageGenerationForTransaction();
-          if (stage + 1 == selected_tokens[request_index].size())
+          auto stage_plan = plan.requests[request_index];
+          if (stage + 1 == selected_tokens[request_index].size()) {
+            requests_[request_index]->RecordSampledDraftAcceptance(
+                accepted_draft_counts[request_index]);
+          } else {
+            stage_plan.sequence_length_before =
+                requests_[request_index]->CurrentSequenceLength() - 1;
+          }
+          const auto stage_result =
+              requests_[request_index]->StageGenerationForTransaction(stage_plan);
+          if (stage + 1 == selected_tokens[request_index].size()) {
             results[request_index] = stage_result;
-          else if (!stage_result.token_appended || stage_result.done)
+          } else if (!stage_result.token_appended || stage_result.done) {
             throw std::logic_error("An accepted sampled draft unexpectedly ended the request.");
+          }
         }
       } else {
         for (size_t request_index : active) {
           auto& request = requests_[request_index];
-          request->sequence_length_before_sampling_ = request->CurrentSequenceLength();
+          auto stage_plan = plan.requests[request_index];
+          stage_plan.sequence_length_before = request->CurrentSequenceLength();
           request->search_->CommitToken(selected_tokens[request_index][stage]);
-          const auto stage_result = request->StageGenerationForTransaction();
-          if (stage + 1 == selected_tokens[request_index].size())
+          if (stage + 1 == selected_tokens[request_index].size()) {
+            request->RecordSampledDraftAcceptance(
+                accepted_draft_counts[request_index]);
+            stage_plan = plan.requests[request_index];
+          }
+          const auto stage_result =
+              request->StageGenerationForTransaction(stage_plan);
+          if (stage + 1 == selected_tokens[request_index].size()) {
             results[request_index] = stage_result;
-          else if (!stage_result.token_appended || stage_result.done)
+          } else if (!stage_result.token_appended || stage_result.done) {
             throw std::logic_error("An accepted sampled draft unexpectedly ended the request.");
+          }
         }
       }
-    }
-    for (size_t i = 0; i < requests_.size(); ++i) {
-      if (!selected_tokens[i].empty())
-        requests_[i]->RecordSampledDraftAcceptance(accepted_draft_counts[i]);
     }
   }
 
@@ -762,7 +780,8 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
     if (requests_[i]->DraftVerificationCompletedGeneration()) {
       results[i] =
           requests_[i]->StageDraftCompletionForTransaction();
-    } else if (requests_[i]->IsChunkComplete() && selected_tokens[i].empty()) {
+    } else if (requests_[i]->IsChunkComplete() && selected_tokens[i].empty() &&
+               !sampled_by_batched_sampler[i]) {
       results[i] = requests_[i]->ApplyLogitsForTransaction(logits[i], guidance_applied);
     }
   }

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -176,6 +176,10 @@ std::vector<DeviceSpan<float>> ScheduledRequests::ProcessLogits() {
   return logits;
 }
 
+Tensor* ScheduledRequests::HiddenStates() const {
+  return decoder_state_ ? decoder_state_->HiddenStates() : nullptr;
+}
+
 std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
     std::vector<DeviceSpan<float>>& verify_rows) {
   if (std::none_of(draft_token_counts_.begin(), draft_token_counts_.end(),

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -343,6 +343,12 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
     }
 
     if (UsesRandomSampling(requests_[i]->SearchOptions())) {
+      // Draft acceptance is sequential: each row is drawn only if the previous draw matched its
+      // draft, which the batched device sampler cannot express. These draws therefore come from
+      // the Request's own host stream (checkpointed with the transaction) rather than its device
+      // BatchedSamplerState. search.random_seed consequently reproduces a given decode path, not
+      // output across decode paths, because whether drafts are admitted depends on batch
+      // composition. See "Seeded sampling" in docs/paged_attention_engine.md.
       const auto drafts = requests_[i]->StagedDraftTokens();
       const size_t token_budget = requests_[i]->RemainingTurnTokenBudget();
       requests_[i]->RewindDraftsForTransaction(0);
@@ -501,6 +507,26 @@ BatchedGuidanceMaskStatus CollectBatchedGuidanceMasks(
                       : BatchedGuidanceMaskStatus::NoEligibleGuidance;
 }
 
+float* PackedLogitsRowBase(std::vector<DeviceSpan<float>>& logits, size_t vocab_size) {
+  if (logits.empty() || vocab_size == 0) {
+    return nullptr;
+  }
+  // Span() dereferences the row's backing buffer, and an empty row has none, so every row must be
+  // proven to be a full vocabulary row before any pointer is taken.
+  for (const auto& row : logits) {
+    if (row.size() != vocab_size) {
+      return nullptr;
+    }
+  }
+  float* const first_row = logits.front().Span().data();
+  for (size_t i = 0; i < logits.size(); ++i) {
+    if (logits[i].Span().data() != first_row + i * vocab_size) {
+      return nullptr;
+    }
+  }
+  return first_row;
+}
+
 bool ScheduledRequests::TryApplyBatchedGuidanceMasks(std::vector<DeviceSpan<float>>& logits) {
   if (!sampling_plan_ || logits.empty()) {
     return false;
@@ -517,12 +543,9 @@ bool ScheduledRequests::TryApplyBatchedGuidanceMasks(std::vector<DeviceSpan<floa
 
   const size_t vocab_size = static_cast<size_t>(model_->config_->model.vocab_size);
   const size_t words_per_row = (vocab_size + 31) / 32;
-  float* const first_row = logits.front().Span().data();
-  for (size_t i = 0; i < logits.size(); ++i) {
-    if (logits[i].size() != vocab_size ||
-        logits[i].Span().data() != first_row + i * vocab_size) {
-      return false;
-    }
+  float* const first_row = PackedLogitsRowBase(logits, vocab_size);
+  if (!first_row) {
+    return false;
   }
 
   if (CollectBatchedGuidanceMasks(

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -288,10 +288,6 @@ std::vector<DeviceSpan<float>> ScheduledRequests::ProcessLogits() {
   return logits;
 }
 
-Tensor* ScheduledRequests::HiddenStates() const {
-  return decoder_state_ ? decoder_state_->HiddenStates() : nullptr;
-}
-
 std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
     std::vector<DeviceSpan<float>>& verify_rows,
     std::vector<std::vector<int32_t>>& selected_tokens,

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -108,9 +108,13 @@ struct ScheduledRequests {
                                     std::vector<RequestStepResult>* results = nullptr);
   bool TryApplyBatchedGuidanceMasks(std::vector<DeviceSpan<float>>& logits);
   // Verifies each drafted request's proposal against the target model's own rows, rewinds the
-  // rejected tail, and returns the one row per request that the sampler must select from.
+  // rejected tail, and returns the one row per request that the sampler must select from. For a
+  // randomly sampled request, selected_tokens holds the accepted deterministic proposal prefix
+  // plus the target-distributed correction or bonus token to commit.
   std::vector<DeviceSpan<float>> SelectSampledRows(
-      std::vector<DeviceSpan<float>>& verify_rows);
+      std::vector<DeviceSpan<float>>& verify_rows,
+      std::vector<std::vector<int32_t>>& selected_tokens,
+      std::vector<size_t>& accepted_draft_counts);
 
   std::vector<std::shared_ptr<Request>> requests_;
   // Drafts the transaction stages onto each request's sequence, in scheduled row order. Empty

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -21,6 +21,12 @@ BatchedGuidanceMaskStatus CollectBatchedGuidanceMasks(
     size_t words_per_row,
     std::vector<uint32_t>& masks);
 
+// Returns the base pointer of the packed logits block when every entry is a full vocabulary row
+// laid out back to back, or nullptr otherwise. A sampled request that verified drafts contributes
+// an empty row, which has no backing buffer at all, so every row must be proven before any pointer
+// is taken from one.
+float* PackedLogitsRowBase(std::vector<DeviceSpan<float>>& logits, size_t vocab_size);
+
 struct BatchedSamplingPlan {
   void Reserve(size_t capacity, size_t verification_capacity) {
     requests.reserve(capacity);

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -90,6 +90,7 @@ struct ScheduledRequests {
   Tensor* HiddenStates() const;
 
   std::vector<DeviceSpan<float>> ProcessLogits();
+  Tensor* HiddenStates() const;
 
   void GenerateNextTokens(std::vector<RequestStepResult>& results);
   void ScheduleGuidanceMasks() noexcept;

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -90,7 +90,6 @@ struct ScheduledRequests {
   Tensor* HiddenStates() const;
 
   std::vector<DeviceSpan<float>> ProcessLogits();
-  Tensor* HiddenStates() const;
 
   void GenerateNextTokens(std::vector<RequestStepResult>& results);
   void ScheduleGuidanceMasks() noexcept;

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -328,6 +328,9 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
       const auto resource_result = cache_manager_->PlanStepResources(plan);
       if (resource_result.executable &&
           plan.requests.size() == selected_request_count) {
+        for (const auto& entry : plan.requests) {
+          token_counts[entry.scheduling_order] = entry.unprocessed_token_count;
+        }
         break;
       }
 

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -76,6 +76,19 @@ struct OgaSpeculativeStats : OgaAbstract {
     return value;
   }
 
+  uint64_t GetAcceptanceLengthCount(size_t accepted_length) const {
+    uint64_t value{};
+    OgaCheckResult(OgaSpeculativeStatsGetAcceptanceLengthCount(
+        this, accepted_length, &value));
+    return value;
+  }
+
+  size_t GetAcceptanceLengthHistogramSize() const {
+    size_t value{};
+    OgaCheckResult(OgaSpeculativeStatsGetAcceptanceLengthHistogramSize(this, &value));
+    return value;
+  }
+
   double GetNumber(const char* name) const {
     double value;
     OgaCheckResult(OgaSpeculativeStatsGetNumber(this, name, &value));
@@ -1128,6 +1141,15 @@ struct OgaEngine : OgaAbstract {
     size_t count{};
     OgaCheckResult(OgaEngineMaxDraftTokensPerProposal(this, &count));
     return count;
+  }
+
+  /**
+   * \brief Cumulative target/head work and committed draft acceptance statistics.
+   */
+  std::unique_ptr<OgaSpeculativeStats> GetSpeculativeStats() const {
+    OgaSpeculativeStats* stats;
+    OgaCheckResult(OgaEngineGetSpeculativeStats(this, &stats));
+    return std::unique_ptr<OgaSpeculativeStats>(stats);
   }
 
   std::unique_ptr<OgaRequest> CreateRequest(

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -938,6 +938,28 @@ OgaResult* OGA_API_CALL OgaSpeculativeStatsGetCount(
   OGA_CATCH
 }
 
+OgaResult* OGA_API_CALL OgaSpeculativeStatsGetAcceptanceLengthCount(
+    const OgaSpeculativeStats* stats, size_t accepted_length, uint64_t* value) {
+  OGA_TRY
+  if (!stats || !value)
+    throw std::invalid_argument("stats and value must not be null.");
+  if (accepted_length >= stats->acceptance_length_histogram.size())
+    throw std::out_of_range("accepted_length is outside the statistics histogram.");
+  *value = stats->acceptance_length_histogram[accepted_length];
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OGA_API_CALL OgaSpeculativeStatsGetAcceptanceLengthHistogramSize(
+    const OgaSpeculativeStats* stats, size_t* value) {
+  OGA_TRY
+  if (!stats || !value)
+    throw std::invalid_argument("stats and value must not be null.");
+  *value = stats->acceptance_length_histogram.size();
+  return nullptr;
+  OGA_CATCH
+}
+
 OgaResult* OGA_API_CALL OgaSpeculativeStatsGetNumber(
     const OgaSpeculativeStats* stats, const char* name, double* value) {
   OGA_TRY
@@ -1704,6 +1726,21 @@ OgaResult* OgaEngineMaxDraftTokensPerProposal(const OgaEngine* engine, size_t* o
     throw std::runtime_error("out must not be null.");
   }
   *out = engine->MaxDraftTokensPerStep();
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OgaEngineGetSpeculativeStats(
+    const OgaEngine* engine, OgaSpeculativeStats** out) {
+  OGA_TRY
+  if (!engine) {
+    throw std::runtime_error("engine must not be null.");
+  }
+  if (!out) {
+    throw std::runtime_error("out must not be null.");
+  }
+  *out = ReturnUnique<OgaSpeculativeStats>(
+      std::make_unique<Generators::SpeculativeStats>(engine->GetSpeculativeStats()));
   return nullptr;
   OGA_CATCH
 }

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -819,6 +819,14 @@ OGA_EXPORT void OGA_API_CALL OgaDestroySpeculativeStats(OgaSpeculativeStats* sta
 OGA_EXPORT OgaResult* OGA_API_CALL OgaSpeculativeStatsGetCount(
     const OgaSpeculativeStats* stats, const char* name, uint64_t* value);
 
+/** \brief Gets the number of rounds that accepted exactly the requested number of draft tokens. */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaSpeculativeStatsGetAcceptanceLengthCount(
+    const OgaSpeculativeStats* stats, size_t accepted_length, uint64_t* value);
+
+/** \brief Gets the number of bins in the acceptance-length histogram. */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaSpeculativeStatsGetAcceptanceLengthHistogramSize(
+    const OgaSpeculativeStats* stats, size_t* value);
+
 /** \brief Gets a timing, rate, ratio, average, or speedup value from a statistics snapshot. */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaSpeculativeStatsGetNumber(
     const OgaSpeculativeStats* stats, const char* name, double* value);
@@ -1456,6 +1464,20 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaRequestSetDraftTokens(OgaRequest* request,
  * \return OgaResult containing the error message on failure, or nullptr on success.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaEngineMaxDraftTokensPerProposal(const OgaEngine* engine, size_t* out);
+
+/**
+ * \brief Returns a cumulative snapshot of Engine speculative-decoding statistics.
+ *
+ * Target and draft forward-pass counters include successful model executions even if a later
+ * transaction phase rolls back. Proposal, acceptance, and acceptance-length counters include only
+ * committed speculative steps.
+ *
+ * \param[in] engine The engine to query.
+ * \param[out] out The newly allocated statistics snapshot. Destroy it with OgaDestroySpeculativeStats.
+ * \return OgaResult containing the error message on failure, or nullptr on success.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaEngineGetSpeculativeStats(
+    const OgaEngine* engine, OgaSpeculativeStats** out);
 
 /**
  * \brief Destroys the given request.

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -1443,9 +1443,12 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaRequestClose(OgaRequest* request);
  * \brief Proposes speculative draft tokens for the request's next decode operation.
  *
  * The request must be ready to decode. The operation then runs one row per draft on top of its own
- * token, verifies each draft against the model's prediction, and keeps the accepted prefix. Passing
- * an empty sequence clears the proposal. Requires a greedy request and an engine whose cache can
- * roll a rejected draft back (see OgaEngineMaxDraftTokensPerProposal).
+ * token, verifies each draft against the model's prediction, and keeps the accepted prefix. The
+ * proposal applies to the next step only:
+ * a committed step consumes it whether or not it could verify it. Passing an empty sequence clears
+ * the proposal. Random target sampling is supported for deterministic draft proposals when top_k
+ * is positive. Requires an engine whose cache can roll a rejected draft back (see
+ * OgaEngineMaxDraftTokensPerProposal).
  *
  * \param[in] request The request to propose drafts for.
  * \param[in] tokens One sequence holding the draft continuation, in order.

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -965,9 +965,7 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def("has_pending_requests", &OgaEngine::HasPendingRequests)
       .def("max_draft_tokens_per_proposal", &OgaEngine::MaxDraftTokensPerProposal,
            "Speculative draft tokens a request may attach to one proposal; zero when unsupported.")
-      .def("get_speculative_stats", [](const OgaEngine& engine) {
-        return ToSpeculativeStatsDict(*engine.GetSpeculativeStats());
-      }, "Return cumulative speculative-decoding telemetry.");
+      .def("get_speculative_stats", [](const OgaEngine& engine) { return ToSpeculativeStatsDict(*engine.GetSpeculativeStats()); }, "Return cumulative speculative-decoding telemetry.");
 
   pybind11::class_<OgaStreamingProcessor>(m, "StreamingProcessor")
       .def(pybind11::init([](OgaModel& model) { return OgaStreamingProcessor::Create(model); }),

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -306,6 +306,14 @@ pybind11::dict ToSpeculativeStatsDict(const OgaSpeculativeStats& stats) {
                           "target_overhead_ratio", "estimated_speedup", "observed_speedup",
                           "adaptive_k_throughput"})
     d[key] = stats.GetNumber(key);
+  pybind11::list acceptance_length_histogram;
+  for (size_t accepted_length = 0;
+       accepted_length < stats.GetAcceptanceLengthHistogramSize();
+       ++accepted_length) {
+    acceptance_length_histogram.append(
+        stats.GetAcceptanceLengthCount(accepted_length));
+  }
+  d["acceptance_length_histogram"] = std::move(acceptance_length_histogram);
   return d;
 }
 
@@ -956,7 +964,10 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
           pybind11::arg("buffer"))
       .def("has_pending_requests", &OgaEngine::HasPendingRequests)
       .def("max_draft_tokens_per_proposal", &OgaEngine::MaxDraftTokensPerProposal,
-           "Speculative draft tokens a request may attach to one proposal; zero when unsupported.");
+           "Speculative draft tokens a request may attach to one proposal; zero when unsupported.")
+      .def("get_speculative_stats", [](const OgaEngine& engine) {
+        return ToSpeculativeStatsDict(*engine.GetSpeculativeStats());
+      }, "Return cumulative speculative-decoding telemetry.");
 
   pybind11::class_<OgaStreamingProcessor>(m, "StreamingProcessor")
       .def(pybind11::init([](OgaModel& model) { return OgaStreamingProcessor::Create(model); }),

--- a/test/cpp/engine/engine_run_tests.cpp
+++ b/test/cpp/engine/engine_run_tests.cpp
@@ -2129,6 +2129,46 @@ TEST_F(EngineRunTest, RolledBackSpeculativeRunLeavesProposalPendingAndRetryable)
   EXPECT_EQ(request->TurnGeneratedTokens(), generated_after_prefill + 3);
 }
 
+TEST_F(EngineRunTest, RolledBackTerminalDraftCanRetryWithoutProposal) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto first_params = MakeGreedyParams(*model_);
+  auto first = CreateEngineRequest(engine.engine, *first_params);
+  first->BeginTurn(Prompt(10), std::optional<size_t>{2});
+  auto control = std::make_shared<RequestPostProcessingControl>();
+  auto second_params = MakeGreedyParams(*model_);
+  FailingPostProcessingDevice device{*second_params->p_device, control};
+  second_params->p_device = &device;
+  auto second = CreateEngineRequest(engine.engine, *second_params);
+  second->BeginTurn(Prompt(20));
+
+  std::array<EngineEvent, 2> initial;
+  ASSERT_EQ(engine.engine->Run(initial), 2u);
+  ASSERT_EQ(first->TurnGeneratedTokens(), 1u);
+
+  first->SetDraftTokens(std::array<int32_t, 1>{11});
+  engine.executor->SetVerifyRowTokens({11, filler, filler});
+  control->fail = true;
+
+  EXPECT_EQ(RunOne(*engine.engine).flags, EngineEventFlagRetryable);
+  EXPECT_FALSE(first->DraftVerificationCompletedGeneration());
+  EXPECT_EQ(first->PendingDraftTokenCount(), 1u);
+
+  first->SetDraftTokens(std::span<const int32_t>{});
+  engine.executor->SetVerifyRowTokens({filler, filler});
+  control->fail = false;
+  std::array<EngineEvent, 2> retried;
+  ASSERT_EQ(engine.engine->Run(retried), 2u);
+  EXPECT_EQ(retried[0].request, first);
+  EXPECT_EQ(retried[0].token, filler);
+  EXPECT_EQ(retried[0].flags,
+            EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(retried[0].finish_reason, GenerationFinishReason::TurnLimit);
+}
+
 TEST_F(EngineRunTest, DraftsRequireRollbackAndPerTokenLogitsCapabilities) {
   auto engine =
       MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
@@ -2198,6 +2238,59 @@ TEST_F(EngineRunTest, InvalidDraftReplacementPreservesPendingProposal) {
   EXPECT_EQ(events[2].token, 25);
 }
 
+TEST_F(EngineRunTest, MtpPlanningAbortRestoresExistingShadowForRetry) {
+  model_ = LoadSyntheticPagedMtpModel();
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeMtpDoublesEngine(model_, filler);
+  auto request = CreateRequestWithPrompt(
+      engine.engine, *model_, Prompt(10));
+
+  ASSERT_EQ(RunOne(*engine.engine).request, request);
+  ASSERT_GT(request->PendingDraftTokenCount(), 0u);
+  ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+  const auto before_abort = request->Snapshot();
+  const size_t pending_drafts = request->PendingDraftTokenCount();
+  const int draft_calls_before_abort = engine.mtp_executor->decode_calls;
+
+  engine.mtp_cache->ThrowPlanningBadAllocOnce();
+  const auto retryable = RunOne(*engine.engine);
+  EXPECT_EQ(retryable.flags, EngineEventFlagRetryable);
+  EXPECT_EQ(request->Snapshot().current_sequence_length,
+            before_abort.current_sequence_length);
+  EXPECT_EQ(request->Snapshot().processed_sequence_length,
+            before_abort.processed_sequence_length);
+  EXPECT_EQ(request->PendingDraftTokenCount(), pending_drafts);
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+
+  const auto retried = RunOne(*engine.engine);
+  EXPECT_EQ(retried.request, request);
+  EXPECT_NE(retried.flags & EngineEventFlagToken, 0u);
+  EXPECT_GT(engine.mtp_executor->decode_calls, draft_calls_before_abort);
+}
+
+TEST_F(EngineRunTest, MtpRollbackFailureMarksEngineUnhealthy) {
+  model_ = LoadSyntheticPagedMtpModel();
+  const int32_t eos = EosToken(*model_);
+  auto engine = MakeMtpDoublesEngine(
+      model_, eos == 5 ? 6 : 5);
+  auto request = CreateRequestWithPrompt(
+      engine.engine, *model_, Prompt(10));
+
+  ASSERT_EQ(RunOne(*engine.engine).request, request);
+  ASSERT_GT(request->PendingDraftTokenCount(), 0u);
+  engine.mtp_cache->ThrowReleaseFailureOnce();
+  engine.mtp_executor->SetNextFailure(
+      ScriptedExecutionFailure::RetryableDuringExecution);
+
+  const auto failure = RunOne(*engine.engine);
+  EXPECT_EQ(failure.request, request);
+  EXPECT_EQ(failure.flags,
+            EngineEventFlagTurnFinished | EngineEventFlagFailed);
+  EXPECT_EQ(failure.error_code, EngineErrorCode::EngineExecutionFailure);
+  EXPECT_THROW(static_cast<void>(RunOne(*engine.engine)), EngineStepError);
+}
+
 // ---------------------------------------------------------------------------------------------
 // Composite decoder-state transactions (paged KV + fixed state pool)
 //
@@ -2223,6 +2316,48 @@ TEST_F(EngineRunTest, DensePagedModelHasNoFixedStateReservation) {
 
   EXPECT_EQ(RunOne(*engine.engine).request, request);
   EXPECT_FALSE(engine.cache->FixedStateSnapshot().has_value());
+}
+
+TEST_F(EngineRunTest, CompositeMixedPrefillDefersResidentDraft) {
+  model_ = LoadSyntheticCompositeModel();
+  model_->config_->engine.dynamic_batching->max_scheduled_tokens = 3;
+  const int32_t eos = EosToken(*model_);
+  auto engine = MakeCompositeDoublesEngine(
+      model_, eos == 5 ? 6 : 5);
+  auto decode = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+
+  ASSERT_EQ(RunOne(*engine.engine).request, decode);
+  const auto decode_before_mixed = decode->Snapshot();
+  decode->SetDraftTokens(std::array<int32_t, 1>{11});
+  const std::array<int32_t, 5> long_prompt{2, 3, 4, 5, 6};
+  auto prefill = CreateRequestWithPrompt(
+      engine.engine, *model_, long_prompt);
+
+  engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
+    ASSERT_NE(context.plan, nullptr);
+    ASSERT_EQ(context.plan->requests.size(), 2u);
+    EXPECT_EQ(context.plan->token_count, 2u);
+    const auto& decode_entry = context.plan->requests[0];
+    EXPECT_EQ(decode_entry.request_id, decode.get());
+    EXPECT_EQ(decode_entry.unprocessed_token_count, 1u);
+    EXPECT_EQ(decode_entry.draft_token_count, 0u);
+    EXPECT_EQ(decode_entry.whole_sequence_cache_slots,
+              static_cast<size_t>(decode->CurrentSequenceLength()));
+    const auto& prefill_entry = context.plan->requests[1];
+    EXPECT_EQ(prefill_entry.request_id, prefill.get());
+    EXPECT_EQ(prefill_entry.unprocessed_token_count, 1u);
+    for (const auto& binding : context.fixed_state_bindings) {
+      for (size_t row = 0; row < context.plan->requests.size(); ++row) {
+        FillFixedOutputRow(binding, row, static_cast<float>(row + 1));
+      }
+    }
+  });
+
+  EXPECT_EQ(RunOne(*engine.engine).request, decode);
+  EXPECT_EQ(decode->ProcessedSequenceLength(),
+            decode_before_mixed.processed_sequence_length + 1);
+  EXPECT_EQ(prefill->ProcessedSequenceLength(), 1);
+  EXPECT_TRUE(prefill->IsPrefill());
 }
 
 TEST_F(EngineRunTest, CompositeReservationExposesRowsAndCommitsBothStates) {

--- a/test/cpp/engine/engine_run_tests.cpp
+++ b/test/cpp/engine/engine_run_tests.cpp
@@ -2238,7 +2238,7 @@ TEST_F(EngineRunTest, InvalidDraftReplacementPreservesPendingProposal) {
   EXPECT_EQ(events[2].token, 25);
 }
 
-TEST_F(EngineRunTest, MtpPlanningAbortRestoresExistingShadowForRetry) {
+TEST_F(EngineRunTest, MtpPlanningFailureCommitsTargetStepWithoutDrafts) {
   model_ = LoadSyntheticPagedMtpModel();
   const int32_t eos = EosToken(*model_);
   const int32_t filler = eos == 5 ? 6 : 5;
@@ -2246,27 +2246,122 @@ TEST_F(EngineRunTest, MtpPlanningAbortRestoresExistingShadowForRetry) {
   auto request = CreateRequestWithPrompt(
       engine.engine, *model_, Prompt(10));
 
-  ASSERT_EQ(RunOne(*engine.engine).request, request);
+  std::array<EngineEvent, 8> storage;
+  ASSERT_GT(engine.engine->Run(storage), 0u);
   ASSERT_GT(request->PendingDraftTokenCount(), 0u);
   ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
   const auto before_abort = request->Snapshot();
-  const size_t pending_drafts = request->PendingDraftTokenCount();
   const int draft_calls_before_abort = engine.mtp_executor->decode_calls;
 
+  // MTP drafting is optional acceleration: a recoverable head failure must release only MTP state
+  // and still let the mandatory target step commit.
   engine.mtp_cache->ThrowPlanningBadAllocOnce();
-  const auto retryable = RunOne(*engine.engine);
-  EXPECT_EQ(retryable.flags, EngineEventFlagRetryable);
-  EXPECT_EQ(request->Snapshot().current_sequence_length,
+  const size_t degraded_count = engine.engine->Run(storage);
+  ASSERT_GT(degraded_count, 0u);
+  EXPECT_EQ(storage.front().request, request);
+  EXPECT_NE(storage.front().flags & EngineEventFlagToken, 0u);
+  EXPECT_GT(request->Snapshot().current_sequence_length,
             before_abort.current_sequence_length);
-  EXPECT_EQ(request->Snapshot().processed_sequence_length,
-            before_abort.processed_sequence_length);
-  EXPECT_EQ(request->PendingDraftTokenCount(), pending_drafts);
+  EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
   EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+  EXPECT_EQ(engine.engine->GetSpeculativeStats().standard_fallback_steps, 1u);
 
-  const auto retried = RunOne(*engine.engine);
-  EXPECT_EQ(retried.request, request);
-  EXPECT_NE(retried.flags & EngineEventFlagToken, 0u);
+  // The next step drafts again from the restored shadow.
+  ASSERT_GT(engine.engine->Run(storage), 0u);
+  EXPECT_GT(request->PendingDraftTokenCount(), 0u);
   EXPECT_GT(engine.mtp_executor->decode_calls, draft_calls_before_abort);
+  EXPECT_EQ(engine.engine->GetSpeculativeStats().standard_fallback_steps, 1u);
+}
+
+TEST_F(EngineRunTest, PersistentMtpFailureKeepsTheRequestAdvancing) {
+  model_ = LoadSyntheticPagedMtpModel();
+  const int32_t eos = EosToken(*model_);
+  auto engine = MakeMtpDoublesEngine(model_, eos == 5 ? 6 : 5);
+  auto request = CreateRequestWithPrompt(
+      engine.engine, *model_, Prompt(10));
+
+  // A head failure that never clears must degrade to ordinary decoding instead of livelocking on
+  // a rolled back target step that commits no progress.
+  engine.mtp_cache->ThrowPlanningBadAllocAlways();
+  std::array<EngineEvent, 8> storage;
+  int64_t previous_length = request->Snapshot().current_sequence_length;
+  constexpr int kSteps = 4;
+  for (int step = 0; step < kSteps; ++step) {
+    const size_t count = engine.engine->Run(storage);
+    ASSERT_EQ(count, 1u);
+    ASSERT_EQ(storage.front().request, request);
+    ASSERT_NE(storage.front().flags & EngineEventFlagToken, 0u);
+    const int64_t length = request->Snapshot().current_sequence_length;
+    EXPECT_GT(length, previous_length);
+    previous_length = length;
+    EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
+  }
+  EXPECT_EQ(engine.engine->GetSpeculativeStats().standard_fallback_steps,
+            static_cast<size_t>(kSteps));
+}
+
+TEST_F(EngineRunTest, ContinuationDropsTheMtpShadowFromThePreviousTurn) {
+  model_ = LoadSyntheticPagedMtpModel();
+  const int32_t eos = EosToken(*model_);
+  auto engine = MakeMtpDoublesEngine(model_, eos == 5 ? 6 : 5);
+  auto request = CreateRequestWithPrompt(
+      engine.engine, *model_, Prompt(10));
+
+  std::array<EngineEvent, 8> storage;
+  ASSERT_GT(engine.engine->Run(storage), 0u);
+  ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+
+  engine.executor->SetForcedToken(eos);
+  bool turn_finished = false;
+  for (int attempt = 0; attempt < 8 && !turn_finished; ++attempt) {
+    const size_t count = engine.engine->Run(storage);
+    for (size_t i = 0; i < count; ++i) {
+      turn_finished |= (storage[i].flags & EngineEventFlagTurnFinished) != 0;
+    }
+  }
+  ASSERT_TRUE(turn_finished);
+  ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+
+  // The new turn appends a prompt the shadow never sees, so keeping it would leave the shadow a
+  // concatenation of generated tokens across turns with the intervening prompt missing.
+  request->BeginTurn(Prompt(4));
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 0u);
+
+  engine.executor->SetForcedToken(eos == 5 ? 6 : 5);
+  ASSERT_GT(engine.engine->Run(storage), 0u);
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+}
+
+TEST_F(EngineRunTest, CancelDropsTheMtpShadow) {
+  model_ = LoadSyntheticPagedMtpModel();
+  const int32_t eos = EosToken(*model_);
+  auto engine = MakeMtpDoublesEngine(model_, eos == 5 ? 6 : 5);
+  auto request = CreateRequestWithPrompt(
+      engine.engine, *model_, Prompt(10));
+
+  std::array<EngineEvent, 8> storage;
+  ASSERT_GT(engine.engine->Run(storage), 0u);
+  ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+
+  EXPECT_TRUE(request->Cancel(request->CurrentTurnId()));
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 0u);
+}
+
+TEST_F(EngineRunTest, SpeculativeStatsRejectOffOwnerThreadReads) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+
+  std::exception_ptr off_thread_error;
+  std::thread off_owner_thread([&] {
+    try {
+      static_cast<void>(engine.engine->GetSpeculativeStats());
+    } catch (...) {
+      off_thread_error = std::current_exception();
+    }
+  });
+  off_owner_thread.join();
+
+  ASSERT_NE(off_thread_error, nullptr);
+  EXPECT_THROW(std::rethrow_exception(off_thread_error), std::runtime_error);
 }
 
 TEST_F(EngineRunTest, MtpRollbackFailureMarksEngineUnhealthy) {

--- a/test/cpp/engine/engine_run_tests.cpp
+++ b/test/cpp/engine/engine_run_tests.cpp
@@ -1833,6 +1833,46 @@ TEST_F(EngineRunTest, SpeculativeRunAcceptingEveryDraftEmitsBonusToken) {
   EXPECT_EQ(request->TurnGeneratedTokens(), generated_after_prefill + 4);
 }
 
+TEST_F(EngineRunTest, SpeculativeTelemetryAggregatesAcceptanceLengths) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto request =
+      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  ASSERT_EQ(RunOne(*engine.engine).request, request);
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 12, 21, 22});
+  std::array<EngineEvent, 4> events;
+  ASSERT_EQ(engine.engine->Run(events), 3u);
+
+  request->SetDraftTokens(std::vector<int32_t>{14, 15});
+  engine.executor->SetVerifyRowTokens({24, 25, 26});
+  ASSERT_EQ(engine.engine->Run(events), 1u);
+
+  request->SetDraftTokens(std::vector<int32_t>{16});
+  engine.executor->SetVerifyRowTokens({16, 26});
+  ASSERT_EQ(engine.engine->Run(events), 2u);
+
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.target_forward_passes, 4u);
+  EXPECT_EQ(stats.draft_forward_passes, 0u);
+  EXPECT_EQ(stats.rounds, 3u);
+  EXPECT_EQ(stats.draft_tokens_proposed, 6u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 5u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 3u);
+  EXPECT_EQ(stats.zero_accept_rounds, 1u);
+  EXPECT_EQ(stats.partial_accept_rounds, 1u);
+  EXPECT_EQ(stats.full_accept_rounds, 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[0], 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[1], 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[2], 1u);
+  EXPECT_FLOAT_EQ(stats.acceptance_rate, 3.0f / 5.0f);
+  EXPECT_FLOAT_EQ(stats.avg_draft_tokens_per_round, 2.0f);
+}
+
 TEST_F(EngineRunTest, SpeculativeOverflowCancellationFinishesLastTokenEvent) {
   const int32_t eos = EosToken(*model_);
   const int32_t filler = eos == 5 ? 6 : 5;

--- a/test/cpp/engine/engine_run_tests.cpp
+++ b/test/cpp/engine/engine_run_tests.cpp
@@ -1766,6 +1766,120 @@ TEST_F(EngineRunTest, SpeculativeRunKeepsAcceptedPrefixAndEmitsAllTokens) {
   EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
 }
 
+TEST_F(EngineRunTest, SampledSpeculativeRunKeepsAcceptedPrefixAndCorrection) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+
+  auto request = CreateRequestWithPrompt(engine.engine, *params, Prompt(10));
+  ASSERT_EQ(RunOne(*engine.engine).request, request);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  const size_t generated_after_prefill = request->TurnGeneratedTokens();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 12, 21, 22});
+
+  std::array<EngineEvent, 3> events;
+  ASSERT_EQ(engine.engine->Run(events), 3u);
+  EXPECT_EQ(events[0].token, 11);
+  EXPECT_EQ(events[1].token, 12);
+  EXPECT_EQ(events[2].token, 21);
+  for (const auto& event : events) {
+    EXPECT_EQ(event.request, request);
+    EXPECT_EQ(event.flags, EngineEventFlagToken);
+  }
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 3);
+  EXPECT_EQ(request->TurnGeneratedTokens(), generated_after_prefill + 3);
+  EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 3u);
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.draft_tokens_proposed, 3u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 3u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 2u);
+}
+
+TEST_F(EngineRunTest, SampledSpeculativeBatchHandlesMixedDraftLengths) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  std::vector<std::shared_ptr<Request>> requests;
+  for (int32_t prompt_seed : {20, 30}) {
+    auto params = MakeGreedyParams(*model_);
+    params->search.do_sample = true;
+    params->search.top_k = 3;
+    params->search.temperature = 0.01f;
+    params->search.random_seed = static_cast<unsigned int>(1234 + prompt_seed);
+    requests.push_back(
+        CreateRequestWithPrompt(engine.engine, *params, Prompt(prompt_seed)));
+  }
+
+  std::array<EngineEvent, 2> prefill_events;
+  ASSERT_EQ(engine.engine->Run(prefill_events), 2u);
+  requests[0]->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  requests[1]->SetDraftTokens(std::vector<int32_t>{14});
+  engine.executor->SetVerifyRowTokens({11, 22, 23, 24, 14, 25});
+
+  std::array<EngineEvent, 4> events;
+  ASSERT_EQ(engine.engine->Run(events), 4u);
+  EXPECT_EQ(events[0].request, requests[0]);
+  EXPECT_EQ(events[0].token, 11);
+  EXPECT_EQ(events[1].request, requests[0]);
+  EXPECT_EQ(events[1].token, 22);
+  EXPECT_EQ(events[2].request, requests[1]);
+  EXPECT_EQ(events[2].token, 14);
+  EXPECT_EQ(events[3].request, requests[1]);
+  EXPECT_EQ(events[3].token, 25);
+  for (const auto& event : events) {
+    EXPECT_EQ(event.flags, EngineEventFlagToken);
+  }
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.rounds, 2u);
+  EXPECT_EQ(stats.draft_tokens_proposed, 4u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 3u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 2u);
+}
+
+TEST_F(EngineRunTest, SampledSpeculativeRunRespectsTurnTokenLimit) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(10), std::optional<size_t>{3});
+
+  ASSERT_EQ(RunOne(*engine.engine).request, request);
+  ASSERT_EQ(request->TurnGeneratedTokens(), 1u);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 12, 13, 25});
+
+  std::array<EngineEvent, 4> events;
+  ASSERT_EQ(engine.engine->Run(events), 2u);
+  EXPECT_EQ(events[0].token, 11);
+  EXPECT_EQ(events[0].flags, EngineEventFlagToken);
+  EXPECT_EQ(events[1].token, 12);
+  EXPECT_EQ(events[1].flags,
+            EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(events[1].finish_reason, GenerationFinishReason::TurnLimit);
+  EXPECT_EQ(request->status_, RequestStatus::TurnComplete);
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 2);
+  EXPECT_EQ(request->TurnGeneratedTokens(), 3u);
+}
+
 // The bonus row predicting EOS ends the turn without appending it, so the step's only visible
 // tokens are the accepted drafts.
 TEST_F(EngineRunTest, SpeculativeRunWithEosBonusTokenEmitsOnlyAcceptedDrafts) {

--- a/test/cpp/engine/engine_test_doubles.h
+++ b/test/cpp/engine/engine_test_doubles.h
@@ -104,7 +104,8 @@ struct RecordingCacheManager : CacheManager {
   size_t ResidentRequestCount() const override { return allocated_.size(); }
 
   StepPlanningResult PlanStepResources(StepPlan& plan) const override {
-    if (std::exchange(throw_planning_bad_alloc_, false)) {
+    if (always_throw_planning_bad_alloc_ ||
+        std::exchange(throw_planning_bad_alloc_, false)) {
       throw std::bad_alloc{};
     }
     if (std::exchange(throw_planning_consistency_, false)) {
@@ -293,6 +294,7 @@ struct RecordingCacheManager : CacheManager {
     max_draft_tokens_per_step_ = token_count;
   }
   void ThrowPlanningBadAllocOnce() { throw_planning_bad_alloc_ = true; }
+  void ThrowPlanningBadAllocAlways() { always_throw_planning_bad_alloc_ = true; }
   void ThrowPlanningConsistencyOnce() {
     throw_planning_consistency_ = true;
   }
@@ -340,6 +342,7 @@ struct RecordingCacheManager : CacheManager {
   size_t max_query_tokens_per_request_{};
   size_t max_draft_tokens_per_step_{};
   mutable bool throw_planning_bad_alloc_{};
+  mutable bool always_throw_planning_bad_alloc_{};
   mutable bool throw_planning_consistency_{};
   mutable bool overselect_planning_once_{};
   bool throw_prepare_failure_{};

--- a/test/cpp/engine/engine_test_doubles.h
+++ b/test/cpp/engine/engine_test_doubles.h
@@ -487,7 +487,7 @@ struct RecordingModelExecutor : ModelExecutor {
         std::make_unique<ScriptedDecoderIO>(
             model_, scheduled_requests, cache_manager_, forced_token_,
             failure == ScriptedExecutionFailure::PostProcessing,
-        context.plan, verify_row_tokens_, hidden_size_, hidden_type_));
+            context.plan, verify_row_tokens_, hidden_size_, hidden_type_));
     static_cast<void>(context);
   }
 

--- a/test/cpp/engine/engine_test_doubles.h
+++ b/test/cpp/engine/engine_test_doubles.h
@@ -207,6 +207,8 @@ struct RecordingCacheManager : CacheManager {
             cache.scripted_fixed_new_slot_count_;
         throw_prepare_ =
             std::exchange(cache.throw_prepare_failure_, false);
+        throw_release_ =
+            std::exchange(cache.throw_release_failure_, false);
       }
 
       std::span<const FixedStateSlotHandle> FixedStateSlots() const override {
@@ -249,6 +251,10 @@ struct RecordingCacheManager : CacheManager {
         if (committed_) {
           throw std::logic_error("Cannot release a committed recording cache reservation.");
         }
+        if (throw_release_) {
+          throw std::runtime_error(
+              "Injected cache transaction release failure.");
+        }
         cache_.reservation_release_calls++;
         released_ = true;
       }
@@ -259,6 +265,7 @@ struct RecordingCacheManager : CacheManager {
       size_t fixed_state_staging_bytes_{};
       size_t fixed_state_new_slot_count_{};
       bool throw_prepare_{};
+      bool throw_release_{};
       bool committed_{};
       bool released_{};
     };
@@ -293,6 +300,7 @@ struct RecordingCacheManager : CacheManager {
     overselect_planning_once_ = true;
   }
   void ThrowPrepareFailureOnce() { throw_prepare_failure_ = true; }
+  void ThrowReleaseFailureOnce() { throw_release_failure_ = true; }
   // Forces the composite plan/reservation consistency guard in Engine::StepDynamic. PlanStepResources
   // publishes `plan`, and every reservation reports slots, new-slot count, and staging bytes, so a
   // test can make the planned resources disagree with the reservation the Engine actually receives.
@@ -335,6 +343,7 @@ struct RecordingCacheManager : CacheManager {
   mutable bool throw_planning_consistency_{};
   mutable bool overselect_planning_once_{};
   bool throw_prepare_failure_{};
+  bool throw_release_failure_{};
   std::shared_ptr<CallTrace> trace_;
   bool can_allocate_verdict_{true};
   const void* unserviceable_request_id_{};
@@ -676,6 +685,37 @@ inline CompositeDoublesEngine MakeCompositeDoublesEngine(std::shared_ptr<Model> 
   EngineDependencies dependencies{std::move(cache), std::move(scheduler), std::move(executor)};
   auto engine = std::make_shared<Engine>(std::move(model), std::move(dependencies));
   return CompositeDoublesEngine{std::move(engine), cache_observer, executor_observer};
+}
+
+inline MtpDoublesEngine MakeMtpDoublesEngine(std::shared_ptr<Model> model,
+                                             int32_t forced_token) {
+  auto cache = std::make_shared<RecordingCacheManager>(model, /*capacity=*/8);
+  cache->SetMaxDraftTokensPerStep(3);
+  auto* cache_observer = cache.get();
+  auto scheduler = Scheduler::Create(model, cache);
+  auto executor = std::make_unique<RecordingModelExecutor>(
+      model, cache, forced_token);
+  executor->EnableHiddenStatesOutput(model->config_->model.decoder.hidden_size);
+  auto* executor_observer = executor.get();
+
+  auto mtp_model = std::make_shared<DecoderOnly_Model>(
+      CreateMtpDecoderConfig(*model->config_), GetOrtEnv());
+  auto mtp_cache = std::make_shared<RecordingCacheManager>(
+      mtp_model, /*capacity=*/8);
+  auto* mtp_cache_observer = mtp_cache.get();
+  auto mtp_executor = std::make_unique<RecordingModelExecutor>(
+      mtp_model, mtp_cache, forced_token);
+  mtp_executor->EnableHiddenStatesOutput(
+      mtp_model->config_->model.decoder.hidden_size);
+  auto* mtp_executor_observer = mtp_executor.get();
+
+  EngineDependencies dependencies{
+      std::move(cache), std::move(scheduler), std::move(executor),
+      std::move(mtp_model), std::move(mtp_cache), std::move(mtp_executor)};
+  auto engine = std::make_shared<Engine>(std::move(model), std::move(dependencies));
+  return MtpDoublesEngine{
+      nullptr, std::move(engine), cache_observer, executor_observer,
+      mtp_cache_observer, mtp_executor_observer, nullptr};
 }
 
 }  // namespace test

--- a/test/cpp/engine/engine_test_doubles.h
+++ b/test/cpp/engine/engine_test_doubles.h
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -14,6 +15,7 @@
 #include <vector>
 
 #include "generator/generators.h"
+#include "search.h"
 #include "engine/cache_manager.h"
 #include "engine/model_executor.h"
 #include "engine/scheduler.h"
@@ -188,6 +190,7 @@ struct RecordingCacheManager : CacheManager {
   }
 
   std::unique_ptr<CacheStepReservation> ReserveStep(const StepPlan& plan) override {
+    reserve_calls++;
     struct Reservation final : CacheStepReservation {
       Reservation(RecordingCacheManager& cache, const StepPlan& plan)
           : cache_{cache} {
@@ -238,6 +241,7 @@ struct RecordingCacheManager : CacheManager {
           throw std::logic_error("Recording cache reservation can only commit once.");
         }
         cache_.Allocate(newly_admitted_);
+        cache_.reservation_commit_calls++;
         committed_ = true;
       }
 
@@ -245,6 +249,7 @@ struct RecordingCacheManager : CacheManager {
         if (committed_) {
           throw std::logic_error("Cannot release a committed recording cache reservation.");
         }
+        cache_.reservation_release_calls++;
         released_ = true;
       }
 
@@ -258,6 +263,11 @@ struct RecordingCacheManager : CacheManager {
       bool released_{};
     };
 
+    size_t newly_admitted = 0;
+    for (const auto& entry : plan.requests) {
+      newly_admitted += entry.newly_admitted ? 1 : 0;
+    }
+    reserved_new_request_counts.push_back(newly_admitted);
     return std::make_unique<Reservation>(*this, plan);
   }
 
@@ -312,6 +322,10 @@ struct RecordingCacheManager : CacheManager {
   int allocate_calls{0};
   int deallocate_calls{0};
   int step_calls{0};
+  int reserve_calls{0};
+  int reservation_commit_calls{0};
+  int reservation_release_calls{0};
+  std::vector<size_t> reserved_new_request_counts;
 
  private:
   size_t capacity_;
@@ -343,7 +357,9 @@ struct ScriptedDecoderIO : DecoderIO {
                     std::shared_ptr<CacheManager> cache_manager, int32_t forced_token,
                     bool fail_process_logits = false,
                     const StepPlan* plan = nullptr,
-                    std::span<const int32_t> row_tokens = {})
+                    std::span<const int32_t> row_tokens = {},
+                    int64_t hidden_size = 0,
+                    ONNXTensorElementDataType hidden_type = Ort::TypeToTensorType<float>)
       : DecoderIO(model, scheduled_requests, cache_manager),
         vocab_size_{static_cast<int64_t>(model->config_->model.vocab_size)},
         fail_process_logits_{fail_process_logits} {
@@ -374,6 +390,15 @@ struct ScriptedDecoderIO : DecoderIO {
       cpu_span[static_cast<int64_t>(row) * vocab_size_ + token] = 100.0f;
     }
     device_span.CopyCpuToDevice();
+
+    if (hidden_size > 0) {
+      hidden_states_ = std::make_unique<Tensor>(model->p_device_inputs_, hidden_type);
+      const size_t hidden_rows = plan ? plan->token_count : scheduled_requests.size();
+      const std::array<int64_t, 2> hidden_shape{
+          static_cast<int64_t>(hidden_rows), hidden_size};
+      hidden_states_->CreateTensor(hidden_shape);
+      hidden_states_->GetByteSpan().Zero();
+    }
   }
 
   std::vector<DeviceSpan<float>> ProcessLogits() override {
@@ -388,10 +413,13 @@ struct ScriptedDecoderIO : DecoderIO {
     return rows;
   }
 
+  Tensor* HiddenStates() const override { return hidden_states_.get(); }
+
  private:
   int64_t vocab_size_;
   size_t row_count_{};
   bool fail_process_logits_{};
+  std::unique_ptr<Tensor> hidden_states_;
 };
 
 enum class ScriptedExecutionFailure {
@@ -425,7 +453,13 @@ struct RecordingModelExecutor : ModelExecutor {
       for (const auto& entry : context.plan->requests)
         request_ids.push_back(entry.request_id);
       decoded_request_ids.push_back(std::move(request_ids));
+      std::vector<int64_t> sequence_lengths;
+      sequence_lengths.reserve(context.plan->requests.size());
+      for (const auto& entry : context.plan->requests)
+        sequence_lengths.push_back(entry.sequence_length_before);
+      decoded_sequence_lengths_before.push_back(std::move(sequence_lengths));
     }
+    used_device_input_ids.push_back(!context.input_ids.empty());
     if (trace_) trace_->Record("Decode");
     const auto failure = std::exchange(next_failure_, ScriptedExecutionFailure::None);
     if (failure == ScriptedExecutionFailure::RetryableBeforeExecution) {
@@ -453,7 +487,7 @@ struct RecordingModelExecutor : ModelExecutor {
         std::make_unique<ScriptedDecoderIO>(
             model_, scheduled_requests, cache_manager_, forced_token_,
             failure == ScriptedExecutionFailure::PostProcessing,
-            context.plan, verify_row_tokens_));
+        context.plan, verify_row_tokens_, hidden_size_, hidden_type_));
     static_cast<void>(context);
   }
 
@@ -471,11 +505,19 @@ struct RecordingModelExecutor : ModelExecutor {
   void SetSupportsDraftVerification(bool supported) {
     supports_draft_verification_ = supported;
   }
+  void EnableHiddenStatesOutput(
+      int64_t hidden_size,
+      ONNXTensorElementDataType hidden_type = Ort::TypeToTensorType<float>) {
+    hidden_size_ = hidden_size;
+    hidden_type_ = hidden_type;
+  }
 
   int decode_calls{0};
   std::vector<size_t> decoded_batch_sizes;
   std::vector<size_t> decoded_token_counts;
   std::vector<std::vector<const void*>> decoded_request_ids;
+  std::vector<std::vector<int64_t>> decoded_sequence_lengths_before;
+  std::vector<bool> used_device_input_ids;
 
  private:
   std::shared_ptr<Model> model_;
@@ -486,6 +528,90 @@ struct RecordingModelExecutor : ModelExecutor {
   std::function<void(ExecutionContext&)> on_execute_;
   std::vector<int32_t> verify_row_tokens_;
   bool supports_draft_verification_{true};
+  int64_t hidden_size_{};
+  ONNXTensorElementDataType hidden_type_{Ort::TypeToTensorType<float>};
+};
+
+struct CountingCudaDeviceState {
+  size_t device_to_host_copies{};
+  size_t synchronize_calls{};
+  std::vector<int> argmax_rows;
+};
+
+struct CountingCudaMemory final : DeviceBuffer {
+  CountingCudaMemory(size_t size, std::shared_ptr<CountingCudaDeviceState> state)
+      : storage_{std::make_unique<uint8_t[]>(size)}, state_{std::move(state)} {
+    size_in_bytes_ = size;
+    p_cpu_ = p_device_ = storage_.get();
+  }
+
+  CountingCudaMemory(void* memory, size_t size,
+                     std::shared_ptr<CountingCudaDeviceState> state)
+      : state_{std::move(state)} {
+    size_in_bytes_ = size;
+    p_cpu_ = p_device_ = static_cast<uint8_t*>(memory);
+  }
+
+  const char* GetType() const override { return "test_cuda"; }
+  void AllocateCpu() override {}
+  void CopyDeviceToCpu() override { ++state_->device_to_host_copies; }
+  void CopyCpuToDevice() override {}
+  void CopyFrom(size_t begin_dest, DeviceBuffer& source,
+                size_t begin_source, size_t size_in_bytes) override {
+    std::memmove(p_device_ + begin_dest, source.p_device_ + begin_source, size_in_bytes);
+  }
+  void Zero() override { std::memset(p_device_, 0, size_in_bytes_); }
+
+ private:
+  std::unique_ptr<uint8_t[]> storage_;
+  std::shared_ptr<CountingCudaDeviceState> state_;
+};
+
+struct CountingCudaDevice final : DeviceInterface {
+  CountingCudaDevice()
+      : state{std::make_shared<CountingCudaDeviceState>()} {}
+
+  DeviceType GetType() const override { return DeviceType::CUDA; }
+  void InitOrt(const OrtApi&, Ort::Allocator&) override {}
+  Ort::Allocator& GetAllocator() override {
+    return GetDeviceInterface(DeviceType::CPU)->GetAllocator();
+  }
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override { return {}; }
+  std::string GetExecutionProviderName() const override { return "test_cuda"; }
+  std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
+    return std::make_shared<CountingCudaMemory>(size, state);
+  }
+  std::shared_ptr<DeviceBuffer> WrapMemoryBase(void* memory, size_t size) override {
+    return std::make_shared<CountingCudaMemory>(memory, size, state);
+  }
+  std::unique_ptr<Search> CreateGreedy(const GeneratorParams& params) override {
+    return std::make_unique<GreedySearch_Cpu>(params);
+  }
+  std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override {
+    return std::make_unique<BeamSearch_Cpu>(params);
+  }
+  std::unique_ptr<KeyValueCache> CreateKeyValueCache(State&) override { return {}; }
+  void Synchronize() override { ++state->synchronize_calls; }
+
+  bool ArgMaxDevice(const void* logits, ONNXTensorElementDataType logits_type,
+                    int num_rows, int vocab_size,
+                    DeviceSpan<int32_t> out_tokens) override {
+    if (logits_type != Ort::TypeToTensorType<float> ||
+        out_tokens.size() < static_cast<size_t>(num_rows)) {
+      return false;
+    }
+    state->argmax_rows.push_back(num_rows);
+    const auto* values = static_cast<const float*>(logits);
+    auto output = out_tokens.Span();
+    for (int row = 0; row < num_rows; ++row) {
+      const auto* begin = values + static_cast<size_t>(row) * vocab_size;
+      output[row] = static_cast<int32_t>(
+          std::max_element(begin, begin + vocab_size) - begin);
+    }
+    return true;
+  }
+
+  std::shared_ptr<CountingCudaDeviceState> state;
 };
 
 // An Engine wired with the recording doubles above, together with non-owning observers of those
@@ -508,6 +634,16 @@ struct CompositeDoublesEngine {
   std::shared_ptr<Engine> engine;
   PagedCacheManager* cache;
   RecordingModelExecutor* executor;
+};
+
+struct MtpDoublesEngine {
+  std::unique_ptr<CountingCudaDevice> device;
+  std::shared_ptr<Engine> engine;
+  RecordingCacheManager* cache;
+  RecordingModelExecutor* executor;
+  RecordingCacheManager* mtp_cache;
+  RecordingModelExecutor* mtp_executor;
+  std::shared_ptr<CountingCudaDeviceState> device_state;
 };
 
 inline DoublesEngine MakeDoublesEngine(std::shared_ptr<Model> model, size_t capacity, int32_t forced_token) {

--- a/test/cpp/engine/engine_test_helpers.h
+++ b/test/cpp/engine/engine_test_helpers.h
@@ -37,6 +37,9 @@ inline std::shared_ptr<Model> LoadSyntheticPagedMtpModel() {
   config->model.mtp.head_size = 1;
   config->model.mtp.inputs.hidden_states = "past_key_values.1.key";
   config->model.mtp.outputs.hidden_states = "hidden_states";
+  // Engine::CreateDependencies sets this on the target decoder when a head is configured. Tests
+  // that drive ModelExecutor directly have to mirror it to get the hidden-states output bound.
+  config->engine.hidden_states_output_required = true;
   return CreateModel(GetOrtEnv(), std::move(config));
 }
 
@@ -72,6 +75,7 @@ inline std::shared_ptr<Model> LoadSyntheticCompositeModel() {
 inline std::shared_ptr<Model> LoadSyntheticCompositeMtpModel() {
   auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/synthetic-composite");
   config->model.mtp.filename = "unused-mtp-head.onnx";
+  config->engine.hidden_states_output_required = true;
   return CreateModel(GetOrtEnv(), std::move(config));
 }
 

--- a/test/cpp/engine/engine_test_helpers.h
+++ b/test/cpp/engine/engine_test_helpers.h
@@ -32,7 +32,11 @@ inline std::shared_ptr<Model> LoadSyntheticPagedModel() {
 
 inline std::shared_ptr<Model> LoadSyntheticPagedMtpModel() {
   auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/synthetic-paged");
-  config->model.mtp.filename = "unused-mtp-head.onnx";
+  config->model.mtp.filename = "decoder.onnx";
+  config->model.mtp.num_key_value_heads = 1;
+  config->model.mtp.head_size = 1;
+  config->model.mtp.inputs.hidden_states = "past_key_values.1.key";
+  config->model.mtp.outputs.hidden_states = "hidden_states";
   return CreateModel(GetOrtEnv(), std::move(config));
 }
 

--- a/test/cpp/engine/guidance_processor_tests.cpp
+++ b/test/cpp/engine/guidance_processor_tests.cpp
@@ -281,6 +281,26 @@ TEST_F(GuidanceProcessorTest, BatchedMasksFallBackOnInvalidGuidedRow) {
             BatchedGuidanceMaskStatus::FallbackRequired);
 }
 
+TEST_F(GuidanceProcessorTest, PackedLogitsRejectDraftVerifiedSampledRow) {
+  constexpr size_t kVocabSize = 4;
+  auto packed = model_->p_device_->Allocate<float>(kVocabSize * 2);
+  std::vector<DeviceSpan<float>> logits{
+      packed.subspan(0, kVocabSize), packed.subspan(kVocabSize, kVocabSize)};
+  EXPECT_EQ(PackedLogitsRowBase(logits, kVocabSize),
+            logits.front().Span().data());
+
+  // A sampled request that verified drafts drew its token on the host and contributes an empty row.
+  // Row 0 must not be dereferenced to establish the packed base pointer.
+  std::vector<DeviceSpan<float>> mixed{
+      DeviceSpan<float>{}, packed.subspan(kVocabSize, kVocabSize)};
+  EXPECT_EQ(PackedLogitsRowBase(mixed, kVocabSize), nullptr);
+
+  // Rows that are not laid out back to back cannot be masked as one block either.
+  std::vector<DeviceSpan<float>> unpacked{
+      packed.subspan(kVocabSize, kVocabSize), packed.subspan(0, kVocabSize)};
+  EXPECT_EQ(PackedLogitsRowBase(unpacked, kVocabSize), nullptr);
+}
+
 TEST_F(GuidanceProcessorTest, AsyncMaskFailureRollsBackAndCanRetry) {
   auto request = NewAssignedRequest(/*max_length_beyond_prompt=*/4);
   auto& processor = InstallFake(*request);

--- a/test/cpp/engine/mtp_config_tests.cpp
+++ b/test/cpp/engine/mtp_config_tests.cpp
@@ -93,6 +93,9 @@ TEST(MtpDecoderConfigTest, ProjectsPagedDecoderWithoutMainFixedState) {
   EXPECT_FALSE(head.state_groups.has_value());
   EXPECT_TRUE(head.pipeline.empty());
   EXPECT_TRUE(projected->model.mtp.filename.empty());
+  // The projection clears model.mtp, so the head's own demand for hidden states must be recorded
+  // explicitly. Without it a chained draft cannot feed the next stage.
+  EXPECT_TRUE(projected->engine.hidden_states_output_required);
   ASSERT_EQ(head.layer_types.size(), 1u);
   EXPECT_EQ(head.layer_types[0], "full_attention");
   EXPECT_THROW(CreateMtpDecoderConfig(*projected), std::runtime_error);

--- a/test/cpp/engine/paged_key_value_cache_tests.cpp
+++ b/test/cpp/engine/paged_key_value_cache_tests.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <array>
+#include <limits>
 
 #include <gtest/gtest.h>
 
@@ -426,6 +427,41 @@ TEST(PagedKeyValueCacheManifestTest, BlockCapacityUsesParticipatingLayerCount) {
           /*head_size=*/2,
           /*full_layer_count=*/2,
           /*element_size=*/2),
+      std::runtime_error);
+}
+
+TEST(PagedKeyValueCacheManifestTest, ExplicitBlockCountCoversBothPools) {
+  // Without a head, an explicit num_blocks is used verbatim.
+  EXPECT_EQ(
+      ResolveConfiguredPagedBlockCount(
+          /*configured_num_blocks=*/100,
+          /*primary_bytes_per_block=*/64,
+          /*auxiliary_bytes_per_block=*/0),
+      100u);
+
+  // num_blocks is the combined budget: 100 blocks of 64 bytes is 6400 bytes, which holds 66 blocks
+  // of the 96 bytes one target block plus one head block cost together.
+  EXPECT_EQ(
+      ResolveConfiguredPagedBlockCount(
+          /*configured_num_blocks=*/100,
+          /*primary_bytes_per_block=*/64,
+          /*auxiliary_bytes_per_block=*/32),
+      66u);
+
+  // A budget too small to leave a block for each pool is rejected rather than silently allocating
+  // an extra head pool outside the configured sizing contract.
+  EXPECT_THROW(
+      ResolveConfiguredPagedBlockCount(
+          /*configured_num_blocks=*/1,
+          /*primary_bytes_per_block=*/32,
+          /*auxiliary_bytes_per_block=*/64),
+      std::runtime_error);
+
+  EXPECT_THROW(
+      ResolveConfiguredPagedBlockCount(
+          /*configured_num_blocks=*/std::numeric_limits<size_t>::max(),
+          /*primary_bytes_per_block=*/64,
+          /*auxiliary_bytes_per_block=*/32),
       std::runtime_error);
 }
 

--- a/test/cpp/engine/paged_key_value_cache_tests.cpp
+++ b/test/cpp/engine/paged_key_value_cache_tests.cpp
@@ -389,6 +389,21 @@ TEST(PagedKeyValueCacheManifestTest, BlockCapacityUsesParticipatingLayerCount) {
           /*element_size=*/2),
       48u);
 
+  // One auxiliary layer with the same geometry adds 32 bytes to the primary model's 64 bytes per
+  // block, so both pools together fit 96 blocks in the same 90%-adjusted memory budget.
+  EXPECT_EQ(
+      ComputePagedBlockCapacity(
+          /*available_memory_bytes=*/10240,
+          /*gpu_utilization_factor=*/1.0f,
+          /*reserved_memory_bytes=*/0,
+          /*block_size=*/4,
+          /*num_key_value_heads=*/1,
+          /*head_size=*/2,
+          /*full_layer_count=*/2,
+          /*element_size=*/2,
+          /*auxiliary_bytes_per_block=*/32),
+      96u);
+
   EXPECT_EQ(
       ComputePagedBlockCapacity(
           /*available_memory_bytes=*/10240,


### PR DESCRIPTION
## Description

Adds chained multi-token-prediction drafting to the paged batch engine on top of #2494. The runtime keeps compact GDN and convolution state transitions, MTP draft inputs, and accepted-prefix publication coordinated with the target request transaction without restoring dense recurrent checkpoints or changing the ONNX Runtime dependency.

This replaces #2459 with the compact replay and composite-transaction design.

## Summary of Changes

### Chained MTP execution

- Runs configured MTP heads sequentially and verifies variable-length draft prefixes in the target batch.
- Keeps hidden-state and token handoff on device between MTP heads when supported.
- Supports greedy and sampled target requests, including deterministic batched sampling for draft verification.
- Rolls target, auxiliary KV, fixed state, search state, RNG state, and staged tokens back together on failure.

### Scheduling and state management

- Reserves MTP KV capacity alongside target paged KV and compact fixed-state resources.
- Defers drafts when decode and prefill requests share a step, avoiding unsupported mixed speculative rows while still progressing both requests.
- Discards rejected speculative rows so paged cache capacity can be reused.
- Preserves compact fixed-state replay using one convolution value or packed GDN capsule per transition; no intermediate dense checkpoints are captured.

### Telemetry and APIs

- Aggregates speculative step, draft, accepted-token, and accepted-length statistics in the engine.
- Exposes cumulative telemetry through the C++, C, and Python APIs as `Engine::GetSpeculativeStats` / `OgaEngineGetSpeculativeStats` / `Engine.get_speculative_stats`.

## Testing

- `build/Linux/Debug/engine_unit_tests` (295/295 passed)
- `cmake --build build/Linux/Debug` (passed)
- Python import/API smoke test for `Engine.get_speculative_stats` (passed)
- Focused MTP, speculative sampling, telemetry, and mixed-prefill tests (14/14 passed)

### Performance validation

Measured on one NVIDIA H200 with the CUDA Release build from stack head `dabb4103`, ORT CUDA 1.30.0, `qwen38_mtp_gdn_native_compact_final`, `K=7`, 1,024 generated tokens, CUDA graphs off, 2 warmups, and 3 measured runs:

| Prompt tokens | Decode tokens/s | Wall tokens/s | Evaluated-draft acceptance |
|---:|---:|---:|---:|
| 512 | 139.92 | 138.15 | 70.37% |
| 2,048 | 138.59 | 132.99 | 70.45% |
| 8,192 | 111.26 | 97.63 | 67.63% |

All measured runs produced deterministic output hashes and speculative counters. The compact model loaded without dense-checkpoint compatibility warnings.

## Dependencies

- Based on #2494.
- Does not include builder/export changes from Stack A.
- Does not require an ONNX Runtime package or submodule bump.

## Checklist

- [x] Tests added/updated
- [x] No dense recurrent checkpoints
- [x] No ONNX Runtime dependency bump
- [x] Public C/C++/Python telemetry bindings validated