### PR TITLE
Set top_k to 0 in top-p tests

### DIFF
--- a/test/cpp/sampling_tests.cpp
+++ b/test/cpp/sampling_tests.cpp
@@ -823,6 +823,9 @@ TEST(SamplingTests, BatchedSamplingTopPNvTensorRtRtx) {
                                    0.1f, 0.1f, 0.1f, 0.1f, 0.6f};
 
   setup.params->SetSearchOption("top_p", 0.25f);
+  // top_k defaults to 50, which exceeds this test's overlaid vocab_size and is rejected as an
+  // invalid request. Set top_k = vocab_size to express "consider all tokens" for pure top-p.
+  setup.params->SetSearchOption("top_k", vocab_size);
 
   auto generator = OgaGenerator::Create(*setup.model, *setup.params);
   generator->SetLogits(*OgaTensor::Create(logits_cpu.data(), std::array<int64_t, 2>{batch_size, vocab_size}));
@@ -901,6 +904,9 @@ TEST(SamplingTests, RandomizedSamplingTopPNvTensorRtRtx) {
   }
 
   setup.params->SetSearchOption("top_p", p);
+  // top_k defaults to 50, which exceeds this test's overlaid vocab_size and is rejected as an
+  // invalid request. Set top_k = vocab_size to express "consider all tokens" for pure top-p.
+  setup.params->SetSearchOption("top_k", vocab_size);
 
   std::random_device rd;
   std::mt19937 engine(rd());

--- a/test/cpp/sampling_tests.cpp
+++ b/test/cpp/sampling_tests.cpp
@@ -824,8 +824,8 @@ TEST(SamplingTests, BatchedSamplingTopPNvTensorRtRtx) {
 
   setup.params->SetSearchOption("top_p", 0.25f);
   // top_k defaults to 50, which exceeds this test's overlaid vocab_size and is rejected as an
-  // invalid request. Set top_k = vocab_size to express "consider all tokens" for pure top-p.
-  setup.params->SetSearchOption("top_k", vocab_size);
+  // invalid request. k=0 disables top-k, routing to SampleTopP.
+  setup.params->SetSearchOption("top_k", 0);
 
   auto generator = OgaGenerator::Create(*setup.model, *setup.params);
   generator->SetLogits(*OgaTensor::Create(logits_cpu.data(), std::array<int64_t, 2>{batch_size, vocab_size}));
@@ -905,8 +905,8 @@ TEST(SamplingTests, RandomizedSamplingTopPNvTensorRtRtx) {
 
   setup.params->SetSearchOption("top_p", p);
   // top_k defaults to 50, which exceeds this test's overlaid vocab_size and is rejected as an
-  // invalid request. Set top_k = vocab_size to express "consider all tokens" for pure top-p.
-  setup.params->SetSearchOption("top_k", vocab_size);
+  // invalid request. k=0 disables top-k, routing to SampleTopP.
+  setup.params->SetSearchOption("top_k", 0);
 
   std::random_device rd;
   std::mt19937 engine(rd());


### PR DESCRIPTION
## Set top_k to 0 in NvTensorRtRtx top-p tests

Two pure top-p tests failed at generator creation:

SamplingTests.BatchedSamplingTopPNvTensorRtRtx
SamplingTests.RandomizedSamplingTopPNvTensorRtRtx

```
    C++ exception with description "top_k (50) must be less than or equal to vocab_size (5)"
    C++ exception with description "top_k (50) must be less than or equal to vocab_size (21)"
```

Both overlay a tiny vocabulary (5 and 21 tokens) but leave `top_k` at its default
of 50, so `Generator::InitializeSamplingMethod` rejected the request before
sampling ran.  

Also neither test exercise the pure top_p path, since top_k default 50 exceeds 1 , so it always goes for kTopKTopP sampling.


Fix: set `top_k = 0` in the two tests, which expresses "consider all
tokens" without tripping the validation. Also adds coverage to kTopP path.

Test-only change. 