### PR TITLE
Validate Qwen vision embedding output

### DIFF
--- a/src/models/qwen_vl_model.cpp
+++ b/src/models/qwen_vl_model.cpp
@@ -166,19 +166,13 @@ void Qwen2_5_VL_PipelineState::InjectVisionEmbeddings(const std::string& embeddi
   }
 
   OrtValue* embeddings_ortvalue = it->second.get();
-  auto shape = embeddings_ortvalue->GetTensorTypeAndShapeInfo()->GetShape();
-  float* embeddings_data = embeddings_ortvalue->GetTensorMutableData<float>();
+  auto embeddings_info = embeddings_ortvalue->GetTensorTypeAndShapeInfo();
+  if (embeddings_info->GetElementType() != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+    throw std::runtime_error("Vision embedding injection: embeddings output must have float elements");
+  }
+  auto shape = embeddings_info->GetShape();
 
   auto vision_shape = image_features_value_->GetTensorTypeAndShapeInfo()->GetShape();
-  const float* vision_data = image_features_value_->GetTensorData<float>();
-
-  const int64_t embedding_dim = shape[2];
-  const int64_t num_vision_tokens = vision_shape[0];
-  const int64_t vision_dim = vision_shape[1];
-  if (vision_dim != embedding_dim) {
-    throw std::runtime_error("Vision embedding injection: dimension mismatch - vision_dim=" + std::to_string(vision_dim) +
-                             ", embedding_dim=" + std::to_string(embedding_dim));
-  }
 
   constexpr int32_t image_token_id = 151655;
 
@@ -187,13 +181,18 @@ void Qwen2_5_VL_PipelineState::InjectVisionEmbeddings(const std::string& embeddi
   }
 
   OrtValue* input_ids_ortvalue = input_ids_->Get();
-  auto input_ids_shape = input_ids_ortvalue->GetTensorTypeAndShapeInfo()->GetShape();
+  auto input_ids_info = input_ids_ortvalue->GetTensorTypeAndShapeInfo();
   const int32_t* token_ids_cpu = input_ids_ortvalue->GetTensorData<int32_t>();
 
-  int64_t total_tokens = 1;
-  for (auto dim : input_ids_shape) total_tokens *= dim;
+  const size_t total_tokens = input_ids_info->GetElementCount();
+  ValidateVisionEmbeddingShapes(shape, embeddings_info->GetElementCount(), vision_shape, total_tokens);
+  float* embeddings_data = embeddings_ortvalue->GetTensorMutableData<float>();
+  const float* vision_data = image_features_value_->GetTensorData<float>();
+  const int64_t num_vision_tokens = vision_shape[0];
+  const int64_t embedding_dim = shape.back();
+  const int64_t vision_dim = vision_shape[1];
 
-  for (int64_t i = 0; i < total_tokens; ++i) {
+  for (size_t i = 0; i < total_tokens; ++i) {
     if (token_ids_cpu[i] == image_token_id && image_embed_consumed_ < static_cast<size_t>(num_vision_tokens)) {
       std::memcpy(embeddings_data + (i * embedding_dim),
                   vision_data + (image_embed_consumed_ * vision_dim),

--- a/src/models/qwen_vl_model.h
+++ b/src/models/qwen_vl_model.h
@@ -5,6 +5,30 @@
 
 namespace Generators {
 
+inline void ValidateVisionEmbeddingShapes(std::span<const int64_t> embeddings_shape,
+                                          size_t embeddings_element_count,
+                                          std::span<const int64_t> vision_shape,
+                                          size_t input_token_count) {
+  if (embeddings_shape.size() != 2 && embeddings_shape.size() != 3) {
+    throw std::runtime_error("Vision embedding injection: expected embeddings rank 2 or 3, got " +
+                             std::to_string(embeddings_shape.size()));
+  }
+  if (vision_shape.size() != 2) {
+    throw std::runtime_error("Vision embedding injection: expected vision features rank 2, got " +
+                             std::to_string(vision_shape.size()));
+  }
+
+  const int64_t embedding_dim = embeddings_shape.back();
+  const int64_t vision_dim = vision_shape[1];
+  if (embedding_dim <= 0 || vision_dim != embedding_dim) {
+    throw std::runtime_error("Vision embedding injection: dimension mismatch - vision_dim=" + std::to_string(vision_dim) +
+                             ", embedding_dim=" + std::to_string(embedding_dim));
+  }
+  if (input_token_count > embeddings_element_count / static_cast<size_t>(embedding_dim)) {
+    throw std::runtime_error("Vision embedding injection: embeddings output cannot hold all input tokens");
+  }
+}
+
 // Qwen2.5-VL pipeline model integrating vision pipeline + decoder pipeline.
 // Loads decoder pipeline sessions (handled by base) and constructs vision pipeline sessions.
 // State runs vision once (on first SetExtraInputs when pixel_values arrives) to produce image_features

--- a/src/models/qwen_vl_model.h
+++ b/src/models/qwen_vl_model.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "span.h"
+
 #include "decoder_only_pipeline.h"
 #include "qwen_vl_vision.h"
 
@@ -24,8 +26,12 @@ inline void ValidateVisionEmbeddingShapes(std::span<const int64_t> embeddings_sh
     throw std::runtime_error("Vision embedding injection: dimension mismatch - vision_dim=" + std::to_string(vision_dim) +
                              ", embedding_dim=" + std::to_string(embedding_dim));
   }
-  if (input_token_count > embeddings_element_count / static_cast<size_t>(embedding_dim)) {
-    throw std::runtime_error("Vision embedding injection: embeddings output cannot hold all input tokens");
+  const size_t token_capacity = embeddings_element_count / static_cast<size_t>(embedding_dim);
+  if (input_token_count > token_capacity) {
+    throw std::runtime_error(
+        "Vision embedding injection: embeddings output cannot hold all input tokens "
+        "(input_token_count=" +
+        std::to_string(input_token_count) + ", capacity=" + std::to_string(token_capacity) + ")");
   }
 }
 

--- a/test/cpp/model_tests.cpp
+++ b/test/cpp/model_tests.cpp
@@ -14,12 +14,39 @@
 #include <gtest/gtest.h>
 
 #include "models/model.h"
+#include "models/qwen_vl_model.h"
 #include "models/qwen_vl_vision.h"
 
 #include "test_utils.h"
 
 // External global variable from main.cpp for custom model path
 extern std::string g_custom_model_path;
+
+TEST(ModelTests, QwenVisionEmbeddingShapeValidation) {
+  EXPECT_NO_THROW(Generators::ValidateVisionEmbeddingShapes(
+      std::array<int64_t, 3>{1, 1437, 4096}, 1437 * 4096,
+      std::array<int64_t, 2>{1426, 4096}, 1437));
+  EXPECT_NO_THROW(Generators::ValidateVisionEmbeddingShapes(
+      std::array<int64_t, 2>{1437, 4096}, 1437 * 4096,
+      std::array<int64_t, 2>{1426, 4096}, 1437));
+
+  EXPECT_THROW(Generators::ValidateVisionEmbeddingShapes(
+                   std::array<int64_t, 3>{1, 1, 4096}, 4096,
+                   std::array<int64_t, 2>{1426, 4096}, 1437),
+               std::runtime_error);
+  EXPECT_THROW(Generators::ValidateVisionEmbeddingShapes(
+                   std::array<int64_t, 1>{4096}, 4096,
+                   std::array<int64_t, 2>{1, 4096}, 1),
+               std::runtime_error);
+  EXPECT_THROW(Generators::ValidateVisionEmbeddingShapes(
+                   std::array<int64_t, 2>{1, 4096}, 4096,
+                   std::array<int64_t, 1>{4096}, 1),
+               std::runtime_error);
+  EXPECT_THROW(Generators::ValidateVisionEmbeddingShapes(
+                   std::array<int64_t, 2>{1, 0}, 0,
+                   std::array<int64_t, 2>{1, 0}, 1),
+               std::runtime_error);
+}
 
 // To generate this file:
 // python convert_generation.py --model_type gpt2 -m hf-internal-testing/tiny-random-gpt2 --output tiny_gpt2_greedysearch_fp16.onnx --use_gpu --max_length 20

--- a/test/cpp/model_tests.cpp
+++ b/test/cpp/model_tests.cpp
@@ -1,17 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <array>
 #include <cstring>  // for memcmp
+#include <filesystem>
 #include <iostream>
 #include <random>
-#include <filesystem>
 #include <string>
+
 #include <gtest/gtest.h>
 
 #include "span.h"
 #define OGA_USE_SPAN 1
 #include <ort_genai.h>
-#include <gtest/gtest.h>
 
 #include "models/model.h"
 #include "models/qwen_vl_model.h"
@@ -30,10 +31,16 @@ TEST(ModelTests, QwenVisionEmbeddingShapeValidation) {
       std::array<int64_t, 2>{1437, 4096}, 1437 * 4096,
       std::array<int64_t, 2>{1426, 4096}, 1437));
 
-  EXPECT_THROW(Generators::ValidateVisionEmbeddingShapes(
-                   std::array<int64_t, 3>{1, 1, 4096}, 4096,
-                   std::array<int64_t, 2>{1426, 4096}, 1437),
-               std::runtime_error);
+  try {
+    Generators::ValidateVisionEmbeddingShapes(
+        std::array<int64_t, 3>{1, 1, 4096}, 4096,
+        std::array<int64_t, 2>{1426, 4096}, 1437);
+    FAIL() << "Expected insufficient embedding capacity to be rejected";
+  } catch (const std::runtime_error& error) {
+    EXPECT_STREQ(error.what(),
+                 "Vision embedding injection: embeddings output cannot hold all input tokens "
+                 "(input_token_count=1437, capacity=1)");
+  }
   EXPECT_THROW(Generators::ValidateVisionEmbeddingShapes(
                    std::array<int64_t, 1>{4096}, 4096,
                    std::array<int64_t, 2>{1, 4096}, 1),


### PR DESCRIPTION
This pull request improves the robustness of vision embedding injection in the Qwen2.5-VL model by centralizing and expanding validation of tensor shapes and element types, and by adding targeted unit tests. The main changes ensure that runtime errors due to shape mismatches or invalid data types are caught early and handled with clear error messages.

Validation improvements:

* Added a new function `ValidateVisionEmbeddingShapes` in `qwen_vl_model.h` to check that embeddings and vision feature tensors have the correct rank, matching dimensions, and sufficient size for all input tokens.
* Updated `InjectVisionEmbeddings` in `qwen_vl_model.cpp` to call `ValidateVisionEmbeddingShapes` and to explicitly check that the embeddings tensor contains float elements, throwing descriptive exceptions otherwise. [[1]](diffhunk://#diff-3fa7e7513c99aac23c4b74e20e690d2c86022914e398f46a8faee5d9a8d9e5ebL169-L181) [[2]](diffhunk://#diff-3fa7e7513c99aac23c4b74e20e690d2c86022914e398f46a8faee5d9a8d9e5ebL190-R195)

Testing:

* Added a new unit test `QwenVisionEmbeddingShapeValidation` in `model_tests.cpp` to verify that valid shapes pass and invalid shapes throw the expected runtime errors.