### PR TITLE
Fix compact state configuration and staging

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -514,7 +514,6 @@ struct SharedInitializers_Element : JSON::Element {
 using DecoderStateGroup = Config::Model::Decoder::StateGroup;
 using DecoderStateGroupKind = Config::Model::Decoder::StateGroupKind;
 using DecoderStateUpdate = Config::Model::Decoder::StateUpdate;
-using DecoderStateUpdateKind = Config::Model::Decoder::StateUpdateKind;
 
 struct StateUpdate_Element : JSON::Element {
   explicit StateUpdate_Element(DecoderStateUpdate& v) : v_{v} {}
@@ -522,15 +521,6 @@ struct StateUpdate_Element : JSON::Element {
   void OnValue(std::string_view name, JSON::Value value) override {
     if (name == "enabled") {
       v_.enabled = JSON::Get<bool>(value);
-    } else if (name == "kind") {
-      const auto kind = JSON::Get<std::string_view>(value);
-      if (kind == "causal_conv") {
-        v_.kind = DecoderStateUpdateKind::CausalConv;
-      } else if (kind == "gated_delta_net") {
-        v_.kind = DecoderStateUpdateKind::GatedDeltaNet;
-      } else {
-        throw std::runtime_error("Unsupported decoder state update kind '" + std::string{kind} + "'");
-      }
     } else if (name == "capacity") {
       const auto capacity = SafeDoubleToInt64(
           JSON::Get<double>(value), "model.decoder.state_groups.state_update.capacity");
@@ -539,14 +529,6 @@ struct StateUpdate_Element : JSON::Element {
                                  std::to_string(Config::Model::Decoder::MaxStateUpdateCapacity) + "]");
       }
       v_.capacity = static_cast<int>(capacity);
-    } else if (name == "capture_count") {
-      v_.capture_count = JSON::Get<std::string_view>(value);
-    } else if (name == "value") {
-      v_.value = JSON::Get<std::string_view>(value);
-    } else if (name == "active") {
-      v_.active = JSON::Get<std::string_view>(value);
-    } else if (name == "capsule") {
-      v_.capsule = JSON::Get<std::string_view>(value);
     } else if (name == "key_head_count") {
       const auto count = SafeDoubleToInt64(
           JSON::Get<double>(value), "model.decoder.state_groups.state_update.key_head_count");
@@ -563,57 +545,6 @@ struct StateUpdate_Element : JSON::Element {
   DecoderStateUpdate& v_;
 };
 
-struct StateBinding_Element : JSON::Element {
-  explicit StateBinding_Element(Config::Model::Decoder::StateBinding& v) : v_{v} {}
-
-  void OnValue(std::string_view name, JSON::Value value) override {
-    if (name == "input") {
-      v_.input = JSON::Get<std::string_view>(value);
-    } else if (name == "output") {
-      v_.output = JSON::Get<std::string_view>(value);
-    } else {
-      throw JSON::unknown_value_error{};
-    }
-  }
-
- private:
-  Config::Model::Decoder::StateBinding& v_;
-};
-
-struct StateBindings_Element : JSON::Element {
-  explicit StateBindings_Element(DecoderStateGroup& v) : v_{v} {}
-
-  Element& OnObject(std::string_view name) override {
-    std::optional<Config::Model::Decoder::StateBinding>* binding{};
-    std::unique_ptr<StateBinding_Element>* element{};
-    if (name == "key") {
-      binding = &v_.key;
-      element = &key_;
-    } else if (name == "value") {
-      binding = &v_.value;
-      element = &value_;
-    } else if (name == "state") {
-      binding = &v_.state;
-      element = &state_;
-    } else {
-      throw JSON::unknown_value_error{};
-    }
-
-    if (binding->has_value()) {
-      throw std::runtime_error("Duplicate decoder state binding semantic '" + std::string{name} + "'");
-    }
-    binding->emplace();
-    *element = std::make_unique<StateBinding_Element>(binding->value());
-    return **element;
-  }
-
- private:
-  DecoderStateGroup& v_;
-  std::unique_ptr<StateBinding_Element> key_;
-  std::unique_ptr<StateBinding_Element> value_;
-  std::unique_ptr<StateBinding_Element> state_;
-};
-
 struct StateGroup_Element : JSON::Element {
   explicit StateGroup_Element(DecoderStateGroup& v) : v_{v} {}
 
@@ -622,8 +553,10 @@ struct StateGroup_Element : JSON::Element {
       const auto kind = JSON::Get<std::string_view>(value);
       if (kind == "paged_kv") {
         v_.kind = DecoderStateGroupKind::PagedKeyValue;
-      } else if (kind == "fixed") {
-        v_.kind = DecoderStateGroupKind::Fixed;
+      } else if (kind == "fixed_conv") {
+        v_.kind = DecoderStateGroupKind::FixedConv;
+      } else if (kind == "fixed_recurrent") {
+        v_.kind = DecoderStateGroupKind::FixedRecurrent;
       } else {
         throw std::runtime_error("Unsupported decoder state group kind '" + std::string{kind} + "'");
       }
@@ -633,9 +566,6 @@ struct StateGroup_Element : JSON::Element {
   }
 
   Element& OnObject(std::string_view name) override {
-    if (name == "bindings") {
-      return bindings_;
-    }
     if (name == "state_update") {
       if (v_.state_update) {
         throw std::runtime_error("Duplicate decoder state_update declaration");
@@ -657,7 +587,6 @@ struct StateGroup_Element : JSON::Element {
  private:
   DecoderStateGroup& v_;
   IntArray_Element layer_ids_{v_.layer_ids};
-  StateBindings_Element bindings_{v_};
   std::unique_ptr<StateUpdate_Element> state_update_;
 };
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -536,6 +536,12 @@ struct StateUpdate_Element : JSON::Element {
         throw std::runtime_error("Decoder state update key_head_count must be positive");
       }
       v_.key_head_count = static_cast<int>(count);
+    } else if (name == "kind" || name == "capture_count" || name == "value" ||
+               name == "active" || name == "capsule") {
+      throw std::runtime_error(
+          "Legacy decoder state_update field '" + std::string{name} +
+          "' is no longer supported; move state-update binding templates to "
+          "model.decoder.inputs and model.decoder.outputs");
     } else {
       throw JSON::unknown_value_error{};
     }
@@ -557,6 +563,11 @@ struct StateGroup_Element : JSON::Element {
         v_.kind = DecoderStateGroupKind::FixedConv;
       } else if (kind == "fixed_recurrent") {
         v_.kind = DecoderStateGroupKind::FixedRecurrent;
+      } else if (kind == "fixed") {
+        throw std::runtime_error(
+            "Decoder state group kind 'fixed' is no longer supported; use 'fixed_conv' or "
+            "'fixed_recurrent' and move binding templates to model.decoder.inputs and "
+            "model.decoder.outputs");
       } else {
         throw std::runtime_error("Unsupported decoder state group kind '" + std::string{kind} + "'");
       }
@@ -573,6 +584,11 @@ struct StateGroup_Element : JSON::Element {
       v_.state_update.emplace();
       state_update_ = std::make_unique<StateUpdate_Element>(*v_.state_update);
       return *state_update_;
+    }
+    if (name == "bindings") {
+      throw std::runtime_error(
+          "Legacy decoder state group bindings are no longer supported; move binding templates "
+          "to model.decoder.inputs and model.decoder.outputs");
     }
     throw JSON::unknown_value_error{};
   }

--- a/src/config.h
+++ b/src/config.h
@@ -391,12 +391,8 @@ struct Config {
       enum class StateGroupKind {
         Invalid,
         PagedKeyValue,
-        Fixed,
-      };
-
-      struct StateBinding {
-        std::string input;
-        std::string output;
+        FixedConv,
+        FixedRecurrent,
       };
 
       enum class StateUpdateKind {
@@ -408,22 +404,14 @@ struct Config {
       static constexpr int MaxStateUpdateCapacity = 8;
 
       struct StateUpdate {
-        StateUpdateKind kind{StateUpdateKind::Invalid};
         int capacity{};
-        std::string capture_count;
-        std::string value;
         bool enabled{true};
-        std::string active;
-        std::string capsule;
         int key_head_count{};
       };
 
       struct StateGroup {
         StateGroupKind kind{StateGroupKind::Invalid};
         std::vector<int> layer_ids;
-        std::optional<StateBinding> key;
-        std::optional<StateBinding> value;
-        std::optional<StateBinding> state;
         std::optional<StateUpdate> state_update;
       };
 

--- a/src/engine/fixed_state_pool.cpp
+++ b/src/engine/fixed_state_pool.cpp
@@ -147,7 +147,7 @@ struct FixedStateReservation::Storage {
   std::vector<bool> provisional;
   std::vector<uint64_t> expected_state_generations;
   std::vector<uint64_t> target_tokens;
-  std::vector<std::shared_ptr<OrtValue>> staging_backing;
+  std::vector<std::shared_ptr<OrtValue>> binding_backing;
   std::vector<size_t> capture_counts;
   std::vector<std::unique_ptr<OrtValue>> gathered_inputs;
   std::vector<std::unique_ptr<OrtValue>> staged_outputs;
@@ -970,7 +970,7 @@ FixedStateReservation FixedStatePool::Reserve(
   storage->provisional.resize(requests.size());
   storage->expected_state_generations.resize(requests.size());
   storage->target_tokens.resize(requests.size());
-  storage->staging_backing.reserve(impl_->tensors.size() * 4 + 2);
+  storage->binding_backing.reserve(impl_->tensors.size() * 4 + 2);
   storage->capture_counts.resize(requests.size());
   storage->commit_step_tokens.assign(requests.size(), 0);
   storage->commit_kept_tokens.assign(requests.size(), 0);
@@ -994,7 +994,7 @@ FixedStateReservation FixedStatePool::Reserve(
         CheckedMultiply(batch_rows, sizeof(int32_t), "capture_count tensor view"),
         capture_count_shape,
         ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32);
-    storage->staging_backing.push_back(impl_->state_update_capture_count_staging);
+    storage->binding_backing.push_back(impl_->state_update_capture_count_staging);
     storage->staging_bytes = CheckedAdd(
         storage->staging_bytes,
         CheckedMultiply(batch_rows, sizeof(int32_t), "capture_count staging allocation"),
@@ -1007,7 +1007,7 @@ FixedStateReservation FixedStatePool::Reserve(
           impl_->state_update_active_staging->GetTensorMutableData<void>(),
           sizeof(int32_t), active_shape,
           ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32);
-      storage->staging_backing.push_back(impl_->state_update_active_staging);
+      storage->binding_backing.push_back(impl_->state_update_active_staging);
       storage->state_update_active->GetTensorMutableData<int32_t>()[0] =
           capture_state_updates ? 1 : 0;
       storage->staging_bytes = CheckedAdd(
@@ -1026,8 +1026,8 @@ FixedStateReservation FixedStatePool::Reserve(
         spec.output_staging->GetTensorMemoryInfo(),
         spec.output_staging->GetTensorMutableData<void>(),
         tensor_bytes, shape, spec.data_type);
-    storage->staging_backing.push_back(spec.gathered_staging);
-    storage->staging_backing.push_back(spec.output_staging);
+    storage->binding_backing.push_back(spec.gathered_staging);
+    storage->binding_backing.push_back(spec.output_staging);
     FixedStateReservation::Storage::StateUpdateTensors state_updates;
     const auto make_update_output_view = [&storage, batch_rows, capture_state_updates](
                                              const Impl::StateUpdateOutputSpec& output,
@@ -1040,7 +1040,7 @@ FixedStateReservation FixedStatePool::Reserve(
       auto view = OrtValue::CreateTensor(
           backing->GetTensorMemoryInfo(), backing->GetTensorMutableData<void>(),
           tensor_bytes, StorageShape(batch_rows, output.session_shape), output.data_type);
-      storage->staging_backing.push_back(backing);
+      storage->binding_backing.push_back(backing);
       return view;
     };
     state_updates.value = make_update_output_view(

--- a/src/engine/fixed_state_pool.cpp
+++ b/src/engine/fixed_state_pool.cpp
@@ -207,6 +207,8 @@ struct FixedStatePool::Impl {
     // auto-sizing and cannot fail after a step is planned.
     std::shared_ptr<OrtValue> gathered_staging;
     std::shared_ptr<OrtValue> output_staging;
+    std::shared_ptr<OrtValue> state_update_value_staging;
+    std::shared_ptr<OrtValue> state_update_capsule_staging;
   };
 
   struct Slot {
@@ -338,6 +340,8 @@ struct FixedStatePool::Impl {
   size_t state_update_capacity{};
   std::string state_update_capture_count_name;
   std::string state_update_active_name;
+  std::shared_ptr<OrtValue> state_update_capture_count_staging;
+  std::shared_ptr<OrtValue> state_update_active_staging;
   uint64_t next_reservation_id{1};
   uint64_t active_reservation_id{};
   bool healthy{true};
@@ -633,6 +637,11 @@ FixedStatePool::FixedStatePool(std::shared_ptr<Model> model, size_t capacity)
           CheckedMultiply(CheckedMultiply(capacity, spec.row_bytes, "persistent allocation"),
                           spec.banks.size() + 2, "persistent allocation"),
           "persistent allocation");
+      impl_->persistent_bytes = CheckedAdd(
+          impl_->persistent_bytes,
+          CheckedMultiply(capacity, spec.state_update_row_bytes,
+                          "state_update persistent allocation"),
+          "state_update persistent allocation");
       impl_->zeroing_scratch_bytes = CheckedAdd(
           impl_->zeroing_scratch_bytes, spec.row_bytes,
           "zeroing scratch allocation");
@@ -664,6 +673,18 @@ FixedStatePool::FixedStatePool(std::shared_ptr<Model> model, size_t capacity)
   impl_->state_update_capacity = state_update_capacity;
   impl_->state_update_capture_count_name = state_update_capture_count_name;
   impl_->state_update_active_name = state_update_active_name;
+  if (impl_->state_update_capacity != 0) {
+    impl_->persistent_bytes = CheckedAdd(
+        impl_->persistent_bytes,
+        CheckedMultiply(capacity, sizeof(int32_t),
+                        "state_update capture_count persistent allocation"),
+        "state_update capture_count persistent allocation");
+    if (!impl_->state_update_active_name.empty()) {
+      impl_->persistent_bytes = CheckedAdd(
+          impl_->persistent_bytes, sizeof(int32_t),
+          "state_update active persistent allocation");
+    }
+  }
   if (impl_->fixed_session_batch_size != 0) {
     throw std::runtime_error(
         "Dynamic batching requires fixed decoder state groups with a dynamic batch axis, but "
@@ -686,6 +707,28 @@ FixedStatePool::FixedStatePool(std::shared_ptr<Model> model, size_t capacity)
         impl_->device->GetAllocator(), bank_shape, spec.data_type);
     spec.output_staging = OrtValue::CreateTensor(
         impl_->device->GetAllocator(), bank_shape, spec.data_type);
+    const auto allocate_state_update_staging = [&](const Impl::StateUpdateOutputSpec& output) {
+      if (output.name.empty()) {
+        return std::shared_ptr<OrtValue>{};
+      }
+      return std::shared_ptr<OrtValue>{OrtValue::CreateTensor(
+          impl_->device->GetAllocator(), StorageShape(capacity, output.session_shape),
+          output.data_type)};
+    };
+    spec.state_update_value_staging = allocate_state_update_staging(spec.state_update_value);
+    spec.state_update_capsule_staging = allocate_state_update_staging(spec.state_update_capsule);
+  }
+  if (impl_->state_update_capacity != 0) {
+    const std::array<int64_t, 1> capture_count_shape{static_cast<int64_t>(capacity)};
+    impl_->state_update_capture_count_staging = OrtValue::CreateTensor(
+        impl_->device->GetAllocator(), capture_count_shape,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32);
+    if (!impl_->state_update_active_name.empty()) {
+      const std::array<int64_t, 1> active_shape{1};
+      impl_->state_update_active_staging = OrtValue::CreateTensor(
+          impl_->model->allocator_cpu_, active_shape,
+          ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32);
+    }
   }
 
   // Allocate and validate every tensor before enqueueing device work. Once the first asynchronous
@@ -927,7 +970,7 @@ FixedStateReservation FixedStatePool::Reserve(
   storage->provisional.resize(requests.size());
   storage->expected_state_generations.resize(requests.size());
   storage->target_tokens.resize(requests.size());
-  storage->staging_backing.reserve(impl_->tensors.size() * 2);
+  storage->staging_backing.reserve(impl_->tensors.size() * 4 + 2);
   storage->capture_counts.resize(requests.size());
   storage->commit_step_tokens.assign(requests.size(), 0);
   storage->commit_kept_tokens.assign(requests.size(), 0);
@@ -946,8 +989,12 @@ FixedStateReservation FixedStatePool::Reserve(
     storage->state_update_capture_count_name = impl_->state_update_capture_count_name;
     const std::array<int64_t, 1> capture_count_shape{static_cast<int64_t>(batch_rows)};
     storage->state_update_capture_count = OrtValue::CreateTensor(
-        impl_->device->GetAllocator(), capture_count_shape,
+        impl_->state_update_capture_count_staging->GetTensorMemoryInfo(),
+        impl_->state_update_capture_count_staging->GetTensorMutableData<void>(),
+        CheckedMultiply(batch_rows, sizeof(int32_t), "capture_count tensor view"),
+        capture_count_shape,
         ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32);
+    storage->staging_backing.push_back(impl_->state_update_capture_count_staging);
     storage->staging_bytes = CheckedAdd(
         storage->staging_bytes,
         CheckedMultiply(batch_rows, sizeof(int32_t), "capture_count staging allocation"),
@@ -956,8 +1003,11 @@ FixedStateReservation FixedStatePool::Reserve(
       storage->state_update_active_name = impl_->state_update_active_name;
       const std::array<int64_t, 1> active_shape{1};
       storage->state_update_active = OrtValue::CreateTensor(
-          impl_->model->allocator_cpu_, active_shape,
+          impl_->state_update_active_staging->GetTensorMemoryInfo(),
+          impl_->state_update_active_staging->GetTensorMutableData<void>(),
+          sizeof(int32_t), active_shape,
           ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32);
+      storage->staging_backing.push_back(impl_->state_update_active_staging);
       storage->state_update_active->GetTensorMutableData<int32_t>()[0] =
           capture_state_updates ? 1 : 0;
       storage->staging_bytes = CheckedAdd(
@@ -979,16 +1029,24 @@ FixedStateReservation FixedStatePool::Reserve(
     storage->staging_backing.push_back(spec.gathered_staging);
     storage->staging_backing.push_back(spec.output_staging);
     FixedStateReservation::Storage::StateUpdateTensors state_updates;
-    const auto allocate_update_output = [&](const Impl::StateUpdateOutputSpec& output) {
+    const auto make_update_output_view = [&storage, batch_rows, capture_state_updates](
+                                             const Impl::StateUpdateOutputSpec& output,
+                                             const std::shared_ptr<OrtValue>& backing) {
       if (!capture_state_updates || output.name.empty()) {
         return std::unique_ptr<OrtValue>{};
       }
-      return OrtValue::CreateTensor(
-          impl_->device->GetAllocator(), StorageShape(batch_rows, output.session_shape),
-          output.data_type);
+      const size_t tensor_bytes = CheckedMultiply(
+          batch_rows, output.row_bytes, "state_update tensor view");
+      auto view = OrtValue::CreateTensor(
+          backing->GetTensorMemoryInfo(), backing->GetTensorMutableData<void>(),
+          tensor_bytes, StorageShape(batch_rows, output.session_shape), output.data_type);
+      storage->staging_backing.push_back(backing);
+      return view;
     };
-    state_updates.value = allocate_update_output(spec.state_update_value);
-    state_updates.capsule = allocate_update_output(spec.state_update_capsule);
+    state_updates.value = make_update_output_view(
+        spec.state_update_value, spec.state_update_value_staging);
+    state_updates.capsule = make_update_output_view(
+        spec.state_update_capsule, spec.state_update_capsule_staging);
 
     storage->staging_bytes = CheckedAdd(
         storage->staging_bytes,

--- a/src/engine/fixed_state_pool.cpp
+++ b/src/engine/fixed_state_pool.cpp
@@ -29,6 +29,18 @@ std::string ExpandBinding(const std::string& binding, int layer_id) {
   return name;
 }
 
+std::pair<const std::string&, const std::string&> FixedStateTemplates(
+    const Config::Model::Decoder& decoder,
+    StateGroupKind kind) {
+  if (kind == StateGroupKind::FixedConv) {
+    return {decoder.inputs.past_conv_names, decoder.outputs.present_conv_names};
+  }
+  if (kind == StateGroupKind::FixedRecurrent) {
+    return {decoder.inputs.past_recurrent_names, decoder.outputs.present_recurrent_names};
+  }
+  throw std::logic_error("Fixed state pool received a non-fixed state group.");
+}
+
 size_t CheckedMultiply(size_t left, size_t right, std::string_view description) {
   if (left != 0 && right > std::numeric_limits<size_t>::max() / left) {
     throw std::runtime_error(
@@ -519,19 +531,20 @@ FixedStatePool::FixedStatePool(std::shared_ptr<Model> model, size_t capacity)
   const ModelStateManifest manifest{impl_->model->config_->model.decoder};
   manifest.ValidateSession(impl_->model->session_info_);
 
+  const auto& decoder = impl_->model->config_->model.decoder;
   for (const auto& group : manifest.StateGroups()) {
-    if (group.kind != StateGroupKind::Fixed) {
+    if (group.kind != StateGroupKind::FixedConv &&
+        group.kind != StateGroupKind::FixedRecurrent) {
       continue;
     }
-    if (!group.state) {
-      throw std::logic_error("Fixed state pool received a fixed group without a state binding.");
-    }
+    const auto [input_template, output_template] =
+        FixedStateTemplates(decoder, group.kind);
     for (const int layer_id : group.layer_ids) {
       Impl::TensorSpec spec;
       spec.kind = group.kind;
       spec.layer_id = layer_id;
-      spec.input_name = ExpandBinding(group.state->input, layer_id);
-      spec.output_name = ExpandBinding(group.state->output, layer_id);
+      spec.input_name = ExpandBinding(input_template, layer_id);
+      spec.output_name = ExpandBinding(output_template, layer_id);
       spec.data_type =
           impl_->model->session_info_.GetInputDataType(spec.input_name);
       spec.session_shape =
@@ -559,10 +572,12 @@ FixedStatePool::FixedStatePool(std::shared_ptr<Model> model, size_t capacity)
       if (group.state_update) {
         const auto& update = *group.state_update;
         spec.state_update_enabled = update.enabled;
-        spec.state_update_kind = update.kind;
+        spec.state_update_kind = group.kind == StateGroupKind::FixedConv
+                                     ? Config::Model::Decoder::StateUpdateKind::CausalConv
+                                     : Config::Model::Decoder::StateUpdateKind::GatedDeltaNet;
         spec.state_update_capacity = static_cast<size_t>(update.capacity);
-        spec.state_update_capture_count_name = update.capture_count;
-        spec.state_update_active_name = update.active;
+        spec.state_update_capture_count_name = decoder.inputs.state_update_capture_count;
+        spec.state_update_active_name = decoder.inputs.state_update_active;
 
         const auto load_update_output = [&](const std::string& output_template) {
           Impl::StateUpdateOutputSpec output;
@@ -588,14 +603,20 @@ FixedStatePool::FixedStatePool(std::shared_ptr<Model> model, size_t capacity)
           return output;
         };
 
-        spec.state_update_value = load_update_output(update.value);
-        spec.state_update_capsule = load_update_output(update.capsule);
+        spec.state_update_value = load_update_output(
+            group.kind == StateGroupKind::FixedConv
+                ? decoder.outputs.state_update_conv_value_names
+                : std::string{});
+        spec.state_update_capsule = load_update_output(
+            group.kind == StateGroupKind::FixedRecurrent
+                ? decoder.outputs.state_update_recurrent_capsule_names
+                : std::string{});
         spec.state_update_row_bytes = CheckedAdd(
             spec.state_update_value.row_bytes, spec.state_update_capsule.row_bytes,
             "state_update staging allocation");
         spec.state_update_channel_count = static_cast<size_t>(spec.session_shape[1]);
         spec.state_update_state_width = static_cast<size_t>(spec.session_shape[2]);
-        if (update.kind == Config::Model::Decoder::StateUpdateKind::CausalConv) {
+        if (group.kind == StateGroupKind::FixedConv) {
           const size_t element_size = Ort::SizeOf(spec.data_type);
           if (element_size != 2 && element_size != 4) {
             throw std::runtime_error(

--- a/src/engine/paged_key_value_cache.cpp
+++ b/src/engine/paged_key_value_cache.cpp
@@ -20,12 +20,6 @@ StateGroup ResolvePagedKeyValueGroup(const Config::Model::Decoder& decoder) {
   if (!decoder.state_groups) {
     StateGroup group;
     group.kind = StateGroupKind::PagedKeyValue;
-    group.key = Config::Model::Decoder::StateBinding{
-        decoder.inputs.past_key_names,
-        decoder.outputs.present_key_names};
-    group.value = Config::Model::Decoder::StateBinding{
-        decoder.inputs.past_value_names,
-        decoder.outputs.present_value_names};
     group.layer_ids.reserve(decoder.num_hidden_layers);
     for (int layer_id = 0; layer_id < decoder.num_hidden_layers; ++layer_id) {
       group.layer_ids.push_back(layer_id);
@@ -52,11 +46,9 @@ StateGroup ResolvePagedKeyValueGroup(const Config::Model::Decoder& decoder) {
     throw std::runtime_error(
         "Dynamic batching requires one paged_kv decoder state group");
   }
-  if (!paged_group->key || !paged_group->value ||
-      paged_group->layer_ids.empty()) {
+  if (paged_group->layer_ids.empty()) {
     throw std::runtime_error(
-        "Dynamic batching requires a non-empty paged_kv decoder state group "
-        "with key and value bindings");
+        "Dynamic batching requires a non-empty paged_kv decoder state group");
   }
   return *paged_group;
 }
@@ -64,7 +56,7 @@ StateGroup ResolvePagedKeyValueGroup(const Config::Model::Decoder& decoder) {
 ONNXTensorElementDataType KeyValueCacheType(const std::shared_ptr<Model>& model,
                                             const StateGroup& paged_group) {
   const auto key_name = ComposeKeyValueName(
-      paged_group.key->input,
+      model->config_->model.decoder.inputs.past_key_names,
       paged_group.layer_ids.front());
   return model->session_info_.GetInputDataType(key_name);
 }
@@ -228,10 +220,10 @@ PagedKeyValueCache::PagedKeyValueCache(std::shared_ptr<Model> model)
     cache_.push_back(LayerCache{
         OrtValue::CreateTensor(model->p_device_kvcache_->GetAllocator(), cache_shape_per_layer, dtype),  // Key cache
         OrtValue::CreateTensor(model->p_device_kvcache_->GetAllocator(), cache_shape_per_layer, dtype),  // Value cache
-        ComposeKeyValueName(paged_group.key->input, layer_id),
-        ComposeKeyValueName(paged_group.value->input, layer_id),
-        ComposeKeyValueName(paged_group.key->output, layer_id),
-        ComposeKeyValueName(paged_group.value->output, layer_id)});
+        ComposeKeyValueName(decoder.inputs.past_key_names, layer_id),
+        ComposeKeyValueName(decoder.inputs.past_value_names, layer_id),
+        ComposeKeyValueName(decoder.outputs.present_key_names, layer_id),
+        ComposeKeyValueName(decoder.outputs.present_value_names, layer_id)});
   }
   block_pool_ = std::make_unique<BlockPool>(block_size, num_blocks);
   if (Windowed()) {

--- a/src/models/model_state_manifest.cpp
+++ b/src/models/model_state_manifest.cpp
@@ -13,17 +13,59 @@ namespace Generators {
 namespace {
 
 using Decoder = Config::Model::Decoder;
-using StateBinding = Decoder::StateBinding;
 using StateGroup = Decoder::StateGroup;
 using StateGroupKind = Decoder::StateGroupKind;
 using StateUpdateKind = Decoder::StateUpdateKind;
+
+struct StateBinding {
+  std::string_view semantic;
+  const std::string& input;
+  const std::string& output;
+};
+
+std::vector<StateBinding> StateBindingsFor(
+    const Decoder::Inputs& inputs,
+    const Decoder::Outputs& outputs,
+    StateGroupKind kind) {
+  switch (kind) {
+    case StateGroupKind::PagedKeyValue:
+      return {
+          {"key", inputs.past_key_names, outputs.present_key_names},
+          {"value", inputs.past_value_names, outputs.present_value_names},
+      };
+    case StateGroupKind::FixedConv:
+      return {{"state", inputs.past_conv_names, outputs.present_conv_names}};
+    case StateGroupKind::FixedRecurrent:
+      return {{"state", inputs.past_recurrent_names, outputs.present_recurrent_names}};
+    case StateGroupKind::Invalid:
+      return {};
+  }
+  return {};
+}
+
+bool IsFixedKind(StateGroupKind kind) {
+  return kind == StateGroupKind::FixedConv ||
+         kind == StateGroupKind::FixedRecurrent;
+}
+
+StateUpdateKind StateUpdateKindFor(StateGroupKind kind) {
+  if (kind == StateGroupKind::FixedConv) {
+    return StateUpdateKind::CausalConv;
+  }
+  if (kind == StateGroupKind::FixedRecurrent) {
+    return StateUpdateKind::GatedDeltaNet;
+  }
+  return StateUpdateKind::Invalid;
+}
 
 std::string_view StateGroupKindName(StateGroupKind kind) {
   switch (kind) {
     case StateGroupKind::PagedKeyValue:
       return "paged_kv";
-    case StateGroupKind::Fixed:
-      return "fixed";
+    case StateGroupKind::FixedConv:
+      return "fixed_conv";
+    case StateGroupKind::FixedRecurrent:
+      return "fixed_recurrent";
     case StateGroupKind::Invalid:
       return "invalid";
   }
@@ -153,46 +195,51 @@ void ValidateRank(std::string_view group_label,
 
 void ValidateStateUpdateSession(std::string_view group_label,
                                 const StateGroup& group,
+                                const Decoder::Inputs& inputs,
+                                const Decoder::Outputs& outputs,
                                 const ModelStateMetadata& metadata) {
   if (!group.state_update) {
     return;
   }
 
   const auto& update = *group.state_update;
-  if (!metadata.HasInput(update.capture_count)) {
+  const auto update_kind = StateUpdateKindFor(group.kind);
+  const auto& capture_count_name = inputs.state_update_capture_count;
+  if (!metadata.HasInput(capture_count_name)) {
     throw std::runtime_error(
         std::string{group_label} + " state_update capture_count input was not found: " +
-        update.capture_count);
+        capture_count_name);
   }
   const TensorMetadata capture_count{
-      metadata.GetInputDataType(update.capture_count),
-      metadata.GetInputShape(update.capture_count),
-      update.capture_count};
+      metadata.GetInputDataType(capture_count_name),
+      metadata.GetInputShape(capture_count_name),
+      capture_count_name};
   if (capture_count.data_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
     throw std::runtime_error(
-        std::string{group_label} + " state_update capture_count input '" + update.capture_count +
+        std::string{group_label} + " state_update capture_count input '" + capture_count_name +
         "' must have int32 dtype");
   }
   ValidateRank(group_label, "state_update capture_count input", capture_count, 1);
 
-  if (!update.active.empty()) {
-    if (!metadata.HasInput(update.active)) {
+  const auto& active_name = inputs.state_update_active;
+  if (!active_name.empty()) {
+    if (!metadata.HasInput(active_name)) {
       throw std::runtime_error(
-          std::string{group_label} + " state_update active input was not found: " + update.active);
+          std::string{group_label} + " state_update active input was not found: " + active_name);
     }
     const TensorMetadata active{
-        metadata.GetInputDataType(update.active),
-        metadata.GetInputShape(update.active),
-        update.active};
+        metadata.GetInputDataType(active_name),
+        metadata.GetInputShape(active_name),
+        active_name};
     if (active.data_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
       throw std::runtime_error(
-          std::string{group_label} + " state_update active input '" + update.active +
+          std::string{group_label} + " state_update active input '" + active_name +
           "' must have int32 dtype");
     }
     ValidateRank(group_label, "state_update active input", active, 1);
     if (active.shape[0] != 1) {
       throw std::runtime_error(
-          std::string{group_label} + " state_update active input '" + update.active +
+          std::string{group_label} + " state_update active input '" + active_name +
           "' must have shape [1]");
     }
   }
@@ -212,23 +259,24 @@ void ValidateStateUpdateSession(std::string_view group_label,
         output_name};
   };
 
+  const auto state_binding = StateBindingsFor(inputs, outputs, group.kind).front();
   for (const int layer_id : group.layer_ids) {
-    const auto state_name = ExpandBinding(group.state->output, layer_id);
+    const auto state_name = ExpandBinding(state_binding.output, layer_id);
     const TensorMetadata state{
         metadata.GetOutputDataType(state_name),
         metadata.GetOutputShape(state_name),
         state_name};
     ValidateRank(
         group_label, "state output", state,
-        update.kind == StateUpdateKind::CausalConv ? 3 : 4);
+        update_kind == StateUpdateKind::CausalConv ? 3 : 4);
     if (!DimensionsCompatible(state.shape[0], capture_count.shape[0])) {
       throw std::runtime_error(
-          std::string{group_label} + " state_update capture_count input '" + update.capture_count +
+          std::string{group_label} + " state_update capture_count input '" + capture_count_name +
           "' has batch dimension incompatible with state output '" + state.name + "'");
     }
 
-    if (update.kind == StateUpdateKind::CausalConv) {
-      const auto value = get_output("value", update.value, layer_id);
+    if (update_kind == StateUpdateKind::CausalConv) {
+      const auto value = get_output("value", outputs.state_update_conv_value_names, layer_id);
       ValidateRank(group_label, "state_update value output", value, 3);
       if (value.data_type != state.data_type) {
         throw std::runtime_error(
@@ -243,7 +291,8 @@ void ValidateStateUpdateSession(std::string_view group_label,
             "' has incompatible batch, capacity, or channel dimensions");
       }
     } else {
-      const auto capsule = get_output("capsule", update.capsule, layer_id);
+      const auto capsule = get_output(
+          "capsule", outputs.state_update_recurrent_capsule_names, layer_id);
       ValidateRank(group_label, "state_update capsule output", capsule, 2);
       if (state.data_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT ||
           capsule.data_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
@@ -272,7 +321,9 @@ void ValidateStateUpdateSession(std::string_view group_label,
 }  // namespace
 
 ModelStateManifest::ModelStateManifest(const Decoder& decoder)
-    : state_groups_{decoder.state_groups.value_or(std::vector<StateGroup>{})} {
+    : state_groups_{decoder.state_groups.value_or(std::vector<StateGroup>{})},
+      inputs_{decoder.inputs},
+      outputs_{decoder.outputs} {
   ValidateConfig(decoder);
 }
 
@@ -285,7 +336,8 @@ bool ModelStateManifest::HasStateGroupKind(StateGroupKind kind) const {
 }
 
 bool ModelStateManifest::HasFixedStateGroups() const {
-  return HasStateGroupKind(StateGroupKind::Fixed);
+  return HasStateGroupKind(StateGroupKind::FixedConv) ||
+         HasStateGroupKind(StateGroupKind::FixedRecurrent);
 }
 
 void ModelStateManifest::ValidateConfig(const Decoder& decoder) {
@@ -298,7 +350,7 @@ void ModelStateManifest::ValidateConfig(const Decoder& decoder) {
 
   std::set<int> paged_layers;
   std::set<std::string> expanded_bindings;
-  std::optional<std::pair<std::pair<int, std::string>, std::string>> fixed_state_update_contract;
+  std::optional<int> fixed_state_update_capacity;
   std::optional<bool> fixed_state_update_enabled;
   size_t fixed_group_count{};
   size_t fixed_state_update_group_count{};
@@ -313,58 +365,45 @@ void ModelStateManifest::ValidateConfig(const Decoder& decoder) {
       throw std::runtime_error(group_label + " must contain at least one layer_id");
     }
 
-    if (group.kind == StateGroupKind::PagedKeyValue) {
-      if (!group.key || !group.value || group.state) {
-        throw std::runtime_error(group_label + " requires exactly key and value bindings");
-      }
-    } else if (!group.state || group.key || group.value) {
-      throw std::runtime_error(group_label + " requires exactly one state binding");
-    }
-    if (group.kind == StateGroupKind::Fixed) {
+    if (IsFixedKind(group.kind)) {
       ++fixed_group_count;
     }
 
     if (group.state_update) {
       ++fixed_state_update_group_count;
       const auto& update = *group.state_update;
-      if (group.kind != StateGroupKind::Fixed) {
+      if (!IsFixedKind(group.kind)) {
         throw std::runtime_error(group_label + " only fixed state groups support state_update");
-      }
-      if (update.kind == StateUpdateKind::Invalid) {
-        throw std::runtime_error(group_label + " state_update is missing kind");
       }
       if (update.capacity < 1 || update.capacity > Decoder::MaxStateUpdateCapacity) {
         throw std::runtime_error(
             group_label + " state_update capacity must be in [1, " +
             std::to_string(Decoder::MaxStateUpdateCapacity) + "]");
       }
-      if (update.capture_count.empty()) {
+      if (decoder.inputs.state_update_capture_count.empty()) {
         throw std::runtime_error(group_label + " state_update is missing capture_count");
       }
-      if (update.capture_count.find('%') != std::string::npos) {
+      if (decoder.inputs.state_update_capture_count.find('%') != std::string::npos) {
         throw std::runtime_error(
             group_label + " state_update capture_count must be a graph input name, not a template");
       }
-      if (update.active.find('%') != std::string::npos) {
+      if (decoder.inputs.state_update_active.find('%') != std::string::npos) {
         throw std::runtime_error(
             group_label + " state_update active must be a graph input name, not a template");
       }
-      if (update.kind == StateUpdateKind::CausalConv) {
-        if (update.value.empty() || !update.capsule.empty() || update.key_head_count != 0) {
-          throw std::runtime_error(group_label + " causal_conv state_update requires only value");
-        }
-      } else if (!update.value.empty() || update.capsule.empty() || update.key_head_count <= 0) {
+      if (group.kind == StateGroupKind::FixedConv && update.key_head_count != 0) {
+        throw std::runtime_error(group_label + " fixed_conv state_update does not use key_head_count");
+      }
+      if (group.kind == StateGroupKind::FixedRecurrent && update.key_head_count <= 0) {
         throw std::runtime_error(
-            group_label + " gated_delta_net state_update requires capsule and key_head_count");
+            group_label + " fixed_recurrent state_update requires key_head_count");
       }
 
-      const auto contract = std::pair{std::pair{update.capacity, update.capture_count}, update.active};
-      if (!fixed_state_update_contract) {
-        fixed_state_update_contract = contract;
-      } else if (*fixed_state_update_contract != contract) {
+      if (!fixed_state_update_capacity) {
+        fixed_state_update_capacity = update.capacity;
+      } else if (*fixed_state_update_capacity != update.capacity) {
         throw std::runtime_error(
-            "All fixed state_update groups must use the same capacity and capture_count input, "
-            "and the same active input");
+            "All fixed state_update groups must use the same capacity");
       }
       if (!fixed_state_update_enabled) {
         fixed_state_update_enabled = update.enabled;
@@ -394,9 +433,9 @@ void ModelStateManifest::ValidateConfig(const Decoder& decoder) {
       }
     }
 
-    const auto validate_binding = [&](std::string_view semantic, const StateBinding& binding) {
-      ValidateBindingTemplate(group_label, semantic, "input", binding.input);
-      ValidateBindingTemplate(group_label, semantic, "output", binding.output);
+    const auto validate_binding = [&](const StateBinding& binding) {
+      ValidateBindingTemplate(group_label, binding.semantic, "input", binding.input);
+      ValidateBindingTemplate(group_label, binding.semantic, "output", binding.output);
       for (const int layer_id : group.layer_ids) {
         for (const auto& name : {
                  ExpandBinding(binding.input, layer_id),
@@ -409,33 +448,21 @@ void ModelStateManifest::ValidateConfig(const Decoder& decoder) {
       }
     };
 
-    if (group.key) {
-      validate_binding("key", *group.key);
-    }
-    if (group.value) {
-      validate_binding("value", *group.value);
-    }
-    if (group.state) {
-      validate_binding("state", *group.state);
+    for (const auto& binding : StateBindingsFor(decoder.inputs, decoder.outputs, group.kind)) {
+      validate_binding(binding);
     }
     if (group.state_update) {
-      const auto& update = *group.state_update;
-      const auto validate_update_output = [&](std::string_view semantic,
-                                              const std::string& output_template) {
-        if (output_template.empty()) {
-          return;
+      const auto& output_template = group.kind == StateGroupKind::FixedConv
+                                        ? decoder.outputs.state_update_conv_value_names
+                                        : decoder.outputs.state_update_recurrent_capsule_names;
+      ValidateBindingTemplate(group_label, "state_update", "output", output_template);
+      for (const int layer_id : group.layer_ids) {
+        const auto output_name = ExpandBinding(output_template, layer_id);
+        if (!expanded_bindings.insert(output_name).second) {
+          throw std::runtime_error(
+              group_label + " resolves more than one binding to '" + output_name + "'");
         }
-        ValidateBindingTemplate(group_label, semantic, "output", output_template);
-        for (const int layer_id : group.layer_ids) {
-          const auto output_name = ExpandBinding(output_template, layer_id);
-          if (!expanded_bindings.insert(output_name).second) {
-            throw std::runtime_error(
-                group_label + " resolves more than one binding to '" + output_name + "'");
-          }
-        }
-      };
-      validate_update_output("state_update.value", update.value);
-      validate_update_output("state_update.capsule", update.capsule);
+      }
     }
   }
 
@@ -451,18 +478,18 @@ void ModelStateManifest::ValidateSession(const ModelStateMetadata& metadata) con
     const auto& group = state_groups_[group_index];
     const auto group_label = StateGroupLabel(group_index, group.kind);
     std::optional<TensorMetadata> paged_reference;
-    const auto validate_binding = [&](std::string_view semantic, const StateBinding& binding) {
+    const auto validate_binding = [&](const StateBinding& binding) {
       for (const int layer_id : group.layer_ids) {
         const auto input_name = ExpandBinding(binding.input, layer_id);
         const auto output_name = ExpandBinding(binding.output, layer_id);
         if (!metadata.HasInput(input_name)) {
           throw std::runtime_error(
-              group_label + " binding '" + std::string{semantic} +
+              group_label + " binding '" + std::string{binding.semantic} +
               "' input was not found: " + input_name);
         }
         if (!metadata.HasOutput(output_name)) {
           throw std::runtime_error(
-              group_label + " binding '" + std::string{semantic} +
+              group_label + " binding '" + std::string{binding.semantic} +
               "' output was not found: " + output_name);
         }
 
@@ -474,7 +501,7 @@ void ModelStateManifest::ValidateSession(const ModelStateMetadata& metadata) con
             metadata.GetOutputDataType(output_name),
             metadata.GetOutputShape(output_name),
             output_name};
-        ValidateCompatiblePair(group_label, semantic, input, output);
+        ValidateCompatiblePair(group_label, binding.semantic, input, output);
 
         if (group.kind == StateGroupKind::PagedKeyValue) {
           ValidatePagedGeometry(group_label, input, paged_reference);
@@ -483,16 +510,10 @@ void ModelStateManifest::ValidateSession(const ModelStateMetadata& metadata) con
       }
     };
 
-    if (group.key) {
-      validate_binding("key", *group.key);
+    for (const auto& binding : StateBindingsFor(inputs_, outputs_, group.kind)) {
+      validate_binding(binding);
     }
-    if (group.value) {
-      validate_binding("value", *group.value);
-    }
-    if (group.state) {
-      validate_binding("state", *group.state);
-    }
-    ValidateStateUpdateSession(group_label, group, metadata);
+    ValidateStateUpdateSession(group_label, group, inputs_, outputs_, metadata);
   }
 }
 

--- a/src/models/model_state_manifest.h
+++ b/src/models/model_state_manifest.h
@@ -36,6 +36,8 @@ class ModelStateManifest {
 
  private:
   std::vector<Config::Model::Decoder::StateGroup> state_groups_;
+  Config::Model::Decoder::Inputs inputs_;
+  Config::Model::Decoder::Outputs outputs_;
 };
 
 }  // namespace Generators

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1349,49 +1349,27 @@ class Model:
 
         state_groups = []
         if full_attention_layers:
-            state_groups.append(self.make_paged_key_value_state_group(full_attention_layers, inputs, outputs))
+            state_groups.append(self.make_paged_key_value_state_group(full_attention_layers))
         if conv_layers:
             state_groups.append(
                 {
-                    "kind": "fixed",
+                    "kind": "fixed_conv",
                     "layer_ids": conv_layers,
-                    "bindings": {
-                        "state": {
-                            "input": inputs["past_conv_names"],
-                            "output": outputs["present_conv_names"],
-                        }
-                    },
                 }
             )
         if recurrent_layers:
             state_groups.append(
                 {
-                    "kind": "fixed",
+                    "kind": "fixed_recurrent",
                     "layer_ids": recurrent_layers,
-                    "bindings": {
-                        "state": {
-                            "input": inputs["past_recurrent_names"],
-                            "output": outputs["present_recurrent_names"],
-                        }
-                    },
                 }
             )
         return state_groups
 
-    def make_paged_key_value_state_group(self, layer_ids, inputs, outputs):
+    def make_paged_key_value_state_group(self, layer_ids):
         return {
             "kind": "paged_kv",
             "layer_ids": layer_ids,
-            "bindings": {
-                "key": {
-                    "input": inputs["past_key_names"],
-                    "output": outputs["present_key_names"],
-                },
-                "value": {
-                    "input": inputs["past_value_names"],
-                    "output": outputs["present_value_names"],
-                },
-            },
         }
 
     def make_key_value_cache_names(self, layer_id):

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -727,7 +727,7 @@ class Qwen35TextModel(Model):
         ]
         state_groups = []
         if full_attention_layers:
-            state_groups.append(self.make_paged_key_value_state_group(full_attention_layers, inputs, outputs))
+            state_groups.append(self.make_paged_key_value_state_group(full_attention_layers))
         if not linear_attention_layers:
             return state_groups
 
@@ -735,31 +735,19 @@ class Qwen35TextModel(Model):
             self.context_length_attrs["state_update_capacity"] if "state_update_capture_count" in inputs else 0
         )
 
-        for state_name, layer_ids, input_key, output_key in (
-            ("conv", conv_layers, "past_conv_names", "present_conv_names"),
-            ("recurrent", linear_attention_layers, "past_recurrent_names", "present_recurrent_names"),
+        for state_name, layer_ids in (
+            ("conv", conv_layers),
+            ("recurrent", linear_attention_layers),
         ):
             group = {
-                "kind": "fixed",
+                "kind": f"fixed_{state_name}",
                 "layer_ids": layer_ids,
-                "bindings": {
-                    "state": {
-                        "input": inputs[input_key],
-                        "output": outputs[output_key],
-                    }
-                },
             }
             if state_update_capacity:
                 state_update = {
-                    "kind": "causal_conv" if state_name == "conv" else "gated_delta_net",
                     "capacity": state_update_capacity,
-                    "capture_count": inputs["state_update_capture_count"],
-                    "active": inputs["state_update_active"],
                 }
-                if state_name == "conv":
-                    state_update["value"] = outputs["state_update_conv_value_names"]
-                else:
-                    state_update["capsule"] = outputs["state_update_recurrent_capsule_names"]
+                if state_name == "recurrent":
                     state_update["key_head_count"] = self.linear_num_key_heads
                 group["state_update"] = state_update
             state_groups.append(group)

--- a/test/cpp/engine/dynamic_batching_config_tests.cpp
+++ b/test/cpp/engine/dynamic_batching_config_tests.cpp
@@ -108,25 +108,15 @@ TEST(DecoderStateGroupsConfigTest, ParsesSparseHybridManifest) {
     "state_groups": [
       {
         "kind": "paged_kv",
-        "layer_ids": [3],
-        "bindings": {
-          "key": {"input": "past_key_values.%d.key", "output": "present.%d.key"},
-          "value": {"input": "past_key_values.%d.value", "output": "present.%d.value"}
-        }
+        "layer_ids": [3]
       },
       {
-        "kind": "fixed",
-        "layer_ids": [0, 1, 2],
-        "bindings": {
-          "state": {"input": "past_key_values.%d.conv_state", "output": "present.%d.conv_state"}
-        }
+        "kind": "fixed_conv",
+        "layer_ids": [0, 1, 2]
       },
       {
-        "kind": "fixed",
-        "layer_ids": [0, 1, 2],
-        "bindings": {
-          "state": {"input": "past_key_values.%d.recurrent_state", "output": "present.%d.recurrent_state"}
-        }
+        "kind": "fixed_recurrent",
+        "layer_ids": [0, 1, 2]
       }
     ]
   })");
@@ -136,9 +126,9 @@ TEST(DecoderStateGroupsConfigTest, ParsesSparseHybridManifest) {
   ASSERT_EQ(state_groups.size(), 3u);
   EXPECT_EQ(state_groups[0].kind, Config::Model::Decoder::StateGroupKind::PagedKeyValue);
   EXPECT_EQ(state_groups[0].layer_ids, std::vector<int>({3}));
-  EXPECT_EQ(state_groups[1].kind, Config::Model::Decoder::StateGroupKind::Fixed);
+  EXPECT_EQ(state_groups[1].kind, Config::Model::Decoder::StateGroupKind::FixedConv);
   EXPECT_EQ(state_groups[1].layer_ids, std::vector<int>({0, 1, 2}));
-  EXPECT_EQ(state_groups[2].kind, Config::Model::Decoder::StateGroupKind::Fixed);
+  EXPECT_EQ(state_groups[2].kind, Config::Model::Decoder::StateGroupKind::FixedRecurrent);
   EXPECT_EQ(state_groups[2].layer_ids, std::vector<int>({0, 1, 2}));
   EXPECT_EQ(config.model.decoder.inputs.past_conv_names, "past_key_values.%d.conv_state");
   EXPECT_EQ(config.model.decoder.inputs.past_recurrent_names, "past_key_values.%d.recurrent_state");
@@ -155,8 +145,7 @@ TEST(DecoderStateGroupsConfigTest, OverlayValidationIsTransactional) {
   auto config = LoadDecoderConfig(R"({
     "num_hidden_layers": 1,
     "state_groups": [{
-      "kind": "fixed", "layer_ids": [0],
-      "bindings": {"state": {"input": "past.%d", "output": "present.%d"}}
+      "kind": "fixed_conv", "layer_ids": [0]
     }]
   })");
 
@@ -164,8 +153,7 @@ TEST(DecoderStateGroupsConfigTest, OverlayValidationIsTransactional) {
       OverlayConfig(config, R"({
         "model": {"decoder": {
           "state_groups": [{
-            "kind": "fixed", "layer_ids": [1],
-            "bindings": {"state": {"input": "past.%d", "output": "present.%d"}}
+            "kind": "fixed_conv", "layer_ids": [1]
           }]
         }}
       })"),
@@ -173,7 +161,7 @@ TEST(DecoderStateGroupsConfigTest, OverlayValidationIsTransactional) {
 
   ASSERT_TRUE(config.model.decoder.state_groups);
   ASSERT_EQ(config.model.decoder.state_groups->size(), 1u);
-  EXPECT_EQ(config.model.decoder.state_groups->front().kind, Config::Model::Decoder::StateGroupKind::Fixed);
+  EXPECT_EQ(config.model.decoder.state_groups->front().kind, Config::Model::Decoder::StateGroupKind::FixedConv);
   EXPECT_EQ(config.model.decoder.state_groups->front().layer_ids, std::vector<int>({0}));
 }
 
@@ -193,42 +181,40 @@ TEST(DecoderStateGroupsConfigTest, RejectsMissingOrUnknownKind) {
 
 TEST(DecoderStateGroupsConfigTest, AllowsIndependentFixedGroupsOnTheSameLayer) {
   EXPECT_NO_THROW(LoadDecoderConfig(
-      R"({"num_hidden_layers": 1, "state_groups": [
-        {"kind": "fixed", "layer_ids": [0],
-         "bindings": {"state": {"input": "past_conv.%d", "output": "present_conv.%d"}}},
-        {"kind": "fixed", "layer_ids": [0],
-         "bindings": {"state": {"input": "past_recurrent.%d", "output": "present_recurrent.%d"}}}
-      ]})"));
+      R"({"num_hidden_layers": 1,
+          "inputs": {"past_recurrent_names": "past_recurrent.%d"},
+          "outputs": {"present_recurrent_names": "present_recurrent.%d"},
+          "state_groups": [
+            {"kind": "fixed_conv", "layer_ids": [0]},
+            {"kind": "fixed_recurrent", "layer_ids": [0]}
+          ]})"));
 }
 
 TEST(DecoderStateGroupsConfigTest, RejectsMalformedBindingTemplates) {
   ExpectStateGroupError(
-      R"({"num_hidden_layers": 1, "state_groups": [{
-        "kind": "fixed", "layer_ids": [0],
-        "bindings": {"state": {"input": "past.recurrent", "output": "present.%d.recurrent"}}
-      }]})",
+      R"({"num_hidden_layers": 1,
+          "inputs": {"past_recurrent_names": "past.recurrent"},
+          "state_groups": [{"kind": "fixed_recurrent", "layer_ids": [0]}]})",
       "expected exactly one %d");
 
   ExpectStateGroupError(
-      R"({"num_hidden_layers": 1, "state_groups": [{
-        "kind": "fixed", "layer_ids": [0],
-        "bindings": {"state": {"input": "past.%d.recurrent"}}
-      }]})",
+      R"({"num_hidden_layers": 1,
+          "inputs": {"past_recurrent_names": "past.%d.recurrent"},
+          "outputs": {"present_recurrent_names": ""},
+          "state_groups": [{"kind": "fixed_recurrent", "layer_ids": [0]}]})",
       "missing its output template");
 }
 
 TEST(DecoderStateGroupsConfigTest, RejectsDuplicateOrOutOfRangeLayerIds) {
   ExpectStateGroupError(
       R"({"num_hidden_layers": 2, "state_groups": [{
-        "kind": "fixed", "layer_ids": [0, 0],
-        "bindings": {"state": {"input": "past.%d", "output": "present.%d"}}
+        "kind": "fixed_recurrent", "layer_ids": [0, 0]
       }]})",
       "duplicate layer_id 0");
 
   ExpectStateGroupError(
       R"({"num_hidden_layers": 2, "state_groups": [{
-        "kind": "fixed", "layer_ids": [2],
-        "bindings": {"state": {"input": "past.%d", "output": "present.%d"}}
+        "kind": "fixed_recurrent", "layer_ids": [2]
       }]})",
       "outside [0, num_hidden_layers)");
 }
@@ -236,24 +222,26 @@ TEST(DecoderStateGroupsConfigTest, RejectsDuplicateOrOutOfRangeLayerIds) {
 TEST(DecoderStateGroupsConfigTest, RejectsPagedLayerOverlap) {
   ExpectStateGroupError(
       R"({"num_hidden_layers": 1, "state_groups": [
-        {"kind": "paged_kv", "layer_ids": [0], "bindings": {
-          "key": {"input": "past_a.%d.key", "output": "present_a.%d.key"},
-          "value": {"input": "past_a.%d.value", "output": "present_a.%d.value"}}},
-        {"kind": "paged_kv", "layer_ids": [0], "bindings": {
-          "key": {"input": "past_b.%d.key", "output": "present_b.%d.key"},
-          "value": {"input": "past_b.%d.value", "output": "present_b.%d.value"}}}
+        {"kind": "paged_kv", "layer_ids": [0]},
+        {"kind": "paged_kv", "layer_ids": [0]}
       ]})",
       "overlaps another paged_kv group at layer_id 0");
 }
 
 TEST(DecoderStateGroupsConfigTest, RejectsDuplicateExpandedBindings) {
   ExpectStateGroupError(
-      R"({"num_hidden_layers": 1, "state_groups": [
-        {"kind": "fixed", "layer_ids": [0],
-         "bindings": {"state": {"input": "past.%d", "output": "present_conv.%d"}}},
-        {"kind": "fixed", "layer_ids": [0],
-         "bindings": {"state": {"input": "past.%d", "output": "present_recurrent.%d"}}}
-      ]})",
+      R"({"num_hidden_layers": 1,
+          "inputs": {
+            "past_conv_names": "past.%d",
+            "past_recurrent_names": "past.%d"
+          },
+          "outputs": {
+            "present_recurrent_names": "present_recurrent.%d"
+          },
+          "state_groups": [
+            {"kind": "fixed_conv", "layer_ids": [0]},
+            {"kind": "fixed_recurrent", "layer_ids": [0]}
+          ]})",
       "resolves more than one binding to 'past.0'");
 }
 

--- a/test/cpp/engine/dynamic_batching_config_tests.cpp
+++ b/test/cpp/engine/dynamic_batching_config_tests.cpp
@@ -179,6 +179,27 @@ TEST(DecoderStateGroupsConfigTest, RejectsMissingOrUnknownKind) {
       "Unsupported decoder state group kind 'unknown'");
 }
 
+TEST(DecoderStateGroupsConfigTest, RejectsLegacySchemaWithMigrationGuidance) {
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [{
+        "kind": "fixed", "layer_ids": [0]
+      }]})",
+      "use 'fixed_conv' or 'fixed_recurrent'");
+
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [{
+        "kind": "fixed_conv", "layer_ids": [0],
+        "state_update": {"kind": "causal_conv", "capacity": 3}
+      }]})",
+      "Legacy decoder state_update field 'kind'");
+
+  ExpectStateGroupError(
+      R"({"num_hidden_layers": 1, "state_groups": [{
+        "kind": "fixed_conv", "layer_ids": [0], "bindings": {}
+      }]})",
+      "move binding templates to model.decoder.inputs and model.decoder.outputs");
+}
+
 TEST(DecoderStateGroupsConfigTest, AllowsIndependentFixedGroupsOnTheSameLayer) {
   EXPECT_NO_THROW(LoadDecoderConfig(
       R"({"num_hidden_layers": 1,

--- a/test/cpp/engine/fixed_state_pool_tests.cpp
+++ b/test/cpp/engine/fixed_state_pool_tests.cpp
@@ -136,10 +136,10 @@ TEST_F(FixedStatePoolTest, UsesManifestBindingOrderAndSessionGeometry) {
 
   ASSERT_EQ(reservation.Bindings().size(), 4u);
   using Kind = Config::Model::Decoder::StateGroupKind;
-  EXPECT_EQ(reservation.Bindings()[0].kind, Kind::Fixed);
-  EXPECT_EQ(reservation.Bindings()[1].kind, Kind::Fixed);
-  EXPECT_EQ(reservation.Bindings()[2].kind, Kind::Fixed);
-  EXPECT_EQ(reservation.Bindings()[3].kind, Kind::Fixed);
+  EXPECT_EQ(reservation.Bindings()[0].kind, Kind::FixedConv);
+  EXPECT_EQ(reservation.Bindings()[1].kind, Kind::FixedConv);
+  EXPECT_EQ(reservation.Bindings()[2].kind, Kind::FixedRecurrent);
+  EXPECT_EQ(reservation.Bindings()[3].kind, Kind::FixedRecurrent);
   // Convolution group first, then recurrent group, each in layer order.
   EXPECT_EQ(reservation.Bindings()[0].layer_id, 0);
   EXPECT_STREQ(reservation.Bindings()[0].input_name, "past_conv.0");
@@ -465,9 +465,17 @@ TEST_F(FixedStatePoolTest, ReportsPersistentStagingAndReleaseAccounting) {
   constexpr size_t bytes_per_request =
       2 * (2 * 3) * sizeof(float) +     // convolution: 2 layers, row [2, 3]
       2 * (2 * 2 * 2) * sizeof(float);  // recurrent: 2 layers, row [2, 2, 2]
+    constexpr size_t state_update_bytes_per_request =
+      2 * (3 * 2) * sizeof(float) +            // convolution: 2 layers, row [3, 2]
+      2 * (3 * (2 + 2 + 2 * 2)) * sizeof(float);  // recurrent: 2 layers, row [24]
+    constexpr size_t persistent_state_update_control_bytes =
+      3 * sizeof(int32_t) + sizeof(int32_t);  // capacity-sized counts plus one active flag
   constexpr size_t state_update_control_bytes = 2 * sizeof(int32_t) + sizeof(int32_t);
-  // Two state banks plus capacity-sized gather and output staging buffers.
-  EXPECT_EQ(pool->PersistentBytes(), 4 * 3 * bytes_per_request);
+    // Two state banks, capacity-sized state/output/update staging, and update controls.
+    EXPECT_EQ(pool->PersistentBytes(),
+        4 * 3 * bytes_per_request +
+          3 * state_update_bytes_per_request +
+          persistent_state_update_control_bytes);
   EXPECT_EQ(pool->ZeroingScratchBytes(), bytes_per_request);
   EXPECT_EQ(pool->ActiveStagingBytes(), 0u);
 

--- a/test/cpp/engine/fixed_state_pool_tests.cpp
+++ b/test/cpp/engine/fixed_state_pool_tests.cpp
@@ -163,23 +163,34 @@ TEST_F(FixedStatePoolTest, UsesManifestBindingOrderAndSessionGeometry) {
   EXPECT_EQ(reservation.TargetTokens()[0], 1u);
 }
 
-TEST_F(FixedStatePoolTest, ReusesPreallocatedStagingAcrossReservations) {
+TEST_F(FixedStatePoolTest, ReusesPreallocatedStagingAcrossReservationBatchSizes) {
   auto pool = MakePool(2);
   std::vector<void*> input_addresses;
   std::vector<void*> output_addresses;
+  std::vector<void*> update_addresses;
+  void* capture_count_address{};
+  void* active_address{};
   {
-    auto first_requests = One(kRequestA);
+    auto first_requests = One(kRequestA, /*target_tokens=*/4, /*capture_count=*/3);
     auto first = pool->Reserve(first_requests);
     for (const auto& binding : first.Bindings()) {
       input_addresses.push_back(
           binding.input->GetTensorMutableData<void>());
       output_addresses.push_back(
           binding.output->GetTensorMutableData<void>());
+      OrtValue* update = binding.state_update_value
+                             ? binding.state_update_value
+                             : binding.state_update_capsule;
+      ASSERT_NE(update, nullptr);
+      update_addresses.push_back(update->GetTensorMutableData<void>());
     }
+    capture_count_address = first.Bindings()[0].state_update_capture_count->GetTensorMutableData<void>();
+    active_address = first.Bindings()[0].state_update_active->GetTensorMutableData<void>();
     first.Discard();
   }
 
-  auto second_requests = One(kRequestB);
+  const std::array<Request, 2> second_requests{
+      Request{kRequestB, 4, 3}, Request{kRequestC, 3, 2}};
   auto second = pool->Reserve(second_requests);
   ASSERT_EQ(second.Bindings().size(), input_addresses.size());
   for (size_t index = 0; index < second.Bindings().size(); ++index) {
@@ -187,7 +198,20 @@ TEST_F(FixedStatePoolTest, ReusesPreallocatedStagingAcrossReservations) {
               input_addresses[index]);
     EXPECT_EQ(second.Bindings()[index].output->GetTensorMutableData<void>(),
               output_addresses[index]);
+    OrtValue* update = second.Bindings()[index].state_update_value
+                           ? second.Bindings()[index].state_update_value
+                           : second.Bindings()[index].state_update_capsule;
+    ASSERT_NE(update, nullptr);
+    EXPECT_EQ(update->GetTensorMutableData<void>(), update_addresses[index]);
   }
+  EXPECT_EQ(second.Bindings()[0].state_update_capture_count->GetTensorMutableData<void>(),
+            capture_count_address);
+  EXPECT_EQ(second.Bindings()[0].state_update_active->GetTensorMutableData<void>(),
+            active_address);
+  EXPECT_EQ(second.Bindings()[0].state_update_value->GetTensorTypeAndShapeInfo()->GetShape(),
+            (std::vector<int64_t>{2, 3, 2}));
+  EXPECT_EQ(second.Bindings()[2].state_update_capsule->GetTensorTypeAndShapeInfo()->GetShape(),
+            (std::vector<int64_t>{2, 24}));
 }
 
 TEST_F(FixedStatePoolTest, FreshRowsGatherZeroAndCommitPublishes) {
@@ -465,17 +489,17 @@ TEST_F(FixedStatePoolTest, ReportsPersistentStagingAndReleaseAccounting) {
   constexpr size_t bytes_per_request =
       2 * (2 * 3) * sizeof(float) +     // convolution: 2 layers, row [2, 3]
       2 * (2 * 2 * 2) * sizeof(float);  // recurrent: 2 layers, row [2, 2, 2]
-    constexpr size_t state_update_bytes_per_request =
-      2 * (3 * 2) * sizeof(float) +            // convolution: 2 layers, row [3, 2]
+  constexpr size_t state_update_bytes_per_request =
+      2 * (3 * 2) * sizeof(float) +               // convolution: 2 layers, row [3, 2]
       2 * (3 * (2 + 2 + 2 * 2)) * sizeof(float);  // recurrent: 2 layers, row [24]
-    constexpr size_t persistent_state_update_control_bytes =
+  constexpr size_t persistent_state_update_control_bytes =
       3 * sizeof(int32_t) + sizeof(int32_t);  // capacity-sized counts plus one active flag
   constexpr size_t state_update_control_bytes = 2 * sizeof(int32_t) + sizeof(int32_t);
-    // Two state banks, capacity-sized state/output/update staging, and update controls.
-    EXPECT_EQ(pool->PersistentBytes(),
-        4 * 3 * bytes_per_request +
-          3 * state_update_bytes_per_request +
-          persistent_state_update_control_bytes);
+  // Two state banks, capacity-sized state/output/update staging, and update controls.
+  EXPECT_EQ(pool->PersistentBytes(),
+            4 * 3 * bytes_per_request +
+                3 * state_update_bytes_per_request +
+                persistent_state_update_control_bytes);
   EXPECT_EQ(pool->ZeroingScratchBytes(), bytes_per_request);
   EXPECT_EQ(pool->ActiveStagingBytes(), 0u);
 

--- a/test/cpp/engine/model_state_manifest_tests.cpp
+++ b/test/cpp/engine/model_state_manifest_tests.cpp
@@ -71,25 +71,24 @@ Config::Model::Decoder MakeSparseDecoder() {
 
   Decoder decoder;
   decoder.num_hidden_layers = 4;
+  decoder.inputs.past_key_names = "past.%d.key";
+  decoder.inputs.past_value_names = "past.%d.value";
+  decoder.inputs.past_conv_names = "past.%d.conv";
+  decoder.inputs.past_recurrent_names = "past.%d.recurrent";
+  decoder.outputs.present_key_names = "present.%d.key";
+  decoder.outputs.present_value_names = "present.%d.value";
+  decoder.outputs.present_conv_names = "present.%d.conv";
+  decoder.outputs.present_recurrent_names = "present.%d.recurrent";
   decoder.state_groups = std::vector<Decoder::StateGroup>{
       Decoder::StateGroup{
           Decoder::StateGroupKind::PagedKeyValue,
-          {1, 3},
-          Decoder::StateBinding{"past.%d.key", "present.%d.key"},
-          Decoder::StateBinding{"past.%d.value", "present.%d.value"},
-          std::nullopt},
+          {1, 3}},
       Decoder::StateGroup{
-          Decoder::StateGroupKind::Fixed,
-          {0, 2},
-          std::nullopt,
-          std::nullopt,
-          Decoder::StateBinding{"past.%d.conv", "present.%d.conv"}},
+          Decoder::StateGroupKind::FixedConv,
+          {0, 2}},
       Decoder::StateGroup{
-          Decoder::StateGroupKind::Fixed,
-          {0, 2},
-          std::nullopt,
-          std::nullopt,
-          Decoder::StateBinding{"past.%d.recurrent", "present.%d.recurrent"}}};
+          Decoder::StateGroupKind::FixedRecurrent,
+          {0, 2}}};
   return decoder;
 }
 
@@ -143,7 +142,9 @@ TEST(ModelStateManifestTest, ReportsStateGroupCapabilities) {
   EXPECT_TRUE(hybrid.HasStateGroupKind(
       Config::Model::Decoder::StateGroupKind::PagedKeyValue));
   EXPECT_TRUE(hybrid.HasStateGroupKind(
-      Config::Model::Decoder::StateGroupKind::Fixed));
+      Config::Model::Decoder::StateGroupKind::FixedConv));
+  EXPECT_TRUE(hybrid.HasStateGroupKind(
+      Config::Model::Decoder::StateGroupKind::FixedRecurrent));
   EXPECT_TRUE(hybrid.HasFixedStateGroups());
 
   Config::Model::Decoder legacy;
@@ -226,7 +227,7 @@ TEST(ModelStateManifestTest, RejectsIncompatiblePagedGeometry) {
 
 TEST(ModelStateManifestTest, RejectsMissingFixedConvDecoderBinding) {
   auto decoder = MakeSparseDecoder();
-  (*decoder.state_groups)[1].state->input = "missing.%d.conv";
+  decoder.inputs.past_conv_names = "missing.%d.conv";
   const ModelStateManifest manifest{decoder};
   const auto metadata = MakeValidMetadata();
 
@@ -238,12 +239,9 @@ TEST(ModelStateManifestTest, DecoderModelLoadValidatesDecoderBindings) {
   const auto model_path = fs::path{std::string{MODEL_PATH "engine/dummy-decoder"}};
   const auto invalid_overlay = R"({
     "model": {"decoder": {
+      "outputs": {"present_key_names": "missing.%d.key"},
       "state_groups": [{
-        "kind": "paged_kv", "layer_ids": [0],
-        "bindings": {
-          "key": {"input": "past_key_values.%d.key", "output": "missing.%d.key"},
-          "value": {"input": "past_key_values.%d.value", "output": "present.%d.value"}
-        }
+        "kind": "paged_kv", "layer_ids": [0]
       }]
     }}
   })";
@@ -256,11 +254,7 @@ TEST(ModelStateManifestTest, DecoderModelLoadsWithValidDecoderBindings) {
   const auto valid_overlay = R"({
     "model": {"decoder": {
       "state_groups": [{
-        "kind": "paged_kv", "layer_ids": [0],
-        "bindings": {
-          "key": {"input": "past_key_values.%d.key", "output": "present.%d.key"},
-          "value": {"input": "past_key_values.%d.value", "output": "present.%d.value"}
-        }
+        "kind": "paged_kv", "layer_ids": [0]
       }]
     }}
   })";
@@ -299,7 +293,8 @@ TEST(ModelStateManifestTest, AcceptsSparsePagedDynamicEngineContract) {
   decoder.state_groups->erase(
       std::remove_if(decoder.state_groups->begin(), decoder.state_groups->end(),
                      [](const auto& group) {
-                       return group.kind == Config::Model::Decoder::StateGroupKind::Fixed;
+                       return group.kind == Config::Model::Decoder::StateGroupKind::FixedConv ||
+                              group.kind == Config::Model::Decoder::StateGroupKind::FixedRecurrent;
                      }),
       decoder.state_groups->end());
 

--- a/test/cpp/engine/paged_key_value_cache_tests.cpp
+++ b/test/cpp/engine/paged_key_value_cache_tests.cpp
@@ -488,10 +488,8 @@ TEST(PagedKeyValueCacheManifestTest, RejectsFixedStateGroupsAbsentFromSession) {
   // session has no such tensors, so pool construction rejects the group at session validation.
   auto model = LoadSyntheticPagedModel();
   Config::Model::Decoder::StateGroup fixed_group;
-  fixed_group.kind = Config::Model::Decoder::StateGroupKind::Fixed;
+  fixed_group.kind = Config::Model::Decoder::StateGroupKind::FixedConv;
   fixed_group.layer_ids = {0};
-  fixed_group.state = Config::Model::Decoder::StateBinding{
-      "past_fixed.%d", "present_fixed.%d"};
   model->config_->model.decoder.state_groups->push_back(std::move(fixed_group));
 
   EXPECT_THROW(

--- a/test/models/engine/synthetic-composite/genai_config.json
+++ b/test/models/engine/synthetic-composite/genai_config.json
@@ -24,32 +24,31 @@
         "past_sequence_lengths": "past_sequence_lengths",
         "attention_metadata": "attention_metadata",
         "position_ids": "position_ids",
-        "past_key_names": "legacy_past.%d.key",
-        "past_value_names": "legacy_past.%d.value"
+        "past_key_names": "past_key_values.%d.key",
+        "past_value_names": "past_key_values.%d.value",
+        "past_conv_names": "past_conv.%d",
+        "past_recurrent_names": "past_recurrent.%d",
+        "state_update_capture_count": "state_update_capture_count",
+        "state_update_active": ""
       },
       "outputs": {
         "logits": "logits",
-        "present_key_names": "legacy_present.%d.key",
-        "present_value_names": "legacy_present.%d.value"
+        "present_key_names": "present.%d.key",
+        "present_value_names": "present.%d.value",
+        "present_conv_names": "present_conv.%d",
+        "present_recurrent_names": "present_recurrent.%d",
+        "state_update_conv_value_names": "state_update.%d.conv_value",
+        "state_update_recurrent_capsule_names": "state_update.%d.recurrent_capsule"
       },
       "state_groups": [
         {
-          "kind": "fixed",
+          "kind": "fixed_conv",
           "layer_ids": [
             0,
             3
           ],
-          "bindings": {
-            "state": {
-              "input": "past_conv.%d",
-              "output": "present_conv.%d"
-            }
-          },
           "state_update": {
-            "kind": "causal_conv",
-            "capacity": 3,
-            "capture_count": "state_update_capture_count",
-            "value": "state_update.%d.conv_value"
+            "capacity": 3
           }
         },
         {
@@ -57,35 +56,16 @@
           "layer_ids": [
             1,
             4
-          ],
-          "bindings": {
-            "key": {
-              "input": "past_key_values.%d.key",
-              "output": "present.%d.key"
-            },
-            "value": {
-              "input": "past_key_values.%d.value",
-              "output": "present.%d.value"
-            }
-          }
+          ]
         },
         {
-          "kind": "fixed",
+          "kind": "fixed_recurrent",
           "layer_ids": [
             2,
             5
           ],
-          "bindings": {
-            "state": {
-              "input": "past_recurrent.%d",
-              "output": "present_recurrent.%d"
-            }
-          },
           "state_update": {
-            "kind": "gated_delta_net",
             "capacity": 3,
-            "capture_count": "state_update_capture_count",
-            "capsule": "state_update.%d.recurrent_capsule",
             "key_head_count": 1
           }
         }

--- a/test/models/engine/synthetic-hybrid/genai_config.json
+++ b/test/models/engine/synthetic-hybrid/genai_config.json
@@ -20,50 +20,38 @@
       "inputs": {
         "input_ids": "input_ids",
         "attention_mask": "attention_mask",
-        "position_ids": "position_ids"
+        "position_ids": "position_ids",
+        "past_conv_names": "past_conv.%d",
+        "past_recurrent_names": "past_recurrent.%d",
+        "state_update_capture_count": "state_update_capture_count",
+        "state_update_active": "state_update_active"
       },
       "outputs": {
-        "logits": "logits"
+        "logits": "logits",
+        "present_conv_names": "present_conv.%d",
+        "present_recurrent_names": "present_recurrent.%d",
+        "state_update_conv_value_names": "state_update.%d.conv_value",
+        "state_update_recurrent_capsule_names": "state_update.%d.recurrent_capsule"
       },
       "state_groups": [
         {
-          "kind": "fixed",
+          "kind": "fixed_conv",
           "layer_ids": [
             0,
             3
           ],
-          "bindings": {
-            "state": {
-              "input": "past_conv.%d",
-              "output": "present_conv.%d"
-            }
-          },
           "state_update": {
-            "kind": "causal_conv",
-            "capacity": 3,
-            "capture_count": "state_update_capture_count",
-            "active": "state_update_active",
-            "value": "state_update.%d.conv_value"
+            "capacity": 3
           }
         },
         {
-          "kind": "fixed",
+          "kind": "fixed_recurrent",
           "layer_ids": [
             2,
             5
           ],
-          "bindings": {
-            "state": {
-              "input": "past_recurrent.%d",
-              "output": "present_recurrent.%d"
-            }
-          },
           "state_update": {
-            "kind": "gated_delta_net",
             "capacity": 3,
-            "capture_count": "state_update_capture_count",
-            "active": "state_update_active",
-            "capsule": "state_update.%d.recurrent_capsule",
             "key_head_count": 1
           }
         }

--- a/test/models/engine/synthetic-paged/genai_config.json
+++ b/test/models/engine/synthetic-paged/genai_config.json
@@ -23,13 +23,13 @@
         "cumulative_sequence_lengths": "cumulative_sequence_lengths",
         "past_sequence_lengths": "past_sequence_lengths",
         "attention_metadata": "attention_metadata",
-        "past_key_names": "legacy_past.%d.key",
-        "past_value_names": "legacy_past.%d.value"
+        "past_key_names": "past_key_values.%d.key",
+        "past_value_names": "past_key_values.%d.value"
       },
       "outputs": {
         "logits": "logits",
-        "present_key_names": "legacy_present.%d.key",
-        "present_value_names": "legacy_present.%d.value"
+        "present_key_names": "present.%d.key",
+        "present_value_names": "present.%d.value"
       },
       "state_groups": [
         {
@@ -37,17 +37,7 @@
           "layer_ids": [
             1,
             4
-          ],
-          "bindings": {
-            "key": {
-              "input": "past_key_values.%d.key",
-              "output": "present.%d.key"
-            },
-            "value": {
-              "input": "past_key_values.%d.value",
-              "output": "present.%d.value"
-            }
-          }
+          ]
         }
       ]
     }

--- a/test/python/builder/test_decoder_state_groups.py
+++ b/test/python/builder/test_decoder_state_groups.py
@@ -121,10 +121,6 @@ def test_common_paged_builder_emits_paged_kv_group(monkeypatch, tmp_path):
         {
             "kind": "paged_kv",
             "layer_ids": list(range(64)),
-            "bindings": {
-                "key": {"input": "past_key_values.%d.key", "output": "present.%d.key"},
-                "value": {"input": "past_key_values.%d.value", "output": "present.%d.value"},
-            },
         }
     ]
 
@@ -159,10 +155,6 @@ def test_qwen_all_attention_builder_emits_paged_kv_group(monkeypatch, tmp_path):
                 {
                     "kind": "paged_kv",
                     "layer_ids": [0],
-                    "bindings": {
-                        "key": {"input": "past_key_values.%d.key", "output": "present.%d.key"},
-                        "value": {"input": "past_key_values.%d.value", "output": "present.%d.value"},
-                    },
                 }
             ],
         ),
@@ -170,9 +162,8 @@ def test_qwen_all_attention_builder_emits_paged_kv_group(monkeypatch, tmp_path):
             ["conv"],
             [
                 {
-                    "kind": "fixed",
+                    "kind": "fixed_conv",
                     "layer_ids": [0],
-                    "bindings": {"state": {"input": "past.%d.conv", "output": "present.%d.conv"}},
                 }
             ],
         ),
@@ -180,14 +171,12 @@ def test_qwen_all_attention_builder_emits_paged_kv_group(monkeypatch, tmp_path):
             ["linear_attention"],
             [
                 {
-                    "kind": "fixed",
+                    "kind": "fixed_conv",
                     "layer_ids": [0],
-                    "bindings": {"state": {"input": "past.%d.conv", "output": "present.%d.conv"}},
                 },
                 {
-                    "kind": "fixed",
+                    "kind": "fixed_recurrent",
                     "layer_ids": [0],
-                    "bindings": {"state": {"input": "past.%d.recurrent", "output": "present.%d.recurrent"}},
                 },
             ],
         ),
@@ -222,8 +211,8 @@ def test_qwen38_official_geometry_emits_exact_sparse_groups(monkeypatch, tmp_pat
     groups = config["model"]["decoder"]["state_groups"]
     assert [group["kind"] for group in groups] == [
         "paged_kv",
-        "fixed",
-        "fixed",
+        "fixed_conv",
+        "fixed_recurrent",
     ]
     assert groups[0]["layer_ids"] == list(range(3, 64, 4))
     assert groups[1]["layer_ids"] == [i for i in range(64) if (i + 1) % 4 != 0]
@@ -278,22 +267,14 @@ def test_qwen38_compact_state_groups_are_checkpoint_free(monkeypatch, tmp_path):
 
     conv_group, recurrent_group = config["model"]["decoder"]["state_groups"][1:]
     assert conv_group["state_update"] == {
-        "kind": "causal_conv",
         "capacity": 3,
-        "capture_count": "state_update_capture_count",
-        "active": "state_update_active",
-        "value": "state_update.%d.conv_value",
     }
     assert recurrent_group["state_update"] == {
-        "kind": "gated_delta_net",
         "capacity": 3,
-        "capture_count": "state_update_capture_count",
-        "active": "state_update_active",
-        "capsule": "state_update.%d.recurrent_capsule",
         "key_head_count": 2,
     }
     for group in (conv_group, recurrent_group):
-        assert "checkpoints" not in group["bindings"]["state"]
+        assert "bindings" not in group
         assert "checkpoint_count" not in group
         assert "checkpoint_alignment" not in group
 

--- a/test/python/create/create_synthetic_composite_model.py
+++ b/test/python/create/create_synthetic_composite_model.py
@@ -197,44 +197,21 @@ def create_decoder(output_dir):
 def create_config(output_dir):
     state_groups = [
         {
-            "kind": "fixed",
+            "kind": "fixed_conv",
             "layer_ids": CONV_LAYERS,
-            "bindings": {"state": {"input": "past_conv.%d", "output": "present_conv.%d"}},
             "state_update": {
-                "kind": "causal_conv",
                 "capacity": STATE_UPDATE_CAPACITY,
-                "capture_count": "state_update_capture_count",
-                "value": "state_update.%d.conv_value",
             },
         },
         {
             "kind": "paged_kv",
             "layer_ids": PAGED_LAYERS,
-            "bindings": {
-                "key": {
-                    "input": "past_key_values.%d.key",
-                    "output": "present.%d.key",
-                },
-                "value": {
-                    "input": "past_key_values.%d.value",
-                    "output": "present.%d.value",
-                },
-            },
         },
         {
-            "kind": "fixed",
+            "kind": "fixed_recurrent",
             "layer_ids": RECURRENT_LAYERS,
-            "bindings": {
-                "state": {
-                    "input": "past_recurrent.%d",
-                    "output": "present_recurrent.%d",
-                }
-            },
             "state_update": {
-                "kind": "gated_delta_net",
                 "capacity": STATE_UPDATE_CAPACITY,
-                "capture_count": "state_update_capture_count",
-                "capsule": "state_update.%d.recurrent_capsule",
                 "key_head_count": 1,
             },
         },
@@ -262,13 +239,21 @@ def create_config(output_dir):
                     "past_sequence_lengths": "past_sequence_lengths",
                     "attention_metadata": "attention_metadata",
                     "position_ids": "position_ids",
-                    "past_key_names": "legacy_past.%d.key",
-                    "past_value_names": "legacy_past.%d.value",
+                    "past_key_names": "past_key_values.%d.key",
+                    "past_value_names": "past_key_values.%d.value",
+                    "past_conv_names": "past_conv.%d",
+                    "past_recurrent_names": "past_recurrent.%d",
+                    "state_update_capture_count": "state_update_capture_count",
+                    "state_update_active": "",
                 },
                 "outputs": {
                     "logits": "logits",
-                    "present_key_names": "legacy_present.%d.key",
-                    "present_value_names": "legacy_present.%d.value",
+                    "present_key_names": "present.%d.key",
+                    "present_value_names": "present.%d.value",
+                    "present_conv_names": "present_conv.%d",
+                    "present_recurrent_names": "present_recurrent.%d",
+                    "state_update_conv_value_names": "state_update.%d.conv_value",
+                    "state_update_recurrent_capsule_names": "state_update.%d.recurrent_capsule",
                 },
                 "state_groups": state_groups,
             },

--- a/test/python/create/create_synthetic_hybrid_model.py
+++ b/test/python/create/create_synthetic_hybrid_model.py
@@ -183,37 +183,31 @@ def create_config(output_dir):
                     "input_ids": "input_ids",
                     "attention_mask": "attention_mask",
                     "position_ids": "position_ids",
+                    "past_conv_names": "past_conv.%d",
+                    "past_recurrent_names": "past_recurrent.%d",
+                    "state_update_capture_count": "state_update_capture_count",
+                    "state_update_active": "state_update_active",
                 },
                 "outputs": {
                     "logits": "logits",
+                    "present_conv_names": "present_conv.%d",
+                    "present_recurrent_names": "present_recurrent.%d",
+                    "state_update_conv_value_names": "state_update.%d.conv_value",
+                    "state_update_recurrent_capsule_names": "state_update.%d.recurrent_capsule",
                 },
                 "state_groups": [
                     {
-                        "kind": "fixed",
+                        "kind": "fixed_conv",
                         "layer_ids": CONV_LAYERS,
-                        "bindings": {
-                            "state": {"input": "past_conv.%d", "output": "present_conv.%d"},
-                        },
                         "state_update": {
-                            "kind": "causal_conv",
                             "capacity": STATE_UPDATE_CAPACITY,
-                            "capture_count": "state_update_capture_count",
-                            "active": "state_update_active",
-                            "value": "state_update.%d.conv_value",
                         },
                     },
                     {
-                        "kind": "fixed",
+                        "kind": "fixed_recurrent",
                         "layer_ids": RECURRENT_LAYERS,
-                        "bindings": {
-                            "state": {"input": "past_recurrent.%d", "output": "present_recurrent.%d"},
-                        },
                         "state_update": {
-                            "kind": "gated_delta_net",
                             "capacity": STATE_UPDATE_CAPACITY,
-                            "capture_count": "state_update_capture_count",
-                            "active": "state_update_active",
-                            "capsule": "state_update.%d.recurrent_capsule",
                             "key_head_count": 1,
                         },
                     },

--- a/test/python/create/create_synthetic_paged_model.py
+++ b/test/python/create/create_synthetic_paged_model.py
@@ -196,28 +196,18 @@ def create_config(output_dir):
                     "cumulative_sequence_lengths": "cumulative_sequence_lengths",
                     "past_sequence_lengths": "past_sequence_lengths",
                     "attention_metadata": "attention_metadata",
-                    "past_key_names": "legacy_past.%d.key",
-                    "past_value_names": "legacy_past.%d.value",
+                    "past_key_names": "past_key_values.%d.key",
+                    "past_value_names": "past_key_values.%d.value",
                 },
                 "outputs": {
                     "logits": "logits",
-                    "present_key_names": "legacy_present.%d.key",
-                    "present_value_names": "legacy_present.%d.value",
+                    "present_key_names": "present.%d.key",
+                    "present_value_names": "present.%d.value",
                 },
                 "state_groups": [
                     {
                         "kind": "paged_kv",
                         "layer_ids": PAGED_LAYERS,
-                        "bindings": {
-                            "key": {
-                                "input": "past_key_values.%d.key",
-                                "output": "present.%d.key",
-                            },
-                            "value": {
-                                "input": "past_key_values.%d.value",
-                                "output": "present.%d.value",
-                            },
-                        },
                     }
                 ],
             },

--- a/test/python/test_onnxruntime_genai_hybrid_engine.py
+++ b/test/python/test_onnxruntime_genai_hybrid_engine.py
@@ -63,7 +63,7 @@ def test_fixture_declares_sparse_paged_and_fixed_groups():
     config = json.loads((_MODEL_DIR / "genai_config.json").read_text())
     groups = config["model"]["decoder"]["state_groups"]
     assert config["model"]["decoder"]["inputs"]["position_ids"] == "position_ids"
-    assert [group["kind"] for group in groups] == ["fixed", "paged_kv", "fixed"]
+    assert [group["kind"] for group in groups] == ["fixed_conv", "paged_kv", "fixed_recurrent"]
     assert [group["layer_ids"] for group in groups] == [[0, 3], [1, 4], [2, 5]]
 
 


### PR DESCRIPTION
## Description

This follow-up addresses the two deferred review comments from #2454. It reapplies the decoder-I/O-owned state binding schema from #2463 and preallocates compact state-update staging so speculative fixed-state replay does not allocate device buffers after scheduling.

## Summary of Changes

### State Manifest Configuration

- Move reusable state binding templates to decoder inputs and outputs, while state groups retain layer membership and per-group update geometry.
- Update fixed convolution, fixed recurrent, and paged KV consumers to use the revised manifest schema.
- Align model-builder output, synthetic model configurations, and manifest/configuration tests with the schema from #2463.

### Fixed-State Staging

- Allocate capacity-sized compact value, capsule, capture-count, and active buffers when `FixedStatePool` is constructed.
- Create exact-batch tensor views over the preallocated buffers in `Reserve()` and retain their backing storage for the reservation lifetime.
- Include compact-update buffers in persistent memory accounting and verify address reuse across different reservation batch sizes.

## Testing

- `lintrunner -a`
- `cmake --build build/cu130/Release --target engine_unit_tests -j $(nproc)`
- `build/cu130/Release/engine_unit_tests --gtest_color=no --gtest_filter='FixedStatePoolTest.*:CudaFixedStatePoolTest.*:DecoderStateGroupsConfigTest.*:ModelStateManifestTest.*:PagedKeyValueCacheTest.*'` (65 passed)
- `python3 -m pytest test/python/builder/test_decoder_state_groups.py -q --tb=short` (25 passed)
- `git diff --check origin/main...HEAD`

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [x] Documentation not required; this aligns the implementation with the already-reviewed #2463 schema
