### PR TITLE
Bind resident fixed state directly

### DIFF
--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -106,7 +106,7 @@ When an explicit manifest is present, model loading resolves each group's decode
 
 The dynamic Engine requires exactly one `paged_kv` group. It allocates cache tensors only for that group's logical layer IDs, expands their exact binding names without renumbering, derives the cache dtype from the first validated key input, and sizes an automatic block pool using the number of participating full-attention layers after reserving storage for participating sliding-window layers. Every configured sliding-window layer must belong to the paged group. Multiple paged groups are rejected because the Engine currently owns one shared paged pool. The synthesized legacy group preserves dense sequential behavior when no explicit manifest exists.
 
-`fixed_conv` and `fixed_recurrent` groups may accompany the required `paged_kv` group. `ValidateDynamicEngineCompatibility` accepts them (it still rejects any configuration without exactly one `paged_kv` group), and `PagedCacheManager` constructs a `FixedStatePool` with `max_batch_size` slots when at least one fixed group is present. The composite manager reserves, stages, and commits fixed slots together with the paged blocks (see "Fixed request-state pools" below), while `HybridDecoderIO` binds their gathered inputs and staged outputs alongside the packed variable-length inputs. Expanded fixed bindings must resolve to real session inputs and outputs; the pool rejects absent or incompatible bindings.
+`fixed_conv` and `fixed_recurrent` groups may accompany the required `paged_kv` group. `ValidateDynamicEngineCompatibility` accepts them (it still rejects any configuration without exactly one `paged_kv` group), and `PagedCacheManager` constructs a `FixedStatePool` with `max_batch_size` slots when at least one fixed group is present. The composite manager reserves and commits fixed slots together with the paged blocks (see "Fixed request-state pools" below), while `HybridDecoderIO` binds either direct bank views or gathered/staged fallback tensors alongside the packed variable-length inputs. Expanded fixed bindings must resolve to real session inputs and outputs; the pool rejects absent or incompatible bindings.
 
 Fixed state currently requires `engine.dynamic_batching`; static batching is rejected because
 `StaticBatchDecoderIO` does not own request-indexed fixed-state bindings.
@@ -389,7 +389,11 @@ The paged sub-reservation:
 
 Reservation is all-or-nothing. If all planned blocks cannot be reserved, the engine treats that as an execution contract failure because planning had already declared the step executable.
 
-The fixed sub-reservation, when present, admits the same rows in the same order. A request that already owns a committed fixed slot keeps it; every other request is admitted provisionally into a free slot. The reservation gathers each row's committed (or zeroed, for a new admission) state into a contiguous model input and allocates a separate staged output tensor. Its `target_tokens` mirror the paged `target_cache_slots`, so both states commit at one token boundary. `StepPlan::fixed_state` records the fixed row count, new-slot count, and staging bytes; `Engine::StepDynamic()` then proves the reservation matches that plan exactly -- required flag, row count, new-slot count, staging bytes, and per-row request identity -- and fails fatally on any mismatch. A composite reservation wraps exactly one paged reservation and the Engine holds at most one at a time, so the paged split-commit contract (its constructor reserves its own `committed_tables_` headroom, and the pool permits a single live reservation) holds without any cross-reservation aggregate check.
+The fixed sub-reservation, when present, admits the same rows in the same order. A request that already owns a committed fixed slot keeps it; every other request is admitted provisionally into a free slot. After resource selection and token-budget assignment, an all-resident batch is ordered by fixed slot before packed offsets are calculated. When those slots form a contiguous interval, the pool normalizes any minority bank rows to a canonical active bank, then binds that bank interval directly as model input and the corresponding inactive-bank interval as model output. New admissions and fragmented intervals retain the gather/output staging fallback. Free slots have no visible bank, so admission aligns their bank selector with a coherent resident cohort; this prevents stale parity from a previous owner from unnecessarily disabling the next direct reservation.
+
+Physical execution ordering does not change ready-notification ordering. Each row retains its logical scheduler rank, and the Engine restores that order when it publishes ready requests after the transaction commits.
+
+The fixed `target_tokens` mirror the paged `target_cache_slots`, so both states commit at one token boundary. `StepPlan::fixed_state` records the fixed row count, new-slot count, and binding footprint; `Engine::StepDynamic()` then proves the reservation matches that plan exactly -- required flag, row count, new-slot count, bytes, and per-row request identity -- and fails fatally on any mismatch. A composite reservation wraps exactly one paged reservation and the Engine holds at most one at a time, so the paged split-commit contract (its constructor reserves its own `committed_tables_` headroom, and the pool permits a single live reservation) holds without any cross-reservation aggregate check.
 
 While the reservation is active, decoder input preparation can view a combined block table containing:
 
@@ -418,7 +422,7 @@ On the transactional dynamic path, `PagedCacheManager::PrepareStep()` updates th
 
 The physical key and value cache tensors are long-lived. What changes per step is the block table that maps each request's logical sequence blocks to physical cache blocks.
 
-`ExecutionContext` also exposes the fixed slot handles, staged bindings, and staging-byte count in the exact scheduled request order. `HybridDecoderIO` adopts the complete `VarlenDecoderIO` contract and appends these fixed bindings without changing packed token order or logits processing.
+`ExecutionContext` also exposes the fixed slot handles, state bindings, and binding-byte count in the exact scheduled request order. `HybridDecoderIO` adopts the complete `VarlenDecoderIO` contract and appends these fixed bindings without changing packed token order or logits processing.
 
 ### 8. Pack variable-length model inputs
 
@@ -501,7 +505,7 @@ Requests that appended a token or became complete are placed in a staged ready l
 
 The commit order in `Engine::StepDynamic()` is deliberate:
 
-1. Prepare the reservation: validate every ownership and capacity precondition of both sub-reservations and copy each fixed staged output into its slot's inactive persistent bank, synchronizing without publishing anything. This is the last step that performs fallible device work, and a failure here is fatal even though committed state is intact, because a partially written inactive bank cannot be proven consistent for a retry. The publish steps below do only host-side work; they can still throw on a state-machine misuse (for example a double publish), and the Engine treats any such throw as fatal too.
+1. Prepare the reservation: validate every ownership and capacity precondition of both sub-reservations. A fallback reservation copies each fixed staged output into its slot's inactive persistent bank. A direct reservation has already written full-step outputs there; if speculative verification keeps only a prefix, compact replay reconstructs the accepted state from the untouched active bank into that same inactive bank. Preparation synchronizes without publishing anything. This is the last step that performs fallible device work, and a failure here is fatal even though committed state is intact, because a partially written inactive bank cannot be proven consistent for a retry. The publish steps below do only host-side work; they can still throw on a state-machine misuse (for example a double publish), and the Engine treats any such throw as fatal too.
 2. Commit the request search checkpoints and sampler checkpoint.
 3. Publish the reservation: paged occupancy first, then the fixed bank flip.
 4. Commit each request's lightweight bookkeeping.
@@ -569,7 +573,7 @@ Rollback performs both parts:
 
 After a successful rollback, committed request state and committed cache state match the state before the step began. The caller receives an `EngineStepError` with either `RetryableBatchAbort` or `ExecutionCapacityExceeded`, and the engine remains healthy. Calling `Step()` again with unchanged memory availability and workload composition may produce the same capacity failure.
 
-The model may have written data into reserved cache memory and into fixed output staging before the failure. Discard is safe because neither was published as committed ownership or state: reserved blocks were never added to committed block tables, and staged fixed outputs were never copied into a slot's active bank. Future users overwrite that storage before treating it as valid.
+The model may have written data into reserved cache memory and into fixed output staging or an inactive direct bank before the failure. Discard is safe because neither was published as committed ownership or state: reserved blocks were never added to committed block tables, and the fixed active bank was never changed. Future users overwrite that storage before treating it as valid.
 
 ### Fatal failure
 
@@ -718,14 +722,15 @@ that is not discoverable as committed ownership until commit. There is no separa
 allocation surface.
 
 A reservation accepts requests in scheduled row order and exposes ordered handles,
-bindings, and target tokens. It gathers each resident row from the slot's active
-persistent bank and each freshly admitted row from a single reusable zeroed row,
-into contiguous model inputs, and allocates distinct staged output tensors. It
-never binds an output over committed state. All host validation and slot planning
-complete before any device copy is enqueued; once gather copies are in flight the
-pool synchronizes before returning, and a failure drains the device and marks the
-pool unhealthy without leaving partially mutated slots. The reservation reports its
-`PlannedStagingBytes` (gather plus staged output) up front.
+bindings, and target tokens. A contiguous resident interval binds its active bank
+directly as model input and its inactive bank as model output. If resident banks
+differ, the pool first copies only minority rows into a canonical bank and changes
+their selectors after synchronization; this representation-only normalization does
+not advance request state. New admissions and fragmented intervals gather committed
+or zero state into contiguous model inputs and use distinct staged outputs. No path
+binds an output over visible committed state. The reservation reports its input/output
+binding footprint through the retained `PlannedStagingBytes` API; direct views overlap
+storage already counted by `PersistentBytes`.
 
 Every tensor is backed by two persistent `[capacity, row...]` banks, and each slot
 records which bank is currently active (holds its visible committed state). This
@@ -739,11 +744,13 @@ and then publish them at a single infallible boundary:
   left it (ownership, identity, generation, and reservation id), that publishing it
   cannot overflow a generation, and that no row regresses below its slot's
   `committed_tokens`.
-- **`PrepareCommit()`** is the fallible device-staging phase: it re-validates, then
-  copies each staged output row into the slot's **inactive** bank and synchronizes.
-  The active (visible) bank is never touched, so a failure leaves committed state
-  exactly as it was; it drains the device and marks the pool unhealthy because the
-  inactive banks may be left partially written. The reservation becomes `Prepared`.
+- **`PrepareCommit()`** is the fallible device-completion phase: it re-validates,
+  copies fallback outputs into the **inactive** bank, or replays a partially accepted
+  compact update over a direct output, and synchronizes. A fully accepted direct
+  output needs no state copy. The active (visible) bank is never touched, so a
+  failure leaves committed state exactly as it was; it drains the device and marks
+  the pool unhealthy because the inactive banks may be left partially written. The
+  reservation becomes `Prepared`.
 - **`PublishCommit()`** is `noexcept` and performs no fallible or device work: it
   flips each slot to its freshly written bank, advances `state_generation`, sets
   `committed_tokens` to the row's `target_tokens`, and publishes provisional
@@ -759,10 +766,11 @@ consistent but cannot prove the inactive banks are whole), and `Discard()` on a
 failed reservation is a no-op.
 
 Only one reservation is live at a time. A reservation holds the pool's
-single-reservation lock and its gather/output staging memory for its whole
+single-reservation lock and its input/output binding backing for its whole
 lifetime, and both are released when the reservation object is destroyed (an
-uncommitted or prepared reservation also discards itself then). `ActiveStagingBytes`
-therefore tracks the live reservation. The caller admits the next batch by letting
+uncommitted or prepared reservation also discards itself then). The retained
+`ActiveStagingBytes` API tracks the live binding footprint, which overlaps persistent
+banks for a direct reservation. The caller admits the next batch by letting
 the previous reservation go out of scope after committing or discarding it; a
 committed reservation's accessors stay valid until then because they read
 reservation-owned storage.
@@ -774,7 +782,7 @@ slot's inactive bank is only ever written (never read) before it becomes active,
 the persistent banks never need construction-time zeroing. The pool therefore does
 not zero on release, and does not zero gather or staged tensors. It reports its
 persistent bytes (both state banks and both staging buffers), reusable zeroing scratch bytes, and
-the active reservation's viewed gather/output staging bytes separately. The two-bank design trades roughly double
+the active reservation's input/output binding footprint separately. The two-bank design trades roughly double
 the persistent footprint for a publish that is a host-only bank flip with no device
 copy, which is what lets `PublishCommit()` be `noexcept`.
 
@@ -786,13 +794,14 @@ reserves both, `PrepareCommit()`/`Commit()` stage and publish both, and
 removal and abandoned-request reclamation release a request's fixed slot together with its paged
 blocks; a completed turn remains resident until one of those lifecycle events. `HybridDecoderIO` composes the packed
 `VarlenDecoderIO` inputs and logits handling with the reservation's fixed input and
-staged output bindings. Fixed-state models execute eagerly because packed position and
+output bindings. Fixed-state models execute eagerly because packed position and
 transaction-scoped state bindings are not yet part of the CUDA graph compatibility contract.
 
 The pool allocates capacity-sized gather and output staging buffers at construction, before paged
-KV auto-sizing queries available memory. Each reservation creates exact-row tensor views over that
-storage. This keeps per-step staging inside the model's memory budget and prevents a planned step
-from failing later because its fixed-state device buffers could not be allocated.
+KV auto-sizing queries available memory. Fallback reservations create exact-row tensor views over
+that storage; eligible resident reservations instead view exact intervals of the persistent banks.
+This keeps fallback staging inside the model's memory budget and prevents a planned step from
+failing later because its fixed-state device buffers could not be allocated.
 
 Fixed slots and paged block tables each maintain a preallocated flat request index. Ownership
 publication updates these indexes without allocation, while planning resolves every resident and

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -510,6 +510,25 @@ StepPlanningResult PagedCacheManager::PlanStepResources(StepPlan& plan) const {
   return result;
 }
 
+void PagedCacheManager::OrderStepForExecution(StepPlan& plan) const {
+  if (!fixed_state_pool_ ||
+      std::any_of(plan.requests.begin(), plan.requests.end(),
+                  [](const RequestStepPlan& entry) { return entry.newly_admitted; })) {
+    return;
+  }
+
+  std::sort(plan.requests.begin(), plan.requests.end(),
+            [this](const RequestStepPlan& left, const RequestStepPlan& right) {
+              const auto left_state = fixed_state_pool_->CommittedState(left.request_id);
+              const auto right_state = fixed_state_pool_->CommittedState(right.request_id);
+              if (!left_state || !right_state) {
+                throw StepPlanningConsistencyError(
+                    "Cannot order a resident batch with missing fixed state.");
+              }
+              return left_state->handle.slot < right_state->handle.slot;
+            });
+}
+
 std::unique_ptr<CacheStepReservation> PagedCacheManager::ReserveStep(const StepPlan& plan) {
   return std::make_unique<CompositeCacheStepReservation>(
       *key_value_cache_, fixed_state_pool_.get(), cache_allocated_requests_, plan);

--- a/src/engine/cache_manager.h
+++ b/src/engine/cache_manager.h
@@ -95,6 +95,10 @@ struct CacheManager {
     throw std::logic_error("Cache manager does not support transactional step planning.");
   }
 
+  // Reorders already-selected and budgeted rows for execution without changing request
+  // admission or per-request token budgets.
+  virtual void OrderStepForExecution(StepPlan&) const {}
+
   virtual std::unique_ptr<CacheStepReservation> ReserveStep(const StepPlan&) {
     throw std::logic_error("Cache manager does not support transactional reservation.");
   }
@@ -177,6 +181,8 @@ struct PagedCacheManager : CacheManager {
   }
 
   StepPlanningResult PlanStepResources(StepPlan& plan) const override;
+
+  void OrderStepForExecution(StepPlan& plan) const override;
 
   std::unique_ptr<CacheStepReservation> ReserveStep(const StepPlan& plan) override;
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -451,6 +451,23 @@ std::shared_ptr<Request> Engine::StepDynamic() {
           staged_ready_requests_.push_back(request);
         }
       }
+      std::sort(staged_ready_requests_.begin(), staged_ready_requests_.end(),
+                [this](const std::shared_ptr<Request>& left,
+                       const std::shared_ptr<Request>& right) {
+                  const auto scheduling_order = [this](const Request* request) {
+                    const auto entry = std::find_if(
+                        step_plan_.requests.begin(), step_plan_.requests.end(),
+                        [request](const RequestStepPlan& candidate) {
+                          return candidate.request_id == request;
+                        });
+                    if (entry == step_plan_.requests.end()) {
+                      throw std::logic_error(
+                          "Ready request is absent from the committed step plan.");
+                    }
+                    return entry->scheduling_order;
+                  };
+                  return scheduling_order(left.get()) < scheduling_order(right.get());
+                });
     } catch (...) {
       const auto post_processing_error = std::current_exception();
       rollback_transaction();

--- a/src/engine/fixed_state_pool.cpp
+++ b/src/engine/fixed_state_pool.cpp
@@ -135,7 +135,7 @@ struct FixedStateReservation::Storage {
   std::vector<bool> provisional;
   std::vector<uint64_t> expected_state_generations;
   std::vector<uint64_t> target_tokens;
-  std::vector<std::shared_ptr<OrtValue>> staging_backing;
+  std::vector<std::shared_ptr<OrtValue>> binding_backing;
   std::vector<size_t> capture_counts;
   std::vector<std::unique_ptr<OrtValue>> gathered_inputs;
   std::vector<std::unique_ptr<OrtValue>> staged_outputs;
@@ -155,6 +155,7 @@ struct FixedStateReservation::Storage {
   std::vector<FixedStateBinding> bindings;
   size_t staging_bytes{};
   bool captures_state_updates{};
+  bool uses_direct_bindings{};
 };
 
 struct FixedStatePool::Impl {
@@ -188,7 +189,7 @@ struct FixedStatePool::Impl {
     // Two persistent [capacity, row...] banks per tensor. Each slot reads its currently active bank
     // and a commit stages into the inactive bank, so publish is a bank flip with no device work and
     // a failed prepare cannot corrupt the visible (active) state. See PrepareCommit/PublishCommit.
-    std::array<std::unique_ptr<OrtValue>, 2> banks;
+    std::array<std::shared_ptr<OrtValue>, 2> banks;
     std::unique_ptr<OrtValue> zero_row;  // [1, row...] reusable zeroed gather source.
     // Capacity-sized backing storage shared by the single live reservation. Reservations expose
     // exact-row tensor views over these buffers, so staging allocation is paid before paged KV
@@ -401,6 +402,10 @@ size_t FixedStateReservation::NewSlotCount() const {
 
 bool FixedStateReservation::CapturesStateUpdates() const {
   return storage_ && storage_->captures_state_updates;
+}
+
+bool FixedStateReservation::UsesDirectBindings() const {
+  return storage_ && storage_->uses_direct_bindings;
 }
 
 void FixedStateReservation::CommitPrefix(size_t row, size_t step_tokens, size_t kept_tokens) {
@@ -728,9 +733,9 @@ size_t FixedStatePool::ActiveStagingBytes() const {
 }
 
 size_t FixedStatePool::PlannedStagingBytes(size_t row_count, bool captures_state_updates) const {
-  // One gather input and one staged output per fixed tensor, each `row_count` rows wide, plus the
-  // compact capture buffers when the step requests them. This mirrors the accumulation in Reserve()
-  // so the plan and the resulting reservation agree exactly.
+  // One input and one output binding per fixed tensor, each `row_count` rows wide, plus compact
+  // capture buffers when requested. Direct views overlap persistent banks; the byte footprint stays
+  // geometry-only so the plan and reservation agree before eligibility is determined.
   size_t bytes = 0;
   if (impl_->state_update_capacity != 0) {
     bytes = CheckedAdd(
@@ -899,6 +904,83 @@ FixedStateReservation FixedStatePool::Reserve(
     plan.push_back(row);
   }
 
+  // A free slot's bank selector has no visible meaning. Align every provisional row with a
+  // coherent resident cohort so their first joint commit leaves all rows on the same bank and the
+  // next reservation can use direct bindings. When there are no residents, choose bank zero as the
+  // canonical starting point so reused free slots do not inherit stale parity from prior owners.
+  std::optional<uint8_t> admission_active_bank;
+  bool mixed_resident_banks = false;
+  for (const auto& row : plan) {
+    if (row.provisional) {
+      continue;
+    }
+    const uint8_t active_bank = impl_->slots[row.slot_index].active_bank;
+    if (!admission_active_bank) {
+      admission_active_bank = active_bank;
+    } else if (*admission_active_bank != active_bank) {
+      mixed_resident_banks = true;
+      break;
+    }
+  }
+  const uint8_t provisional_active_bank =
+      mixed_resident_banks ? 0 : admission_active_bank.value_or(0);
+
+  // A contiguous resident interval can bind directly after all rows use the same active bank.
+  // Normalize only minority rows by copying their visible state to the cohort's canonical bank.
+  // The copy does not advance request state: both banks contain the same committed value, and the
+  // host bank selector changes only after every copy completes successfully.
+  bool direct_layout = true;
+  const size_t first_direct_slot = plan.front().slot_index;
+  size_t bank_one_count = 0;
+  for (size_t row = 0; row < plan.size(); ++row) {
+    direct_layout &= !plan[row].provisional &&
+                     plan[row].slot_index == first_direct_slot + row;
+    if (!plan[row].provisional) {
+      bank_one_count += impl_->slots[plan[row].slot_index].active_bank;
+    }
+  }
+  uint8_t direct_active_bank = 0;
+  if (direct_layout) {
+    const size_t bank_zero_count = plan.size() - bank_one_count;
+    direct_active_bank = bank_one_count > bank_zero_count
+                             ? 1
+                         : bank_zero_count > bank_one_count
+                             ? 0
+                             : impl_->slots[first_direct_slot].active_bank;
+    bool normalization_enqueued = false;
+    try {
+      for (const auto& spec : impl_->tensors) {
+        for (const auto& row : plan) {
+          const auto& slot = impl_->slots[row.slot_index];
+          if (slot.active_bank == direct_active_bank) {
+            continue;
+          }
+          auto destination = ByteWrapTensor(
+                                 *impl_->device, *spec.banks[direct_active_bank])
+                                 .subspan(row.slot_index * spec.row_bytes, spec.row_bytes);
+          const auto source =
+              ByteWrapTensor(*impl_->device, *spec.banks[slot.active_bank])
+                  .subspan(row.slot_index * spec.row_bytes, spec.row_bytes);
+          destination.CopyFrom(source);
+          normalization_enqueued = true;
+        }
+      }
+      if (normalization_enqueued) {
+        impl_->device->Synchronize();
+        for (const auto& row : plan) {
+          impl_->slots[row.slot_index].active_bank = direct_active_bank;
+        }
+      }
+    } catch (...) {
+      impl_->healthy = false;
+      try {
+        impl_->device->Synchronize();
+      } catch (...) {
+      }
+      throw;
+    }
+  }
+
   // Phase 2: allocate staging tensors and record binding metadata (host allocations only).
   auto storage = std::make_unique<FixedStateReservation::Storage>();
   storage->model_keepalive = impl_->model;
@@ -906,7 +988,7 @@ FixedStateReservation FixedStatePool::Reserve(
   storage->provisional.resize(requests.size());
   storage->expected_state_generations.resize(requests.size());
   storage->target_tokens.resize(requests.size());
-  storage->staging_backing.reserve(impl_->tensors.size() * 2);
+  storage->binding_backing.reserve(impl_->tensors.size() * 2);
   storage->capture_counts.resize(requests.size());
   storage->commit_step_tokens.assign(requests.size(), 0);
   storage->commit_kept_tokens.assign(requests.size(), 0);
@@ -921,6 +1003,7 @@ FixedStateReservation FixedStatePool::Reserve(
   storage->bindings.reserve(impl_->tensors.size());
 
   const size_t batch_rows = requests.size();
+  storage->uses_direct_bindings = direct_layout;
   if (impl_->state_update_capacity != 0) {
     storage->state_update_capture_count_name = impl_->state_update_capture_count_name;
     const std::array<int64_t, 1> capture_count_shape{static_cast<int64_t>(batch_rows)};
@@ -947,16 +1030,31 @@ FixedStateReservation FixedStatePool::Reserve(
     const auto shape = StorageShape(batch_rows, spec.session_shape);
     const size_t tensor_bytes = CheckedMultiply(
         batch_rows, spec.row_bytes, "staging tensor view");
+    OrtValue* input_backing =
+        storage->uses_direct_bindings
+            ? spec.banks[direct_active_bank].get()
+            : spec.gathered_staging.get();
+    OrtValue* output_backing =
+        storage->uses_direct_bindings
+            ? spec.banks[direct_active_bank ^ 1u].get()
+            : spec.output_staging.get();
+    const size_t byte_offset =
+        storage->uses_direct_bindings ? first_direct_slot * spec.row_bytes : 0;
     auto gathered = OrtValue::CreateTensor(
-        spec.gathered_staging->GetTensorMemoryInfo(),
-        spec.gathered_staging->GetTensorMutableData<void>(),
+        input_backing->GetTensorMemoryInfo(),
+        static_cast<uint8_t*>(input_backing->GetTensorMutableData<void>()) + byte_offset,
         tensor_bytes, shape, spec.data_type);
     auto staged = OrtValue::CreateTensor(
-        spec.output_staging->GetTensorMemoryInfo(),
-        spec.output_staging->GetTensorMutableData<void>(),
+        output_backing->GetTensorMemoryInfo(),
+        static_cast<uint8_t*>(output_backing->GetTensorMutableData<void>()) + byte_offset,
         tensor_bytes, shape, spec.data_type);
-    storage->staging_backing.push_back(spec.gathered_staging);
-    storage->staging_backing.push_back(spec.output_staging);
+    if (storage->uses_direct_bindings) {
+      storage->binding_backing.push_back(spec.banks[direct_active_bank]);
+      storage->binding_backing.push_back(spec.banks[direct_active_bank ^ 1u]);
+    } else {
+      storage->binding_backing.push_back(spec.gathered_staging);
+      storage->binding_backing.push_back(spec.output_staging);
+    }
     FixedStateReservation::Storage::StateUpdateTensors state_updates;
     const auto allocate_update_output = [&](const Impl::StateUpdateOutputSpec& output) {
       if (!capture_state_updates || output.name.empty()) {
@@ -1050,17 +1148,19 @@ FixedStateReservation FixedStatePool::Reserve(
       }
       capture_count_span.CopyCpuToDevice();
     }
-    for (size_t tensor_index = 0; tensor_index < impl_->tensors.size();
-         ++tensor_index) {
-      const auto& spec = impl_->tensors[tensor_index];
-      auto& gathered = *storage->gathered_inputs[tensor_index];
-      for (size_t row = 0; row < plan.size(); ++row) {
-        if (plan[row].provisional) {
-          impl_->GatherZeroRow(spec, row, gathered);
-        } else {
-          impl_->GatherResidentRow(spec, plan[row].slot_index,
-                                   impl_->slots[plan[row].slot_index].active_bank,
-                                   row, gathered);
+    if (!storage->uses_direct_bindings) {
+      for (size_t tensor_index = 0; tensor_index < impl_->tensors.size();
+           ++tensor_index) {
+        const auto& spec = impl_->tensors[tensor_index];
+        auto& gathered = *storage->gathered_inputs[tensor_index];
+        for (size_t row = 0; row < plan.size(); ++row) {
+          if (plan[row].provisional) {
+            impl_->GatherZeroRow(spec, row, gathered);
+          } else {
+            impl_->GatherResidentRow(spec, plan[row].slot_index,
+                                     impl_->slots[plan[row].slot_index].active_bank,
+                                     row, gathered);
+          }
         }
       }
     }
@@ -1088,6 +1188,7 @@ FixedStateReservation FixedStatePool::Reserve(
     slot.state_generation = 0;
     slot.committed_tokens = 0;
     slot.reservation_id = reservation_id;
+    slot.active_bank = provisional_active_bank;
     slot.ownership = FixedStateSlotOwnership::Reserved;
   }
 
@@ -1249,8 +1350,10 @@ void FixedStatePool::PrepareCommit(FixedStateReservation& reservation) {
         const uint8_t inactive_bank = slot.active_bank ^ 1u;
         const size_t kept_tokens = storage.commit_kept_tokens[row];
         if (kept_tokens == 0 || kept_tokens == storage.commit_step_tokens[row]) {
-          impl_->StageRowIntoInactiveBank(
-              spec, storage.handles[row].slot, inactive_bank, row, staged);
+          if (!storage.uses_direct_bindings) {
+            impl_->StageRowIntoInactiveBank(
+                spec, storage.handles[row].slot, inactive_bank, row, staged);
+          }
           continue;
         }
 

--- a/src/engine/fixed_state_pool.h
+++ b/src/engine/fixed_state_pool.h
@@ -137,6 +137,8 @@ class FixedStateReservation {
   size_t PlannedStagingBytes() const;
   size_t NewSlotCount() const;
   bool CapturesStateUpdates() const;
+  // True when model inputs and outputs view the active and inactive persistent banks directly.
+  bool UsesDirectBindings() const;
   void CommitPrefix(size_t row, size_t step_tokens, size_t kept_tokens);
 
   // Commit is split into three phases so a composite Engine transaction can validate and stage all
@@ -192,11 +194,12 @@ class FixedStatePool {
   size_t CommittedSlotCount() const;
   size_t PersistentBytes() const;
   size_t ZeroingScratchBytes() const;
+  // Retained staging API reports the live input/output binding footprint. Direct bank views overlap
+  // PersistentBytes(); fallback and compact-update buffers use dedicated storage.
   size_t ActiveStagingBytes() const;
-  // Gather+output staging bytes a reservation of `row_count` scheduled rows will view. A pure
-  // function of the pool's tensor geometry, so composite step planning can size the transaction
-  // before the reservation exists; it equals the resulting reservation's PlannedStagingBytes() for
-  // a reservation whose rows request compact captures iff `captures_state_updates` is set.
+  // Input/output binding footprint for `row_count` scheduled rows, plus compact capture storage
+  // when requested. A pure function of tensor geometry, so composite planning can verify the
+  // reservation before its direct-binding eligibility is known.
   size_t PlannedStagingBytes(size_t row_count, bool captures_state_updates = false) const;
   bool SupportsStateUpdates() const;
   size_t StateUpdateCapacity() const;

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -268,17 +268,22 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
     throw StepPlanningConsistencyError(error.what());
   }
 
+  for (size_t index = 0; index < plan.requests.size(); ++index) {
+    auto& entry = plan.requests[index];
+    entry.scheduling_order = index;
+    entry.unprocessed_token_count = token_counts[index];
+    entry.target_cache_slots = RequiredSlots(
+        selected_processed_lengths[index],
+        entry.unprocessed_token_count);
+  }
+  cache_manager_->OrderStepForExecution(plan);
+
   // VarlenDecoderIO concatenates every request's pending tokens into one flat input. These offsets
   // describe that packed layout and identify the last logits row for each request, which is the row
   // used to sample its next token.
   size_t packed_token_offset = 0;
   plan.graph_capture_eligible = true;
-  for (size_t i = 0; i < plan.requests.size(); ++i) {
-    auto& entry = plan.requests[i];
-    entry.unprocessed_token_count = token_counts[i];
-    entry.target_cache_slots = RequiredSlots(
-        selected_processed_lengths[i],
-        entry.unprocessed_token_count);
+  for (auto& entry : plan.requests) {
     entry.packed_token_offset = packed_token_offset;
     entry.logits_row_index =
         packed_token_offset + entry.unprocessed_token_count - 1;

--- a/src/engine/step_plan.h
+++ b/src/engine/step_plan.h
@@ -62,6 +62,7 @@ struct RequestStepPlan {
   size_t whole_sequence_cache_slots{};  // KV slots the whole sequence needs; admitted and reserved on this.
   bool is_prefill{};
   bool newly_admitted{};
+  size_t scheduling_order{};  // Logical scheduler order before physical execution ordering.
 };
 
 // Fixed decoder-state demand for a step, planned atomically with the paged-block demand so the
@@ -72,7 +73,7 @@ struct FixedStateResourcePlan {
   bool required{};          // The plan needs fixed slots this step (the model has fixed groups).
   size_t row_count{};       // Fixed rows the reservation must expose, one per scheduled request.
   size_t new_slot_count{};  // Rows that admit a fresh request and consume a free fixed slot.
-  size_t staging_bytes{};   // Gather+output staging bytes the reservation must allocate.
+  size_t staging_bytes{};   // Input/output binding footprint; direct views overlap persistent banks.
 };
 
 struct StepPlan {

--- a/test/cpp/engine/engine_step_tests.cpp
+++ b/test/cpp/engine/engine_step_tests.cpp
@@ -1578,6 +1578,63 @@ TEST_F(EngineStepTest, CompositeCompletionRemovalFreesSlotForReadmission) {
   EXPECT_EQ(engine.cache->Snapshot().requests[0].request_id, second.get());
 }
 
+TEST_F(EngineStepTest, CompositeOrdersResidentRowsByFixedSlotAfterAdmission) {
+  model_ = LoadSyntheticCompositeModel();
+  auto engine = MakeCompositeDoublesEngine(model_, /*forced_token=*/5);
+  auto first = MintRequest(*model_, Prompt(10));
+  auto second = MintRequest(*model_, Prompt(20));
+  engine.engine->AddRequest(first);
+  engine.engine->AddRequest(second);
+  engine.executor->SetExecutionCallback([](ExecutionContext& context) {
+    for (size_t row = 0; row < context.fixed_state_slots.size(); ++row) {
+      for (const auto& binding : context.fixed_state_bindings) {
+        FillFixedOutputRow(binding, row, 10.0f + static_cast<float>(row));
+      }
+    }
+  });
+  EXPECT_EQ(engine.engine->Step(), first);
+  EXPECT_EQ(engine.engine->Step(), second);
+
+  auto fixed = engine.cache->FixedStateSnapshot();
+  ASSERT_TRUE(fixed.has_value());
+  ASSERT_EQ(FixedSlotFor(*fixed, first.get()).slot, 0u);
+  ASSERT_EQ(FixedSlotFor(*fixed, second.get()).slot, 1u);
+  first->Remove();
+
+  auto replacement = MintRequest(*model_, Prompt(30));
+  engine.engine->AddRequest(replacement);
+  engine.executor->SetExecutionCallback([](ExecutionContext& context) {
+    for (size_t row = 0; row < context.fixed_state_slots.size(); ++row) {
+      for (const auto& binding : context.fixed_state_bindings) {
+        FillFixedOutputRow(binding, row, 20.0f + static_cast<float>(row));
+      }
+    }
+  });
+  EXPECT_EQ(engine.engine->Step(), second);
+  EXPECT_EQ(engine.engine->Step(), replacement);
+
+  fixed = engine.cache->FixedStateSnapshot();
+  ASSERT_TRUE(fixed.has_value());
+  ASSERT_EQ(FixedSlotFor(*fixed, replacement.get()).slot, 0u);
+  ASSERT_EQ(FixedSlotFor(*fixed, second.get()).slot, 1u);
+
+  engine.executor->SetExecutionCallback(
+      [&](ExecutionContext& context) {
+        ASSERT_EQ(context.plan->fixed_state.new_slot_count, 0u);
+        ASSERT_EQ(context.plan->requests.size(), 2u);
+        EXPECT_EQ(context.plan->requests[0].request_id, replacement.get());
+        EXPECT_EQ(context.plan->requests[1].request_id, second.get());
+        EXPECT_EQ(context.fixed_state_slots[0].slot, 0u);
+        EXPECT_EQ(context.fixed_state_slots[1].slot, 1u);
+        for (const auto& binding : context.fixed_state_bindings) {
+          FillFixedOutputRow(binding, 0, 30.0f);
+          FillFixedOutputRow(binding, 1, 31.0f);
+        }
+      });
+  EXPECT_EQ(engine.engine->Step(), second);
+  EXPECT_EQ(engine.engine->Step(), replacement);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace Generators

--- a/test/cpp/engine/fixed_state_pool_tests.cpp
+++ b/test/cpp/engine/fixed_state_pool_tests.cpp
@@ -263,6 +263,7 @@ TEST_F(FixedStatePoolTest, StagedOutputsBecomeVisibleOnlyAfterCommit) {
   {
     auto requests = One(kRequestA);
     auto reservation = pool->Reserve(requests);
+    ASSERT_TRUE(reservation.UsesDirectBindings());
     for (const auto& binding : reservation.Bindings()) {
       ExpectInputRow(binding, 0, 4.0f);
       FillStagedRow(binding, 0, 9.0f);
@@ -338,6 +339,113 @@ TEST_F(FixedStatePoolTest, RepeatedCommitsAdvanceGenerationAndTokens) {
   auto requests = One(kRequestA);
   auto reservation = pool->Reserve(requests);
   ExpectInputRows(reservation, 0, 2.0f);
+}
+
+TEST_F(FixedStatePoolTest, ResidentRowsBindDirectlyAndAlternateBanks) {
+  auto pool = MakePool(2);
+  MakeResident(*pool, kRequestA, 11.0f);
+  MakeResident(*pool, kRequestB, 22.0f);
+
+  const std::array<Request, 2> requests{Request{kRequestA, 2}, Request{kRequestB, 2}};
+  void* first_input{};
+  void* first_output{};
+  {
+    auto reservation = pool->Reserve(requests);
+    ASSERT_TRUE(reservation.UsesDirectBindings());
+    ASSERT_EQ(reservation.Bindings().size(), 4u);
+    for (const auto& binding : reservation.Bindings()) {
+      ExpectInputRow(binding, 0, 11.0f);
+      ExpectInputRow(binding, 1, 22.0f);
+    }
+    first_input = reservation.Bindings()[0].input->GetTensorMutableData<void>();
+    first_output = reservation.Bindings()[0].output->GetTensorMutableData<void>();
+    EXPECT_NE(first_input, first_output);
+    FillStagedRows(reservation, 0, 33.0f);
+    FillStagedRows(reservation, 1, 44.0f);
+    reservation.Commit();
+  }
+
+  auto reservation = pool->Reserve(requests);
+  ASSERT_TRUE(reservation.UsesDirectBindings());
+  EXPECT_EQ(reservation.Bindings()[0].input->GetTensorMutableData<void>(), first_output);
+  EXPECT_EQ(reservation.Bindings()[0].output->GetTensorMutableData<void>(), first_input);
+  ExpectInputRows(reservation, 0, 33.0f);
+  ExpectInputRows(reservation, 1, 44.0f);
+}
+
+TEST_F(FixedStatePoolTest, DirectBindingsFallBackForUnsupportedRowLayouts) {
+  auto pool = MakePool(3);
+  MakeResident(*pool, kRequestA, 11.0f);
+  MakeResident(*pool, kRequestB, 22.0f);
+
+  {
+    const std::array<Request, 2> reordered{Request{kRequestB, 2}, Request{kRequestA, 2}};
+    auto reservation = pool->Reserve(reordered);
+    EXPECT_FALSE(reservation.UsesDirectBindings());
+    reservation.Discard();
+  }
+  {
+    const std::array<Request, 2> with_admission{Request{kRequestA, 2}, Request{kRequestC, 1}};
+    auto reservation = pool->Reserve(with_admission);
+    EXPECT_FALSE(reservation.UsesDirectBindings());
+    reservation.Discard();
+  }
+  {
+    auto reservation = pool->Reserve(One(kRequestA, 2));
+    ASSERT_TRUE(reservation.UsesDirectBindings());
+    FillStagedRows(reservation, 0, 33.0f);
+    reservation.Commit();
+  }
+  {
+    const std::array<Request, 2> mixed_banks{Request{kRequestA, 3}, Request{kRequestB, 2}};
+    auto reservation = pool->Reserve(mixed_banks);
+    ASSERT_TRUE(reservation.UsesDirectBindings());
+    ExpectInputRows(reservation, 0, 33.0f);
+    ExpectInputRows(reservation, 1, 22.0f);
+  }
+}
+
+TEST_F(FixedStatePoolTest, DirectBindingsSupportContiguousRowsAtNonzeroOffset) {
+  auto pool = MakePool(3);
+  const auto handle_a = MakeResident(*pool, kRequestA, 11.0f);
+  MakeResident(*pool, kRequestB, 22.0f);
+  MakeResident(*pool, kRequestC, 33.0f);
+  pool->Release(handle_a);
+
+  const std::array<Request, 2> requests{Request{kRequestB, 2}, Request{kRequestC, 2}};
+  auto reservation = pool->Reserve(requests);
+  ASSERT_TRUE(reservation.UsesDirectBindings());
+  ASSERT_EQ(reservation.Handles()[0].slot, 1u);
+  ASSERT_EQ(reservation.Handles()[1].slot, 2u);
+  ExpectInputRows(reservation, 0, 22.0f);
+  ExpectInputRows(reservation, 1, 33.0f);
+}
+
+TEST_F(FixedStatePoolTest, AdmissionAlignsReusedSlotWithResidentBank) {
+  auto pool = MakePool(2);
+  const auto handle_a = MakeResident(*pool, kRequestA, 11.0f);
+  MakeResident(*pool, kRequestB, 22.0f);
+  pool->Release(handle_a);
+  {
+    auto reservation = pool->Reserve(One(kRequestB, 2));
+    ASSERT_TRUE(reservation.UsesDirectBindings());
+    FillStagedRows(reservation, 0, 23.0f);
+    reservation.Commit();
+  }
+  {
+    const std::array<Request, 2> admission{Request{kRequestC, 1}, Request{kRequestB, 3}};
+    auto reservation = pool->Reserve(admission);
+    ASSERT_FALSE(reservation.UsesDirectBindings());
+    FillStagedRows(reservation, 0, 33.0f);
+    FillStagedRows(reservation, 1, 24.0f);
+    reservation.Commit();
+  }
+
+  const std::array<Request, 2> resident{Request{kRequestC, 2}, Request{kRequestB, 4}};
+  auto reservation = pool->Reserve(resident);
+  ASSERT_TRUE(reservation.UsesDirectBindings());
+  ExpectInputRows(reservation, 0, 33.0f);
+  ExpectInputRows(reservation, 1, 24.0f);
 }
 
 TEST_F(FixedStatePoolTest, RejectsCommitThatRegressesCommittedTokens) {
@@ -529,6 +637,7 @@ TEST_F(FixedStatePoolTest, CompactPartialAcceptanceReplaysConvAndGdn) {
   MakeResident(*pool, kRequestA, 4.0f);
   {
     auto reservation = pool->Reserve(One(kRequestA, 4, 3));
+    ASSERT_TRUE(reservation.UsesDirectBindings());
     FillStagedRows(reservation, 0, 99.0f);
     const std::array<float, 6> conv_values{10.0f, 11.0f, 20.0f, 21.0f, 30.0f, 31.0f};
     const std::array<float, 6> decay{0.5f, 0.25f, 1.0f, 0.5f, 1.0f, 1.0f};
@@ -557,6 +666,75 @@ TEST_F(FixedStatePoolTest, CompactPartialAcceptanceReplaysConvAndGdn) {
   ExpectInputRow(reservation.Bindings()[1], 0, expected_conv);
   ExpectInputRow(reservation.Bindings()[2], 0, expected_gdn);
   ExpectInputRow(reservation.Bindings()[3], 0, expected_gdn);
+}
+
+TEST_F(FixedStatePoolTest, DirectBindingsMixPartialAndFullAcceptance) {
+  auto pool = MakePool(2);
+  MakeResident(*pool, kRequestA, 4.0f);
+  MakeResident(*pool, kRequestB, 5.0f);
+  {
+    auto reservation = pool->Reserve(One(kRequestA, 2));
+    ASSERT_TRUE(reservation.UsesDirectBindings());
+    FillStagedRows(reservation, 0, 4.0f);
+    reservation.Commit();
+  }
+
+  const std::array<Request, 2> requests{
+      Request{kRequestA, 4, 3}, Request{kRequestB, 4, 3}};
+  {
+    auto reservation = pool->Reserve(requests);
+    ASSERT_TRUE(reservation.UsesDirectBindings());
+    FillStagedRows(reservation, 0, 99.0f);
+    FillStagedRows(reservation, 1, 77.0f);
+    const std::array<float, 6> conv_values{10.0f, 11.0f, 20.0f, 21.0f, 30.0f, 31.0f};
+    const std::array<float, 6> decay{0.5f, 0.25f, 1.0f, 0.5f, 1.0f, 1.0f};
+    const std::array<float, 6> key{2.0f, 3.0f, 4.0f, 5.0f, 1.0f, 1.0f};
+    const std::array<float, 12> delta{
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f,
+        7.0f, 8.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    for (const auto& binding : reservation.Bindings()) {
+      if (binding.state_update_kind ==
+          Config::Model::Decoder::StateUpdateKind::CausalConv) {
+        FillConvUpdates(binding, 0, conv_values);
+      } else {
+        FillGdnUpdates(binding, 0, decay, key, delta);
+      }
+    }
+    reservation.CommitPrefix(0, 4, 2);
+    reservation.CommitPrefix(1, 4, 4);
+    reservation.Commit();
+  }
+
+  EXPECT_EQ(pool->CommittedTokens(pool->HandleFor(kRequestA)), 2u);
+  EXPECT_EQ(pool->CommittedTokens(pool->HandleFor(kRequestB)), 4u);
+  const std::array<Request, 2> committed{
+      Request{kRequestA, 2}, Request{kRequestB, 4}};
+  auto reservation = pool->Reserve(committed);
+  ASSERT_TRUE(reservation.UsesDirectBindings());
+  const std::array<float, 6> expected_conv{4.0f, 10.0f, 20.0f, 4.0f, 11.0f, 21.0f};
+  const std::array<float, 8> expected_gdn{
+      24.0f, 30.0f, 30.0f, 38.0f, 31.5f, 40.0f, 36.5f, 46.5f};
+  ExpectInputRow(reservation.Bindings()[0], 0, expected_conv);
+  ExpectInputRow(reservation.Bindings()[2], 0, expected_gdn);
+  ExpectInputRows(reservation, 1, 77.0f);
+}
+
+TEST_F(FixedStatePoolTest, DirectBindingStorageOutlivesPool) {
+  std::optional<FixedStateReservation> reservation;
+  {
+    auto pool = MakePool(1);
+    MakeResident(*pool, kRequestA, 4.0f);
+    reservation.emplace(pool->Reserve(One(kRequestA, 2)));
+    ASSERT_TRUE(reservation->UsesDirectBindings());
+    ExpectInputRows(*reservation, 0, 4.0f);
+    FillStagedRows(*reservation, 0, 7.0f);
+  }
+
+  EXPECT_EQ(reservation->State(), FixedStateReservationState::Failed);
+  ExpectInputRows(*reservation, 0, 4.0f);
+  for (const auto& binding : reservation->Bindings()) {
+    EXPECT_FLOAT_EQ(binding.output->GetTensorData<float>()[0], 7.0f);
+  }
 }
 
 #if USE_CUDA
@@ -596,6 +774,7 @@ TEST(CudaFixedStatePoolTest, CompactPartialAcceptanceReplaysConvAndGdn) {
   }
   {
     auto reservation = pool.Reserve(One(kRequestA, 4, 3));
+    ASSERT_TRUE(reservation.UsesDirectBindings());
     for (const auto& binding : reservation.Bindings()) {
       fill_tensor_value(*binding.output, 99.0f);
     }

--- a/test/cpp/engine/scheduler_contract_tests.cpp
+++ b/test/cpp/engine/scheduler_contract_tests.cpp
@@ -29,6 +29,14 @@ std::vector<int32_t> Prompt(int32_t seed) {
   return {base, base + 1, base + 2};
 }
 
+struct ReverseExecutionOrderCacheManager : RecordingCacheManager {
+  using RecordingCacheManager::RecordingCacheManager;
+
+  void OrderStepForExecution(StepPlan& plan) const override {
+    std::reverse(plan.requests.begin(), plan.requests.end());
+  }
+};
+
 class SchedulerContractTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -120,6 +128,37 @@ TEST_F(SchedulerContractTest, DynamicPreservesRequestOrder) {
   EXPECT_EQ(plan.requests[0].request, first);
   EXPECT_EQ(plan.requests[1].request, second);
   EXPECT_EQ(plan.requests[2].request, third);
+}
+
+TEST_F(SchedulerContractTest, ExecutionOrderingPreservesAssignedTokenBudgets) {
+  auto cache = std::make_shared<ReverseExecutionOrderCacheManager>(
+      model_, /*capacity=*/8);
+  model_->config_->engine.dynamic_batching->max_scheduled_tokens = 3;
+  DynamicBatchScheduler scheduler(model_, cache);
+
+  auto first = Assigned(10);
+  auto second = Assigned(20);
+  first->Params()->search.chunk_size = 1;
+  second->Params()->search.chunk_size = 3;
+  scheduler.AddRequest(first);
+  scheduler.AddRequest(second);
+  StepPlan plan;
+
+  const auto result = scheduler.PlanStep(plan);
+
+  ASSERT_TRUE(result.executable);
+  ASSERT_EQ(plan.requests.size(), 2u);
+  EXPECT_EQ(plan.requests[0].request, second);
+  EXPECT_EQ(plan.requests[0].scheduling_order, 1u);
+  EXPECT_EQ(plan.requests[0].unprocessed_token_count, 2u);
+  EXPECT_EQ(plan.requests[0].packed_token_offset, 0u);
+  EXPECT_EQ(plan.requests[0].logits_row_index, 1u);
+  EXPECT_EQ(plan.requests[1].request, first);
+  EXPECT_EQ(plan.requests[1].scheduling_order, 0u);
+  EXPECT_EQ(plan.requests[1].unprocessed_token_count, 1u);
+  EXPECT_EQ(plan.requests[1].packed_token_offset, 2u);
+  EXPECT_EQ(plan.requests[1].logits_row_index, 2u);
+  EXPECT_EQ(plan.token_count, 3u);
 }
 
 TEST_F(SchedulerContractTest, DynamicHonorsCapacityBackpressure) {


### PR DESCRIPTION
## Summary

Add a model-agnostic zero-copy fast path for manifest-described fixed decoder state.

After request selection and token-budget assignment, all-resident rows are ordered by fixed-state slot. A contiguous interval binds its active persistent bank directly as decoder input and its inactive bank directly as decoder output. New admissions and fragmented intervals retain the existing staged fallback from #2454.

## Motivation

Qwen3.8-27B has approximately 146.8 MiB of fixed convolution and recurrent state per request. The existing path gathers and stages that entire state around every model step, moving approximately 293.6 MiB/request/step. At B8 this is approximately 2.29 GiB of state copies per decode step.

The direct path removes those copies without changing the model graph or fixed-state manifest.

## Design

- Bind only all-resident, contiguous slot intervals directly.
- Keep model inputs on the active bank and outputs on the inactive bank.
- Normalize minority resident rows to a canonical bank before binding when bank parity differs. Selectors change only after the copies synchronize successfully.
- Align provisional slots with a coherent resident cohort so reused slots do not retain stale parity.
- Preserve the existing staged fallback for admissions and fragmented intervals.
- Preserve #2454 compact replay: partial speculative acceptance replays from the untouched active bank into the inactive bank, while full acceptance publishes the model-written inactive output.
- Assign physical execution order only after token budgets are attached to requests and before packed offsets are calculated.
- Retain logical scheduler rank and restore it when publishing ready notifications.
- Retain bank allocations through reservation-owned shared backing so direct views remain valid across pool teardown.

No model-specific checks, ONNX graph changes, or `DeviceInterface` ABI changes are introduced.

## Performance

Measured on A100 80 GB with Qwen3.8-27B INT4, the same #2454-compatible model and ORT runtime, five measured runs per fixed batch:

| Batch | #2454 | Direct binding | Change |
|---:|---:|---:|---:|
| B1 | 53.32 tok/s | 56.86 tok/s | +6.6% |
| B2 | 83.41 tok/s | 91.98 tok/s | +10.3% |
| B4 | 136.00 tok/s | 160.07 tok/s | +17.7% |
| B8 | 160.88 tok/s | 194.66 tok/s | +21.0% |

An 80-request sustained workload with continuous replacement and unequal output lengths improved from 123.96 to 140.97 output tok/s (+13.7%).

All baseline and optimized runs produced identical per-request greedy token IDs.