### PR TITLE
Run a DFlash2 block drafter in the batch engine

### DIFF
--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -399,14 +399,17 @@ The dynamic Engine can verify a continuation together with a request's next deco
 can propose tokens before the next step with `Request::SetDraftTokens` (`OgaRequestSetDraftTokens`
 in C or `Request.set_draft_tokens` in Python). When `model.mtp` names an auxiliary draft head, the
 Engine also maintains an internal shadow Request and automatically proposes a chained greedy
-continuation after each committed target step.
+continuation after each committed target step. Alternatively, `model.dflash2` runs a block drafter
+over the target's packed auxiliary hidden states. A model cannot configure both automatic drafters.
 
 Query the internal `Engine::MaxDraftTokensPerStep` capability through
 `OgaEngineMaxDraftTokensPerProposal`, `OgaEngine::MaxDraftTokensPerProposal`, or
 `Engine.max_draft_tokens_per_proposal` before proposing work. Zero means that the decoder does not
 return one logits row per packed token or that its cache/state cannot commit an accepted prefix.
 The reported value is a capability limit, not a guarantee that every proposed token fits the next
-step's global token budget or current cache capacity.
+step's global token budget or current cache capacity. Automatic drafters also leave room for the
+target's correction token and cap each proposal by the Request's session limit and remaining Turn
+token budget.
 
 The request must already belong to the Engine, have completed prefill, and be ready to decode.
 Verification supports greedy target selection and random target sampling with a positive `top_k`;
@@ -1113,6 +1116,10 @@ variable-size output does not have persistent graph buffers. Engine construction
 rank, element type, and static width against the drafter input before allocating cache resources.
 The drafter run is synchronous because its packed inputs and outputs are owned by one proposal
 call, so `model.dflash2.run_options` cannot disable execution-provider synchronization.
+The direct drafter session also uses graph id `-1`: its variable-shaped proposal tensors are
+allocated per call and therefore cannot be captured safely. If this optional post-commit drafter
+run fails, the Engine discards any partial proposal, releases the drafter, and still publishes the
+already committed target events; subsequent Turns continue without automatic DFlash 2 proposals.
 
 ## Backpressure and fairness
 

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -1123,6 +1123,11 @@ allocated per call and therefore cannot be captured safely. If this optional pos
 run fails, the Engine discards any partial proposal, releases the drafter, and still publishes the
 already committed target events; subsequent Turns continue without automatic DFlash 2 proposals.
 
+The drafter keeps a fixed sliding-window ring per request from that request's first decode step
+until it is closed, so its pool is sized for `max_batch_size` rings. A request that first decodes
+while every ring is taken is skipped for the rest of its life and decodes without DFlash 2 drafts;
+the drafter keeps serving the requests that already hold a ring.
+
 ## Backpressure and fairness
 
 Continuous batching does not mean every pending request runs on every step.

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -1107,6 +1107,13 @@ Graph buffers are allocated once at configured limits and reshaped as static vie
 
 Prefill and mixed-token steps use graph id `-1`, which tells the CUDA execution provider to run eagerly.
 
+An Engine-hosted DFlash 2 drafter also forces eager target execution. Its target decoder output is
+the packed auxiliary hidden-state tensor named by `model.dflash2.main_aux_hidden_states`; that
+variable-size output does not have persistent graph buffers. Engine construction validates its
+rank, element type, and static width against the drafter input before allocating cache resources.
+The drafter run is synchronous because its packed inputs and outputs are owned by one proposal
+call, so `model.dflash2.run_options` cannot disable execution-provider synchronization.
+
 ## Backpressure and fairness
 
 Continuous batching does not mean every pending request runs on every step.

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -454,9 +454,10 @@ one block for each pool is rejected at Engine construction.
 **Failure isolation.** The target decode is mandatory; MTP drafting is optional acceleration. A
 recoverable head failure (cache pressure, shape mismatch, binding or session error) releases only
 MTP state, and the target step still commits — without drafts for that step — and increments
-`standard_fallback_steps` in the speculative statistics. Only a contract violation, or a failure to
-roll MTP state back, marks the Engine unhealthy. A persistent head failure therefore degrades to
-ordinary decoding instead of stalling the request.
+`standard_fallback_steps` and `mtp_failures` in the speculative statistics. The first failure is
+logged, and three consecutive failures disable automatic MTP drafting for that Engine. Only a
+contract violation, or a failure to roll MTP state back, marks the Engine unhealthy. A persistent
+head failure therefore degrades to ordinary decoding without repeatedly running a broken head.
 
 **Shadow lifecycle.** The head's shadow Request mirrors only the suffix the target committed during
 the current turn. Beginning a continuation and canceling a turn both drop the shadow and release its
@@ -471,8 +472,9 @@ verify is skipped for that step and picks drafting back up on its next decode st
 decode paths. A verified drafted step draws its target tokens from the Request's own host random
 stream because acceptance is sequential, while an ordinary batched step draws from the device
 sampler state. Whether drafts are admitted depends on batch composition and cache pressure, so a
-seeded run is only bit-reproducible against another run scheduled the same way. Disable `model.mtp`
-when exact cross-scheduling reproducibility is required.
+seeded run is only bit-reproducible against another run with the same supplied drafts and scheduling
+path. Disabling `model.mtp` does not make caller-provided drafts scheduling-independent; exact
+repeatability requires replaying the same proposals and schedule.
 
 **Telemetry thread ownership.** `Engine::GetSpeculativeStats` (`OgaEngineGetSpeculativeStats`,
 `Engine.get_speculative_stats`) reads counters that `Run()` mutates without synchronization. Like

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -1112,21 +1112,26 @@ Graph buffers are allocated once at configured limits and reshaped as static vie
 
 Prefill and mixed-token steps use graph id `-1`, which tells the CUDA execution provider to run eagerly.
 
-An Engine-hosted DFlash 2 drafter also forces eager target execution. Its target decoder output is
-the packed auxiliary hidden-state tensor named by `model.dflash2.main_aux_hidden_states`; that
-variable-size output does not have persistent graph buffers. Engine construction validates its
-rank, element type, and static width against the drafter input before allocating cache resources.
+An Engine-hosted DFlash 2 drafter consumes the packed auxiliary hidden-state tensor named by
+`model.dflash2.main_aux_hidden_states`. Single-token target decode steps bind that output through
+persistent graph buffers and remain eligible for CUDA graph capture; prefill and draft-verification
+steps remain eager. Engine construction validates the output's rank, element type, and static width
+against the drafter input before allocating cache resources.
 The drafter run is synchronous because its packed inputs and outputs are owned by one proposal
 call, so `model.dflash2.run_options` cannot disable execution-provider synchronization.
 The direct drafter session also uses graph id `-1`: its variable-shaped proposal tensors are
 allocated per call and therefore cannot be captured safely. If this optional post-commit drafter
-run fails, the Engine discards any partial proposal, releases the drafter, and still publishes the
-already committed target events; subsequent Turns continue without automatic DFlash 2 proposals.
+run fails, the Engine discards any partial proposal and still publishes the already committed target
+events. A transient failure is retried on the next step; three consecutive failures disable DFlash 2
+for the Engine. `dflash2_failures` and `dflash2_disables` report those events.
 
 The drafter keeps a fixed sliding-window ring per request from that request's first decode step
 until it is closed, so its pool is sized for `max_batch_size` rings. A request that first decodes
 while every ring is taken is skipped for the rest of its life and decodes without DFlash 2 drafts;
-the drafter keeps serving the requests that already hold a ring.
+the drafter keeps serving the requests that already hold a ring. This makes `max_batch_size` the
+DFlash 2 service-capacity limit across both active and idle long-lived requests, not merely the
+per-step scheduler limit. `dflash2_admission_misses` reports requests denied a ring because that
+capacity was occupied.
 
 ## Backpressure and fairness
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -543,6 +543,8 @@ struct DecoderOutputs_Element : JSON::Element {
       v_.state_update_recurrent_capsule_names = JSON::Get<std::string_view>(value);
     } else if (name == "hidden_states") {
       v_.hidden_states = JSON::Get<std::string_view>(value);
+    } else if (name == "aux_hidden_states") {
+      v_.aux_hidden_states = JSON::Get<std::string_view>(value);
     } else if (name == "outputs") {
       v_.outputs = JSON::Get<std::string_view>(value);
     } else if (name == "lstm_hidden_state") {
@@ -1122,6 +1124,137 @@ struct Mtp_Element : JSON::Element {
   SharedInitializers_Element shared_initializers_{v_.shared_initializers};
 };
 
+struct Dflash2Inputs_Element : JSON::Element {
+  explicit Dflash2Inputs_Element(Config::Model::Dflash2::Inputs& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "aux_hidden_states") {
+      v_.aux_hidden_states = JSON::Get<std::string_view>(value);
+    } else if (name == "input_ids") {
+      v_.input_ids = JSON::Get<std::string_view>(value);
+    } else if (name == "q_row_map") {
+      v_.q_row_map = JSON::Get<std::string_view>(value);
+    } else if (name == "qkv_row_map") {
+      v_.qkv_row_map = JSON::Get<std::string_view>(value);
+    } else if (name == "block_row_index") {
+      v_.block_row_index = JSON::Get<std::string_view>(value);
+    } else if (name == "cumulative_sequence_lengths") {
+      v_.cumulative_sequence_lengths = JSON::Get<std::string_view>(value);
+    } else if (name == "past_sequence_lengths") {
+      v_.past_sequence_lengths = JSON::Get<std::string_view>(value);
+    } else if (name == "block_table") {
+      v_.block_table = JSON::Get<std::string_view>(value);
+    } else if (name == "attention_metadata") {
+      v_.attention_metadata = JSON::Get<std::string_view>(value);
+    } else if (name == "past_key_names") {
+      v_.past_key_names = JSON::Get<std::string_view>(value);
+    } else if (name == "past_value_names") {
+      v_.past_value_names = JSON::Get<std::string_view>(value);
+    } else {
+      throw JSON::unknown_value_error{};
+    }
+  }
+
+ private:
+  Config::Model::Dflash2::Inputs& v_;
+};
+
+struct Dflash2Outputs_Element : JSON::Element {
+  explicit Dflash2Outputs_Element(Config::Model::Dflash2::Outputs& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "candidate_ids") {
+      v_.candidate_ids = JSON::Get<std::string_view>(value);
+    } else if (name == "scores") {
+      v_.scores = JSON::Get<std::string_view>(value);
+    } else if (name == "present_key_names") {
+      v_.present_key_names = JSON::Get<std::string_view>(value);
+    } else if (name == "present_value_names") {
+      v_.present_value_names = JSON::Get<std::string_view>(value);
+    } else {
+      throw JSON::unknown_value_error{};
+    }
+  }
+
+ private:
+  Config::Model::Dflash2::Outputs& v_;
+};
+
+struct Dflash2_Element : JSON::Element {
+  explicit Dflash2_Element(Config::Model::Dflash2& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    if (name == "filename") {
+      v_.filename = JSON::Get<std::string_view>(value);
+    } else if (name == "num_hidden_layers") {
+      v_.num_hidden_layers = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (v_.num_hidden_layers <= 0) throw std::out_of_range("num_hidden_layers must be > 0");
+    } else if (name == "num_key_value_heads") {
+      v_.num_key_value_heads = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (v_.num_key_value_heads <= 0) throw std::out_of_range("num_key_value_heads must be > 0");
+    } else if (name == "head_size") {
+      v_.head_size = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (v_.head_size <= 0) throw std::out_of_range("head_size must be > 0");
+    } else if (name == "block_size") {
+      v_.block_size = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (v_.block_size <= 1) throw std::out_of_range("block_size must be > 1");
+    } else if (name == "num_draft_tokens") {
+      v_.num_draft_tokens = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (v_.num_draft_tokens <= 0) throw std::out_of_range("num_draft_tokens must be > 0");
+    } else if (name == "selector_top_k") {
+      v_.selector_top_k = SafeDoubleToInt(JSON::Get<double>(value), name);
+      if (v_.selector_top_k <= 0) throw std::out_of_range("selector_top_k must be > 0");
+    } else if (name == "mask_token_id") {
+      v_.mask_token_id = SafeDoubleToInt(JSON::Get<double>(value), name);
+    } else if (name == "sliding_window") {
+      v_.sliding_window = SafeDoubleToInt(JSON::Get<double>(value), name);
+    } else if (name == "main_aux_hidden_states") {
+      v_.main_aux_hidden_states = JSON::Get<std::string_view>(value);
+    } else {
+      throw JSON::unknown_value_error{};
+    }
+  }
+
+  Element& OnObject(std::string_view name) override {
+    if (name == "session_options") {
+      v_.session_options = Config::SessionOptions{};
+      session_options_ = std::make_unique<SessionOptions_Element>(*v_.session_options);
+      return *session_options_;
+    }
+    if (name == "run_options") {
+      v_.run_options = Config::RunOptions{};
+      run_options_ = std::make_unique<RunOptions_Element>(*v_.run_options);
+      return *run_options_;
+    }
+    if (name == "inputs") {
+      return inputs_;
+    }
+    if (name == "outputs") {
+      return outputs_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
+  Element& OnArray(std::string_view name) override {
+    if (name == "shared_initializers") {
+      return shared_initializers_;
+    }
+    if (name == "aux_hidden_state_layers") {
+      return aux_hidden_state_layers_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
+ private:
+  Config::Model::Dflash2& v_;
+  std::unique_ptr<SessionOptions_Element> session_options_;
+  std::unique_ptr<RunOptions_Element> run_options_;
+  Dflash2Inputs_Element inputs_{v_.inputs};
+  Dflash2Outputs_Element outputs_{v_.outputs};
+  SharedInitializers_Element shared_initializers_{v_.shared_initializers};
+  IntArray_Element aux_hidden_state_layers_{v_.aux_hidden_state_layers};
+};
+
 struct VisionInputs_Element : JSON::Element {
   explicit VisionInputs_Element(Config::Model::Vision::Inputs& v) : v_{v} {}
 
@@ -1681,6 +1814,9 @@ struct Model_Element : JSON::Element {
     if (name == "mtp") {
       return mtp_;
     }
+    if (name == "dflash2") {
+      return dflash2_;
+    }
     throw JSON::unknown_value_error{};
   }
 
@@ -1697,6 +1833,7 @@ struct Model_Element : JSON::Element {
   Joiner_Element joiner_{v_.joiner};
   VAD_Element vad_{v_.vad};
   Mtp_Element mtp_{v_.mtp};
+  Dflash2_Element dflash2_{v_.dflash2};
 };
 
 // Throws std::runtime_error (rather than std::overflow_error/std::invalid_argument) on failure.

--- a/src/config.h
+++ b/src/config.h
@@ -477,6 +477,9 @@ struct Config {
         std::string state_update_conv_value_names{Defaults::StateUpdateConvValueName};
         std::string state_update_recurrent_capsule_names{Defaults::StateUpdateRecurrentCapsuleName};
         std::string hidden_states;  // Last hidden state output (when exported with include_hidden_states; e.g. fed to the MTP head)
+        // Residual streams tapped at model.dflash2.aux_hidden_state_layers, concatenated on the
+        // last axis. Empty unless the model was exported with aux_hidden_state_layers.
+        std::string aux_hidden_states;
 
         // RNNT decoder outputs
         std::string outputs;
@@ -546,6 +549,51 @@ struct Config {
         std::string present_value_names{Defaults::PresentValueName};
       } outputs;
     } mtp;
+
+    // DFlash 2 block-drafter metadata. Unlike MTP the drafter is not decoder-shaped: it reads the
+    // main model's auxiliary hidden states, predicts a whole block of tokens at once, and returns
+    // a candidate lattice (top-k ids per slot plus the pairwise edge scores) that the engine walks
+    // greedily. The Engine drives its session directly rather than through a Model.
+    struct Dflash2 {
+      std::string filename;  // e.g. "dflash2.onnx"
+      std::optional<SessionOptions> session_options;
+      std::optional<RunOptions> run_options;
+      std::vector<SharedInitializer> shared_initializers;
+
+      int num_hidden_layers{};
+      int num_key_value_heads{};
+      int head_size{};
+      int block_size{};        // Query rows per request: the anchor token plus one mask per draft.
+      int num_draft_tokens{};  // block_size - 1
+      int selector_top_k{};
+      int mask_token_id{};
+      int sliding_window{-1};
+      std::vector<int> aux_hidden_state_layers;
+
+      // Name of the main decoder's auxiliary hidden-states output that feeds the drafter.
+      std::string main_aux_hidden_states{"aux_hidden_states"};
+
+      struct Inputs {
+        std::string aux_hidden_states{"aux_hidden_states"};
+        std::string input_ids{Defaults::InputIdsName};
+        std::string q_row_map{"q_row_map"};
+        std::string qkv_row_map{"qkv_row_map"};
+        std::string block_row_index{"block_row_index"};
+        std::string cumulative_sequence_lengths{Defaults::CumulativeSequenceLengthsName};
+        std::string past_sequence_lengths{Defaults::PastSequenceLengthsName};
+        std::string block_table{Defaults::BlockTableName};
+        std::string attention_metadata{Defaults::AttentionMetadataName};
+        std::string past_key_names{Defaults::PastKeyName};
+        std::string past_value_names{Defaults::PastValueName};
+      } inputs;
+
+      struct Outputs {
+        std::string candidate_ids{"draft_candidate_ids"};
+        std::string scores{"draft_scores"};
+        std::string present_key_names{Defaults::PresentKeyName};
+        std::string present_value_names{Defaults::PresentValueName};
+      } outputs;
+    } dflash2;
 
     std::optional<Decoder> draft;
 

--- a/src/config.h
+++ b/src/config.h
@@ -652,6 +652,8 @@ struct Config {
     // and the head feeds the next link of a chained draft. Models that merely export hidden states
     // leave it false so an ordinary step does not pay for the extra output.
     bool hidden_states_output_required{};
+    // Runtime-only counterpart for the auxiliary hidden states consumed by DFlash 2.
+    bool aux_hidden_states_output_required{};
   } engine;  // Engine settings
 
   void AddMapping(const std::string& nominal_name, const std::string& graph_name);

--- a/src/decoding/speculative_stats.h
+++ b/src/decoding/speculative_stats.h
@@ -36,6 +36,7 @@ struct SpeculativeStats {
   size_t cooldown_steps{};
   size_t cooldown_remaining{};
   size_t standard_fallback_steps{};
+  size_t mtp_failures{};
   size_t full_accept_rounds{};
   size_t partial_accept_rounds{};
   size_t zero_accept_rounds{};

--- a/src/decoding/speculative_stats.h
+++ b/src/decoding/speculative_stats.h
@@ -37,6 +37,9 @@ struct SpeculativeStats {
   size_t cooldown_remaining{};
   size_t standard_fallback_steps{};
   size_t mtp_failures{};
+  size_t dflash2_failures{};
+  size_t dflash2_disables{};
+  size_t dflash2_admission_misses{};
   size_t full_accept_rounds{};
   size_t partial_accept_rounds{};
   size_t zero_accept_rounds{};

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -261,23 +261,6 @@ std::unique_ptr<State> Dflash2Model::CreateState(DeviceSpan<int32_t>, const Gene
   throw std::logic_error("The DFlash 2 drafter is driven by the Engine and has no State.");
 }
 
-size_t Dflash2Drafter::BytesPerBlock(const Config& config, size_t paged_block_size) {
-  const auto& dflash2 = config.model.dflash2;
-  if (dflash2.filename.empty()) {
-    return 0;
-  }
-  // K and V, for every layer, for every slot in a block. The cache element width follows the
-  // drafter body, which is bfloat16.
-  size_t bytes = CheckedMultiply(size_t{2}, static_cast<size_t>(dflash2.num_hidden_layers),
-                                 "DFlash 2 cache bytes per block");
-  bytes = CheckedMultiply(bytes, paged_block_size, "DFlash 2 cache bytes per block");
-  bytes = CheckedMultiply(bytes, static_cast<size_t>(dflash2.num_key_value_heads),
-                          "DFlash 2 cache bytes per block");
-  bytes = CheckedMultiply(bytes, static_cast<size_t>(dflash2.head_size),
-                          "DFlash 2 cache bytes per block");
-  return CheckedMultiply(bytes, sizeof(uint16_t), "DFlash 2 cache bytes per block");
-}
-
 size_t Dflash2Drafter::PoolBlocks(const Config& config, size_t paged_block_size,
                                   size_t max_batch_size) {
   const auto& dflash2 = config.model.dflash2;
@@ -372,8 +355,29 @@ void Dflash2Drafter::AllocateCache() {
   }
 }
 
-Dflash2Drafter::RequestState& Dflash2Drafter::StateFor(const Request* request) {
-  return requests_[request];
+bool Dflash2Drafter::Admit(const Feed& feed) {
+  if (requests_.contains(feed.request)) {
+    return true;
+  }
+  // The drafter cannot backfill K/V for context whose auxiliary hidden states have already been
+  // consumed, so a request can only join from the start of its sequence. Requests that arrive when
+  // the ring pool is full decode without DFlash 2 drafts instead of taking the whole drafter down.
+  if (feed.first_position != 0) {
+    return false;
+  }
+  if (ring_blocks_ != 0) {
+    if (free_blocks_.size() < ring_blocks_) {
+      return false;
+    }
+    // Claim the whole ring now so a second new request in the same step sees the smaller pool.
+    EnsureBlocks(requests_[feed.request], 0);
+    return true;
+  }
+  if (free_blocks_.empty()) {
+    return false;
+  }
+  requests_.emplace(feed.request, RequestState{});
+  return true;
 }
 
 void Dflash2Drafter::EnsureBlocks(RequestState& state, size_t positions) {
@@ -408,20 +412,32 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   const size_t num_spec = static_cast<size_t>(config_.num_draft_tokens);
   const size_t top_k = static_cast<size_t>(config_.selector_top_k);
 
-  // Batch layout. Every feed contributes its context rows so the drafter cache never develops a
-  // hole; only the feeds that asked also contribute a query block.
-  std::vector<size_t> block_feed_indices;
+  // Only requests the ring pool can hold take part; the rest keep decoding without drafts.
+  std::vector<size_t> served;
+  served.reserve(feeds.size());
   for (size_t i = 0; i < feeds.size(); ++i) {
+    if (Admit(feeds[i])) {
+      served.push_back(i);
+    }
+  }
+  if (served.empty()) {
+    return;
+  }
+
+  // Batch layout. Every served feed contributes its context rows so the drafter cache never
+  // develops a hole; only the feeds that asked also contribute a query block.
+  std::vector<size_t> block_feed_indices;
+  for (const size_t i : served) {
     if (feeds[i].wants_drafts) {
       block_feed_indices.push_back(i);
     }
   }
   // The graph reshapes the query rows to [batch, block_size, hidden], so it needs at least one
-  // block. When nothing is eligible, borrow the first feed's slot and drop its lattice: the block
-  // rows only write scratch K/V at positions a later step overwrites.
+  // block. When nothing is eligible, borrow the first served feed's slot and drop its lattice: the
+  // block rows only write scratch K/V at positions a later step overwrites.
   const bool drafts_wanted = !block_feed_indices.empty();
   if (!drafts_wanted) {
-    block_feed_indices.push_back(0);
+    block_feed_indices.push_back(served.front());
   }
   std::vector<size_t> block_slot_of_feed(feeds.size(), block_feed_indices.size());
   for (size_t slot = 0; slot < block_feed_indices.size(); ++slot) {
@@ -432,8 +448,8 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
       CheckedMultiply(block_feed_indices.size(), block_size, "DFlash 2 block rows");
   CheckedMetadataValue(num_block_rows, "DFlash 2 block rows");
   size_t num_ctx_rows = 0;
-  for (const auto& feed : feeds) {
-    num_ctx_rows = CheckedAdd(num_ctx_rows, feed.aux_row_count, "DFlash 2 context rows");
+  for (const size_t i : served) {
+    num_ctx_rows = CheckedAdd(num_ctx_rows, feeds[i].aux_row_count, "DFlash 2 context rows");
   }
 
   PackedLayout layout;
@@ -443,8 +459,8 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   layout.q_row_map.reserve(reserved_rows);
   layout.qkv_row_map.reserve(reserved_rows);
   layout.block_row_index.reserve(num_block_rows);
-  layout.cumulative_sequence_lengths.reserve(feeds.size() + 1);
-  layout.past_sequence_lengths.reserve(feeds.size());
+  layout.cumulative_sequence_lengths.reserve(served.size() + 1);
+  layout.past_sequence_lengths.reserve(served.size());
 
   // Rows this step actually ingests, after a windowed drafter drops the ones its query block can
   // never read.
@@ -453,9 +469,9 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   size_t ctx_row = 0;
   size_t max_blocks = 0;
   num_ctx_rows = 0;
-  for (size_t i = 0; i < feeds.size(); ++i) {
+  for (const size_t i : served) {
     const auto& feed = feeds[i];
-    auto& state = StateFor(feed.request);
+    auto& state = requests_[feed.request];
     if (state.cached_positions != feed.first_position) {
       throw std::logic_error(
           "The DFlash 2 drafter's cached context is not contiguous with the target's step.");
@@ -473,7 +489,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
       CheckedAdd(num_ctx_rows, num_block_rows, "DFlash 2 packed rows"),
       "DFlash 2 packed rows");
 
-  for (size_t i = 0; i < feeds.size(); ++i) {
+  for (const size_t i : served) {
     const auto& feed = feeds[i];
     auto& state = requests_[feed.request];
     const size_t first_position = CheckedAdd(
@@ -552,7 +568,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   auto source_bytes = aux_hidden_states.GetByteSpan();
   auto destination_bytes = packed_aux->GetByteSpan();
   size_t destination_row = 0;
-  for (size_t i = 0; i < feeds.size(); ++i) {
+  for (const size_t i : served) {
     if (ingest_count[i] == 0) {
       continue;
     }
@@ -582,27 +598,27 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   fill_int32(*qkv_row_map, layout.qkv_row_map);
   auto block_row_index = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(num_block_rows)});
   fill_int32(*block_row_index, layout.block_row_index);
-  auto cumulative = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(feeds.size() + 1)});
+  auto cumulative = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(served.size() + 1)});
   fill_int32(*cumulative, layout.cumulative_sequence_lengths);
-  auto past_lengths = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(feeds.size())});
+  auto past_lengths = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(served.size())});
   fill_int32(*past_lengths, layout.past_sequence_lengths);
 
   auto block_table = make(Ort::TypeToTensorType<int32_t>,
-                          {static_cast<int64_t>(feeds.size()), static_cast<int64_t>(max_blocks)});
+                          {static_cast<int64_t>(served.size()), static_cast<int64_t>(max_blocks)});
   {
     auto span = block_table->GetDeviceSpan<int32_t>();
     auto cpu = span.CpuSpan();
     std::fill(cpu.begin(), cpu.end(), int32_t{-1});
-    for (size_t i = 0; i < feeds.size(); ++i) {
-      const auto& blocks = requests_[feeds[i].request].blocks;
+    for (size_t row = 0; row < served.size(); ++row) {
+      const auto& blocks = requests_[feeds[served[row]].request].blocks;
       if (ring_blocks_ == 0) {
-        std::copy(blocks.begin(), blocks.end(), cpu.begin() + i * max_blocks);
+        std::copy(blocks.begin(), blocks.end(), cpu.begin() + row * max_blocks);
         continue;
       }
       // A windowed drafter repeats its ring across every column: column j holds the block that
       // owns position j * block_size, which is ring[j % ring_blocks].
       for (size_t column = 0; column < max_blocks; ++column) {
-        cpu[i * max_blocks + column] = blocks[column % blocks.size()];
+        cpu[row * max_blocks + column] = blocks[column % blocks.size()];
       }
     }
     span.CopyCpuToDevice();

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -1,0 +1,440 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "generator/generators.h"
+#include "dflash2_drafter.h"
+#include "engine/request.h"
+#include "models/io/kv_cache.h"
+
+#include <algorithm>
+#include <limits>
+#include <numeric>
+
+namespace Generators {
+
+namespace {
+
+// The drafter's packed stream is [context rows of request 0, its block rows, context rows of
+// request 1, ...]. PagedAttention derives each row's position from past_sequence_lengths plus its
+// offset within the request, so the block rows land at the anchor's position and the ones after it.
+struct PackedLayout {
+  std::vector<int32_t> q_row_map;
+  std::vector<int32_t> qkv_row_map;
+  std::vector<int32_t> block_row_index;
+  std::vector<int32_t> cumulative_sequence_lengths{0};
+  std::vector<int32_t> past_sequence_lengths;
+  int32_t max_query_len{};
+  int32_t max_kv_len{};
+  int32_t min_kv_len{std::numeric_limits<int32_t>::max()};
+};
+
+}  // namespace
+
+std::unique_ptr<Config> CreateDflash2Config(const Config& config) {
+  const auto& dflash2 = config.model.dflash2;
+  if (dflash2.filename.empty()) {
+    throw std::runtime_error("model.dflash2.filename is required to create a DFlash 2 drafter.");
+  }
+  if (dflash2.num_hidden_layers <= 0 || dflash2.num_key_value_heads <= 0 || dflash2.head_size <= 0 ||
+      dflash2.block_size <= 1 || dflash2.num_draft_tokens <= 0) {
+    throw std::runtime_error("model.dflash2 geometry must be positive and describe a block of >1 token.");
+  }
+  if (dflash2.num_draft_tokens != dflash2.block_size - 1) {
+    throw std::runtime_error("model.dflash2.num_draft_tokens must be block_size - 1.");
+  }
+
+  auto projected = std::make_unique<Config>(config);
+  auto& decoder = projected->model.decoder;
+  decoder.filename = dflash2.filename;
+  if (dflash2.session_options) {
+    decoder.session_options = *dflash2.session_options;
+  }
+  decoder.run_options = dflash2.run_options;
+  decoder.shared_initializers = dflash2.shared_initializers;
+  decoder.num_hidden_layers = dflash2.num_hidden_layers;
+  decoder.num_key_value_heads = dflash2.num_key_value_heads;
+  decoder.head_size = dflash2.head_size;
+  decoder.state_groups.reset();
+  decoder.sliding_window.reset();
+  return projected;
+}
+
+Dflash2Model::Dflash2Model(std::unique_ptr<Config> config, OrtEnv& ort_env)
+    : Model{std::move(config)} {
+  session_ = CreateSession(ort_env, config_->model.decoder.filename, session_options_.get());
+  session_info_.Add(*session_);
+}
+
+std::unique_ptr<State> Dflash2Model::CreateState(DeviceSpan<int32_t>, const GeneratorParams&) const {
+  throw std::logic_error("The DFlash 2 drafter is driven by the Engine and has no State.");
+}
+
+size_t Dflash2Drafter::BytesPerBlock(const Config& config, size_t paged_block_size) {
+  const auto& dflash2 = config.model.dflash2;
+  if (dflash2.filename.empty()) {
+    return 0;
+  }
+  // K and V, for every layer, for every slot in a block. The cache element width follows the
+  // drafter body, which is bfloat16.
+  return size_t{2} * static_cast<size_t>(dflash2.num_hidden_layers) * paged_block_size *
+         static_cast<size_t>(dflash2.num_key_value_heads) * static_cast<size_t>(dflash2.head_size) *
+         sizeof(uint16_t);
+}
+
+size_t Dflash2Drafter::PoolBlocks(const Config& config, size_t paged_block_size,
+                                 size_t max_batch_size) {
+  const auto& dflash2 = config.model.dflash2;
+  if (dflash2.filename.empty()) {
+    return 0;
+  }
+  if (dflash2.sliding_window <= 0) {
+    throw std::runtime_error(
+        "The Engine-hosted DFlash 2 drafter requires a sliding window; a full-attention drafter "
+        "would need a cache as large as the target's.");
+  }
+  // The window bounds what a query block can ever read, so a request only needs a ring long enough
+  // to hold that window plus the block itself, whatever its context length.
+  const size_t positions = static_cast<size_t>(dflash2.sliding_window) +
+                           2 * static_cast<size_t>(dflash2.block_size);
+  const size_t ring = (positions + paged_block_size - 1) / paged_block_size + 1;
+  return std::max(max_batch_size, size_t{1}) * ring;
+}
+
+Dflash2Drafter::Dflash2Drafter(std::shared_ptr<Dflash2Model> model, size_t paged_block_size,
+                               size_t num_blocks)
+    : model_{std::move(model)},
+      config_{model_->config_->model.dflash2},
+      paged_block_size_{paged_block_size},
+      num_blocks_{num_blocks} {
+  if (paged_block_size_ == 0 || num_blocks_ == 0) {
+    throw std::runtime_error("The DFlash 2 drafter needs a non-empty paged cache pool.");
+  }
+  if (config_.sliding_window > 0) {
+    // Positions older than this are masked out of every query row, so they are never ingested and
+    // the ring may alias them.
+    context_window_ = static_cast<size_t>(config_.sliding_window) +
+                      static_cast<size_t>(config_.block_size);
+    ring_blocks_ =
+        (context_window_ + static_cast<size_t>(config_.block_size) + paged_block_size_ - 1) /
+            paged_block_size_ +
+        1;
+  }
+
+  const auto& inputs = config_.inputs;
+  aux_type_ = model_->session_info_.GetInputDataType(inputs.aux_hidden_states);
+  const auto aux_shape = model_->session_info_.GetInputShape(inputs.aux_hidden_states);
+  if (aux_shape.size() != 2 || aux_shape[1] <= 0) {
+    throw std::runtime_error("model.dflash2 expects a 2-D aux_hidden_states input with a static width.");
+  }
+  aux_hidden_size_ = static_cast<size_t>(aux_shape[1]);
+
+  AllocateCache();
+
+  free_blocks_.resize(num_blocks_);
+  std::iota(free_blocks_.rbegin(), free_blocks_.rend(), int32_t{0});
+
+  run_options_ = OrtRunOptions::Create();
+  if (model_->config_->model.decoder.run_options) {
+    for (const auto& entry : *model_->config_->model.decoder.run_options) {
+      run_options_->AddConfigEntry(entry.first.c_str(), entry.second.c_str());
+    }
+  }
+}
+
+void Dflash2Drafter::AllocateCache() {
+  const size_t layers = static_cast<size_t>(config_.num_hidden_layers);
+  const std::vector<int64_t> shape{static_cast<int64_t>(num_blocks_),
+                                   static_cast<int64_t>(paged_block_size_),
+                                   config_.num_key_value_heads,
+                                   config_.head_size};
+  cache_type_ = model_->session_info_.GetInputDataType(
+      ComposeKeyValueName(config_.inputs.past_key_names, 0));
+  for (size_t layer = 0; layer < layers; ++layer) {
+    for (const auto* pattern : {&config_.inputs.past_key_names, &config_.inputs.past_value_names}) {
+      cache_input_names_.push_back(ComposeKeyValueName(*pattern, static_cast<int>(layer)));
+      auto cache = std::make_unique<Tensor>(model_->p_device_kvcache_, cache_type_);
+      cache->CreateTensor(shape);
+      cache->GetByteSpan().Zero();
+      caches_.push_back(std::move(cache));
+    }
+    cache_output_names_.push_back(ComposeKeyValueName(config_.outputs.present_key_names, static_cast<int>(layer)));
+    cache_output_names_.push_back(ComposeKeyValueName(config_.outputs.present_value_names, static_cast<int>(layer)));
+  }
+}
+
+Dflash2Drafter::RequestState& Dflash2Drafter::StateFor(const Request* request) {
+  return requests_[request];
+}
+
+void Dflash2Drafter::EnsureBlocks(RequestState& state, size_t positions) {
+  const size_t needed =
+      ring_blocks_ != 0 ? ring_blocks_ : (positions + paged_block_size_ - 1) / paged_block_size_;
+  while (state.blocks.size() < needed) {
+    if (free_blocks_.empty()) {
+      throw std::runtime_error("The DFlash 2 drafter's paged cache pool is exhausted.");
+    }
+    state.blocks.push_back(free_blocks_.back());
+    free_blocks_.pop_back();
+  }
+}
+
+void Dflash2Drafter::Release(const Request* request) {
+  auto entry = requests_.find(request);
+  if (entry == requests_.end()) {
+    return;
+  }
+  free_blocks_.insert(free_blocks_.end(), entry->second.blocks.begin(), entry->second.blocks.end());
+  requests_.erase(entry);
+}
+
+void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> feeds,
+                             std::vector<std::vector<int32_t>>& drafts) {
+  drafts.assign(feeds.size(), {});
+  if (feeds.empty()) {
+    return;
+  }
+
+  const size_t block_size = static_cast<size_t>(config_.block_size);
+  const size_t num_spec = static_cast<size_t>(config_.num_draft_tokens);
+  const size_t top_k = static_cast<size_t>(config_.selector_top_k);
+
+  // Batch layout. Every feed contributes its context rows so the drafter cache never develops a
+  // hole; only the feeds that asked also contribute a query block.
+  std::vector<size_t> block_feed_indices;
+  for (size_t i = 0; i < feeds.size(); ++i) {
+    if (feeds[i].wants_drafts) {
+      block_feed_indices.push_back(i);
+    }
+  }
+  // The graph reshapes the query rows to [batch, block_size, hidden], so it needs at least one
+  // block. When nothing is eligible, borrow the first feed's slot and drop its lattice: the block
+  // rows only write scratch K/V at positions a later step overwrites.
+  const bool drafts_wanted = !block_feed_indices.empty();
+  if (!drafts_wanted) {
+    block_feed_indices.push_back(0);
+  }
+  std::vector<size_t> block_slot_of_feed(feeds.size(), block_feed_indices.size());
+  for (size_t slot = 0; slot < block_feed_indices.size(); ++slot) {
+    block_slot_of_feed[block_feed_indices[slot]] = slot;
+  }
+
+  const size_t num_block_rows = block_feed_indices.size() * block_size;
+  size_t num_ctx_rows = 0;
+  for (const auto& feed : feeds) {
+    num_ctx_rows += feed.aux_row_count;
+  }
+
+  PackedLayout layout;
+  layout.q_row_map.reserve(num_ctx_rows + num_block_rows);
+  layout.qkv_row_map.reserve(num_ctx_rows + num_block_rows);
+  layout.block_row_index.reserve(num_block_rows);
+  layout.cumulative_sequence_lengths.reserve(feeds.size() + 1);
+  layout.past_sequence_lengths.reserve(feeds.size());
+
+  // Rows this step actually ingests, after a windowed drafter drops the ones its query block can
+  // never read.
+  std::vector<size_t> ingest_begin(feeds.size());
+  std::vector<size_t> ingest_count(feeds.size());
+  size_t ctx_row = 0;
+  size_t max_blocks = 0;
+  num_ctx_rows = 0;
+  for (size_t i = 0; i < feeds.size(); ++i) {
+    const auto& feed = feeds[i];
+    auto& state = StateFor(feed.request);
+    if (state.cached_positions != feed.first_position) {
+      throw std::logic_error(
+          "The DFlash 2 drafter's cached context is not contiguous with the target's step.");
+    }
+
+    size_t dropped = 0;
+    if (context_window_ != 0 && feed.aux_row_count > context_window_) {
+      dropped = feed.aux_row_count - context_window_;
+    }
+    ingest_begin[i] = feed.aux_row_begin + dropped;
+    ingest_count[i] = feed.aux_row_count - dropped;
+    num_ctx_rows += ingest_count[i];
+  }
+
+  for (size_t i = 0; i < feeds.size(); ++i) {
+    const auto& feed = feeds[i];
+    auto& state = requests_[feed.request];
+    const size_t first_position = feed.first_position + (feed.aux_row_count - ingest_count[i]);
+
+    const size_t slot = block_slot_of_feed[i];
+    const bool has_block = slot < block_feed_indices.size();
+    const size_t block_rows = has_block ? block_size : 0;
+    const size_t query_len = ingest_count[i] + block_rows;
+    if (query_len == 0) {
+      throw std::logic_error("A DFlash 2 feed carries neither context nor a query block.");
+    }
+    const size_t total_positions = first_position + query_len;
+    EnsureBlocks(state, total_positions);
+    max_blocks = std::max(max_blocks,
+                          (total_positions + paged_block_size_ - 1) / paged_block_size_);
+
+    // Context rows borrow the block's first query row; their attention output is discarded.
+    const int32_t borrowed_q_row = has_block ? static_cast<int32_t>(slot * block_size) : 0;
+    for (size_t row = 0; row < ingest_count[i]; ++row) {
+      layout.q_row_map.push_back(borrowed_q_row);
+      layout.qkv_row_map.push_back(static_cast<int32_t>(num_block_rows + ctx_row + row));
+    }
+    for (size_t row = 0; row < block_rows; ++row) {
+      layout.block_row_index.push_back(static_cast<int32_t>(layout.q_row_map.size()));
+      layout.q_row_map.push_back(static_cast<int32_t>(slot * block_size + row));
+      layout.qkv_row_map.push_back(static_cast<int32_t>(slot * block_size + row));
+    }
+    ctx_row += ingest_count[i];
+
+    layout.cumulative_sequence_lengths.push_back(static_cast<int32_t>(layout.q_row_map.size()));
+    layout.past_sequence_lengths.push_back(static_cast<int32_t>(first_position));
+    layout.max_query_len = std::max(layout.max_query_len, static_cast<int32_t>(query_len));
+    layout.max_kv_len = std::max(layout.max_kv_len, static_cast<int32_t>(total_positions));
+    layout.min_kv_len = std::min(layout.min_kv_len, static_cast<int32_t>(total_positions));
+
+    state.cached_positions = feed.first_position + feed.aux_row_count;
+  }
+
+  const size_t num_tokens = layout.q_row_map.size();
+  auto device = model_->p_device_inputs_;
+
+  auto make = [&](ONNXTensorElementDataType type, std::vector<int64_t> shape) {
+    auto tensor = std::make_unique<Tensor>(device, type);
+    tensor->CreateTensor(shape);
+    return tensor;
+  };
+  auto fill_int32 = [](Tensor& tensor, const std::vector<int32_t>& values) {
+    auto span = tensor.GetDeviceSpan<int32_t>();
+    std::copy(values.begin(), values.end(), span.CpuSpan().begin());
+    span.CopyCpuToDevice();
+  };
+
+  auto packed_aux = make(aux_type_, {static_cast<int64_t>(num_ctx_rows),
+                                     static_cast<int64_t>(aux_hidden_size_)});
+  const size_t aux_row_bytes = aux_hidden_size_ * Ort::SizeOf(aux_type_);
+  auto source_bytes = aux_hidden_states.GetByteSpan();
+  auto destination_bytes = packed_aux->GetByteSpan();
+  size_t destination_row = 0;
+  for (size_t i = 0; i < feeds.size(); ++i) {
+    if (ingest_count[i] == 0) {
+      continue;
+    }
+    destination_bytes.subspan(destination_row * aux_row_bytes, ingest_count[i] * aux_row_bytes)
+        .CopyFrom(source_bytes.subspan(ingest_begin[i] * aux_row_bytes,
+                                       ingest_count[i] * aux_row_bytes));
+    destination_row += ingest_count[i];
+  }
+
+  auto input_ids = make(Ort::TypeToTensorType<int64_t>, {static_cast<int64_t>(num_block_rows)});
+  {
+    auto span = input_ids->GetDeviceSpan<int64_t>();
+    auto cpu = span.CpuSpan();
+    for (size_t slot = 0; slot < block_feed_indices.size(); ++slot) {
+      const auto& feed = feeds[block_feed_indices[slot]];
+      cpu[slot * block_size] = feed.wants_drafts ? feed.anchor_token : config_.mask_token_id;
+      for (size_t row = 1; row < block_size; ++row) {
+        cpu[slot * block_size + row] = config_.mask_token_id;
+      }
+    }
+    span.CopyCpuToDevice();
+  }
+
+  auto q_row_map = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(num_tokens)});
+  fill_int32(*q_row_map, layout.q_row_map);
+  auto qkv_row_map = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(num_tokens)});
+  fill_int32(*qkv_row_map, layout.qkv_row_map);
+  auto block_row_index = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(num_block_rows)});
+  fill_int32(*block_row_index, layout.block_row_index);
+  auto cumulative = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(feeds.size() + 1)});
+  fill_int32(*cumulative, layout.cumulative_sequence_lengths);
+  auto past_lengths = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(feeds.size())});
+  fill_int32(*past_lengths, layout.past_sequence_lengths);
+
+  auto block_table = make(Ort::TypeToTensorType<int32_t>,
+                          {static_cast<int64_t>(feeds.size()), static_cast<int64_t>(max_blocks)});
+  {
+    auto span = block_table->GetDeviceSpan<int32_t>();
+    auto cpu = span.CpuSpan();
+    std::fill(cpu.begin(), cpu.end(), int32_t{-1});
+    for (size_t i = 0; i < feeds.size(); ++i) {
+      const auto& blocks = requests_[feeds[i].request].blocks;
+      if (ring_blocks_ == 0) {
+        std::copy(blocks.begin(), blocks.end(), cpu.begin() + i * max_blocks);
+        continue;
+      }
+      // A windowed drafter repeats its ring across every column: column j holds the block that
+      // owns position j * block_size, which is ring[j % ring_blocks].
+      for (size_t column = 0; column < max_blocks; ++column) {
+        cpu[i * max_blocks + column] = blocks[column % blocks.size()];
+      }
+    }
+    span.CopyCpuToDevice();
+  }
+
+  auto metadata = std::make_unique<Tensor>(GetDeviceInterface(DeviceType::CPU),
+                                           Ort::TypeToTensorType<int32_t>);
+  metadata->CreateTensor(std::vector<int64_t>{3});
+  {
+    auto span = metadata->GetDeviceSpan<int32_t>();
+    auto cpu = span.CpuSpan();
+    cpu[0] = layout.max_query_len;
+    cpu[1] = layout.max_kv_len;
+    cpu[2] = layout.min_kv_len;
+  }
+
+  const size_t batch = block_feed_indices.size();
+  auto candidate_ids = make(Ort::TypeToTensorType<int32_t>,
+                            {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
+                             static_cast<int64_t>(top_k)});
+  auto scores = make(Ort::TypeToTensorType<float>,
+                     {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
+                      static_cast<int64_t>(top_k), static_cast<int64_t>(top_k)});
+
+  std::vector<const char*> input_names{
+      config_.inputs.aux_hidden_states.c_str(), config_.inputs.input_ids.c_str(),
+      config_.inputs.q_row_map.c_str(),         config_.inputs.qkv_row_map.c_str(),
+      config_.inputs.block_row_index.c_str(),   config_.inputs.cumulative_sequence_lengths.c_str(),
+      config_.inputs.past_sequence_lengths.c_str(), config_.inputs.block_table.c_str(),
+      config_.inputs.attention_metadata.c_str()};
+  std::vector<OrtValue*> inputs{packed_aux->GetOrtTensor(),  input_ids->GetOrtTensor(),
+                                q_row_map->GetOrtTensor(),   qkv_row_map->GetOrtTensor(),
+                                block_row_index->GetOrtTensor(), cumulative->GetOrtTensor(),
+                                past_lengths->GetOrtTensor(), block_table->GetOrtTensor(),
+                                metadata->GetOrtTensor()};
+  std::vector<const char*> output_names{config_.outputs.candidate_ids.c_str(),
+                                        config_.outputs.scores.c_str()};
+  std::vector<OrtValue*> outputs{candidate_ids->GetOrtTensor(), scores->GetOrtTensor()};
+  for (size_t i = 0; i < caches_.size(); ++i) {
+    input_names.push_back(cache_input_names_[i].c_str());
+    inputs.push_back(caches_[i]->GetOrtTensor());
+    output_names.push_back(cache_output_names_[i].c_str());
+    outputs.push_back(caches_[i]->GetOrtTensor());
+  }
+
+  model_->session_->Run(run_options_.get(), input_names.data(), inputs.data(), input_names.size(),
+                        output_names.data(), outputs.data(), output_names.size());
+
+  if (!drafts_wanted) {
+    return;
+  }
+
+  // The spans own the host mirrors these point into, so they must outlive the reads below.
+  auto candidate_span = candidate_ids->GetDeviceSpan<int32_t>();
+  auto scores_span = scores->GetDeviceSpan<float>();
+  auto candidate_cpu = candidate_span.CopyDeviceToCpu();
+  auto scores_cpu = scores_span.CopyDeviceToCpu();
+  for (size_t slot = 0; slot < block_feed_indices.size(); ++slot) {
+    // Greedy walk of the lattice: slot l's chosen candidate index selects the row of slot l+1's
+    // score matrix, so the drafted block is one coherent path rather than seven independent argmaxes.
+    auto& out = drafts[block_feed_indices[slot]];
+    out.reserve(num_spec);
+    size_t previous = 0;
+    for (size_t step = 0; step < num_spec; ++step) {
+      const float* row = scores_cpu.data() + ((slot * num_spec + step) * top_k + previous) * top_k;
+      const size_t best = static_cast<size_t>(std::max_element(row, row + top_k) - row);
+      out.push_back(candidate_cpu[(slot * num_spec + step) * top_k + best]);
+      previous = best;
+    }
+  }
+}
+
+}  // namespace Generators

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -543,7 +543,6 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     layout.max_query_len = std::max(layout.max_query_len, query_length);
     layout.max_kv_len = std::max(layout.max_kv_len, kv_length);
     layout.min_kv_len = std::min(layout.min_kv_len, kv_length);
-
   }
 
   const size_t num_tokens = layout.q_row_map.size();

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -367,6 +367,7 @@ bool Dflash2Drafter::Admit(const Feed& feed) {
   }
   if (ring_blocks_ != 0) {
     if (free_blocks_.size() < ring_blocks_) {
+      ++admission_misses_;
       return false;
     }
     // Claim the whole ring now so a second new request in the same step sees the smaller pool.
@@ -543,8 +544,6 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     layout.max_kv_len = std::max(layout.max_kv_len, kv_length);
     layout.min_kv_len = std::min(layout.min_kv_len, kv_length);
 
-    state.cached_positions = CheckedAdd(
-        feed.first_position, feed.aux_row_count, "DFlash 2 cached positions");
   }
 
   const size_t num_tokens = layout.q_row_map.size();
@@ -666,6 +665,12 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
 
   model_->session_->Run(run_options_.get(), input_names.data(), inputs.data(), input_names.size(),
                         output_names.data(), outputs.data(), output_names.size());
+
+  for (const size_t i : served) {
+    const auto& feed = feeds[i];
+    requests_[feed.request].cached_positions = CheckedAdd(
+        feed.first_position, feed.aux_row_count, "DFlash 2 cached positions");
+  }
 
   if (!drafts_wanted) {
     return;

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -9,6 +9,8 @@
 #include <algorithm>
 #include <limits>
 #include <numeric>
+#include <string>
+#include <string_view>
 
 namespace Generators {
 
@@ -28,6 +30,28 @@ struct PackedLayout {
   int32_t min_kv_len{std::numeric_limits<int32_t>::max()};
 };
 
+size_t CheckedAdd(size_t left, size_t right, std::string_view description) {
+  if (right > std::numeric_limits<size_t>::max() - left) {
+    throw std::runtime_error(std::string{description} + " exceeds the supported size range.");
+  }
+  return left + right;
+}
+
+size_t CheckedMultiply(size_t left, size_t right, std::string_view description) {
+  if (left != 0 && right > std::numeric_limits<size_t>::max() / left) {
+    throw std::runtime_error(std::string{description} + " exceeds the supported size range.");
+  }
+  return left * right;
+}
+
+int32_t CheckedMetadataValue(size_t value, std::string_view description) {
+  if (value > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+    throw std::runtime_error(
+        std::string{description} + " exceeds the int32 attention metadata range.");
+  }
+  return static_cast<int32_t>(value);
+}
+
 }  // namespace
 
 std::unique_ptr<Config> CreateDflash2Config(const Config& config) {
@@ -36,11 +60,19 @@ std::unique_ptr<Config> CreateDflash2Config(const Config& config) {
     throw std::runtime_error("model.dflash2.filename is required to create a DFlash 2 drafter.");
   }
   if (dflash2.num_hidden_layers <= 0 || dflash2.num_key_value_heads <= 0 || dflash2.head_size <= 0 ||
-      dflash2.block_size <= 1 || dflash2.num_draft_tokens <= 0) {
+      dflash2.block_size <= 1 || dflash2.num_draft_tokens <= 0 || dflash2.selector_top_k <= 0) {
     throw std::runtime_error("model.dflash2 geometry must be positive and describe a block of >1 token.");
   }
   if (dflash2.num_draft_tokens != dflash2.block_size - 1) {
     throw std::runtime_error("model.dflash2.num_draft_tokens must be block_size - 1.");
+  }
+  if (dflash2.run_options) {
+    for (const auto& [name, value] : *dflash2.run_options) {
+      if (name == "disable_synchronize_execution_providers" && value == "1") {
+        throw std::runtime_error(
+            "model.dflash2.run_options cannot disable execution-provider synchronization.");
+      }
+    }
   }
 
   auto projected = std::make_unique<Config>(config);
@@ -57,6 +89,37 @@ std::unique_ptr<Config> CreateDflash2Config(const Config& config) {
   decoder.state_groups.reset();
   decoder.sliding_window.reset();
   return projected;
+}
+
+void ValidateDflash2ModelCompatibility(const Config& config,
+                                       const ModelStateMetadata& target_metadata,
+                                       const ModelStateMetadata& drafter_metadata) {
+  const auto& dflash2 = config.model.dflash2;
+  const auto& target_aux_output = dflash2.main_aux_hidden_states;
+  if (target_aux_output.empty() || !target_metadata.HasOutput(target_aux_output)) {
+    throw std::runtime_error(
+        "model.dflash2.main_aux_hidden_states must name a main-model output.");
+  }
+
+  const auto& drafter_aux_input = dflash2.inputs.aux_hidden_states;
+  if (drafter_aux_input.empty() || !drafter_metadata.HasInput(drafter_aux_input)) {
+    throw std::runtime_error(
+        "model.dflash2.inputs.aux_hidden_states must name a drafter-model input.");
+  }
+
+  const auto target_aux_shape = target_metadata.GetOutputShape(target_aux_output);
+  const auto drafter_aux_shape = drafter_metadata.GetInputShape(drafter_aux_input);
+  if (target_aux_shape.size() != 2 || target_aux_shape[1] <= 0 ||
+      drafter_aux_shape.size() != 2 || drafter_aux_shape[1] <= 0 ||
+      target_aux_shape[1] != drafter_aux_shape[1]) {
+    throw std::runtime_error(
+        "DFlash 2 requires matching 2-D auxiliary hidden-state tensors with a static width.");
+  }
+  if (target_metadata.GetOutputDataType(target_aux_output) !=
+      drafter_metadata.GetInputDataType(drafter_aux_input)) {
+    throw std::runtime_error(
+        "DFlash 2 requires matching auxiliary hidden-state tensor types.");
+  }
 }
 
 Dflash2Model::Dflash2Model(std::unique_ptr<Config> config, OrtEnv& ort_env)
@@ -82,7 +145,7 @@ size_t Dflash2Drafter::BytesPerBlock(const Config& config, size_t paged_block_si
 }
 
 size_t Dflash2Drafter::PoolBlocks(const Config& config, size_t paged_block_size,
-                                 size_t max_batch_size) {
+                                  size_t max_batch_size) {
   const auto& dflash2 = config.model.dflash2;
   if (dflash2.filename.empty()) {
     return 0;
@@ -218,15 +281,20 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     block_slot_of_feed[block_feed_indices[slot]] = slot;
   }
 
-  const size_t num_block_rows = block_feed_indices.size() * block_size;
+  const size_t num_block_rows =
+      CheckedMultiply(block_feed_indices.size(), block_size, "DFlash 2 block rows");
+  CheckedMetadataValue(num_block_rows, "DFlash 2 block rows");
   size_t num_ctx_rows = 0;
   for (const auto& feed : feeds) {
-    num_ctx_rows += feed.aux_row_count;
+    num_ctx_rows = CheckedAdd(num_ctx_rows, feed.aux_row_count, "DFlash 2 context rows");
   }
 
   PackedLayout layout;
-  layout.q_row_map.reserve(num_ctx_rows + num_block_rows);
-  layout.qkv_row_map.reserve(num_ctx_rows + num_block_rows);
+  const size_t reserved_rows =
+      CheckedAdd(num_ctx_rows, num_block_rows, "DFlash 2 packed rows");
+  CheckedMetadataValue(reserved_rows, "DFlash 2 packed rows");
+  layout.q_row_map.reserve(reserved_rows);
+  layout.qkv_row_map.reserve(reserved_rows);
   layout.block_row_index.reserve(num_block_rows);
   layout.cumulative_sequence_lengths.reserve(feeds.size() + 1);
   layout.past_sequence_lengths.reserve(feeds.size());
@@ -250,48 +318,70 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     if (context_window_ != 0 && feed.aux_row_count > context_window_) {
       dropped = feed.aux_row_count - context_window_;
     }
-    ingest_begin[i] = feed.aux_row_begin + dropped;
+    ingest_begin[i] = CheckedAdd(feed.aux_row_begin, dropped, "DFlash 2 auxiliary row offset");
     ingest_count[i] = feed.aux_row_count - dropped;
-    num_ctx_rows += ingest_count[i];
+    num_ctx_rows = CheckedAdd(num_ctx_rows, ingest_count[i], "DFlash 2 context rows");
   }
+  CheckedMetadataValue(
+      CheckedAdd(num_ctx_rows, num_block_rows, "DFlash 2 packed rows"),
+      "DFlash 2 packed rows");
 
   for (size_t i = 0; i < feeds.size(); ++i) {
     const auto& feed = feeds[i];
     auto& state = requests_[feed.request];
-    const size_t first_position = feed.first_position + (feed.aux_row_count - ingest_count[i]);
+    const size_t first_position = CheckedAdd(
+        feed.first_position, feed.aux_row_count - ingest_count[i],
+        "DFlash 2 first position");
 
     const size_t slot = block_slot_of_feed[i];
     const bool has_block = slot < block_feed_indices.size();
     const size_t block_rows = has_block ? block_size : 0;
-    const size_t query_len = ingest_count[i] + block_rows;
+    const size_t query_len =
+        CheckedAdd(ingest_count[i], block_rows, "DFlash 2 query length");
     if (query_len == 0) {
       throw std::logic_error("A DFlash 2 feed carries neither context nor a query block.");
     }
-    const size_t total_positions = first_position + query_len;
+    const size_t total_positions =
+        CheckedAdd(first_position, query_len, "DFlash 2 KV length");
     EnsureBlocks(state, total_positions);
-    max_blocks = std::max(max_blocks,
-                          (total_positions + paged_block_size_ - 1) / paged_block_size_);
+    max_blocks = std::max(
+        max_blocks, (total_positions - 1) / paged_block_size_ + 1);
 
     // Context rows borrow the block's first query row; their attention output is discarded.
-    const int32_t borrowed_q_row = has_block ? static_cast<int32_t>(slot * block_size) : 0;
+    const size_t first_block_row =
+        CheckedMultiply(slot, block_size, "DFlash 2 block row index");
+    const int32_t borrowed_q_row = has_block
+                                       ? CheckedMetadataValue(first_block_row, "DFlash 2 query row")
+                                       : 0;
     for (size_t row = 0; row < ingest_count[i]; ++row) {
       layout.q_row_map.push_back(borrowed_q_row);
-      layout.qkv_row_map.push_back(static_cast<int32_t>(num_block_rows + ctx_row + row));
+      layout.qkv_row_map.push_back(CheckedMetadataValue(
+          CheckedAdd(num_block_rows, CheckedAdd(ctx_row, row, "DFlash 2 context row"),
+                     "DFlash 2 QKV row"),
+          "DFlash 2 QKV row"));
     }
     for (size_t row = 0; row < block_rows; ++row) {
-      layout.block_row_index.push_back(static_cast<int32_t>(layout.q_row_map.size()));
-      layout.q_row_map.push_back(static_cast<int32_t>(slot * block_size + row));
-      layout.qkv_row_map.push_back(static_cast<int32_t>(slot * block_size + row));
+      layout.block_row_index.push_back(
+          CheckedMetadataValue(layout.q_row_map.size(), "DFlash 2 packed row"));
+      const int32_t block_row = CheckedMetadataValue(
+          CheckedAdd(first_block_row, row, "DFlash 2 block row"), "DFlash 2 block row");
+      layout.q_row_map.push_back(block_row);
+      layout.qkv_row_map.push_back(block_row);
     }
-    ctx_row += ingest_count[i];
+    ctx_row = CheckedAdd(ctx_row, ingest_count[i], "DFlash 2 context row");
 
-    layout.cumulative_sequence_lengths.push_back(static_cast<int32_t>(layout.q_row_map.size()));
-    layout.past_sequence_lengths.push_back(static_cast<int32_t>(first_position));
-    layout.max_query_len = std::max(layout.max_query_len, static_cast<int32_t>(query_len));
-    layout.max_kv_len = std::max(layout.max_kv_len, static_cast<int32_t>(total_positions));
-    layout.min_kv_len = std::min(layout.min_kv_len, static_cast<int32_t>(total_positions));
+    layout.cumulative_sequence_lengths.push_back(
+        CheckedMetadataValue(layout.q_row_map.size(), "DFlash 2 cumulative sequence length"));
+    layout.past_sequence_lengths.push_back(
+        CheckedMetadataValue(first_position, "DFlash 2 past sequence length"));
+    const int32_t query_length = CheckedMetadataValue(query_len, "DFlash 2 query length");
+    const int32_t kv_length = CheckedMetadataValue(total_positions, "DFlash 2 KV length");
+    layout.max_query_len = std::max(layout.max_query_len, query_length);
+    layout.max_kv_len = std::max(layout.max_kv_len, kv_length);
+    layout.min_kv_len = std::min(layout.min_kv_len, kv_length);
 
-    state.cached_positions = feed.first_position + feed.aux_row_count;
+    state.cached_positions = CheckedAdd(
+        feed.first_position, feed.aux_row_count, "DFlash 2 cached positions");
   }
 
   const size_t num_tokens = layout.q_row_map.size();
@@ -310,7 +400,8 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
 
   auto packed_aux = make(aux_type_, {static_cast<int64_t>(num_ctx_rows),
                                      static_cast<int64_t>(aux_hidden_size_)});
-  const size_t aux_row_bytes = aux_hidden_size_ * Ort::SizeOf(aux_type_);
+  const size_t aux_row_bytes =
+      CheckedMultiply(aux_hidden_size_, Ort::SizeOf(aux_type_), "DFlash 2 auxiliary row bytes");
   auto source_bytes = aux_hidden_states.GetByteSpan();
   auto destination_bytes = packed_aux->GetByteSpan();
   size_t destination_row = 0;
@@ -391,12 +482,12 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
 
   std::vector<const char*> input_names{
       config_.inputs.aux_hidden_states.c_str(), config_.inputs.input_ids.c_str(),
-      config_.inputs.q_row_map.c_str(),         config_.inputs.qkv_row_map.c_str(),
-      config_.inputs.block_row_index.c_str(),   config_.inputs.cumulative_sequence_lengths.c_str(),
+      config_.inputs.q_row_map.c_str(), config_.inputs.qkv_row_map.c_str(),
+      config_.inputs.block_row_index.c_str(), config_.inputs.cumulative_sequence_lengths.c_str(),
       config_.inputs.past_sequence_lengths.c_str(), config_.inputs.block_table.c_str(),
       config_.inputs.attention_metadata.c_str()};
-  std::vector<OrtValue*> inputs{packed_aux->GetOrtTensor(),  input_ids->GetOrtTensor(),
-                                q_row_map->GetOrtTensor(),   qkv_row_map->GetOrtTensor(),
+  std::vector<OrtValue*> inputs{packed_aux->GetOrtTensor(), input_ids->GetOrtTensor(),
+                                q_row_map->GetOrtTensor(), qkv_row_map->GetOrtTensor(),
                                 block_row_index->GetOrtTensor(), cumulative->GetOrtTensor(),
                                 past_lengths->GetOrtTensor(), block_table->GetOrtTensor(),
                                 metadata->GetOrtTensor()};

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -356,7 +356,7 @@ void Dflash2Drafter::AllocateCache() {
 }
 
 bool Dflash2Drafter::Admit(const Feed& feed) {
-  if (requests_.contains(feed.request)) {
+  if (requests_.find(feed.request) != requests_.end()) {
     return true;
   }
   // The drafter cannot backfill K/V for context whose auxiliary hidden states have already been

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -11,6 +11,7 @@
 #include <numeric>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace Generators {
 
@@ -52,10 +53,78 @@ int32_t CheckedMetadataValue(size_t value, std::string_view description) {
   return static_cast<int32_t>(value);
 }
 
+void InheritProviderOptions(const Config::SessionOptions& parent,
+                            Config::SessionOptions& child) {
+  if (child.providers.empty()) {
+    child.providers = parent.providers;
+  }
+  for (const auto& parent_provider : parent.provider_options) {
+    auto child_provider = std::find_if(
+        child.provider_options.begin(), child.provider_options.end(),
+        [&parent_provider](const Config::ProviderOptions& provider) {
+          return provider.name == parent_provider.name;
+        });
+    if (child_provider == child.provider_options.end()) {
+      child.provider_options.push_back(parent_provider);
+      continue;
+    }
+    if (!child_provider->device_filtering_options) {
+      child_provider->device_filtering_options = parent_provider.device_filtering_options;
+    }
+    for (const auto& parent_option : parent_provider.options) {
+      const bool overridden = std::any_of(
+          child_provider->options.begin(), child_provider->options.end(),
+          [&parent_option](const Config::NamedString& option) {
+            return option.first == parent_option.first;
+          });
+      if (!overridden) {
+        child_provider->options.push_back(parent_option);
+      }
+    }
+  }
+}
+
+void RequireTensor(const ModelStateMetadata& metadata, const std::string& name,
+                   bool input, ONNXTensorElementDataType type, size_t rank) {
+  const bool present = input ? metadata.HasInput(name) : metadata.HasOutput(name);
+  if (name.empty() || !present) {
+    throw std::runtime_error(
+        "model.dflash2 " + std::string{input ? "input '" : "output '"} + name + "' is missing.");
+  }
+  const auto actual_type = input ? metadata.GetInputDataType(name) : metadata.GetOutputDataType(name);
+  const auto shape = input ? metadata.GetInputShape(name) : metadata.GetOutputShape(name);
+  if (actual_type != type || shape.size() != rank) {
+    throw std::runtime_error(
+        "model.dflash2 " + std::string{input ? "input '" : "output '"} + name +
+        "' has an incompatible type or rank.");
+  }
+}
+
+bool DimensionMatches(int64_t actual, int expected) {
+  return actual < 0 || actual == expected;
+}
+
 }  // namespace
+
+size_t Dflash2DraftWidth(size_t capability_limit, size_t configured_limit,
+                         size_t sequence_length_after_step, size_t sequence_limit,
+                         size_t remaining_turn_tokens_after_step) {
+  const size_t sequence_capacity =
+      sequence_length_after_step < sequence_limit &&
+              sequence_limit - sequence_length_after_step > 1
+          ? sequence_limit - sequence_length_after_step - 1
+          : 0;
+  const size_t turn_capacity =
+      remaining_turn_tokens_after_step > 1 ? remaining_turn_tokens_after_step - 1 : 0;
+  return std::min({capability_limit, configured_limit, sequence_capacity, turn_capacity});
+}
 
 std::unique_ptr<Config> CreateDflash2Config(const Config& config) {
   const auto& dflash2 = config.model.dflash2;
+  if (!config.model.mtp.filename.empty()) {
+    throw std::runtime_error(
+        "An Engine model cannot configure both model.mtp and model.dflash2.");
+  }
   if (dflash2.filename.empty()) {
     throw std::runtime_error("model.dflash2.filename is required to create a DFlash 2 drafter.");
   }
@@ -80,6 +149,8 @@ std::unique_ptr<Config> CreateDflash2Config(const Config& config) {
   decoder.filename = dflash2.filename;
   if (dflash2.session_options) {
     decoder.session_options = *dflash2.session_options;
+    InheritProviderOptions(config.model.decoder.session_options,
+                           decoder.session_options);
   }
   decoder.run_options = dflash2.run_options;
   decoder.shared_initializers = dflash2.shared_initializers;
@@ -120,6 +191,64 @@ void ValidateDflash2ModelCompatibility(const Config& config,
     throw std::runtime_error(
         "DFlash 2 requires matching auxiliary hidden-state tensor types.");
   }
+
+  const auto& inputs = dflash2.inputs;
+  for (const auto* name : {&inputs.q_row_map, &inputs.qkv_row_map,
+                           &inputs.block_row_index, &inputs.cumulative_sequence_lengths,
+                           &inputs.past_sequence_lengths}) {
+    RequireTensor(drafter_metadata, *name, true, Ort::TypeToTensorType<int32_t>, 1);
+  }
+  RequireTensor(drafter_metadata, inputs.input_ids, true,
+                Ort::TypeToTensorType<int64_t>, 1);
+  RequireTensor(drafter_metadata, inputs.block_table, true,
+                Ort::TypeToTensorType<int32_t>, 2);
+  RequireTensor(drafter_metadata, inputs.attention_metadata, true,
+                Ort::TypeToTensorType<int32_t>, 1);
+  const auto metadata_shape = drafter_metadata.GetInputShape(inputs.attention_metadata);
+  if (!DimensionMatches(metadata_shape[0], 3)) {
+    throw std::runtime_error("model.dflash2 attention_metadata must contain three values.");
+  }
+
+  RequireTensor(drafter_metadata, dflash2.outputs.candidate_ids, false,
+                Ort::TypeToTensorType<int32_t>, 3);
+  RequireTensor(drafter_metadata, dflash2.outputs.scores, false,
+                Ort::TypeToTensorType<float>, 4);
+  const auto candidate_shape = drafter_metadata.GetOutputShape(dflash2.outputs.candidate_ids);
+  const auto scores_shape = drafter_metadata.GetOutputShape(dflash2.outputs.scores);
+  if (!DimensionMatches(candidate_shape[1], dflash2.num_draft_tokens) ||
+      !DimensionMatches(candidate_shape[2], dflash2.selector_top_k) ||
+      !DimensionMatches(scores_shape[1], dflash2.num_draft_tokens) ||
+      !DimensionMatches(scores_shape[2], dflash2.selector_top_k) ||
+      !DimensionMatches(scores_shape[3], dflash2.selector_top_k)) {
+    throw std::runtime_error("model.dflash2 selector outputs do not match the configured geometry.");
+  }
+
+  ONNXTensorElementDataType cache_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+  for (int layer = 0; layer < dflash2.num_hidden_layers; ++layer) {
+    for (const auto [input_pattern, output_pattern] : {
+             std::pair{&inputs.past_key_names, &dflash2.outputs.present_key_names},
+             std::pair{&inputs.past_value_names, &dflash2.outputs.present_value_names}}) {
+      const auto input_name = ComposeKeyValueName(*input_pattern, layer);
+      const auto output_name = ComposeKeyValueName(*output_pattern, layer);
+      if (input_name.empty() || !drafter_metadata.HasInput(input_name) ||
+          output_name.empty() || !drafter_metadata.HasOutput(output_name)) {
+        throw std::runtime_error("model.dflash2 cache input or output is missing.");
+      }
+      const auto input_type = drafter_metadata.GetInputDataType(input_name);
+      const auto output_type = drafter_metadata.GetOutputDataType(output_name);
+      const auto input_shape = drafter_metadata.GetInputShape(input_name);
+      const auto output_shape = drafter_metadata.GetOutputShape(output_name);
+      if (input_shape.size() != 4 || output_shape.size() != 4 || input_type != output_type ||
+          (cache_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED && input_type != cache_type) ||
+          !DimensionMatches(input_shape[2], dflash2.num_key_value_heads) ||
+          !DimensionMatches(input_shape[3], dflash2.head_size) ||
+          !DimensionMatches(output_shape[2], dflash2.num_key_value_heads) ||
+          !DimensionMatches(output_shape[3], dflash2.head_size)) {
+        throw std::runtime_error("model.dflash2 cache tensors do not match the configured geometry.");
+      }
+      cache_type = input_type;
+    }
+  }
 }
 
 Dflash2Model::Dflash2Model(std::unique_ptr<Config> config, OrtEnv& ort_env)
@@ -139,9 +268,14 @@ size_t Dflash2Drafter::BytesPerBlock(const Config& config, size_t paged_block_si
   }
   // K and V, for every layer, for every slot in a block. The cache element width follows the
   // drafter body, which is bfloat16.
-  return size_t{2} * static_cast<size_t>(dflash2.num_hidden_layers) * paged_block_size *
-         static_cast<size_t>(dflash2.num_key_value_heads) * static_cast<size_t>(dflash2.head_size) *
-         sizeof(uint16_t);
+  size_t bytes = CheckedMultiply(size_t{2}, static_cast<size_t>(dflash2.num_hidden_layers),
+                                 "DFlash 2 cache bytes per block");
+  bytes = CheckedMultiply(bytes, paged_block_size, "DFlash 2 cache bytes per block");
+  bytes = CheckedMultiply(bytes, static_cast<size_t>(dflash2.num_key_value_heads),
+                          "DFlash 2 cache bytes per block");
+  bytes = CheckedMultiply(bytes, static_cast<size_t>(dflash2.head_size),
+                          "DFlash 2 cache bytes per block");
+  return CheckedMultiply(bytes, sizeof(uint16_t), "DFlash 2 cache bytes per block");
 }
 
 size_t Dflash2Drafter::PoolBlocks(const Config& config, size_t paged_block_size,
@@ -155,12 +289,21 @@ size_t Dflash2Drafter::PoolBlocks(const Config& config, size_t paged_block_size,
         "The Engine-hosted DFlash 2 drafter requires a sliding window; a full-attention drafter "
         "would need a cache as large as the target's.");
   }
+  if (paged_block_size == 0) {
+    throw std::runtime_error("The DFlash 2 paged cache block size must be positive.");
+  }
   // The window bounds what a query block can ever read, so a request only needs a ring long enough
   // to hold that window plus the block itself, whatever its context length.
-  const size_t positions = static_cast<size_t>(dflash2.sliding_window) +
-                           2 * static_cast<size_t>(dflash2.block_size);
-  const size_t ring = (positions + paged_block_size - 1) / paged_block_size + 1;
-  return std::max(max_batch_size, size_t{1}) * ring;
+  const size_t positions = CheckedAdd(
+      static_cast<size_t>(dflash2.sliding_window),
+      CheckedMultiply(size_t{2}, static_cast<size_t>(dflash2.block_size),
+                      "DFlash 2 cache ring positions"),
+      "DFlash 2 cache ring positions");
+  const size_t rounded_blocks = positions / paged_block_size +
+                                static_cast<size_t>(positions % paged_block_size != 0);
+  const size_t ring = CheckedAdd(rounded_blocks, size_t{1}, "DFlash 2 cache ring blocks");
+  return CheckedMultiply(std::max(max_batch_size, size_t{1}), ring,
+                         "DFlash 2 cache block count");
 }
 
 Dflash2Drafter::Dflash2Drafter(std::shared_ptr<Dflash2Model> model, size_t paged_block_size,
@@ -199,9 +342,13 @@ Dflash2Drafter::Dflash2Drafter(std::shared_ptr<Dflash2Model> model, size_t paged
   run_options_ = OrtRunOptions::Create();
   if (model_->config_->model.decoder.run_options) {
     for (const auto& entry : *model_->config_->model.decoder.run_options) {
-      run_options_->AddConfigEntry(entry.first.c_str(), entry.second.c_str());
+      if (entry.first != "gpu_graph_id") {
+        run_options_->AddConfigEntry(entry.first.c_str(), entry.second.c_str());
+      }
     }
   }
+  // Proposal tensors are rebuilt for every packed batch, so their addresses are not capturable.
+  run_options_->AddConfigEntry("gpu_graph_id", "-1");
 }
 
 void Dflash2Drafter::AllocateCache() {

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <span>
 #include <unordered_map>
@@ -13,6 +14,10 @@
 namespace Generators {
 
 struct Request;
+
+size_t Dflash2DraftWidth(size_t capability_limit, size_t configured_limit,
+                         size_t sequence_length_after_step, size_t sequence_limit,
+                         size_t remaining_turn_tokens_after_step);
 
 /**
  * @brief Hosts the ``dflash2.onnx`` session.

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -74,9 +74,6 @@ struct Dflash2Drafter {
 
   Dflash2Drafter(std::shared_ptr<Dflash2Model> model, size_t paged_block_size, size_t num_blocks);
 
-  // Bytes of drafter K/V per paged block, so the main cache pool can budget for it up front.
-  static size_t BytesPerBlock(const Config& config, size_t paged_block_size);
-
   // Blocks the pool needs for `max_batch_size` concurrent requests. The drafter is windowed, so a
   // request only needs a fixed ring however long its context grows.
   static size_t PoolBlocks(const Config& config, size_t paged_block_size, size_t max_batch_size);
@@ -84,9 +81,13 @@ struct Dflash2Drafter {
   size_t NumDraftTokens() const { return static_cast<size_t>(config_.num_draft_tokens); }
 
   /**
-   * @brief Ingests every feed's context and drafts for the feeds that asked.
+   * @brief Ingests every served feed's context and drafts for the ones that asked.
    * @param aux_hidden_states The target's packed [token_count, aux_hidden_size] output.
-   * @param drafts Resized to feeds.size(); entry i is empty unless feeds[i].wants_drafts.
+   * @param drafts Resized to feeds.size(); entry i is empty unless feeds[i] was served and asked.
+   *
+   * A request joins the drafter on its first feed, which must start at position zero, and keeps its
+   * ring until Release. Requests that arrive once the ring pool is full are skipped for good rather
+   * than failing the step, so they decode without DFlash 2 drafts.
    */
   void Propose(Tensor& aux_hidden_states, std::span<const Feed> feeds,
                std::vector<std::vector<int32_t>>& drafts);
@@ -100,7 +101,8 @@ struct Dflash2Drafter {
     size_t cached_positions{};  // Positions [0, cached_positions) hold committed context K/V.
   };
 
-  RequestState& StateFor(const Request* request);
+  // Whether the drafter can carry this feed's request, admitting it to the pool when it can.
+  bool Admit(const Feed& feed);
   // Grows a request's block list so positions [0, positions) are addressable. A windowed drafter
   // gets a fixed ring instead, which its block table repeats across every column.
   void EnsureBlocks(RequestState& state, size_t positions);

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -32,6 +32,11 @@ struct Dflash2Model : Model {
 // applies to the drafter session unchanged.
 std::unique_ptr<Config> CreateDflash2Config(const Config& config);
 
+// Validates the auxiliary hidden-state tensor passed from the target to the drafter.
+void ValidateDflash2ModelCompatibility(const Config& config,
+                                       const ModelStateMetadata& target_metadata,
+                                       const ModelStateMetadata& drafter_metadata);
+
 /**
  * @brief Runs the DFlash 2 block drafter for one engine step.
  *

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -79,6 +79,7 @@ struct Dflash2Drafter {
   static size_t PoolBlocks(const Config& config, size_t paged_block_size, size_t max_batch_size);
 
   size_t NumDraftTokens() const { return static_cast<size_t>(config_.num_draft_tokens); }
+  size_t AdmissionMisses() const { return admission_misses_; }
 
   /**
    * @brief Ingests every served feed's context and drafts for the ones that asked.
@@ -124,6 +125,7 @@ struct Dflash2Drafter {
   std::vector<std::string> cache_input_names_, cache_output_names_;
   std::vector<int32_t> free_blocks_;
   std::unordered_map<const Request*, RequestState> requests_;
+  size_t admission_misses_{};
 
   std::unique_ptr<OrtRunOptions> run_options_;
 };

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+#include "models/model.h"
+
+namespace Generators {
+
+struct Request;
+
+/**
+ * @brief Hosts the ``dflash2.onnx`` session.
+ *
+ * The drafter graph is not decoder-shaped, so this only borrows Model for its session options,
+ * shared initializers and device interfaces. It never produces a State.
+ */
+struct Dflash2Model : Model {
+  Dflash2Model(std::unique_ptr<Config> config, OrtEnv& ort_env);
+
+  std::unique_ptr<State> CreateState(DeviceSpan<int32_t>, const GeneratorParams&) const override;
+
+  std::unique_ptr<OrtSession> session_;
+};
+
+// Decoder-shaped view of model.dflash2, so Model's session-option and shared-initializer plumbing
+// applies to the drafter session unchanged.
+std::unique_ptr<Config> CreateDflash2Config(const Config& config);
+
+/**
+ * @brief Runs the DFlash 2 block drafter for one engine step.
+ *
+ * DFlash 2 never re-runs the target's layers. Each step it turns the target's auxiliary hidden
+ * states into per-layer K/V for the tokens the target just committed, writes them into its own
+ * paged cache, and then attends a block of `block_size` query rows (the committed token plus
+ * `num_draft_tokens` mask tokens) over that cache. The block rows produce a lattice -- top-k
+ * candidates per slot plus pairwise edge scores -- which is walked greedily on the host.
+ *
+ * Context rows and query rows travel through one packed PagedAttention call: `qkv_row_map` picks
+ * each packed row's K/V out of `concat(query, context)` and the context rows' attention output is
+ * discarded. That is also what fills the cache, so there is no separate cache-store op.
+ */
+struct Dflash2Drafter {
+  /**
+   * @brief One request's contribution to a step.
+   *
+   * Rows [aux_row_begin, aux_row_begin + aux_row_count) of the target's packed auxiliary hidden
+   * states hold positions [first_position, first_position + aux_row_count). Rejected draft rows
+   * are excluded by the caller, so every row named here is committed context.
+   */
+  struct Feed {
+    Request* request{};
+    size_t aux_row_begin{};
+    size_t aux_row_count{};
+    size_t first_position{};
+    int32_t anchor_token{};
+    bool wants_drafts{};
+  };
+
+  Dflash2Drafter(std::shared_ptr<Dflash2Model> model, size_t paged_block_size, size_t num_blocks);
+
+  // Bytes of drafter K/V per paged block, so the main cache pool can budget for it up front.
+  static size_t BytesPerBlock(const Config& config, size_t paged_block_size);
+
+  // Blocks the pool needs for `max_batch_size` concurrent requests. The drafter is windowed, so a
+  // request only needs a fixed ring however long its context grows.
+  static size_t PoolBlocks(const Config& config, size_t paged_block_size, size_t max_batch_size);
+
+  size_t NumDraftTokens() const { return static_cast<size_t>(config_.num_draft_tokens); }
+
+  /**
+   * @brief Ingests every feed's context and drafts for the feeds that asked.
+   * @param aux_hidden_states The target's packed [token_count, aux_hidden_size] output.
+   * @param drafts Resized to feeds.size(); entry i is empty unless feeds[i].wants_drafts.
+   */
+  void Propose(Tensor& aux_hidden_states, std::span<const Feed> feeds,
+               std::vector<std::vector<int32_t>>& drafts);
+
+  // Returns a request's blocks to the pool. Safe for requests the drafter never saw.
+  void Release(const Request* request);
+
+ private:
+  struct RequestState {
+    std::vector<int32_t> blocks;
+    size_t cached_positions{};  // Positions [0, cached_positions) hold committed context K/V.
+  };
+
+  RequestState& StateFor(const Request* request);
+  // Grows a request's block list so positions [0, positions) are addressable. A windowed drafter
+  // gets a fixed ring instead, which its block table repeats across every column.
+  void EnsureBlocks(RequestState& state, size_t positions);
+  void AllocateCache();
+
+  std::shared_ptr<Dflash2Model> model_;
+  const Config::Model::Dflash2& config_;
+  size_t paged_block_size_{};
+  size_t num_blocks_{};
+  // Context positions the drafter must keep behind the query block. Zero when it is not windowed,
+  // in which case the whole sequence stays resident.
+  size_t context_window_{};
+  size_t ring_blocks_{};
+  size_t aux_hidden_size_{};
+  ONNXTensorElementDataType aux_type_{ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED};
+  ONNXTensorElementDataType cache_type_{ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED};
+
+  std::vector<std::unique_ptr<Tensor>> caches_;  // 2 * num_hidden_layers, key then value per layer
+  std::vector<std::string> cache_input_names_, cache_output_names_;
+  std::vector<int32_t> free_blocks_;
+  std::unordered_map<const Request*, RequestState> requests_;
+
+  std::unique_ptr<OrtRunOptions> run_options_;
+};
+
+}  // namespace Generators

--- a/src/engine/decoders/decoder.h
+++ b/src/engine/decoders/decoder.h
@@ -56,6 +56,10 @@ struct DecoderIO : ModelIO {
 
   virtual Tensor* HiddenStates() const { return nullptr; }
 
+  // The step's packed [total_num_tokens, aux_hidden_size] auxiliary hidden states, or null when
+  // the model was not exported with aux_hidden_state_layers. Row order matches HiddenStates().
+  virtual Tensor* AuxHiddenStates() const { return nullptr; }
+
  protected:
   ScheduledRequests& scheduled_requests_;
   std::shared_ptr<CacheManager> cache_manager_;

--- a/src/engine/decoders/hybrid_decoder_io.h
+++ b/src/engine/decoders/hybrid_decoder_io.h
@@ -20,6 +20,7 @@ struct HybridDecoderIO : DecoderIO {
 
   std::vector<DeviceSpan<float>> ProcessLogits() override;
   Tensor* HiddenStates() const override { return varlen_io_.HiddenStates(); }
+  Tensor* AuxHiddenStates() const override { return varlen_io_.AuxHiddenStates(); }
 
  private:
   // Takes the context by parameter: this IO is moved into ScheduledRequests and outlives the

--- a/src/engine/decoders/simple_decoder.cpp
+++ b/src/engine/decoders/simple_decoder.cpp
@@ -38,7 +38,8 @@ SimpleDecoder::SimpleDecoder(std::shared_ptr<DecoderOnly_Model> model,
   if (IsGraphCaptureEnabled(model_->config_->model.decoder.session_options) &&
       cache_manager_->SupportsDynamicBatching() &&
       !has_fixed_state_groups_ &&
-      !has_position_ids) {
+      !has_position_ids &&
+      model_->config_->model.decoder.outputs.aux_hidden_states.empty()) {
     graph_buffers_ = std::make_unique<VarlenGraphBuffers>(*model_);
   }
 }

--- a/src/engine/decoders/simple_decoder.cpp
+++ b/src/engine/decoders/simple_decoder.cpp
@@ -38,8 +38,7 @@ SimpleDecoder::SimpleDecoder(std::shared_ptr<DecoderOnly_Model> model,
   if (IsGraphCaptureEnabled(model_->config_->model.decoder.session_options) &&
       cache_manager_->SupportsDynamicBatching() &&
       !has_fixed_state_groups_ &&
-      !has_position_ids &&
-      model_->config_->model.decoder.outputs.aux_hidden_states.empty()) {
+      !has_position_ids) {
     graph_buffers_ = std::make_unique<VarlenGraphBuffers>(*model_);
   }
 }

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -559,7 +559,10 @@ void VarlenDecoderIO::PrepareAuxHiddenStates(std::shared_ptr<DecoderOnly_Model> 
                                              ScheduledRequests& scheduled_requests) {
   // Only models exported with aux_hidden_state_layers expose this; it is what a DFlash 2 drafter
   // turns into its own per-layer K/V.
-  const auto& name = model->config_->model.decoder.outputs.aux_hidden_states;
+  const auto& dflash2 = model->config_->model.dflash2;
+  const auto& name = dflash2.filename.empty()
+                         ? model->config_->model.decoder.outputs.aux_hidden_states
+                         : dflash2.main_aux_hidden_states;
   if (name.empty() || !model->session_info_.HasOutput(name)) {
     return;
   }

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -558,11 +558,9 @@ void VarlenDecoderIO::PrepareHiddenStates(std::shared_ptr<DecoderOnly_Model> mod
 void VarlenDecoderIO::PrepareAuxHiddenStates(std::shared_ptr<DecoderOnly_Model> model,
                                              ScheduledRequests& scheduled_requests) {
   // Only models exported with aux_hidden_state_layers expose this; it is what a DFlash 2 drafter
-  // turns into its own per-layer K/V.
-  const auto& dflash2 = model->config_->model.dflash2;
-  const auto& name = dflash2.filename.empty()
-                         ? model->config_->model.decoder.outputs.aux_hidden_states
-                         : dflash2.main_aux_hidden_states;
+  // turns into its own per-layer K/V. Engine construction points this at
+  // model.dflash2.main_aux_hidden_states when a drafter is configured.
+  const auto& name = model->config_->model.decoder.outputs.aux_hidden_states;
   if (name.empty() || !model->session_info_.HasOutput(name)) {
     return;
   }

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -169,6 +169,20 @@ VarlenGraphBuffers::VarlenGraphBuffers(DecoderOnly_Model& model) {
                                                      static_cast<int64_t>(model.config_->model.decoder.hidden_size)},
                                 /*make_static=*/true);
   }
+
+  const auto& aux_hidden_states_name = model.config_->model.decoder.outputs.aux_hidden_states;
+  if (model.config_->engine.aux_hidden_states_output_required &&
+      !aux_hidden_states_name.empty() && model.session_info_.HasOutput(aux_hidden_states_name)) {
+    const auto shape = model.session_info_.GetOutputShape(aux_hidden_states_name);
+    if (shape.size() != 2 || shape[1] <= 0) {
+      throw std::runtime_error("aux_hidden_states must be 2-D with a static width.");
+    }
+    aux_hidden_states = std::make_unique<Tensor>(
+        model.p_device_inputs_, model.session_info_.GetOutputDataType(aux_hidden_states_name));
+    aux_hidden_states->CreateTensor(
+        std::vector<int64_t>{static_cast<int64_t>(max_batch_size), shape[1]},
+        /*make_static=*/true);
+  }
 }
 
 int VarlenGraphBuffers::GraphId(size_t batch_size, size_t block_table_columns) {
@@ -561,24 +575,28 @@ void VarlenDecoderIO::PrepareAuxHiddenStates(std::shared_ptr<DecoderOnly_Model> 
   // turns into its own per-layer K/V. Engine construction points this at
   // model.dflash2.main_aux_hidden_states when a drafter is configured.
   const auto& name = model->config_->model.decoder.outputs.aux_hidden_states;
-  if (name.empty() || !model->session_info_.HasOutput(name)) {
+  if (!model->config_->engine.aux_hidden_states_output_required ||
+      name.empty() || !model->session_info_.HasOutput(name)) {
     return;
   }
-  if (graph_buffers_ != nullptr) {
-    throw std::logic_error("Auxiliary hidden states are not supported by CUDA graph capture.");
-  }
-
   const auto shape = model->session_info_.GetOutputShape(name);
   if (shape.size() != 2 || shape[1] <= 0) {
     throw std::runtime_error("aux_hidden_states must be 2-D with a static width.");
   }
-  aux_hidden_states_ = std::make_unique<Tensor>(model->p_device_inputs_,
-                                                model->session_info_.GetOutputDataType(name));
-  aux_hidden_states_->CreateTensor(
-      std::vector<int64_t>{static_cast<int64_t>(TokenCount(scheduled_requests)), shape[1]});
+  const std::vector<int64_t> output_shape{
+      static_cast<int64_t>(TokenCount(scheduled_requests)), shape[1]};
+  if (graph_buffers_ != nullptr && graph_buffers_->aux_hidden_states != nullptr) {
+    graph_buffers_->aux_hidden_states->CreateTensor(output_shape, /*make_static=*/true);
+    active_aux_hidden_states_ = graph_buffers_->aux_hidden_states.get();
+  } else {
+    aux_hidden_states_ = std::make_unique<Tensor>(model->p_device_inputs_,
+                                                  model->session_info_.GetOutputDataType(name));
+    aux_hidden_states_->CreateTensor(output_shape);
+    active_aux_hidden_states_ = aux_hidden_states_.get();
+  }
 
   output_names_.push_back(name.c_str());
-  outputs_.push_back(aux_hidden_states_->GetOrtTensor());
+  outputs_.push_back(active_aux_hidden_states_->GetOrtTensor());
 }
 
 std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {

--- a/src/engine/decoders/varlen_decoder_io.cpp
+++ b/src/engine/decoders/varlen_decoder_io.cpp
@@ -210,6 +210,7 @@ VarlenDecoderIO::VarlenDecoderIO(std::shared_ptr<DecoderOnly_Model> model,
   PrepareHiddenStatesInput(model, scheduled_requests);
   PrepareLogits(model, scheduled_requests);
   PrepareHiddenStates(model, scheduled_requests);
+  PrepareAuxHiddenStates(model, scheduled_requests);
 
   auto cache = cache_manager->Cache();
   for (size_t i = 0; i < cache->input_names_.size(); ++i) {
@@ -552,6 +553,31 @@ void VarlenDecoderIO::PrepareHiddenStates(std::shared_ptr<DecoderOnly_Model> mod
 
   output_names_.push_back(hidden_states_name.c_str());
   outputs_.push_back(active_hidden_states_->GetOrtTensor());
+}
+
+void VarlenDecoderIO::PrepareAuxHiddenStates(std::shared_ptr<DecoderOnly_Model> model,
+                                             ScheduledRequests& scheduled_requests) {
+  // Only models exported with aux_hidden_state_layers expose this; it is what a DFlash 2 drafter
+  // turns into its own per-layer K/V.
+  const auto& name = model->config_->model.decoder.outputs.aux_hidden_states;
+  if (name.empty() || !model->session_info_.HasOutput(name)) {
+    return;
+  }
+  if (graph_buffers_ != nullptr) {
+    throw std::logic_error("Auxiliary hidden states are not supported by CUDA graph capture.");
+  }
+
+  const auto shape = model->session_info_.GetOutputShape(name);
+  if (shape.size() != 2 || shape[1] <= 0) {
+    throw std::runtime_error("aux_hidden_states must be 2-D with a static width.");
+  }
+  aux_hidden_states_ = std::make_unique<Tensor>(model->p_device_inputs_,
+                                                model->session_info_.GetOutputDataType(name));
+  aux_hidden_states_->CreateTensor(
+      std::vector<int64_t>{static_cast<int64_t>(TokenCount(scheduled_requests)), shape[1]});
+
+  output_names_.push_back(name.c_str());
+  outputs_.push_back(aux_hidden_states_->GetOrtTensor());
 }
 
 std::vector<DeviceSpan<float>> VarlenDecoderIO::ProcessLogits() {

--- a/src/engine/decoders/varlen_decoder_io.h
+++ b/src/engine/decoders/varlen_decoder_io.h
@@ -61,6 +61,8 @@ struct VarlenGraphBuffers {
   std::unique_ptr<Tensor> hidden_states_input;
   // Null unless the model was exported with include_hidden_states.
   std::unique_ptr<Tensor> hidden_states;
+  // Null unless the model exposes auxiliary hidden states for a DFlash 2 drafter.
+  std::unique_ptr<Tensor> aux_hidden_states;
   size_t max_batch_size{};
 };
 
@@ -101,7 +103,7 @@ struct VarlenDecoderIO : DecoderIO {
 
   // The step's packed [total_num_tokens, aux_hidden_size] auxiliary hidden states, or null when
   // the model was not exported with aux_hidden_state_layers. This is what a DFlash 2 drafter reads.
-  Tensor* AuxHiddenStates() const override { return aux_hidden_states_.get(); }
+  Tensor* AuxHiddenStates() const override { return active_aux_hidden_states_; }
 
  private:
   void PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
@@ -132,6 +134,7 @@ struct VarlenDecoderIO : DecoderIO {
   std::unique_ptr<Tensor> hidden_states_;
   Tensor* active_hidden_states_{};
   std::unique_ptr<Tensor> aux_hidden_states_;
+  Tensor* active_aux_hidden_states_{};
   bool logits_are_per_token_{true};
 };
 

--- a/src/engine/decoders/varlen_decoder_io.h
+++ b/src/engine/decoders/varlen_decoder_io.h
@@ -99,6 +99,10 @@ struct VarlenDecoderIO : DecoderIO {
   // the model emits one logits row per packed token.
   Tensor* HiddenStates() const override { return active_hidden_states_; }
 
+  // The step's packed [total_num_tokens, aux_hidden_size] auxiliary hidden states, or null when
+  // the model was not exported with aux_hidden_state_layers. This is what a DFlash 2 drafter reads.
+  Tensor* AuxHiddenStates() const override { return aux_hidden_states_.get(); }
+
  private:
   void PrepareInputIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PreparePositionIds(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
@@ -106,6 +110,7 @@ struct VarlenDecoderIO : DecoderIO {
   void PrepareHiddenStatesInput(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareLogits(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
   void PrepareHiddenStates(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
+  void PrepareAuxHiddenStates(std::shared_ptr<DecoderOnly_Model> model, ScheduledRequests& scheduled_requests);
 
   // Number of packed token rows in this step, which is what both the logits and the hidden states
   // are indexed by.
@@ -126,6 +131,7 @@ struct VarlenDecoderIO : DecoderIO {
   std::unique_ptr<Tensor> logits_fp32_;
   std::unique_ptr<Tensor> hidden_states_;
   Tensor* active_hidden_states_{};
+  std::unique_ptr<Tensor> aux_hidden_states_;
   bool logits_are_per_token_{true};
 };
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -14,6 +14,7 @@ static_assert(kMaxDraftTokensPerStep < kSpeculativeAcceptanceLengthBins);
 namespace {
 
 constexpr size_t kFatalEventOverhead = 2;
+constexpr size_t kMtpFailureDisableThreshold = 3;
 
 struct MtpRollbackError : std::runtime_error {
   using std::runtime_error::runtime_error;
@@ -209,6 +210,37 @@ Engine::~Engine() {
   }
 }
 
+void ValidateMtpModelCompatibility(const Config& config,
+                                   const ModelStateMetadata& target_metadata,
+                                   const ModelStateMetadata& head_metadata) {
+  const auto& mtp = config.model.mtp;
+  if (mtp.main_hidden_states.empty() ||
+      !target_metadata.HasOutput(mtp.main_hidden_states)) {
+    throw std::runtime_error(
+        "model.mtp.main_hidden_states must name a main-model output.");
+  }
+  if (mtp.inputs.hidden_states.empty() ||
+      !head_metadata.HasInput(mtp.inputs.hidden_states)) {
+    throw std::runtime_error(
+        "model.mtp.inputs.hidden_states must name an MTP-head input.");
+  }
+
+  const auto target_shape =
+      target_metadata.GetOutputShape(mtp.main_hidden_states);
+  const auto head_shape = head_metadata.GetInputShape(mtp.inputs.hidden_states);
+  const int64_t hidden_size = config.model.decoder.hidden_size;
+  if (target_shape.size() != 2 || target_shape[1] != hidden_size ||
+      head_shape.size() != 2 || head_shape[1] != hidden_size) {
+    throw std::runtime_error(
+        "MTP requires matching 2-D hidden-state tensors with the configured static width.");
+  }
+  if (target_metadata.GetOutputDataType(mtp.main_hidden_states) !=
+      head_metadata.GetInputDataType(mtp.inputs.hidden_states)) {
+    throw std::runtime_error(
+        "MTP requires matching main-output and head-input hidden-state tensor types.");
+  }
+}
+
 EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
   std::shared_ptr<DecoderOnly_Model> mtp_model;
   size_t mtp_bytes_per_block = 0;
@@ -216,8 +248,13 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
     if (!model->config_->engine.dynamic_batching) {
       throw std::runtime_error("An Engine-hosted MTP head requires dynamic batching.");
     }
+    auto& target_hidden_states =
+        model->config_->model.decoder.outputs.hidden_states;
+    target_hidden_states = model->config_->model.mtp.main_hidden_states;
     mtp_model = std::make_shared<DecoderOnly_Model>(
         CreateMtpDecoderConfig(*model->config_), GetOrtEnv());
+    ValidateMtpModelCompatibility(
+        *model->config_, model->session_info_, mtp_model->session_info_);
     mtp_bytes_per_block = PagedKeyValueCacheBytesPerBlock(mtp_model);
     // The head consumes the target decoder's packed hidden states, so the target must emit them.
     model->config_->engine.hidden_states_output_required = true;
@@ -313,14 +350,14 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
     const int64_t length_after_step = static_cast<int64_t>(first_position + valid_rows) +
                                       (results[i].token_appended ? 1 : 0);
     const size_t sequence_limit =
-        std::min(static_cast<size_t>(search.max_length), entry.request->max_total_tokens_);
+        std::min(static_cast<size_t>(search.max_length), entry.request->MaxTotalTokens());
     const size_t remaining_turn_tokens = entry.request->RemainingTurnTokenBudget();
     const size_t remaining_turn_tokens_after_step =
         results[i].visible_token_count < remaining_turn_tokens
             ? remaining_turn_tokens - results[i].visible_token_count
             : 0;
     const size_t width = Dflash2DraftWidth(
-        max_drafts, static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
+        max_drafts, static_cast<size_t>(entry.request->SpeculativeOptions().max_draft_tokens),
         static_cast<size_t>(length_after_step), sequence_limit,
         remaining_turn_tokens_after_step);
     feed.wants_drafts = width > 0 && results[i].token_appended && !results[i].done && greedy &&
@@ -359,7 +396,7 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     const StepPlan& target_plan,
     const std::vector<RequestStepResult>& target_results,
     ScheduledRequests& target_requests) {
-  if (!mtp_model_ || MaxDraftTokensPerStep() == 0) {
+  if (!mtp_model_ || mtp_disabled_ || MaxDraftTokensPerStep() == 0) {
     return nullptr;
   }
   if (target_results.size() != target_plan.requests.size()) {
@@ -1034,11 +1071,12 @@ bool Engine::CancelRequest(const std::shared_ptr<Request>& request, uint64_t tur
     pending_events_.reserve(pending_events_.size() + 1);
   }
 
+  // The canceled turn's suffix is gone, so the shadow that mirrored it must not survive into the
+  // next turn. Release it before changing request state so a cleanup failure leaves cancellation
+  // retryable.
+  CloseMtpRequest(request);
   const auto counters =
       request->CompleteCancelFromEngine(*this, turn_id);
-  // The canceled turn's suffix is gone, so the shadow that mirrored it must not survive into the
-  // next turn.
-  CloseMtpRequest(request);
   EngineEvent terminal;
   terminal.request = request;
   terminal.turn_id = turn_id;
@@ -1625,13 +1663,31 @@ void Engine::RunDynamic() {
       // commit without drafts. Contract violations and failed MTP rollback stay fatal below.
       try {
         mtp_step = PrepareMtpStep(step_plan_, step_results_, scheduled_requests);
+        mtp_consecutive_failures_ = 0;
       } catch (const MtpRollbackError&) {
         throw;
       } catch (const std::logic_error&) {
         throw;
       } catch (...) {
+        const auto mtp_error = std::current_exception();
         mtp_step.reset();
         ++speculative_stats_.standard_fallback_steps;
+        ++speculative_stats_.mtp_failures;
+        ++mtp_consecutive_failures_;
+        const bool disable_mtp =
+            mtp_consecutive_failures_ >= kMtpFailureDisableThreshold;
+        mtp_disabled_ = disable_mtp;
+        if (mtp_consecutive_failures_ == 1 || disable_mtp) {
+          try {
+            Log("warning", AddExceptionCause(
+                               disable_mtp
+                                   ? "Disabling MTP after repeated proposal failures."
+                                   : "MTP proposal failed; using target-only decoding for this step.",
+                               mtp_error));
+          } catch (...) {
+            // Diagnostics must not turn an optional drafter failure into a target failure.
+          }
+        }
       }
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         if (step_results_[i].visible_token_count != 0 ||
@@ -1728,7 +1784,7 @@ void Engine::RunDynamic() {
           const auto dflash2_error = std::current_exception();
           for (const auto& feed : dflash2_feeds_) {
             if (feed.request) {
-              feed.request->draft_tokens_.clear();
+              feed.request->SetDraftTokens({});
             }
           }
           dflash2_drafter_.reset();

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -227,10 +227,27 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
     if (!model->config_->engine.dynamic_batching) {
       throw std::runtime_error("An Engine-hosted DFlash 2 drafter requires dynamic batching.");
     }
+    auto& dflash2 = model->config_->model.dflash2;
+    auto& target_aux_output = model->config_->model.decoder.outputs.aux_hidden_states;
+    if (dflash2.main_aux_hidden_states.empty()) {
+      dflash2.main_aux_hidden_states = target_aux_output;
+    }
+    if (dflash2.main_aux_hidden_states.empty()) {
+      throw std::runtime_error(
+          "model.dflash2.main_aux_hidden_states must name a main-model output.");
+    }
+    target_aux_output = dflash2.main_aux_hidden_states;
+    if (!model->session_info_.HasOutput(target_aux_output)) {
+      throw std::runtime_error(
+          "model.dflash2.main_aux_hidden_states must name a main-model output.");
+    }
+
     const auto& batching = *model->config_->engine.dynamic_batching;
     const size_t paged_block_size = static_cast<size_t>(batching.block_size);
     auto dflash2_model = std::make_shared<Dflash2Model>(
         CreateDflash2Config(*model->config_), GetOrtEnv());
+    ValidateDflash2ModelCompatibility(
+        *model->config_, model->session_info_, dflash2_model->session_info_);
     // Built before the main pool so the pool's free-memory measurement already excludes it. The
     // drafter is windowed, so its footprint depends on the batch size, not the context length.
     dflash2_drafter = std::make_unique<Dflash2Drafter>(

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "engine.h"
+#include "../logging.h"
 #include "../search.h"
 
 #include <limits>
@@ -311,11 +312,17 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
     // The committed length this step ends at: the accepted prefix plus the token just sampled.
     const int64_t length_after_step = static_cast<int64_t>(first_position + valid_rows) +
                                       (results[i].token_appended ? 1 : 0);
-    const size_t width = std::min(
-        {max_drafts, static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
-         length_after_step + 1 < search.max_length
-             ? static_cast<size_t>(search.max_length - length_after_step - 1)
-             : size_t{0}});
+    const size_t sequence_limit =
+        std::min(static_cast<size_t>(search.max_length), entry.request->max_total_tokens_);
+    const size_t remaining_turn_tokens = entry.request->RemainingTurnTokenBudget();
+    const size_t remaining_turn_tokens_after_step =
+        results[i].visible_token_count < remaining_turn_tokens
+            ? remaining_turn_tokens - results[i].visible_token_count
+            : 0;
+    const size_t width = Dflash2DraftWidth(
+        max_drafts, static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
+        static_cast<size_t>(length_after_step), sequence_limit,
+        remaining_turn_tokens_after_step);
     feed.wants_drafts = width > 0 && results[i].token_appended && !results[i].done && greedy &&
                         search.repetition_penalty == 1.0f && search.no_repeat_ngram_size == 0 &&
                         search.min_length <= length_after_step;
@@ -1715,7 +1722,29 @@ void Engine::RunDynamic() {
         PublishMtpDrafts(*mtp_step);
       }
       if (dflash2_drafter_ && MaxDraftTokensPerStep() > 0) {
-        PublishDflash2Drafts(step_plan_, scheduled_requests);
+        try {
+          PublishDflash2Drafts(step_plan_, scheduled_requests);
+        } catch (...) {
+          const auto dflash2_error = std::current_exception();
+          for (const auto& feed : dflash2_feeds_) {
+            if (feed.request) {
+              feed.request->draft_tokens_.clear();
+            }
+          }
+          dflash2_drafter_.reset();
+          try {
+            try {
+              std::rethrow_exception(dflash2_error);
+            } catch (const std::exception& error) {
+              Log("warning", std::string{"Disabling DFlash 2 after proposal failure: "} + error.what());
+            } catch (...) {
+              Log("warning", "Disabling DFlash 2 after a non-standard proposal failure.");
+            }
+          } catch (...) {
+            // Warning emission must not turn an optional post-commit drafter failure into a fatal
+            // target transaction failure.
+          }
+        }
       }
     } catch (...) {
       MarkUnhealthyAndThrow(
@@ -1816,6 +1845,9 @@ EngineEvent Engine::FailUnserviceableRequest(const void* request_id) {
   }
   scheduler_->RemoveRequest(request);
   CloseMtpRequest(request);
+  if (dflash2_drafter_) {
+    dflash2_drafter_->Release(request.get());
+  }
   request->CompleteFailedTurnFromEngine(*this);
 
   EngineEvent event;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -164,6 +164,7 @@ Engine::Engine(std::shared_ptr<Model> model, EngineDependencies dependencies)
       mtp_model_{std::move(dependencies.mtp_model)},
       mtp_cache_manager_{std::move(dependencies.mtp_cache_manager)},
       mtp_model_executor_{std::move(dependencies.mtp_model_executor)},
+      dflash2_drafter_{std::move(dependencies.dflash2_drafter)},
       make_step_error_{dependencies.make_step_error
                            ? dependencies.make_step_error
                            : MakeEngineStepError} {
@@ -221,6 +222,23 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
     model->config_->engine.hidden_states_output_required = true;
   }
 
+  std::unique_ptr<Dflash2Drafter> dflash2_drafter;
+  if (!model->config_->model.dflash2.filename.empty()) {
+    if (!model->config_->engine.dynamic_batching) {
+      throw std::runtime_error("An Engine-hosted DFlash 2 drafter requires dynamic batching.");
+    }
+    const auto& batching = *model->config_->engine.dynamic_batching;
+    const size_t paged_block_size = static_cast<size_t>(batching.block_size);
+    auto dflash2_model = std::make_shared<Dflash2Model>(
+        CreateDflash2Config(*model->config_), GetOrtEnv());
+    // Built before the main pool so the pool's free-memory measurement already excludes it. The
+    // drafter is windowed, so its footprint depends on the batch size, not the context length.
+    dflash2_drafter = std::make_unique<Dflash2Drafter>(
+        dflash2_model, paged_block_size,
+        Dflash2Drafter::PoolBlocks(*model->config_, paged_block_size,
+                                   static_cast<size_t>(batching.max_batch_size)));
+  }
+
   std::shared_ptr<CacheManager> cache_manager =
       CacheManager::Create(model, mtp_bytes_per_block);
   auto scheduler = Scheduler::Create(model, cache_manager);
@@ -240,7 +258,77 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
 
   return EngineDependencies{
       std::move(cache_manager), std::move(scheduler), std::move(model_executor),
-      std::move(mtp_model), std::move(mtp_cache_manager), std::move(mtp_model_executor)};
+      std::move(mtp_model), std::move(mtp_cache_manager), std::move(mtp_model_executor),
+      std::move(dflash2_drafter)};
+}
+
+void Engine::PrepareDflash2Feeds(const StepPlan& plan,
+                                 const std::vector<RequestStepResult>& results) {
+  const size_t max_drafts = std::min(MaxDraftTokensPerStep(), dflash2_drafter_->NumDraftTokens());
+  dflash2_feeds_.clear();
+  dflash2_feeds_.reserve(plan.requests.size());
+  dflash2_draft_widths_.clear();
+  dflash2_draft_widths_.reserve(plan.requests.size());
+  for (size_t i = 0; i < plan.requests.size(); ++i) {
+    const auto& entry = plan.requests[i];
+    const size_t accepted = entry.request->AcceptedDraftTokenCount();
+    if (accepted > entry.draft_token_count) {
+      throw std::logic_error("DFlash 2 observed more accepted drafts than the target planned.");
+    }
+    // Rejected draft rows carry hidden states for tokens that were never committed; drop them.
+    const size_t valid_rows =
+        entry.unprocessed_token_count - (entry.draft_token_count - accepted);
+    // The step's rows start at the processed cursor, which is also what the decoder passes as
+    // past_sequence_lengths. Deriving it from sequence_length_before instead would be wrong for a
+    // prefill chunk, whose unprocessed count is the chunk rather than the whole pending suffix.
+    const size_t first_position = static_cast<size_t>(entry.request->ProcessedSequenceLength());
+
+    Dflash2Drafter::Feed feed;
+    feed.request = entry.request.get();
+    feed.aux_row_begin = entry.packed_token_offset;
+    feed.aux_row_count = valid_rows;
+    feed.first_position = first_position;
+
+    const auto& search = entry.request->SearchOptions();
+    const bool greedy = !search.do_sample || search.top_k == 1 || search.temperature == 0;
+    // The committed length this step ends at: the accepted prefix plus the token just sampled.
+    const int64_t length_after_step = static_cast<int64_t>(first_position + valid_rows) +
+                                      (results[i].token_appended ? 1 : 0);
+    const size_t width = std::min(
+        {max_drafts, static_cast<size_t>(entry.request->params_->speculative.max_draft_tokens),
+         length_after_step + 1 < search.max_length
+             ? static_cast<size_t>(search.max_length - length_after_step - 1)
+             : size_t{0}});
+    feed.wants_drafts = width > 0 && results[i].token_appended && !results[i].done && greedy &&
+                        search.repetition_penalty == 1.0f && search.no_repeat_ngram_size == 0 &&
+                        search.min_length <= length_after_step;
+    feed.anchor_token = results[i].token;
+    dflash2_feeds_.push_back(feed);
+    dflash2_draft_widths_.push_back(width);
+  }
+}
+
+void Engine::PublishDflash2Drafts(const StepPlan& plan, ScheduledRequests& scheduled_requests) {
+  if (dflash2_feeds_.empty()) {
+    return;
+  }
+  Tensor* aux_hidden_states = scheduled_requests.AuxHiddenStates();
+  if (!aux_hidden_states) {
+    throw std::logic_error("The main decoder did not expose auxiliary hidden states for DFlash 2.");
+  }
+
+  dflash2_drafter_->Propose(*aux_hidden_states, dflash2_feeds_, dflash2_drafts_);
+  ++speculative_stats_.draft_forward_passes;
+  for (size_t i = 0; i < dflash2_feeds_.size(); ++i) {
+    auto& drafts = dflash2_drafts_[i];
+    if (drafts.empty()) {
+      continue;
+    }
+    // The drafter always emits its full block; a request with a narrower budget takes the prefix
+    // of the same greedy path.
+    drafts.resize(std::min(drafts.size(), dflash2_draft_widths_[i]));
+    plan.requests[i].request->SetDraftTokens(drafts);
+  }
 }
 
 std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
@@ -960,6 +1048,9 @@ void Engine::CloseRequest(const std::shared_ptr<Request>& request) {
       cache_manager_->IsResident(request);
 
   CloseMtpRequest(request);
+  if (dflash2_drafter_) {
+    dflash2_drafter_->Release(request.get());
+  }
 
   pending_events_.erase(
       pending_events_.begin(),
@@ -1595,12 +1686,19 @@ void Engine::RunDynamic() {
         CommitMtpStep(*mtp_step);
       }
       RecordSpeculativeCommit(step_plan_);
+      if (dflash2_drafter_ && MaxDraftTokensPerStep() > 0) {
+        // Reads the accepted-draft counts, which CommitStep clears below.
+        PrepareDflash2Feeds(step_plan_, step_results_);
+      }
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         step_plan_.requests[i].request->CommitStep(
             step_plan_.requests[i], step_results_[i]);
       }
       if (mtp_step) {
         PublishMtpDrafts(*mtp_step);
+      }
+      if (dflash2_drafter_ && MaxDraftTokensPerStep() > 0) {
+        PublishDflash2Drafts(step_plan_, scheduled_requests);
       }
     } catch (...) {
       MarkUnhealthyAndThrow(

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -369,7 +369,7 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
   }
 }
 
-void Engine::PublishDflash2Drafts(const StepPlan& plan, ScheduledRequests& scheduled_requests) {
+void Engine::PublishDflash2Drafts(ScheduledRequests& scheduled_requests) {
   if (dflash2_feeds_.empty()) {
     return;
   }
@@ -388,7 +388,7 @@ void Engine::PublishDflash2Drafts(const StepPlan& plan, ScheduledRequests& sched
     // The drafter always emits its full block; a request with a narrower budget takes the prefix
     // of the same greedy path.
     drafts.resize(std::min(drafts.size(), dflash2_draft_widths_[i]));
-    plan.requests[i].request->SetDraftTokens(drafts);
+    dflash2_feeds_[i].request->SetDraftTokens(drafts);
   }
 }
 
@@ -1779,7 +1779,7 @@ void Engine::RunDynamic() {
       }
       if (dflash2_drafter_ && MaxDraftTokensPerStep() > 0) {
         try {
-          PublishDflash2Drafts(step_plan_, scheduled_requests);
+          PublishDflash2Drafts(scheduled_requests);
         } catch (...) {
           const auto dflash2_error = std::current_exception();
           for (const auto& feed : dflash2_feeds_) {

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -15,6 +15,7 @@ namespace {
 
 constexpr size_t kFatalEventOverhead = 2;
 constexpr size_t kMtpFailureDisableThreshold = 3;
+constexpr size_t kDflash2FailureDisableThreshold = 3;
 
 struct MtpRollbackError : std::runtime_error {
   using std::runtime_error::runtime_error;
@@ -286,6 +287,7 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
         CreateDflash2Config(*model->config_), GetOrtEnv());
     ValidateDflash2ModelCompatibility(
         *model->config_, model->session_info_, dflash2_model->session_info_);
+    model->config_->engine.aux_hidden_states_output_required = true;
     // Built before the main pool so the pool's free-memory measurement already excludes it. The
     // drafter is windowed, so its footprint depends on the batch size, not the context length.
     dflash2_drafter = std::make_unique<Dflash2Drafter>(
@@ -360,9 +362,8 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
         max_drafts, static_cast<size_t>(entry.request->SpeculativeOptions().max_draft_tokens),
         static_cast<size_t>(length_after_step), sequence_limit,
         remaining_turn_tokens_after_step);
-    feed.wants_drafts = width > 0 && results[i].token_appended && !results[i].done && greedy &&
-                        search.repetition_penalty == 1.0f && search.no_repeat_ngram_size == 0 &&
-                        search.min_length <= length_after_step;
+    feed.wants_drafts = width > 0 && results[i].token_appended && !results[i].done &&
+                        greedy && !entry.request->DraftTokenValidationError();
     feed.anchor_token = results[i].token;
     dflash2_feeds_.push_back(feed);
     dflash2_draft_widths_.push_back(width);
@@ -1163,6 +1164,12 @@ void Engine::DetachRequestForTeardown(
   }
 
   scheduler_->DetachRequestForTeardown(request);
+  if (dflash2_drafter_) {
+    try {
+      dflash2_drafter_->Release(request.get());
+    } catch (...) {
+    }
+  }
   if (const auto mtp_it = mtp_requests_.find(request.get());
       mtp_it != mtp_requests_.end()) {
     try {
@@ -1743,6 +1750,11 @@ void Engine::RunDynamic() {
       if (mtp_step) {
         mtp_step->reservation->PrepareCommit();
       }
+      if (dflash2_drafter_ && !dflash2_disabled_ && MaxDraftTokensPerStep() > 0) {
+        // Reads accepted-draft counts that CommitStep clears below. Keep this fallible work on the
+        // rollback side of the target transaction's commit boundary.
+        PrepareDflash2Feeds(step_plan_, step_results_);
+      }
     } catch (...) {
       const auto preparation_error = std::current_exception();
       rollback_transaction();
@@ -1766,10 +1778,6 @@ void Engine::RunDynamic() {
         CommitMtpStep(*mtp_step);
       }
       RecordSpeculativeCommit(step_plan_);
-      if (dflash2_drafter_ && MaxDraftTokensPerStep() > 0) {
-        // Reads the accepted-draft counts, which CommitStep clears below.
-        PrepareDflash2Feeds(step_plan_, step_results_);
-      }
       for (size_t i = 0; i < step_plan_.requests.size(); ++i) {
         step_plan_.requests[i].request->CommitStep(
             step_plan_.requests[i], step_results_[i]);
@@ -1777,9 +1785,10 @@ void Engine::RunDynamic() {
       if (mtp_step) {
         PublishMtpDrafts(*mtp_step);
       }
-      if (dflash2_drafter_ && MaxDraftTokensPerStep() > 0) {
+      if (dflash2_drafter_ && !dflash2_disabled_ && MaxDraftTokensPerStep() > 0) {
         try {
           PublishDflash2Drafts(scheduled_requests);
+          dflash2_consecutive_failures_ = 0;
         } catch (...) {
           const auto dflash2_error = std::current_exception();
           for (const auto& feed : dflash2_feeds_) {
@@ -1787,18 +1796,34 @@ void Engine::RunDynamic() {
               feed.request->SetDraftTokens({});
             }
           }
-          dflash2_drafter_.reset();
+          ++speculative_stats_.standard_fallback_steps;
+          ++speculative_stats_.dflash2_failures;
+          ++dflash2_consecutive_failures_;
+          bool contract_error = false;
           try {
-            try {
-              std::rethrow_exception(dflash2_error);
-            } catch (const std::exception& error) {
-              Log("warning", std::string{"Disabling DFlash 2 after proposal failure: "} + error.what());
-            } catch (...) {
-              Log("warning", "Disabling DFlash 2 after a non-standard proposal failure.");
-            }
+            std::rethrow_exception(dflash2_error);
+          } catch (const std::logic_error&) {
+            contract_error = true;
           } catch (...) {
-            // Warning emission must not turn an optional post-commit drafter failure into a fatal
-            // target transaction failure.
+          }
+          const bool disable_dflash2 = contract_error ||
+                                       dflash2_consecutive_failures_ >= kDflash2FailureDisableThreshold;
+          dflash2_disabled_ = disable_dflash2;
+          if (disable_dflash2) {
+            ++speculative_stats_.dflash2_disables;
+          }
+          if (dflash2_consecutive_failures_ == 1 || disable_dflash2) {
+            try {
+              Log("warning", AddExceptionCause(
+                         contract_error
+                           ? "Disabling DFlash 2 after a proposal contract failure."
+                         : disable_dflash2
+                                     ? "Disabling DFlash 2 after repeated proposal failures."
+                                     : "DFlash 2 proposal failed; using target-only decoding for this step.",
+                                 dflash2_error));
+            } catch (...) {
+              // Diagnostics must not turn an optional drafter failure into a target failure.
+            }
           }
         }
       }
@@ -2090,6 +2115,9 @@ SpeculativeStats Engine::GetSpeculativeStats() const {
   // would be a data race.
   ValidateOwnerThread();
   auto stats = speculative_stats_;
+  if (dflash2_drafter_) {
+    stats.dflash2_admission_misses = dflash2_drafter_->AdmissionMisses();
+  }
   if (stats.draft_tokens_evaluated != 0) {
     stats.acceptance_rate = static_cast<float>(stats.draft_tokens_accepted) /
                             static_cast<float>(stats.draft_tokens_evaluated);

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1815,9 +1815,9 @@ void Engine::RunDynamic() {
           if (dflash2_consecutive_failures_ == 1 || disable_dflash2) {
             try {
               Log("warning", AddExceptionCause(
-                         contract_error
-                           ? "Disabling DFlash 2 after a proposal contract failure."
-                         : disable_dflash2
+                                 contract_error
+                                     ? "Disabling DFlash 2 after a proposal contract failure."
+                                 : disable_dflash2
                                      ? "Disabling DFlash 2 after repeated proposal failures."
                                      : "DFlash 2 proposal failed; using target-only decoding for this step.",
                                  dflash2_error));

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -7,6 +7,7 @@
 #include "model_executor.h"
 #include "scheduler.h"
 #include "../decoding/speculative_stats.h"
+#include "../dflash2_drafter.h"
 
 #include <thread>
 
@@ -81,6 +82,7 @@ struct EngineDependencies {
   std::shared_ptr<DecoderOnly_Model> mtp_model;
   std::shared_ptr<CacheManager> mtp_cache_manager;
   std::unique_ptr<ModelExecutor> mtp_model_executor;
+  std::unique_ptr<Dflash2Drafter> dflash2_drafter;
   // Test-only fault injection for allocation-sensitive durable error construction.
   EngineStepErrorFactory make_step_error{};
 };
@@ -222,6 +224,10 @@ struct Engine : std::enable_shared_from_this<Engine>,
   void RollbackMtpStep(MtpStep& step);
   void CommitMtpStep(MtpStep& step);
   void PublishMtpDrafts(MtpStep& step);
+  // Runs the DFlash 2 drafter on a committed step and attaches its block to each request. The
+  // feeds are captured before Request::CommitStep clears the accepted-draft counts they depend on.
+  void PrepareDflash2Feeds(const StepPlan& plan, const std::vector<RequestStepResult>& results);
+  void PublishDflash2Drafts(const StepPlan& plan, ScheduledRequests& scheduled_requests);
   void RecordSpeculativeCommit(const StepPlan& plan) noexcept;
   void CloseMtpRequest(const std::shared_ptr<Request>& request);
   [[noreturn]] void HandleContinuationRestoreFailure(
@@ -244,6 +250,11 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::shared_ptr<CacheManager> mtp_cache_manager_;
   std::unique_ptr<ModelExecutor> mtp_model_executor_;
   std::unordered_map<const Request*, std::shared_ptr<Request>> mtp_requests_;
+  // Present only when model.dflash2 names a block drafter. Owns its own session and paged cache.
+  std::unique_ptr<Dflash2Drafter> dflash2_drafter_;
+  std::vector<Dflash2Drafter::Feed> dflash2_feeds_;
+  std::vector<std::vector<int32_t>> dflash2_drafts_;
+  std::vector<size_t> dflash2_draft_widths_;
   DeviceSpan<int32_t> mtp_device_drafts_;
   DeviceSpan<int32_t> mtp_device_chain_inputs_;
   EngineStepErrorFactory make_step_error_;

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -87,6 +87,10 @@ struct EngineDependencies {
   EngineStepErrorFactory make_step_error{};
 };
 
+void ValidateMtpModelCompatibility(const Config& config,
+                                   const ModelStateMetadata& target_metadata,
+                                   const ModelStateMetadata& head_metadata);
+
 struct EngineTransactionMetrics {
   uint64_t committed_steps{};
   uint64_t capacity_deferrals{};
@@ -250,6 +254,8 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::shared_ptr<CacheManager> mtp_cache_manager_;
   std::unique_ptr<ModelExecutor> mtp_model_executor_;
   std::unordered_map<const Request*, std::shared_ptr<Request>> mtp_requests_;
+  size_t mtp_consecutive_failures_{};
+  bool mtp_disabled_{};
   // Present only when model.dflash2 names a block drafter. Owns its own session and paged cache.
   std::unique_ptr<Dflash2Drafter> dflash2_drafter_;
   std::vector<Dflash2Drafter::Feed> dflash2_feeds_;

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -231,7 +231,7 @@ struct Engine : std::enable_shared_from_this<Engine>,
   // Runs the DFlash 2 drafter on a committed step and attaches its block to each request. The
   // feeds are captured before Request::CommitStep clears the accepted-draft counts they depend on.
   void PrepareDflash2Feeds(const StepPlan& plan, const std::vector<RequestStepResult>& results);
-  void PublishDflash2Drafts(const StepPlan& plan, ScheduledRequests& scheduled_requests);
+  void PublishDflash2Drafts(ScheduledRequests& scheduled_requests);
   void RecordSpeculativeCommit(const StepPlan& plan) noexcept;
   void CloseMtpRequest(const std::shared_ptr<Request>& request);
   [[noreturn]] void HandleContinuationRestoreFailure(

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -261,6 +261,8 @@ struct Engine : std::enable_shared_from_this<Engine>,
   std::vector<Dflash2Drafter::Feed> dflash2_feeds_;
   std::vector<std::vector<int32_t>> dflash2_drafts_;
   std::vector<size_t> dflash2_draft_widths_;
+  size_t dflash2_consecutive_failures_{};
+  bool dflash2_disabled_{};
   DeviceSpan<int32_t> mtp_device_drafts_;
   DeviceSpan<int32_t> mtp_device_chain_inputs_;
   EngineStepErrorFactory make_step_error_;

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -189,6 +189,9 @@ struct Request : std::enable_shared_from_this<Request>,
    * requests compare argmax tokens; sampled requests draw from each target row's bounded
    * top-k/top-p distribution.
    *
+   * Seeded sampled output is reproducible only when both the supplied drafts and scheduling path
+   * are the same. Draft admission changes which random stream performs target sampling.
+   *
    * The proposal applies to the current turn's next committed decode step. A rolled back step
    * leaves it pending, while canceling the turn discards it.
    */

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -288,6 +288,10 @@ std::vector<DeviceSpan<float>> ScheduledRequests::ProcessLogits() {
   return logits;
 }
 
+Tensor* ScheduledRequests::AuxHiddenStates() const {
+  return decoder_state_ ? decoder_state_->AuxHiddenStates() : nullptr;
+}
+
 std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
     std::vector<DeviceSpan<float>>& verify_rows,
     std::vector<std::vector<int32_t>>& selected_tokens,

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -94,6 +94,7 @@ struct ScheduledRequests {
   void AddDecoderState(std::unique_ptr<DecoderIO> decoder_state);
 
   Tensor* HiddenStates() const;
+  Tensor* AuxHiddenStates() const;
 
   std::vector<DeviceSpan<float>> ProcessLogits();
 

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -1109,6 +1109,8 @@ struct OgaRequest : OgaAbstract {
 
   /**
    * \brief Proposes speculative draft tokens for the next decode operation.
+   *
+   * Seeded sampled output is reproducible only with the same proposal and scheduling path.
    */
   void SetDraftTokens(const OgaSequences& tokens) {
     OgaCheckResult(OgaRequestSetDraftTokens(this, &tokens));

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -906,6 +906,8 @@ OgaResult* OGA_API_CALL OgaSpeculativeStatsGetCount(
     *value = stats->cooldown_remaining;
   else if (key == "standard_fallback_steps")
     *value = stats->standard_fallback_steps;
+  else if (key == "mtp_failures")
+    *value = stats->mtp_failures;
   else if (key == "full_accept_rounds")
     *value = stats->full_accept_rounds;
   else if (key == "partial_accept_rounds")

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -908,6 +908,12 @@ OgaResult* OGA_API_CALL OgaSpeculativeStatsGetCount(
     *value = stats->standard_fallback_steps;
   else if (key == "mtp_failures")
     *value = stats->mtp_failures;
+  else if (key == "dflash2_failures")
+    *value = stats->dflash2_failures;
+  else if (key == "dflash2_disables")
+    *value = stats->dflash2_disables;
+  else if (key == "dflash2_admission_misses")
+    *value = stats->dflash2_admission_misses;
   else if (key == "full_accept_rounds")
     *value = stats->full_accept_rounds;
   else if (key == "partial_accept_rounds")

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -1449,6 +1449,8 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaRequestClose(OgaRequest* request);
  * the proposal. Random target sampling is supported for deterministic draft proposals when top_k
  * is positive. Requires an engine whose cache can roll a rejected draft back (see
  * OgaEngineMaxDraftTokensPerProposal).
+ * Seeded sampled output is reproducible only when both the proposal and scheduling path are the
+ * same, because draft admission changes which random stream performs target sampling.
  *
  * \param[in] request The request to propose drafts for.
  * \param[in] tokens One sequence holding the draft continuation, in order.

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -289,6 +289,7 @@ pybind11::dict ToSpeculativeStatsDict(const OgaSpeculativeStats& stats) {
                           "adaptive_k_decreases", "adaptive_k_observations",
                           "adaptive_k_probes", "cooldown_entries", "cooldown_steps",
                           "cooldown_remaining", "standard_fallback_steps", "mtp_failures",
+                          "dflash2_failures", "dflash2_disables", "dflash2_admission_misses",
                           "full_accept_rounds", "partial_accept_rounds", "zero_accept_rounds",
                           "target_verify_forward_passes", "target_reanchor_forward_passes",
                           "target_reconciliation_forward_passes", "ngram_lookup_hits",

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -288,7 +288,7 @@ pybind11::dict ToSpeculativeStatsDict(const OgaSpeculativeStats& stats) {
                           "target_forward_passes", "effective_k", "adaptive_k_increases",
                           "adaptive_k_decreases", "adaptive_k_observations",
                           "adaptive_k_probes", "cooldown_entries", "cooldown_steps",
-                          "cooldown_remaining", "standard_fallback_steps",
+                          "cooldown_remaining", "standard_fallback_steps", "mtp_failures",
                           "full_accept_rounds", "partial_accept_rounds", "zero_accept_rounds",
                           "target_verify_forward_passes", "target_reanchor_forward_passes",
                           "target_reconciliation_forward_passes", "ngram_lookup_hits",
@@ -884,7 +884,9 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
         auto sequences = OgaSequences::Create();
         auto tokens_span = ToSpan(tokens);
         sequences->Append(tokens_span.data(), tokens_span.size());
-        request.SetDraftTokens(*sequences); }, "Propose speculative draft tokens for the next decode operation.")
+        request.SetDraftTokens(*sequences); },
+           "Propose speculative draft tokens for the next decode operation. Sampled output is "
+           "reproducible only with the same proposal and scheduling path.")
       .def("close", &OgaRequest::Close);
 
   pybind11::class_<

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ file(GLOB test_srcs CONFIGURE_DEPENDS
 )
 
 # Keep tests with dedicated white-box executables out of the public-API unit_tests target.
+list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/cpp/dflash2_config_test.cpp")
 list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/cpp/reinit_tests.cpp")
 list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/cpp/search_checkpoint_tests.cpp")
 
@@ -166,6 +167,7 @@ file(GLOB engine_unit_test_srcs CONFIGURE_DEPENDS
   "${CMAKE_CURRENT_SOURCE_DIR}/cpp/engine/*.cpp"
 )
 list(APPEND engine_unit_test_srcs
+  "${CMAKE_CURRENT_SOURCE_DIR}/cpp/dflash2_config_test.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/cpp/search_checkpoint_tests.cpp"
 )
 add_executable(engine_unit_tests ${engine_unit_test_srcs})

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -243,7 +243,6 @@ TEST(Dflash2ConfigTest, ProjectsDrafterWithoutTargetState) {
 
 TEST(Dflash2ConfigTest, AccountsForWindowedPagedCache) {
   const auto config = MakeDflash2Config();
-  EXPECT_EQ(Dflash2Drafter::BytesPerBlock(config, 16), 3072u);
   EXPECT_EQ(Dflash2Drafter::PoolBlocks(config, 8, 3), 15u);
 }
 

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#include "dflash2_drafter.h"
+
+namespace Generators::test {
+namespace {
+
+Config MakeDflash2Config() {
+  Config config;
+  auto& decoder = config.model.decoder;
+  decoder.filename = "target.onnx";
+  decoder.sliding_window = Config::Model::Decoder::SlidingWindow{4096};
+  decoder.state_groups.emplace();
+  decoder.state_groups->push_back(Config::Model::Decoder::StateGroup{
+      Config::Model::Decoder::StateGroupKind::Fixed});
+
+  auto& dflash2 = config.model.dflash2;
+  dflash2.filename = "dflash2.onnx";
+  dflash2.num_hidden_layers = 3;
+  dflash2.num_key_value_heads = 2;
+  dflash2.head_size = 8;
+  dflash2.block_size = 4;
+  dflash2.num_draft_tokens = 3;
+  dflash2.selector_top_k = 2;
+  dflash2.sliding_window = 17;
+  return config;
+}
+
+}  // namespace
+
+TEST(Dflash2ConfigTest, RequiresDrafterFilename) {
+  auto config = MakeDflash2Config();
+  config.model.dflash2.filename.clear();
+  EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RequiresCompleteGeometry) {
+  auto config = MakeDflash2Config();
+  config.model.dflash2.num_key_value_heads = 0;
+  EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RequiresOneDraftPerNonAnchorBlockRow) {
+  auto config = MakeDflash2Config();
+  config.model.dflash2.num_draft_tokens = 2;
+  EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, ProjectsDrafterWithoutTargetState) {
+  const auto projected = CreateDflash2Config(MakeDflash2Config());
+  const auto& decoder = projected->model.decoder;
+  EXPECT_EQ(decoder.filename, "dflash2.onnx");
+  EXPECT_EQ(decoder.num_hidden_layers, 3);
+  EXPECT_EQ(decoder.num_key_value_heads, 2);
+  EXPECT_EQ(decoder.head_size, 8);
+  EXPECT_FALSE(decoder.sliding_window.has_value());
+  EXPECT_FALSE(decoder.state_groups.has_value());
+}
+
+TEST(Dflash2ConfigTest, AccountsForWindowedPagedCache) {
+  const auto config = MakeDflash2Config();
+  EXPECT_EQ(Dflash2Drafter::BytesPerBlock(config, 16), 3072u);
+  EXPECT_EQ(Dflash2Drafter::PoolBlocks(config, 8, 3), 15u);
+}
+
+TEST(Dflash2ConfigTest, RejectsUnboundedCachePool) {
+  auto config = MakeDflash2Config();
+  config.model.dflash2.sliding_window = 0;
+  EXPECT_THROW(Dflash2Drafter::PoolBlocks(config, 8, 3), std::runtime_error);
+}
+
+}  // namespace Generators::test

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -3,6 +3,10 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "dflash2_drafter.h"
 
 namespace Generators::test {
@@ -29,6 +33,57 @@ Config MakeDflash2Config() {
   return config;
 }
 
+struct TensorMetadata {
+  ONNXTensorElementDataType data_type;
+  std::vector<int64_t> shape;
+};
+
+class FakeModelStateMetadata final : public ModelStateMetadata {
+ public:
+  void AddInput(std::string name, ONNXTensorElementDataType data_type,
+                std::vector<int64_t> shape) {
+    inputs_.insert_or_assign(
+        std::move(name), TensorMetadata{data_type, std::move(shape)});
+  }
+
+  void AddOutput(std::string name, ONNXTensorElementDataType data_type,
+                 std::vector<int64_t> shape) {
+    outputs_.insert_or_assign(
+        std::move(name), TensorMetadata{data_type, std::move(shape)});
+  }
+
+  bool HasInput(const std::string& name) const override { return inputs_.contains(name); }
+  bool HasOutput(const std::string& name) const override { return outputs_.contains(name); }
+
+  ONNXTensorElementDataType GetInputDataType(const std::string& name) const override {
+    return inputs_.at(name).data_type;
+  }
+
+  ONNXTensorElementDataType GetOutputDataType(const std::string& name) const override {
+    return outputs_.at(name).data_type;
+  }
+
+  std::vector<int64_t> GetInputShape(const std::string& name) const override {
+    return inputs_.at(name).shape;
+  }
+
+  std::vector<int64_t> GetOutputShape(const std::string& name) const override {
+    return outputs_.at(name).shape;
+  }
+
+ private:
+  std::unordered_map<std::string, TensorMetadata> inputs_;
+  std::unordered_map<std::string, TensorMetadata> outputs_;
+};
+
+std::pair<FakeModelStateMetadata, FakeModelStateMetadata> MakeCompatibleMetadata() {
+  FakeModelStateMetadata target;
+  target.AddOutput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
+  FakeModelStateMetadata drafter;
+  drafter.AddInput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
+  return {std::move(target), std::move(drafter)};
+}
+
 }  // namespace
 
 TEST(Dflash2ConfigTest, RequiresDrafterFilename) {
@@ -41,6 +96,76 @@ TEST(Dflash2ConfigTest, RequiresCompleteGeometry) {
   auto config = MakeDflash2Config();
   config.model.dflash2.num_key_value_heads = 0;
   EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RequiresPositiveSelectorTopK) {
+  auto config = MakeDflash2Config();
+  config.model.dflash2.selector_top_k = 0;
+  EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RejectsAsynchronousExecution) {
+  auto config = MakeDflash2Config();
+  config.model.dflash2.run_options = Config::RunOptions{
+      {"disable_synchronize_execution_providers", "1"}};
+  EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, AcceptsCompatibleAuxiliaryHiddenStates) {
+  const auto config = MakeDflash2Config();
+  const auto [target, drafter] = MakeCompatibleMetadata();
+  EXPECT_NO_THROW(ValidateDflash2ModelCompatibility(config, target, drafter));
+}
+
+TEST(Dflash2ConfigTest, UsesConfiguredTargetOutput) {
+  auto config = MakeDflash2Config();
+  config.model.dflash2.main_aux_hidden_states = "custom_aux_hidden_states";
+  FakeModelStateMetadata target;
+  target.AddOutput("custom_aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
+  FakeModelStateMetadata drafter;
+  drafter.AddInput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
+  EXPECT_NO_THROW(ValidateDflash2ModelCompatibility(config, target, drafter));
+}
+
+TEST(Dflash2ConfigTest, RequiresConfiguredTargetOutput) {
+  const auto config = MakeDflash2Config();
+  FakeModelStateMetadata target;
+  FakeModelStateMetadata drafter;
+  drafter.AddInput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
+  EXPECT_THROW(ValidateDflash2ModelCompatibility(config, target, drafter), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RequiresConfiguredDrafterInput) {
+  const auto config = MakeDflash2Config();
+  FakeModelStateMetadata target;
+  target.AddOutput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
+  const FakeModelStateMetadata drafter;
+  EXPECT_THROW(ValidateDflash2ModelCompatibility(config, target, drafter), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RequiresTwoDimensionalAuxiliaryTensors) {
+  const auto config = MakeDflash2Config();
+  auto [target, drafter] = MakeCompatibleMetadata();
+  target.AddOutput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 4, 16});
+  EXPECT_THROW(ValidateDflash2ModelCompatibility(config, target, drafter), std::runtime_error);
+
+  std::tie(target, drafter) = MakeCompatibleMetadata();
+  drafter.AddInput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 4, 16});
+  EXPECT_THROW(ValidateDflash2ModelCompatibility(config, target, drafter), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RequiresMatchingAuxiliaryWidth) {
+  const auto config = MakeDflash2Config();
+  auto [target, drafter] = MakeCompatibleMetadata();
+  drafter.AddInput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 32});
+  EXPECT_THROW(ValidateDflash2ModelCompatibility(config, target, drafter), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RequiresMatchingAuxiliaryType) {
+  const auto config = MakeDflash2Config();
+  auto [target, drafter] = MakeCompatibleMetadata();
+  drafter.AddInput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {-1, 64});
+  EXPECT_THROW(ValidateDflash2ModelCompatibility(config, target, drafter), std::runtime_error);
 }
 
 TEST(Dflash2ConfigTest, RequiresOneDraftPerNonAnchorBlockRow) {

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -19,7 +20,7 @@ Config MakeDflash2Config() {
   decoder.sliding_window = Config::Model::Decoder::SlidingWindow{4096};
   decoder.state_groups.emplace();
   decoder.state_groups->push_back(Config::Model::Decoder::StateGroup{
-      Config::Model::Decoder::StateGroupKind::Fixed});
+      Config::Model::Decoder::StateGroupKind::FixedConv});
 
   auto& dflash2 = config.model.dflash2;
   dflash2.filename = "dflash2.onnx";
@@ -81,6 +82,24 @@ std::pair<FakeModelStateMetadata, FakeModelStateMetadata> MakeCompatibleMetadata
   target.AddOutput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
   FakeModelStateMetadata drafter;
   drafter.AddInput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
+  drafter.AddInput("input_ids", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, {-1});
+  for (const auto* name : {"q_row_map", "qkv_row_map", "block_row_index",
+                           "cumulative_sequence_lengths", "past_sequence_lengths"}) {
+    drafter.AddInput(name, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, {-1});
+  }
+  drafter.AddInput("block_table", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, {-1, -1});
+  drafter.AddInput("attention_metadata", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, {3});
+  drafter.AddOutput("draft_candidate_ids", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, {-1, 3, 2});
+  drafter.AddOutput("draft_scores", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {-1, 3, 2, 2});
+  for (int layer = 0; layer < 3; ++layer) {
+    const auto suffix = std::to_string(layer);
+    for (const auto* kind : {"key", "value"}) {
+      drafter.AddInput("past_key_values." + suffix + "." + kind,
+                       ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16, {-1, -1, 2, 8});
+      drafter.AddOutput("present." + suffix + "." + kind,
+                        ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16, {-1, -1, 2, 8});
+    }
+  }
   return {std::move(target), std::move(drafter)};
 }
 
@@ -111,6 +130,33 @@ TEST(Dflash2ConfigTest, RejectsAsynchronousExecution) {
   EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
 }
 
+TEST(Dflash2ConfigTest, RejectsSimultaneousMtpDrafter) {
+  auto config = MakeDflash2Config();
+  config.model.mtp.filename = "mtp.onnx";
+  EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, PreservesTargetProviderOptions) {
+  auto config = MakeDflash2Config();
+  config.model.decoder.session_options.providers = {"cuda"};
+  config.model.decoder.session_options.provider_options.push_back(
+      {"cuda", {{"device_id", "1"}, {"arena_extend_strategy", "kSameAsRequested"}}});
+  config.model.dflash2.session_options.emplace();
+  config.model.dflash2.session_options->provider_options.push_back(
+      {"cuda", {{"arena_extend_strategy", "kNextPowerOfTwo"}}});
+
+  const auto projected = CreateDflash2Config(config);
+  const auto& session_options = projected->model.decoder.session_options;
+  ASSERT_EQ(session_options.providers.size(), 1u);
+  EXPECT_EQ(session_options.providers[0], "cuda");
+  ASSERT_EQ(session_options.provider_options.size(), 1u);
+  ASSERT_EQ(session_options.provider_options[0].options.size(), 2u);
+  EXPECT_EQ(session_options.provider_options[0].options[0],
+            Config::NamedString("arena_extend_strategy", "kNextPowerOfTwo"));
+  EXPECT_EQ(session_options.provider_options[0].options[1],
+            Config::NamedString("device_id", "1"));
+}
+
 TEST(Dflash2ConfigTest, AcceptsCompatibleAuxiliaryHiddenStates) {
   const auto config = MakeDflash2Config();
   const auto [target, drafter] = MakeCompatibleMetadata();
@@ -120,10 +166,8 @@ TEST(Dflash2ConfigTest, AcceptsCompatibleAuxiliaryHiddenStates) {
 TEST(Dflash2ConfigTest, UsesConfiguredTargetOutput) {
   auto config = MakeDflash2Config();
   config.model.dflash2.main_aux_hidden_states = "custom_aux_hidden_states";
-  FakeModelStateMetadata target;
+  auto [target, drafter] = MakeCompatibleMetadata();
   target.AddOutput("custom_aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
-  FakeModelStateMetadata drafter;
-  drafter.AddInput("aux_hidden_states", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {-1, 64});
   EXPECT_NO_THROW(ValidateDflash2ModelCompatibility(config, target, drafter));
 }
 
@@ -168,6 +212,18 @@ TEST(Dflash2ConfigTest, RequiresMatchingAuxiliaryType) {
   EXPECT_THROW(ValidateDflash2ModelCompatibility(config, target, drafter), std::runtime_error);
 }
 
+TEST(Dflash2ConfigTest, RequiresCompleteDrafterContract) {
+  const auto config = MakeDflash2Config();
+  auto [target, drafter] = MakeCompatibleMetadata();
+  drafter.AddOutput("draft_scores", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {-1, 3, 2});
+  EXPECT_THROW(ValidateDflash2ModelCompatibility(config, target, drafter), std::runtime_error);
+
+  std::tie(target, drafter) = MakeCompatibleMetadata();
+  drafter.AddInput("past_key_values.1.key", ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16,
+                   {-1, -1, 4, 8});
+  EXPECT_THROW(ValidateDflash2ModelCompatibility(config, target, drafter), std::runtime_error);
+}
+
 TEST(Dflash2ConfigTest, RequiresOneDraftPerNonAnchorBlockRow) {
   auto config = MakeDflash2Config();
   config.model.dflash2.num_draft_tokens = 2;
@@ -195,6 +251,20 @@ TEST(Dflash2ConfigTest, RejectsUnboundedCachePool) {
   auto config = MakeDflash2Config();
   config.model.dflash2.sliding_window = 0;
   EXPECT_THROW(Dflash2Drafter::PoolBlocks(config, 8, 3), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RejectsInvalidCachePoolGeometry) {
+  const auto config = MakeDflash2Config();
+  EXPECT_THROW(Dflash2Drafter::PoolBlocks(config, 0, 3), std::runtime_error);
+  EXPECT_THROW(Dflash2Drafter::PoolBlocks(config, 8, std::numeric_limits<size_t>::max()),
+               std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, CapsDraftWidthBySessionAndTurnLimits) {
+  EXPECT_EQ(Dflash2DraftWidth(7, 5, 8, 10, 9), 1u);
+  EXPECT_EQ(Dflash2DraftWidth(7, 5, 8, 20, 3), 2u);
+  EXPECT_EQ(Dflash2DraftWidth(7, 5, 8, 20, 1), 0u);
+  EXPECT_EQ(Dflash2DraftWidth(7, 5, 9, 10, 9), 0u);
 }
 
 }  // namespace Generators::test

--- a/test/cpp/engine/engine_run_tests.cpp
+++ b/test/cpp/engine/engine_run_tests.cpp
@@ -2560,6 +2560,7 @@ TEST_F(EngineRunTest, MtpPlanningFailureCommitsTargetStepWithoutDrafts) {
   EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
   EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
   EXPECT_EQ(engine.engine->GetSpeculativeStats().standard_fallback_steps, 1u);
+  EXPECT_EQ(engine.engine->GetSpeculativeStats().mtp_failures, 1u);
 
   // The next step drafts again from the restored shadow.
   ASSERT_GT(engine.engine->Run(storage), 0u);
@@ -2580,7 +2581,7 @@ TEST_F(EngineRunTest, PersistentMtpFailureKeepsTheRequestAdvancing) {
   engine.mtp_cache->ThrowPlanningBadAllocAlways();
   std::array<EngineEvent, 8> storage;
   int64_t previous_length = request->Snapshot().current_sequence_length;
-  constexpr int kSteps = 4;
+  constexpr int kSteps = 5;
   for (int step = 0; step < kSteps; ++step) {
     const size_t count = engine.engine->Run(storage);
     ASSERT_EQ(count, 1u);
@@ -2591,8 +2592,9 @@ TEST_F(EngineRunTest, PersistentMtpFailureKeepsTheRequestAdvancing) {
     previous_length = length;
     EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
   }
-  EXPECT_EQ(engine.engine->GetSpeculativeStats().standard_fallback_steps,
-            static_cast<size_t>(kSteps));
+  EXPECT_EQ(engine.engine->GetSpeculativeStats().standard_fallback_steps, 3u);
+  EXPECT_EQ(engine.engine->GetSpeculativeStats().mtp_failures, 3u);
+  EXPECT_EQ(engine.mtp_cache->plan_step_resources_calls, 3);
 }
 
 TEST_F(EngineRunTest, ContinuationDropsTheMtpShadowFromThePreviousTurn) {
@@ -2639,6 +2641,27 @@ TEST_F(EngineRunTest, CancelDropsTheMtpShadow) {
   ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
 
   EXPECT_TRUE(request->Cancel(request->CurrentTurnId()));
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 0u);
+}
+
+TEST_F(EngineRunTest, MtpCleanupFailureLeavesCancellationRetryable) {
+  model_ = LoadSyntheticPagedMtpModel();
+  const int32_t eos = EosToken(*model_);
+  auto engine = MakeMtpDoublesEngine(model_, eos == 5 ? 6 : 5);
+  auto request = CreateRequestWithPrompt(
+      engine.engine, *model_, Prompt(10));
+
+  std::array<EngineEvent, 8> storage;
+  ASSERT_GT(engine.engine->Run(storage), 0u);
+  ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+  const uint64_t turn_id = request->CurrentTurnId();
+
+  engine.mtp_cache->ThrowDeallocateFailureOnce();
+  EXPECT_THROW(request->Cancel(turn_id), std::runtime_error);
+  EXPECT_EQ(request->Status(), RequestStatus::Active);
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+
+  EXPECT_TRUE(request->Cancel(turn_id));
   EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 0u);
 }
 

--- a/test/cpp/engine/engine_run_tests.cpp
+++ b/test/cpp/engine/engine_run_tests.cpp
@@ -2657,7 +2657,7 @@ TEST_F(EngineRunTest, MtpCleanupFailureLeavesCancellationRetryable) {
   const uint64_t turn_id = request->CurrentTurnId();
 
   engine.mtp_cache->ThrowDeallocateFailureOnce();
-  EXPECT_THROW(request->Cancel(turn_id), std::runtime_error);
+  EXPECT_THROW(request->Cancel(turn_id), std::bad_alloc);
   EXPECT_EQ(request->Status(), RequestStatus::Active);
   EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
 

--- a/test/cpp/engine/engine_test_doubles.h
+++ b/test/cpp/engine/engine_test_doubles.h
@@ -114,6 +114,7 @@ struct RecordingCacheManager : CacheManager {
   size_t ResidentRequestCount() const override { return allocated_.size(); }
 
   StepPlanningResult PlanStepResources(StepPlan& plan) const override {
+    plan_step_resources_calls++;
     if (always_throw_planning_bad_alloc_ ||
         std::exchange(throw_planning_bad_alloc_, false)) {
       throw std::bad_alloc{};
@@ -343,6 +344,7 @@ struct RecordingCacheManager : CacheManager {
 
   // Recorded call counts.
   mutable int can_allocate_calls{0};
+  mutable int plan_step_resources_calls{0};
   int allocate_calls{0};
   int deallocate_calls{0};
   int step_calls{0};

--- a/test/cpp/engine/mtp_config_tests.cpp
+++ b/test/cpp/engine/mtp_config_tests.cpp
@@ -2,13 +2,60 @@
 // Licensed under the MIT License.
 
 #include <stdexcept>
+#include <string>
 #include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
 #include "config.h"
+#include "engine/engine.h"
 
 namespace Generators::test {
+namespace {
+
+struct TensorMetadata {
+  ONNXTensorElementDataType data_type;
+  std::vector<int64_t> shape;
+};
+
+class FakeModelStateMetadata final : public ModelStateMetadata {
+ public:
+  void AddInput(std::string name, ONNXTensorElementDataType data_type,
+                std::vector<int64_t> shape) {
+    inputs_.insert_or_assign(
+        std::move(name), TensorMetadata{data_type, std::move(shape)});
+  }
+
+  void AddOutput(std::string name, ONNXTensorElementDataType data_type,
+                 std::vector<int64_t> shape) {
+    outputs_.insert_or_assign(
+        std::move(name), TensorMetadata{data_type, std::move(shape)});
+  }
+
+  bool HasInput(const std::string& name) const override { return inputs_.contains(name); }
+  bool HasOutput(const std::string& name) const override { return outputs_.contains(name); }
+  ONNXTensorElementDataType GetInputDataType(const std::string& name) const override {
+    return inputs_.at(name).data_type;
+  }
+  ONNXTensorElementDataType GetOutputDataType(const std::string& name) const override {
+    return outputs_.at(name).data_type;
+  }
+  std::vector<int64_t> GetInputShape(const std::string& name) const override {
+    return inputs_.at(name).shape;
+  }
+  std::vector<int64_t> GetOutputShape(const std::string& name) const override {
+    return outputs_.at(name).shape;
+  }
+
+ private:
+  std::unordered_map<std::string, TensorMetadata> inputs_;
+  std::unordered_map<std::string, TensorMetadata> outputs_;
+};
+
+}  // namespace
 
 TEST(MtpDecoderConfigTest, ProjectsPagedDecoderWithoutMainFixedState) {
   Config config;
@@ -139,6 +186,38 @@ TEST(MtpDecoderConfigTest, RejectsInvalidConfiguration) {
 
   config.model.decoder.hidden_size = 0;
   expect_error("model.decoder.hidden_size must be positive");
+}
+
+TEST(MtpDecoderConfigTest, ValidatesMainAndHeadHiddenStateContract) {
+  Config config;
+  config.model.decoder.hidden_size = 2048;
+  config.model.mtp.main_hidden_states = "main_hidden";
+  config.model.mtp.inputs.hidden_states = "head_hidden";
+
+  FakeModelStateMetadata target;
+  target.AddOutput("main_hidden", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+                   {-1, 2048});
+  FakeModelStateMetadata head;
+  head.AddInput("head_hidden", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+                {-1, 2048});
+  EXPECT_NO_THROW(ValidateMtpModelCompatibility(config, target, head));
+
+  config.model.mtp.main_hidden_states = "missing";
+  EXPECT_THROW(ValidateMtpModelCompatibility(config, target, head),
+               std::runtime_error);
+  config.model.mtp.main_hidden_states = "main_hidden";
+
+  FakeModelStateMetadata wrong_width;
+  wrong_width.AddInput("head_hidden", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+                       {-1, 1024});
+  EXPECT_THROW(ValidateMtpModelCompatibility(config, target, wrong_width),
+               std::runtime_error);
+
+  FakeModelStateMetadata wrong_type;
+  wrong_type.AddInput("head_hidden", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
+                      {-1, 2048});
+  EXPECT_THROW(ValidateMtpModelCompatibility(config, target, wrong_type),
+               std::runtime_error);
 }
 
 }  // namespace Generators::test


### PR DESCRIPTION
## Description

Adds the DFlash2 block-drafter runtime to the paged batch engine on top of #2495. The target decoder exposes packed auxiliary hidden states, and the drafter ingests committed rows into its own bounded sliding-window KV cache before proposing a coherent token path through the exported candidate lattice.

This replaces #2460 while excluding builder changes already covered by #2487/#2489, diagnostics churn, unsafe mixed-checkpoint experiments, and ONNX Runtime dependency changes.

## Summary of Changes

### Packed target output

- Binds an optional packed `aux_hidden_states` decoder output sized to the active token rows.
- Forwards the output through hybrid decoder IO and scheduled requests without capturing dense recurrent checkpoints.
- Rejects CUDA graph capture for this dynamically sized intermediate output.

### DFlash2 drafter

- Parses runtime-only `model.dflash2` session, geometry, tensor-name, and sliding-window configuration.
- Creates the DFlash2 session before sizing the target cache so its fixed batch-scaled footprint is included in available-memory accounting.
- Maintains a bounded per-request paged KV ring and releases its blocks with request teardown.
- Packs committed context and query-block rows into one drafter execution and walks the candidate/edge-score lattice greedily.

### Engine integration

- Drops hidden-state rows for rejected target drafts before feeding the drafter.
- Proposes only for eligible greedy requests within per-request and maximum-length draft limits.
- Captures feed metadata before request commit clears accepted-prefix counters, then publishes drafts after the target/MTP transaction commits.
- Records DFlash2 forward passes in the shared speculative telemetry.

## Testing

- `build/Linux/Debug/unit_tests` (238 passed, 22 skipped)
- `build/Linux/Debug/engine_unit_tests` (295/295 passed)
- `cmake --build build/Linux/Debug` (passed)
- Added 6 focused tests for DFlash2 geometry validation, config projection, exact KV bytes, bounded ring sizing, and rejection of unbounded cache pools.

### Performance validation

Measured on one NVIDIA H200 with the CUDA Release build from stack head `dabb4103`, ORT CUDA 1.30.0, compact-final native-GDN artifacts, `K=7`, 1,024 generated tokens, CUDA graphs off, 2 warmups, and 3 measured runs:

| Prompt tokens | MTP decode tokens/s | DFlash2 decode tokens/s | DFlash2/MTP |
|---:|---:|---:|---:|
| 512 | 139.92 | 166.40 | 1.189x |
| 2,048 | 138.59 | 155.92 | 1.125x |
| 8,192 | 111.26 | 129.43 | 1.163x |

DFlash2's geometric-mean decode speedup was **1.159x (+15.89%)**. Its evaluated-draft acceptance was 75.13%, 74.60%, and 72.86% respectively. All measured runs produced deterministic output hashes and speculative counters, with no dense-checkpoint compatibility warnings.

## Dependencies

- Based on #2495.
- Uses auxiliary hidden-state exporter support from #2487/#2489 when producing models; builder code is not duplicated here.
- Does not require an ONNX Runtime package or submodule bump.

## Checklist

- [x] Focused unit coverage added
- [x] Full C++ and engine suites pass
- [x] No dense recurrent checkpoints
- [x] No ONNX Runtime dependency bump
- [x] Real-model DFlash2 proposal and throughput validation