### PR TITLE
Add model-independent decoded stop-string matching

### DIFF
--- a/src/stop_string_matcher.cpp
+++ b/src/stop_string_matcher.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "stop_string_matcher.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace Generators {
+
+namespace {
+
+size_t Utf8SequenceLength(unsigned char lead) {
+  if (lead < 0x80) return 1;
+  if (lead >= 0xC2 && lead <= 0xDF) return 2;
+  if (lead >= 0xE0 && lead <= 0xEF) return 3;
+  if (lead >= 0xF0 && lead <= 0xF4) return 4;
+  return 0;  // Continuation byte, overlong two-byte lead (0xC0/0xC1), or out of range (>= 0xF5).
+}
+
+}  // namespace
+
+bool IsValidUtf8(std::string_view bytes) {
+  size_t i = 0;
+  while (i < bytes.size()) {
+    const auto lead = static_cast<unsigned char>(bytes[i]);
+    const size_t length = Utf8SequenceLength(lead);
+    if (length == 0 || i + length > bytes.size())
+      return false;
+
+    for (size_t k = 1; k < length; ++k) {
+      const auto continuation = static_cast<unsigned char>(bytes[i + k]);
+      if (continuation < 0x80 || continuation > 0xBF)
+        return false;
+    }
+
+    // Reject the encodings that are representable in this many bytes but are not the shortest form,
+    // plus UTF-16 surrogates and code points above U+10FFFF.
+    const auto second = length > 1 ? static_cast<unsigned char>(bytes[i + 1]) : static_cast<unsigned char>(0);
+    if (length == 3 && lead == 0xE0 && second < 0xA0) return false;
+    if (length == 3 && lead == 0xED && second > 0x9F) return false;
+    if (length == 4 && lead == 0xF0 && second < 0x90) return false;
+    if (length == 4 && lead == 0xF4 && second > 0x8F) return false;
+
+    i += length;
+  }
+  return true;
+}
+
+StopStringMatcher::StopStringMatcher(std::vector<std::string> stop_strings)
+    : stop_strings_{std::move(stop_strings)} {
+  if (stop_strings_.size() > kMaxStopStringCount)
+    throw std::runtime_error("Too many stop strings: " + std::to_string(stop_strings_.size()) + ", the maximum is " + std::to_string(kMaxStopStringCount) + ".");
+
+  size_t total_bytes = 0;
+  for (size_t i = 0; i < stop_strings_.size(); ++i) {
+    const std::string& stop_string = stop_strings_[i];
+    if (stop_string.empty())
+      throw std::runtime_error("Stop string at index " + std::to_string(i) + " is empty.");
+    if (!IsValidUtf8(stop_string))
+      throw std::runtime_error("Stop string at index " + std::to_string(i) + " is not valid UTF-8.");
+
+    total_bytes += stop_string.size();
+    longest_stop_string_ = std::max(longest_stop_string_, stop_string.size());
+  }
+
+  if (total_bytes > kMaxStopStringTotalBytes)
+    throw std::runtime_error("Stop strings total " + std::to_string(total_bytes) + " bytes, the maximum is " + std::to_string(kMaxStopStringTotalBytes) + ".");
+}
+
+std::optional<StopStringMatch> StopStringMatcher::Consume(std::string_view bytes) {
+  if (match_)
+    return std::nullopt;  // Sticky: the stream ended at the match, so later bytes are dropped.
+
+  consumed_bytes_ += bytes.size();
+  if (stop_strings_.empty()) {
+    safe_.append(bytes);
+    return std::nullopt;
+  }
+
+  // Every match ending at or before the end of the previous chunk was already ruled out, so only
+  // end positions past the retained suffix need to be examined.
+  const size_t searched = pending_.size();
+  pending_.append(bytes);
+
+  if (const auto match = FindMatch(searched)) {
+    safe_.append(pending_, 0, static_cast<size_t>(match->start_offset));
+    match_ = StopStringMatch{match->index, pending_start_offset_ + match->start_offset, pending_start_offset_ + match->end_offset};
+    pending_.clear();
+    pending_start_offset_ = match_->end_offset;
+    return match_;
+  }
+
+  // Only the longest suffix that is still a possible prefix can take part in a later match; the
+  // bytes before it are safe to publish. Suffixes are nested, so no shorter candidate starts
+  // earlier.
+  const size_t release = pending_.size() - LongestPossiblePrefixSuffix();
+  safe_.append(pending_, 0, release);
+  pending_.erase(0, release);
+  pending_start_offset_ += release;
+  return std::nullopt;
+}
+
+std::string StopStringMatcher::TakeSafeOutput() {
+  std::string output = std::move(safe_);
+  safe_.clear();
+  return output;
+}
+
+std::string StopStringMatcher::Flush() {
+  std::string output = TakeSafeOutput();
+  output.append(pending_);
+  pending_start_offset_ += pending_.size();
+  pending_.clear();
+  return output;
+}
+
+void StopStringMatcher::Reset() {
+  safe_.clear();
+  pending_.clear();
+  pending_start_offset_ = 0;
+  consumed_bytes_ = 0;
+  match_.reset();
+}
+
+std::optional<StopStringMatch> StopStringMatcher::FindMatch(size_t min_end) const {
+  for (size_t end = min_end + 1; end <= pending_.size(); ++end) {
+    size_t best_length = 0;
+    size_t best_index = 0;
+    for (size_t i = 0; i < stop_strings_.size(); ++i) {
+      const std::string& stop_string = stop_strings_[i];
+      // Longest first, and the ascending index scan keeps the lowest index for equal lengths.
+      if (stop_string.size() <= end && stop_string.size() > best_length &&
+          pending_.compare(end - stop_string.size(), stop_string.size(), stop_string) == 0) {
+        best_length = stop_string.size();
+        best_index = i;
+      }
+    }
+    if (best_length != 0)
+      return StopStringMatch{best_index, end - best_length, end};
+  }
+  return std::nullopt;
+}
+
+size_t StopStringMatcher::LongestPossiblePrefixSuffix() const {
+  if (stop_strings_.empty())
+    return 0;
+
+  // A complete match was already ruled out, so only proper prefixes are candidates.
+  for (size_t length = std::min(pending_.size(), longest_stop_string_ - 1); length > 0; --length) {
+    for (const std::string& stop_string : stop_strings_) {
+      if (stop_string.size() > length && stop_string.compare(0, length, pending_, pending_.size() - length, length) == 0)
+        return length;
+    }
+  }
+  return 0;
+}
+
+}  // namespace Generators

--- a/src/stop_string_matcher.h
+++ b/src/stop_string_matcher.h
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Generators {
+
+// Documented bounds on a stop-string configuration. They are applied at construction, before any
+// matcher state is allocated, so a caller cannot force unbounded per-request storage. Hosts may
+// enforce smaller limits of their own.
+inline constexpr size_t kMaxStopStringCount = 16;
+inline constexpr size_t kMaxStopStringTotalBytes = 16 * 1024;
+
+// Returns true when `bytes` is a well-formed UTF-8 sequence. Overlong encodings, surrogate code
+// points, values above U+10FFFF, and truncated or stray continuation bytes are all rejected.
+bool IsValidUtf8(std::string_view bytes);
+
+// A completed stop-string match. `start_offset`/`end_offset` are absolute byte offsets into the
+// stream of bytes handed to StopStringMatcher::Consume() since construction or the last Reset(),
+// with `end_offset` exclusive. `index` is the caller's index into the stop-string vector the
+// matcher was constructed with, which is preserved even when two entries have identical bytes.
+struct StopStringMatch {
+  size_t index{};
+  uint64_t start_offset{};
+  uint64_t end_offset{};
+};
+
+// Model-independent, incremental, exact UTF-8 byte matcher for stop strings.
+//
+// The matcher knows nothing about tokens or tokenizers: a caller decodes generated tokens into
+// UTF-8 byte chunks and feeds those chunks to Consume() in order. Chunk boundaries are arbitrary
+// and may split both a stop string and a single code point, so matching is done over the byte
+// stream rather than per chunk. Matching is exact: no Unicode normalization, case folding, or
+// whitespace trimming.
+//
+// Because a chunk may end with a byte sequence that is still a possible prefix of a stop string,
+// output is split into two parts:
+//   * safe output - bytes that provably cannot participate in a later match, retrieved with
+//     TakeSafeOutput() and publishable immediately;
+//   * pending output - the withheld suffix, visible through PendingOutput(), which becomes safe
+//     only when later bytes rule out a match or the stream ends (Flush()).
+// Pending storage is bounded by (longest stop string - 1) bytes between calls, and by that plus
+// the current chunk during a call.
+//
+// When several stop strings could match, the matcher picks deterministically: earliest ending byte,
+// then earliest starting byte (the longest match ending there), then the lowest caller index. With
+// "ab" and "abc" the stream stops as soon as "ab" completes; with "abc" and "bc", which can end on
+// the same byte, "abc" wins.
+//
+// A match is sticky. Once Consume() reports a match, the matcher is done: bytes trailing the match
+// in that same chunk are dropped, later Consume() calls ignore their input and report no match, and
+// the reported match cannot change until Reset().
+class StopStringMatcher {
+ public:
+  // Copies and validates `stop_strings`. Throws std::runtime_error if there are more than
+  // kMaxStopStringCount entries, if the entries total more than kMaxStopStringTotalBytes, or if any
+  // entry is empty or is not well-formed UTF-8. Duplicate entries are allowed and keep their own
+  // caller indices. An empty vector is valid and yields a matcher that never matches.
+  explicit StopStringMatcher(std::vector<std::string> stop_strings);
+
+  // Consumes the next chunk of decoded bytes. The chunk itself need not be valid UTF-8 on its own,
+  // since a code point may straddle a chunk boundary. Returns the match that completes in this
+  // chunk, if any; returns std::nullopt for every call after a match.
+  std::optional<StopStringMatch> Consume(std::string_view bytes);
+
+  // Bytes that cannot be part of a future match, removed from the matcher.
+  std::string TakeSafeOutput();
+
+  // The withheld suffix that is still a possible prefix of a stop string. Invalidated by Consume(),
+  // Flush(), and Reset().
+  std::string_view PendingOutput() const { return pending_; }
+
+  // Ends the stream: no more bytes will be consumed, so the withheld suffix can no longer become
+  // part of a match. Returns the safe output followed by that suffix and empties both. After a
+  // match this returns only the bytes preceding the matched stop string.
+  std::string Flush();
+
+  bool Matched() const { return match_.has_value(); }
+  const std::optional<StopStringMatch>& Match() const { return match_; }
+
+  // Total bytes handed to Consume(), including the chunk that completed a match and excluding
+  // chunks ignored after it.
+  uint64_t ConsumedBytes() const { return consumed_bytes_; }
+
+  const std::vector<std::string>& StopStrings() const { return stop_strings_; }
+
+  // Drops all stream state (offsets, buffered output, and the match) but keeps the configuration.
+  // Used between generation turns.
+  void Reset();
+
+ private:
+  // Best match ending in pending_ at an end index greater than `min_end`, or nullopt. Offsets are
+  // indices into pending_.
+  std::optional<StopStringMatch> FindMatch(size_t min_end) const;
+
+  // Length of the longest suffix of pending_ that is a proper prefix of some stop string.
+  size_t LongestPossiblePrefixSuffix() const;
+
+  std::vector<std::string> stop_strings_;
+  size_t longest_stop_string_{};
+
+  std::string safe_;                 // Bytes cleared for publication.
+  std::string pending_;              // Withheld possible-prefix suffix.
+  uint64_t pending_start_offset_{};  // Absolute offset of pending_[0].
+  uint64_t consumed_bytes_{};
+  std::optional<StopStringMatch> match_;
+};
+
+}  // namespace Generators

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,11 @@ file(GLOB test_srcs CONFIGURE_DEPENDS
 list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/cpp/reinit_tests.cpp")
 list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/cpp/search_checkpoint_tests.cpp")
 
+# unit_tests links the shared library, which exports only the public C API on Windows. The stop
+# string matcher is a self-contained internal component (no ORT, no genai dependencies), so compile
+# its translation unit directly into the test binary rather than relying on exported symbols.
+list(APPEND test_srcs "${CMAKE_SOURCE_DIR}/src/stop_string_matcher.cpp")
+
 if(USE_CUDA AND CMAKE_CUDA_COMPILER AND ENABLE_CUDA_KERNEL_TESTS)
   message(STATUS "Including CUDA kernel tests in the build.")
   file(GLOB cuda_kernel_test_srcs CONFIGURE_DEPENDS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,10 +16,12 @@ file(GLOB test_srcs CONFIGURE_DEPENDS
 list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/cpp/reinit_tests.cpp")
 list(REMOVE_ITEM test_srcs "${CMAKE_CURRENT_SOURCE_DIR}/cpp/search_checkpoint_tests.cpp")
 
-# unit_tests links the shared library, which exports only the public C API on Windows. The stop
-# string matcher is a self-contained internal component (no ORT, no genai dependencies), so compile
-# its translation unit directly into the test binary rather than relying on exported symbols.
-list(APPEND test_srcs "${CMAKE_SOURCE_DIR}/src/stop_string_matcher.cpp")
+# The shared library exports only the public C API on Windows. The stop string matcher is a
+# self-contained internal component (no ORT or GenAI dependencies), so compile its translation unit
+# directly into the test binary there rather than relying on unexported symbols.
+if(WIN32)
+  list(APPEND test_srcs "${CMAKE_SOURCE_DIR}/src/stop_string_matcher.cpp")
+endif()
 
 if(USE_CUDA AND CMAKE_CUDA_COMPILER AND ENABLE_CUDA_KERNEL_TESTS)
   message(STATUS "Including CUDA kernel tests in the build.")

--- a/test/cpp/stop_string_matcher_tests.cpp
+++ b/test/cpp/stop_string_matcher_tests.cpp
@@ -43,7 +43,7 @@ TEST(StopStringMatcherTest, NoMatchFlushesEverything) {
 }
 
 TEST(StopStringMatcherTest, NoStopStringsNeverMatches) {
-  StopStringMatcher matcher{{}};
+  StopStringMatcher matcher{std::vector<std::string>{}};
 
   EXPECT_FALSE(matcher.Consume("STOP anything at all").has_value());
   EXPECT_FALSE(matcher.Matched());

--- a/test/cpp/stop_string_matcher_tests.cpp
+++ b/test/cpp/stop_string_matcher_tests.cpp
@@ -1,0 +1,456 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Model-free tests for the pure stop-string byte matcher. They pin the semantic contract the rest
+// of the stop-string feature is built on: exact UTF-8 byte matching over an incrementally consumed
+// stream, deterministic selection between overlapping stop strings, preserved caller indices,
+// absolute match offsets, a sticky matched state, and bounded withheld output. No tokenizer, model,
+// or ONNX Runtime session is involved.
+
+#include "stop_string_matcher.h"
+
+#include <algorithm>
+#include <optional>
+#include <random>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace Generators::test {
+namespace {
+
+using Generators::IsValidUtf8;
+using Generators::StopStringMatcher;
+
+std::vector<std::string> Strings(std::initializer_list<const char*> values) {
+  return std::vector<std::string>{values.begin(), values.end()};
+}
+
+}  // namespace
+
+TEST(StopStringMatcherTest, NoMatchFlushesEverything) {
+  StopStringMatcher matcher{Strings({"STOP"})};
+
+  EXPECT_FALSE(matcher.Consume("hello ").has_value());
+  EXPECT_FALSE(matcher.Consume("world").has_value());
+  EXPECT_FALSE(matcher.Matched());
+  EXPECT_EQ(matcher.Flush(), "hello world");
+  EXPECT_EQ(matcher.ConsumedBytes(), 11u);
+  EXPECT_TRUE(matcher.PendingOutput().empty());
+  EXPECT_TRUE(matcher.TakeSafeOutput().empty());
+}
+
+TEST(StopStringMatcherTest, NoStopStringsNeverMatches) {
+  StopStringMatcher matcher{{}};
+
+  EXPECT_FALSE(matcher.Consume("STOP anything at all").has_value());
+  EXPECT_FALSE(matcher.Matched());
+  EXPECT_TRUE(matcher.PendingOutput().empty());
+  EXPECT_EQ(matcher.TakeSafeOutput(), "STOP anything at all");
+}
+
+TEST(StopStringMatcherTest, MatchWithinOneChunk) {
+  StopStringMatcher matcher{Strings({"STOP"})};
+
+  const auto match = matcher.Consume("abcSTOPdef");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->index, 0u);
+  EXPECT_EQ(match->start_offset, 3u);
+  EXPECT_EQ(match->end_offset, 7u);
+
+  // The marker and everything after it in the same chunk are withheld from the caller.
+  EXPECT_EQ(matcher.TakeSafeOutput(), "abc");
+  EXPECT_TRUE(matcher.PendingOutput().empty());
+  EXPECT_TRUE(matcher.Matched());
+  ASSERT_TRUE(matcher.Match().has_value());
+  EXPECT_EQ(matcher.Match()->end_offset, 7u);
+}
+
+TEST(StopStringMatcherTest, MatchAtStreamStart) {
+  StopStringMatcher matcher{Strings({"STOP"})};
+
+  const auto match = matcher.Consume("STOP");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->start_offset, 0u);
+  EXPECT_EQ(match->end_offset, 4u);
+  EXPECT_EQ(matcher.Flush(), "");
+}
+
+TEST(StopStringMatcherTest, MatchSplitAcrossTwoChunks) {
+  StopStringMatcher matcher{Strings({"STOP"})};
+
+  EXPECT_FALSE(matcher.Consume("abcST").has_value());
+  EXPECT_EQ(matcher.TakeSafeOutput(), "abc");
+  EXPECT_EQ(matcher.PendingOutput(), "ST");
+
+  const auto match = matcher.Consume("OPtrailing");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->index, 0u);
+  EXPECT_EQ(match->start_offset, 3u);
+  EXPECT_EQ(match->end_offset, 7u);
+  EXPECT_EQ(matcher.ConsumedBytes(), 15u);
+  EXPECT_EQ(matcher.Flush(), "");
+}
+
+TEST(StopStringMatcherTest, MatchSplitAcrossManyChunks) {
+  StopStringMatcher matcher{Strings({"<|end|>"})};
+
+  const std::string stream = "text<|end|>more";
+  std::optional<StopStringMatch> match;
+  std::string published;
+  for (char c : stream) {
+    if (!match) {
+      match = matcher.Consume(std::string_view{&c, 1});
+      published += matcher.TakeSafeOutput();
+    }
+  }
+
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->index, 0u);
+  EXPECT_EQ(match->start_offset, 4u);
+  EXPECT_EQ(match->end_offset, 11u);
+  EXPECT_EQ(published, "text");
+}
+
+TEST(StopStringMatcherTest, EmptyChunksAreNoOps) {
+  StopStringMatcher matcher{Strings({"STOP"})};
+
+  EXPECT_FALSE(matcher.Consume("").has_value());
+  EXPECT_FALSE(matcher.Consume("abST").has_value());
+  EXPECT_FALSE(matcher.Consume("").has_value());
+  EXPECT_EQ(matcher.PendingOutput(), "ST");
+  EXPECT_EQ(matcher.TakeSafeOutput(), "ab");
+
+  const auto match = matcher.Consume("OP");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->start_offset, 2u);
+  EXPECT_EQ(match->end_offset, 6u);
+  EXPECT_EQ(matcher.ConsumedBytes(), 6u);
+}
+
+// Earliest ending byte wins: "ab" completes before "abc" can.
+TEST(StopStringMatcherTest, PrefixOverlapPicksEarliestEnd) {
+  StopStringMatcher matcher{Strings({"abc", "ab"})};
+
+  const auto match = matcher.Consume("xxabc");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->index, 1u);
+  EXPECT_EQ(match->start_offset, 2u);
+  EXPECT_EQ(match->end_offset, 4u);
+  EXPECT_EQ(matcher.TakeSafeOutput(), "xx");
+}
+
+// Same ending byte: the earliest start (the longest match) wins regardless of caller order.
+TEST(StopStringMatcherTest, SuffixOverlapPicksEarliestStart) {
+  StopStringMatcher matcher{Strings({"bc", "abc"})};
+
+  const auto match = matcher.Consume("abc");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->index, 1u);
+  EXPECT_EQ(match->start_offset, 0u);
+  EXPECT_EQ(match->end_offset, 3u);
+}
+
+// Identical start and end: the lowest caller index wins.
+TEST(StopStringMatcherTest, DuplicateStopStringsKeepLowestCallerIndex) {
+  StopStringMatcher matcher{Strings({"end", "stop", "end"})};
+  ASSERT_EQ(matcher.StopStrings().size(), 3u);
+
+  const auto match = matcher.Consume("the end.");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->index, 0u);
+  EXPECT_EQ(match->start_offset, 4u);
+  EXPECT_EQ(match->end_offset, 7u);
+}
+
+TEST(StopStringMatcherTest, CallerIndicesSurviveDuplicatesEarlierInTheList) {
+  StopStringMatcher matcher{Strings({"aa", "aa", "b"})};
+
+  const auto match = matcher.Consume("zb");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->index, 2u);
+  EXPECT_EQ(match->start_offset, 1u);
+  EXPECT_EQ(match->end_offset, 2u);
+}
+
+TEST(StopStringMatcherTest, RepeatedPrefixesMatchAtEarliestCompletion) {
+  StopStringMatcher matcher{Strings({"aaaa"})};
+
+  EXPECT_FALSE(matcher.Consume("aaa").has_value());
+  EXPECT_EQ(matcher.PendingOutput(), "aaa");
+  EXPECT_TRUE(matcher.TakeSafeOutput().empty());
+
+  const auto match = matcher.Consume("aa");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->start_offset, 0u);
+  EXPECT_EQ(match->end_offset, 4u);
+  EXPECT_TRUE(matcher.Flush().empty());
+}
+
+TEST(StopStringMatcherTest, RepeatedPrefixesReleaseUnusableBytes) {
+  StopStringMatcher matcher{Strings({"aaaa"})};
+
+  EXPECT_FALSE(matcher.Consume("baaa").has_value());
+  EXPECT_EQ(matcher.TakeSafeOutput(), "b");
+  EXPECT_EQ(matcher.PendingOutput(), "aaa");
+
+  const auto match = matcher.Consume("a");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->start_offset, 1u);
+  EXPECT_EQ(match->end_offset, 5u);
+}
+
+TEST(StopStringMatcherTest, BytesBeforeMatchAndTrailingBytesInOneChunk) {
+  StopStringMatcher matcher{Strings({"<stop>"})};
+
+  const auto match = matcher.Consume("before<stop>after<stop>");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->start_offset, 6u);
+  EXPECT_EQ(match->end_offset, 12u);
+  EXPECT_EQ(matcher.Flush(), "before");
+}
+
+TEST(StopStringMatcherTest, MultiByteStopStringSplitInsideCodePoint) {
+  const std::string stop = "\xE6\x97\xA5\xE6\x9C\xAC";  // "日本"
+  StopStringMatcher matcher{std::vector<std::string>{stop}};
+
+  EXPECT_FALSE(matcher.Consume("hi \xE6\x97").has_value());
+  EXPECT_EQ(matcher.TakeSafeOutput(), "hi ");
+  EXPECT_EQ(matcher.PendingOutput(), "\xE6\x97");
+
+  EXPECT_FALSE(matcher.Consume("\xA5\xE6\x9C").has_value());
+  const auto match = matcher.Consume("\xAC!");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->start_offset, 3u);
+  EXPECT_EQ(match->end_offset, 9u);
+  EXPECT_EQ(matcher.Flush(), "");
+}
+
+TEST(StopStringMatcherTest, MultiByteTextIsNotMatchedByASharedLeadByte) {
+  StopStringMatcher matcher{std::vector<std::string>{"\xE6\x97\xA5"}};  // "日"
+
+  // "早" (E6 97 A9) shares the first two bytes but must not match.
+  EXPECT_FALSE(matcher.Consume("\xE6\x97\xA9\xE6\x97\xA9").has_value());
+  EXPECT_EQ(matcher.Flush(), "\xE6\x97\xA9\xE6\x97\xA9");
+}
+
+// The pure matcher works on bytes, so a safe prefix may still end inside a code point. Publishing
+// UTF-8-safe chunks is the caller's job; this test pins the byte-level behaviour it must handle.
+TEST(StopStringMatcherTest, SafeOutputMayEndInsideACodePoint) {
+  StopStringMatcher matcher{Strings({"STOP"})};
+
+  EXPECT_FALSE(matcher.Consume("a\xE6\x97").has_value());
+  EXPECT_EQ(matcher.TakeSafeOutput(), "a\xE6\x97");
+  EXPECT_TRUE(matcher.PendingOutput().empty());
+}
+
+TEST(StopStringMatcherTest, MatchedStateIsSticky) {
+  StopStringMatcher matcher{Strings({"ab", "cd"})};
+
+  const auto match = matcher.Consume("xxab");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(matcher.ConsumedBytes(), 4u);
+
+  EXPECT_FALSE(matcher.Consume("cd").has_value());
+  EXPECT_FALSE(matcher.Consume("ab more text").has_value());
+  ASSERT_TRUE(matcher.Match().has_value());
+  EXPECT_EQ(matcher.Match()->index, 0u);
+  EXPECT_EQ(matcher.Match()->start_offset, 2u);
+  EXPECT_EQ(matcher.Match()->end_offset, 4u);
+  EXPECT_EQ(matcher.ConsumedBytes(), 4u);  // Ignored chunks are not counted.
+  EXPECT_EQ(matcher.Flush(), "xx");
+}
+
+TEST(StopStringMatcherTest, ResetRestartsTheStream) {
+  StopStringMatcher matcher{Strings({"STOP"})};
+
+  ASSERT_TRUE(matcher.Consume("abcSTOP").has_value());
+  matcher.Reset();
+
+  EXPECT_FALSE(matcher.Matched());
+  EXPECT_FALSE(matcher.Match().has_value());
+  EXPECT_EQ(matcher.ConsumedBytes(), 0u);
+  EXPECT_TRUE(matcher.PendingOutput().empty());
+  EXPECT_TRUE(matcher.TakeSafeOutput().empty());
+  ASSERT_EQ(matcher.StopStrings().size(), 1u);
+
+  // Offsets restart from zero and the configuration still matches.
+  const auto match = matcher.Consume("zSTOP");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->start_offset, 1u);
+  EXPECT_EQ(match->end_offset, 5u);
+  EXPECT_EQ(matcher.TakeSafeOutput(), "z");
+}
+
+TEST(StopStringMatcherTest, ResetDropsPartialPendingMatch) {
+  StopStringMatcher matcher{Strings({"STOP"})};
+
+  EXPECT_FALSE(matcher.Consume("ST").has_value());
+  matcher.Reset();
+  EXPECT_FALSE(matcher.Consume("OP").has_value());
+  EXPECT_FALSE(matcher.Matched());
+  EXPECT_EQ(matcher.Flush(), "OP");
+}
+
+TEST(StopStringMatcherTest, PendingOutputIsBoundedByLongestStopString) {
+  const std::string longest = "abcdef";
+  StopStringMatcher matcher{Strings({"zz", "abcdef"})};
+
+  // "Xabcde" repeatedly leaves the longest possible prefix ("abcde") withheld without ever
+  // completing a stop string, which is the worst case for pending storage.
+  size_t largest_pending = 0;
+  for (int i = 0; i < 1000; ++i) {
+    ASSERT_FALSE(matcher.Consume("Xabcde").has_value()) << "iteration " << i;
+    largest_pending = std::max(largest_pending, matcher.PendingOutput().size());
+    EXPECT_EQ(matcher.TakeSafeOutput(), i == 0 ? "X" : "abcdeX");
+  }
+
+  EXPECT_EQ(largest_pending, longest.size() - 1);
+}
+
+TEST(StopStringMatcherTest, RejectsInvalidConfigurations) {
+  EXPECT_THROW(StopStringMatcher{Strings({"ok", ""})}, std::runtime_error);
+  EXPECT_THROW(StopStringMatcher{Strings({"\xFF"})}, std::runtime_error);
+  EXPECT_THROW(StopStringMatcher{Strings({"ok", "\xC3"})}, std::runtime_error);        // Truncated.
+  EXPECT_THROW(StopStringMatcher{Strings({"\x80"})}, std::runtime_error);              // Stray continuation.
+  EXPECT_THROW(StopStringMatcher{Strings({"\xED\xA0\x80"})}, std::runtime_error);      // Surrogate.
+  EXPECT_THROW(StopStringMatcher{Strings({"\xC0\xAF"})}, std::runtime_error);          // Overlong.
+  EXPECT_THROW(StopStringMatcher{Strings({"\xF5\x80\x80\x80"})}, std::runtime_error);  // > U+10FFFF.
+  EXPECT_NO_THROW(StopStringMatcher{Strings({"\xF4\x8F\xBF\xBF", "\xC2\x80"})});       // U+10FFFF, U+0080.
+}
+
+TEST(StopStringMatcherTest, EnforcesConfiguredBounds) {
+  std::vector<std::string> at_count_limit(Generators::kMaxStopStringCount, "x");
+  EXPECT_NO_THROW(StopStringMatcher{at_count_limit});
+
+  std::vector<std::string> over_count_limit(Generators::kMaxStopStringCount + 1, "x");
+  EXPECT_THROW(StopStringMatcher{over_count_limit}, std::runtime_error);
+
+  const size_t per_string = Generators::kMaxStopStringTotalBytes / Generators::kMaxStopStringCount;
+  std::vector<std::string> at_byte_limit(Generators::kMaxStopStringCount, std::string(per_string, 'x'));
+  EXPECT_NO_THROW(StopStringMatcher{at_byte_limit});
+
+  std::vector<std::string> over_byte_limit = at_byte_limit;
+  over_byte_limit.back() += 'x';
+  EXPECT_THROW(StopStringMatcher{over_byte_limit}, std::runtime_error);
+}
+
+TEST(StopStringMatcherTest, LongStopStringMatchesAcrossChunks) {
+  const std::string stop(1024, 'z');
+  StopStringMatcher matcher{std::vector<std::string>{stop}};
+
+  EXPECT_FALSE(matcher.Consume("start").has_value());
+  for (size_t i = 0; i + 1 < stop.size(); ++i)
+    ASSERT_FALSE(matcher.Consume("z").has_value()) << "byte " << i;
+  EXPECT_EQ(matcher.PendingOutput().size(), stop.size() - 1);
+
+  const auto match = matcher.Consume("z");
+  ASSERT_TRUE(match.has_value());
+  EXPECT_EQ(match->start_offset, 5u);
+  EXPECT_EQ(match->end_offset, 5u + stop.size());
+  EXPECT_EQ(matcher.Flush(), "start");
+}
+
+TEST(StopStringMatcherTest, IsValidUtf8AcceptsWellFormedSequences) {
+  EXPECT_TRUE(IsValidUtf8(""));
+  EXPECT_TRUE(IsValidUtf8("ascii"));
+  EXPECT_TRUE(IsValidUtf8("\xC2\x80"));          // U+0080.
+  EXPECT_TRUE(IsValidUtf8("\xDF\xBF"));          // U+07FF.
+  EXPECT_TRUE(IsValidUtf8("\xE0\xA0\x80"));      // U+0800.
+  EXPECT_TRUE(IsValidUtf8("\xEF\xBF\xBF"));      // U+FFFF.
+  EXPECT_TRUE(IsValidUtf8("\xF0\x90\x80\x80"));  // U+10000.
+  EXPECT_TRUE(IsValidUtf8("\xF4\x8F\xBF\xBF"));  // U+10FFFF.
+  EXPECT_TRUE(IsValidUtf8(std::string_view{"a\0b", 3}));
+}
+
+TEST(StopStringMatcherTest, IsValidUtf8RejectsMalformedSequences) {
+  EXPECT_FALSE(IsValidUtf8("\x80"));              // Stray continuation.
+  EXPECT_FALSE(IsValidUtf8("\xC0\xAF"));          // Overlong two-byte.
+  EXPECT_FALSE(IsValidUtf8("\xC1\xBF"));          // Overlong two-byte.
+  EXPECT_FALSE(IsValidUtf8("\xE0\x80\xAF"));      // Overlong three-byte.
+  EXPECT_FALSE(IsValidUtf8("\xF0\x80\x80\xAF"));  // Overlong four-byte.
+  EXPECT_FALSE(IsValidUtf8("\xED\xA0\x80"));      // High surrogate.
+  EXPECT_FALSE(IsValidUtf8("\xED\xBF\xBF"));      // Low surrogate.
+  EXPECT_FALSE(IsValidUtf8("\xF4\x90\x80\x80"));  // > U+10FFFF.
+  EXPECT_FALSE(IsValidUtf8("\xF5\x80\x80\x80"));  // Invalid lead.
+  EXPECT_FALSE(IsValidUtf8("\xFF"));              // Invalid lead.
+  EXPECT_FALSE(IsValidUtf8("\xE6\x97"));          // Truncated.
+  EXPECT_FALSE(IsValidUtf8("\xE6\x97\x41"));      // Missing continuation.
+}
+
+namespace {
+
+// Independent whole-stream reference for the selection rules: scan end positions left to right and
+// take the longest stop string ending at the first position where any of them ends, breaking ties
+// by lowest caller index.
+std::optional<StopStringMatch> ReferenceMatch(const std::vector<std::string>& stop_strings, std::string_view stream) {
+  for (size_t end = 1; end <= stream.size(); ++end) {
+    size_t best_length = 0;
+    size_t best_index = 0;
+    for (size_t i = 0; i < stop_strings.size(); ++i) {
+      const std::string& stop_string = stop_strings[i];
+      if (stop_string.size() <= end && stop_string.size() > best_length &&
+          stream.substr(end - stop_string.size(), stop_string.size()) == stop_string) {
+        best_length = stop_string.size();
+        best_index = i;
+      }
+    }
+    if (best_length != 0)
+      return StopStringMatch{best_index, end - best_length, end};
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+// Chunking must not change the outcome: for randomized configurations, streams, and chunk splits,
+// the incremental matcher agrees with the whole-stream reference and publishes exactly the bytes
+// before the match (or the whole stream when nothing matches).
+TEST(StopStringMatcherTest, RandomizedChunkingMatchesWholeStreamReference) {
+  std::mt19937 rng{20260828};
+  const std::string alphabet = "aab";
+
+  for (int trial = 0; trial < 2000; ++trial) {
+    const size_t stop_string_count = 1 + rng() % 3;
+    std::vector<std::string> stop_strings;
+    for (size_t i = 0; i < stop_string_count; ++i) {
+      std::string stop_string;
+      const size_t length = 1 + rng() % 4;
+      for (size_t k = 0; k < length; ++k)
+        stop_string += alphabet[rng() % alphabet.size()];
+      stop_strings.push_back(stop_string);
+    }
+
+    std::string stream;
+    const size_t stream_length = rng() % 24;
+    for (size_t i = 0; i < stream_length; ++i)
+      stream += alphabet[rng() % alphabet.size()];
+
+    StopStringMatcher matcher{stop_strings};
+    std::optional<StopStringMatch> match;
+    std::string published;
+    for (size_t offset = 0; offset < stream.size() && !match;) {
+      const size_t chunk = 1 + rng() % 4;
+      const std::string_view bytes = std::string_view{stream}.substr(offset, chunk);
+      offset += bytes.size();
+      match = matcher.Consume(bytes);
+      published += matcher.TakeSafeOutput();
+    }
+    published += matcher.Flush();
+
+    const auto expected = ReferenceMatch(stop_strings, stream);
+    ASSERT_EQ(match.has_value(), expected.has_value()) << "trial " << trial << " stream '" << stream << "'";
+    if (expected) {
+      EXPECT_EQ(match->index, expected->index) << "trial " << trial << " stream '" << stream << "'";
+      EXPECT_EQ(match->start_offset, expected->start_offset) << "trial " << trial << " stream '" << stream << "'";
+      EXPECT_EQ(match->end_offset, expected->end_offset) << "trial " << trial << " stream '" << stream << "'";
+      EXPECT_EQ(published, stream.substr(0, static_cast<size_t>(expected->start_offset))) << "trial " << trial;
+    } else {
+      EXPECT_EQ(published, stream) << "trial " << trial;
+    }
+  }
+}
+
+}  // namespace Generators::test


### PR DESCRIPTION
## Summary

- Add an incremental exact-byte matcher for decoded UTF-8 stop strings.
- Preserve deterministic caller indices across overlapping and duplicate stop strings.
- Separate immediately publishable output from a bounded suffix that could still complete a match.
- Validate UTF-8 and enforce bounded stop-string configuration.
- Cover chunking, overlap, reset, UTF-8, limits, and randomized oracle parity without requiring a model.

## Motivation

Decoded stop strings can span token boundaries or end inside a token's decoded bytes. Generator and Engine integrations therefore need a shared matcher that operates on the incremental decoded byte stream instead of matching each token's text independently.

This change intentionally adds only model-independent internal infrastructure. It does not change the public API or enable the existing Engine stop-option stubs. Generator and transactional Engine integration will follow in separate PRs.

## Behavior

- Matching is exact UTF-8 byte matching with no normalization, trimming, or case folding.
- Arbitrary input chunking does not affect the result.
- Match selection is deterministic: earliest ending byte, then earliest start/longest match, then lowest caller index.
- Duplicate stop strings remain distinct configuration entries.
- A completed match remains sticky until the matcher is reset.
- Bytes that cannot participate in a future match are released as safe output.
- The retained suffix is bounded by the longest configured stop string minus one byte between calls.
- Empty or malformed UTF-8 strings and configurations above 16 strings or 16 KiB total are rejected.

## Testing

- `StopStringMatcherTest.*`: 27 passed.
- Complete CPU unit suite: 263 passed, 22 skipped.
- Lintrunner: clean.
- Independent randomized audit: more than 27,000 configurations and streams with no oracle divergence.
- Three independent code reviews completed with no findings.