### PR TITLE
[WebGPU] fixes pointer arithmetic bug for multi-image inputs for mistral3 

### DIFF
--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -482,10 +482,6 @@ DeviceSpan<float> PixtralVisionState::Run(int current_length, DeviceSpan<int32_t
   size_t pv_elem_size = element_size(pv_type);
   size_t feat_elem_size = element_size(feat_type);
 
-  // Use the output tensor's actual memory info for sub-tensor views, so views
-  // match the underlying buffer's allocation (CPU or GPU).
-  const auto& feat_mem_info = feat_full->GetTensorMemoryInfo();
-  uint8_t* feat_raw = static_cast<uint8_t*>(feat_full->GetTensorMutableRawData());
   uint8_t* pv_raw = static_cast<uint8_t*>(pv_full->GetTensorMutableRawData());
 
   int64_t feat_offset = 0;
@@ -543,18 +539,21 @@ DeviceSpan<float> PixtralVisionState::Run(int current_length, DeviceSpan<int32_t
           ") + num_feats (" + std::to_string(num_feats) +
           ") exceeds pre-allocated feature buffer (" + std::to_string(total_feats) + ")");
 
-    // Create output sub-tensor view into the pre-allocated feature buffer.
+    // Run into a separate output tensor, then copy into the combined feature buffer.
     std::vector<int64_t> sub_feat_shape = {num_feats, hidden_size};
     auto sub_feat = OrtValue::CreateTensor(
-        feat_mem_info,
-        feat_raw + static_cast<size_t>(feat_offset * hidden_size) * feat_elem_size,
-        static_cast<size_t>(num_feats * hidden_size) * feat_elem_size,
-        std::span<const int64_t>(sub_feat_shape), feat_type);
+        model_.p_device_->GetAllocator(), sub_feat_shape, feat_type);
 
     inputs_[pv_idx] = sub_pv.get();
     outputs_[0] = sub_feat.get();
 
     State::Run(*model_.vision_session_);
+
+    size_t feature_offset_bytes = static_cast<size_t>(feat_offset * hidden_size) * feat_elem_size;
+    size_t feature_size_bytes = static_cast<size_t>(num_feats * hidden_size) * feat_elem_size;
+    ByteWrapTensor(*model_.p_device_, *feat_full)
+        .subspan(feature_offset_bytes, feature_size_bytes)
+        .CopyFrom(ByteWrapTensor(*model_.p_device_, *sub_feat));
 
     feat_offset += num_feats;
   }

--- a/test/python/models/test_mistral3_tokens.py
+++ b/test/python/models/test_mistral3_tokens.py
@@ -230,6 +230,38 @@ class TestTokenExpansionIntegration:
         # invocation before model teardown — important for GPU memory cleanup.
         del generator
 
+    @pytest.mark.skipif(not _has_genai(), reason="onnxruntime_genai not installed")
+    def test_genai_processor_two_images_can_generate(self, test_data_path):
+        """Verify CPU prefill and generation work with two differently sized images."""
+        model_path = Path(test_data_path) / "mistral3"
+        image_paths = [
+            Path(test_data_path) / "images" / "australia.jpg",
+            Path(test_data_path) / "images" / "landscape.jpg",
+        ]
+        if not (model_path / "genai_config.json").is_file():
+            pytest.skip(f"Mistral3 model not found at {model_path} (missing genai_config.json)")
+        for image_path in image_paths:
+            if not image_path.is_file():
+                pytest.skip(f"Test image not found at {image_path}")
+
+        og = importlib.import_module("onnxruntime_genai")
+        model = og.Model(str(model_path))
+        processor = model.create_multimodal_processor()
+        images = og.Images.open(*(str(image_path) for image_path in image_paths))
+        inputs = processor(
+            "<s>[INST][IMG]\n[IMG]\nDescribe both images.[/INST]",
+            images=images,
+        )
+
+        params = og.GeneratorParams(model)
+        params.set_search_options(max_length=4096)
+        generator = og.Generator(model, params)
+        generator.set_inputs(inputs)
+        generator.generate_next_token()
+
+        assert generator.get_next_tokens().size == 1
+        del generator
+
 
 class TestMultiImageTokenExpansion:
     """Tests for multi-image token expansion logic.

--- a/test/python/models/test_mistral3_tokens.py
+++ b/test/python/models/test_mistral3_tokens.py
@@ -260,7 +260,6 @@ class TestTokenExpansionIntegration:
         generator.generate_next_token()
 
         assert generator.get_next_tokens().size == 1
-        del generator
 
 
 class TestMultiImageTokenExpansion:


### PR DESCRIPTION
## Fix WebGPU multi-image Pixtral output handling

The customer's [native multi-image repro](https://github.com/mike-holcomb/multimodal-foundry-local-repros/tree/main/01-native-multi-image-termination) shows that two-image Ministral/Pixtral inference succeeds on CPU and that each image succeeds independently on WebGPU, but the two-image WebGPU case fails in `Generator.SetInputs`, including repeatable `0xC0000005` native access violations.

`PixtralVisionState` ran vision once per image and wrote each result into an offset view of the combined `image_features` output. The WebGPU comment in `src/ep/webgpu/interface.cpp` identified the issue: `p_device_` is a `WGPUBuffer` handle cast to `uint8_t*`, not byte-addressable memory; `p_device_ + offset` is therefore not a valid sub-buffer handle. The first image uses offset zero, while the second image does not.

This change runs each image into a standalone device output tensor and copies it into the combined feature tensor through `ByteWrapTensor(...).subspan(...).CopyFrom(...)`. That path handles nonzero WebGPU offsets safely instead of constructing invalid handle-derived tensor views.
