### PR TITLE
Support DeepStack (Qwen3-VL) in the vision->embedding->decoder pipeline

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -104,6 +104,17 @@ struct Int_Array_Element : JSON::Element {
   std::vector<int>& v_;
 };
 
+struct StringArray_Element : JSON::Element {
+  explicit StringArray_Element(std::vector<std::string>& v) : v_{v} {}
+
+  void OnValue(std::string_view name, JSON::Value value) override {
+    v_.push_back(std::string{JSON::Get<std::string_view>(value)});
+  }
+
+ private:
+  std::vector<std::string>& v_;
+};
+
 struct DeviceFilteringOptions_Element : JSON::Element {
   explicit DeviceFilteringOptions_Element(Config::DeviceFilteringOptions& v) : v_{v} {}
 
@@ -386,8 +397,16 @@ struct DecoderInputs_Element : JSON::Element {
     }
   }
 
+  Element& OnArray(std::string_view name) override {
+    if (name == "deepstack") {
+      return deepstack_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
  private:
   Config::Model::Decoder::Inputs& v_;
+  StringArray_Element deepstack_{v_.deepstack};
 };
 
 struct DecoderOutputs_Element : JSON::Element {
@@ -431,17 +450,6 @@ struct DecoderOutputs_Element : JSON::Element {
 
  private:
   Config::Model::Decoder::Outputs& v_;
-};
-
-struct StringArray_Element : JSON::Element {
-  explicit StringArray_Element(std::vector<std::string>& v) : v_{v} {}
-
-  void OnValue(std::string_view name, JSON::Value value) override {
-    v_.push_back(std::string{JSON::Get<std::string_view>(value)});
-  }
-
- private:
-  std::vector<std::string>& v_;
 };
 
 struct IntArray_Element : JSON::Element {
@@ -1084,8 +1092,16 @@ struct VisionOutputs_Element : JSON::Element {
     }
   }
 
+  Element& OnArray(std::string_view name) override {
+    if (name == "deepstack_features") {
+      return deepstack_features_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
  private:
   Config::Model::Vision::Outputs& v_;
+  StringArray_Element deepstack_features_{v_.deepstack_features};
 };
 
 // Vision pipeline support structures
@@ -1428,8 +1444,16 @@ struct EmbeddingInputs_Element : JSON::Element {
     }
   }
 
+  Element& OnArray(std::string_view name) override {
+    if (name == "deepstack_features") {
+      return deepstack_features_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
  private:
   Config::Model::Embedding::Inputs& v_;
+  StringArray_Element deepstack_features_{v_.deepstack_features};
 };
 
 struct EmbeddingOutputs_Element : JSON::Element {
@@ -1445,8 +1469,16 @@ struct EmbeddingOutputs_Element : JSON::Element {
     }
   }
 
+  Element& OnArray(std::string_view name) override {
+    if (name == "deepstack") {
+      return deepstack_;
+    }
+    throw JSON::unknown_value_error{};
+  }
+
  private:
   Config::Model::Embedding::Outputs& v_;
+  StringArray_Element deepstack_{v_.deepstack};
 };
 
 struct Embedding_Element : JSON::Element {

--- a/src/config.h
+++ b/src/config.h
@@ -251,7 +251,7 @@ struct Config {
 
       struct Outputs {
         std::string embeddings{Defaults::InputsEmbedsName};
-        std::string per_layer_inputs;  // Gemma4: per-layer conditioning from embedding to decoder
+        std::string per_layer_inputs;        // Gemma4: per-layer conditioning from embedding to decoder
         std::vector<std::string> deepstack;  // Qwen3-VL full-length scattered DeepStack features (to decoder)
       } outputs;
     } embedding;

--- a/src/config.h
+++ b/src/config.h
@@ -246,11 +246,13 @@ struct Config {
         std::string input_ids{Defaults::InputIdsName};
         std::string image_features{Defaults::ImageFeaturesName};
         std::string audio_features{Defaults::AudioFeaturesName};
+        std::vector<std::string> deepstack_features;  // Qwen3-VL per-token DeepStack features (from vision)
       } inputs;
 
       struct Outputs {
         std::string embeddings{Defaults::InputsEmbedsName};
         std::string per_layer_inputs;  // Gemma4: per-layer conditioning from embedding to decoder
+        std::vector<std::string> deepstack;  // Qwen3-VL full-length scattered DeepStack features (to decoder)
       } outputs;
     } embedding;
 
@@ -297,6 +299,7 @@ struct Config {
 
       struct Outputs {
         std::string image_features{Defaults::ImageFeaturesName};
+        std::vector<std::string> deepstack_features;  // Qwen3-VL per-token DeepStack features (one per deepstack_visual_index)
       } outputs;
     } vision;
 
@@ -474,6 +477,8 @@ struct Config {
 
         // Parakeet TDT decoder (prediction network) extra inputs
         std::string targets_length;
+
+        std::vector<std::string> deepstack;  // Qwen3-VL full-length scattered DeepStack features (per-layer inject)
       } inputs;
 
       struct Outputs {

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -953,6 +953,12 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
     if (vision_state_) {
       embedding_state_->image_features_->ReuseFeaturesBuffer(*vision_state_->image_features_);
       // Qwen3-VL DeepStack: hand each vision per-token output to the matching embedding input.
+      if (embedding_state_->deepstack_features_in_.size() != vision_state_->deepstack_features_.size()) {
+        throw std::runtime_error("DeepStack config mismatch: embedding.inputs.deepstack_features count (" +
+                                 std::to_string(embedding_state_->deepstack_features_in_.size()) +
+                                 ") must match vision.outputs.deepstack_features count (" +
+                                 std::to_string(vision_state_->deepstack_features_.size()) + ").");
+      }
       for (size_t k = 0; k < embedding_state_->deepstack_features_in_.size(); ++k) {
         embedding_state_->deepstack_features_in_[k]->ReuseFeaturesBuffer(*vision_state_->deepstack_features_[k]);
       }
@@ -975,6 +981,12 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
       embedding_state_->per_layer_inputs_->ReuseEmbeddingsBuffer(*decoder_state_->per_layer_inputs_);
     }
     // Qwen3-VL DeepStack: bind embedding's full-length scattered outputs to the decoder's inputs.
+    if (embedding_state_->deepstack_out_.size() != decoder_state_->deepstack_in_.size()) {
+      throw std::runtime_error("DeepStack config mismatch: embedding.outputs.deepstack count (" +
+                               std::to_string(embedding_state_->deepstack_out_.size()) +
+                               ") must match decoder.inputs.deepstack count (" +
+                               std::to_string(decoder_state_->deepstack_in_.size()) + ").");
+    }
     for (size_t k = 0; k < embedding_state_->deepstack_out_.size(); ++k) {
       embedding_state_->deepstack_out_[k]->ReuseEmbeddingsBuffer(*decoder_state_->deepstack_in_[k]);
     }
@@ -997,6 +1009,12 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
   }
   // Qwen3-VL DeepStack: rebind embedding's full-length outputs (all zeros in generation, no image
   // tokens) to the decoder's inputs so the per-layer Adds become no-ops.
+  if (embedding_state_->deepstack_out_.size() != decoder_state_->deepstack_in_.size()) {
+    throw std::runtime_error("DeepStack config mismatch: embedding.outputs.deepstack count (" +
+                             std::to_string(embedding_state_->deepstack_out_.size()) +
+                             ") must match decoder.inputs.deepstack count (" +
+                             std::to_string(decoder_state_->deepstack_in_.size()) + ").");
+  }
   for (size_t k = 0; k < embedding_state_->deepstack_out_.size(); ++k) {
     embedding_state_->deepstack_out_[k]->ReuseEmbeddingsBuffer(*decoder_state_->deepstack_in_[k]);
   }

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -142,6 +142,14 @@ void VisionState::SetExtraInputs(const std::vector<ExtraInput>& extra_inputs, co
                                                          model_.config_->model.vision.outputs.image_features,
                                                          num_images_, num_image_tokens_);
   image_features_->Add();
+  // Qwen3-VL DeepStack: additional per-token vision outputs (outputs_[1..N]); the multi-image
+  // slicing loop in QwenVisionState::Run relies on these following image_features (outputs_[0]).
+  for (const auto& ds_name : model_.config_->model.vision.outputs.deepstack_features) {
+    auto ds = std::make_unique<MultiModalFeatures>(*this, MultiModalFeatures::Mode::Output,
+                                                   ds_name, num_images_, num_image_tokens_);
+    ds->Add();
+    deepstack_features_.push_back(std::move(ds));
+  }
   extra_inputs_.Add(extra_inputs, model_.vision_session_->GetInputNames());
 }
 
@@ -246,6 +254,16 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
   OrtValue* pv_full = inputs_[pv_idx];
   OrtValue* feat_full = outputs_[0];  // pre-allocated image_features output
 
+  // Qwen3-VL DeepStack outputs (outputs_[1..N]) share image_features' shape/type and are sliced
+  // identically per image. Capture their full buffers so we can restore them after the loop.
+  const size_t num_deepstack = deepstack_features_.size();
+  std::vector<OrtValue*> ds_full(num_deepstack);
+  std::vector<void*> ds_raw(num_deepstack);
+  for (size_t k = 0; k < num_deepstack; ++k) {
+    ds_full[k] = outputs_[1 + k];
+    ds_raw[k] = ds_full[k]->GetTensorMutableRawData();
+  }
+
   // Shapes: pixel_values[total_patches, patch_dim], image_features[total_logical_patches, hidden_size]
   auto pv_info = pv_full->GetTensorTypeAndShapeInfo();
   auto feat_info = feat_full->GetTensorTypeAndShapeInfo();
@@ -348,11 +366,24 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
         static_cast<size_t>(num_feats * hidden_size) * feat_element_size,
         std::span<const int64_t>(sub_feat_shape), feat_type);
 
+    // DeepStack outputs: same shape/type as image_features, sliced at the same feat_offset.
+    std::vector<std::unique_ptr<OrtValue>> sub_ds(num_deepstack);
+    for (size_t k = 0; k < num_deepstack; ++k) {
+      sub_ds[k] = OrtValue::CreateTensor(
+          *cpu_mem,
+          static_cast<uint8_t*>(ds_raw[k]) + static_cast<size_t>(feat_offset * hidden_size) * feat_element_size,
+          static_cast<size_t>(num_feats * hidden_size) * feat_element_size,
+          std::span<const int64_t>(sub_feat_shape), feat_type);
+    }
+
     // Temporarily point the State's inputs/output to the per-image slices,
     // run the session, then advance offsets.
     inputs_[pv_idx] = sub_pv.get();
     inputs_[grid_idx] = sub_grid.get();
     outputs_[0] = sub_feat.get();
+    for (size_t k = 0; k < num_deepstack; ++k) {
+      outputs_[1 + k] = sub_ds[k].get();
+    }
 
     State::Run(*model_.vision_session_);
 
@@ -364,6 +395,9 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
   inputs_[pv_idx] = pv_full;
   inputs_[grid_idx] = grid_full;
   outputs_[0] = feat_full;
+  for (size_t k = 0; k < num_deepstack; ++k) {
+    outputs_[1 + k] = ds_full[k];
+  }
 
   return {};
 }
@@ -630,6 +664,19 @@ void EmbeddingState::SetExtraInputs(const int64_t num_images, const int64_t num_
                                                            num_images, num_image_tokens_);
     image_features_->Add();
   }
+  // Qwen3-VL DeepStack: per-token feature inputs (from vision) and full-length scattered outputs
+  // (to decoder). Both are declared per deepstack_visual_index in genai_config.
+  for (const auto& ds_name : model_.config_->model.embedding.inputs.deepstack_features) {
+    auto ds = std::make_unique<MultiModalFeatures>(*this, MultiModalFeatures::Mode::Input,
+                                                   ds_name, num_images, num_image_tokens_);
+    ds->Add();
+    deepstack_features_in_.push_back(std::move(ds));
+  }
+  for (const auto& ds_name : model_.config_->model.embedding.outputs.deepstack) {
+    auto ds = std::make_unique<Embeddings>(*this, Embeddings::Mode::Output, ds_name);
+    ds->Add();
+    deepstack_out_.push_back(std::move(ds));
+  }
   if (model_.speech_session_) {
     audio_features_ = std::make_unique<MultiModalFeatures>(*this, MultiModalFeatures::Mode::Input,  // Optional model input
                                                            model_.config_->model.embedding.inputs.audio_features,
@@ -649,6 +696,7 @@ void EmbeddingState::SetExtraInputs(const int64_t num_images, const int64_t num_
 void EmbeddingState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, bool is_prompt) {
   input_ids_.Update(next_tokens);
   if (model_.vision_session_) image_features_->Update(is_prompt);
+  for (auto& ds : deepstack_features_in_) ds->Update(is_prompt);
   if (audio_features_) audio_features_->Update(is_prompt);
 }
 
@@ -667,6 +715,14 @@ DecoderState::DecoderState(const MultiModalLanguageModel& model, DeviceSpan<int3
       kv_cache_{model_.p_device_kvcache_->CreateKeyValueCache(*this)},
       recurrent_state_{CreateRecurrentState(*this)} {
   inputs_embeds_.Add();
+
+  // Qwen3-VL DeepStack: full-length feature inputs injected after decoder layers 0/1/2. Allocated
+  // here (owning buffer); the embedding model's matching outputs reuse these buffers each step.
+  for (const auto& ds_name : model_.config_->model.decoder.inputs.deepstack) {
+    auto ds = std::make_unique<Embeddings>(*this, Embeddings::Mode::Input, ds_name);
+    ds->Add();
+    deepstack_in_.push_back(std::move(ds));
+  }
 
   // Gemma4: decoder accepts per_layer_inputs from the embedding model
   if (!model_.config_->model.decoder.inputs.per_layer_inputs.empty()) {
@@ -734,6 +790,7 @@ void DecoderState::PrepareEmbeddingsForPrefill(size_t new_length) {
   // buffers in one run; the decoder then consumes them chunk by chunk.
   inputs_embeds_.UpdateSequenceLength(new_length);
   if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
+  for (auto& ds : deepstack_in_) ds->UpdateSequenceLength(new_length);
 }
 
 DeviceSpan<float> DecoderState::RunPrefillWithChunking(int current_length, DeviceSpan<int32_t>& next_tokens,
@@ -761,6 +818,7 @@ DeviceSpan<float> DecoderState::RunPrefillWithChunking(int current_length, Devic
     // Feed only this chunk's slice of the pre-computed embeddings to the decoder.
     inputs_embeds_.UseChunkView(processed_tokens, current_chunk_size);
     if (per_layer_inputs_) per_layer_inputs_->UseChunkView(processed_tokens, current_chunk_size);
+    for (auto& ds : deepstack_in_) ds->UseChunkView(processed_tokens, current_chunk_size);
 
     // Graph capture is disabled during prefill chunking.
     State::Run(*model_.decoder_session_, /*graph_capture_this_run=*/false);
@@ -787,6 +845,7 @@ void DecoderState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int tot
   logits_.Update(next_tokens, new_length);
   inputs_embeds_.UpdateSequenceLength(new_length);
   if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
+  for (auto& ds : deepstack_in_) ds->UpdateSequenceLength(new_length);
 }
 
 // Overload for pipeline to call
@@ -799,6 +858,7 @@ void DecoderState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int tot
   logits_.Update(next_tokens, new_length);
   inputs_embeds_.UpdateSequenceLength(new_length);
   if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
+  for (auto& ds : deepstack_in_) ds->UpdateSequenceLength(new_length);
 }
 
 MultiModalPipelineState::MultiModalPipelineState(const MultiModalLanguageModel& model, DeviceSpan<int32_t> sequence_lengths, const GeneratorParams& params)
@@ -892,6 +952,10 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
     }
     if (vision_state_) {
       embedding_state_->image_features_->ReuseFeaturesBuffer(*vision_state_->image_features_);
+      // Qwen3-VL DeepStack: hand each vision per-token output to the matching embedding input.
+      for (size_t k = 0; k < embedding_state_->deepstack_features_in_.size(); ++k) {
+        embedding_state_->deepstack_features_in_[k]->ReuseFeaturesBuffer(*vision_state_->deepstack_features_[k]);
+      }
     }
     if (speech_state_ && num_audio_tokens_ > 0) {
       // Reshape speech output from 3D [B, T, hidden] to 2D [B*T, hidden]
@@ -910,6 +974,10 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
     if (embedding_state_->per_layer_inputs_ && decoder_state_->per_layer_inputs_) {
       embedding_state_->per_layer_inputs_->ReuseEmbeddingsBuffer(*decoder_state_->per_layer_inputs_);
     }
+    // Qwen3-VL DeepStack: bind embedding's full-length scattered outputs to the decoder's inputs.
+    for (size_t k = 0; k < embedding_state_->deepstack_out_.size(); ++k) {
+      embedding_state_->deepstack_out_[k]->ReuseEmbeddingsBuffer(*decoder_state_->deepstack_in_[k]);
+    }
     embedding_state_->Run(current_length, next_tokens, next_indices);
 
     auto logits = chunk_prefill
@@ -926,6 +994,11 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
   embedding_state_->inputs_embeds_.ReuseEmbeddingsBuffer(decoder_state_->inputs_embeds_);
   if (embedding_state_->per_layer_inputs_ && decoder_state_->per_layer_inputs_) {
     embedding_state_->per_layer_inputs_->ReuseEmbeddingsBuffer(*decoder_state_->per_layer_inputs_);
+  }
+  // Qwen3-VL DeepStack: rebind embedding's full-length outputs (all zeros in generation, no image
+  // tokens) to the decoder's inputs so the per-layer Adds become no-ops.
+  for (size_t k = 0; k < embedding_state_->deepstack_out_.size(); ++k) {
+    embedding_state_->deepstack_out_[k]->ReuseEmbeddingsBuffer(*decoder_state_->deepstack_in_[k]);
   }
   embedding_state_->Run(current_length, next_tokens, next_indices);
   return decoder_state_->Run(current_length, next_tokens, next_indices);

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -644,13 +644,22 @@ EmbeddingState::EmbeddingState(const MultiModalLanguageModel& model, const Gener
   input_ids_.Add();
   inputs_embeds_.Add();
 
-  // Gemma4: embedding model produces per_layer_inputs alongside inputs_embeds
+  // Auxiliary per-token feature outputs injected into the decoder, paired by construction order
+  // with DecoderState::aux_feature_inputs_. Build per_layer_inputs first (Gemma4, if present),
+  // then one DeepStack output per deepstack_visual_index (Qwen3-VL). A model has at most one of
+  // these families, so the ordering is unambiguous.
   if (!model_.config_->model.embedding.outputs.per_layer_inputs.empty()) {
     auto shape = model_.session_info_.GetOutputShape(model_.config_->model.embedding.outputs.per_layer_inputs);
     int64_t per_layer_dim = shape.size() >= 3 ? shape.back() : 0;
-    per_layer_inputs_ = std::make_unique<Embeddings>(*this, Embeddings::Mode::Output,
-                                                     model_.config_->model.embedding.outputs.per_layer_inputs, per_layer_dim);
-    per_layer_inputs_->Add();
+    auto per_layer_inputs = std::make_unique<Embeddings>(*this, Embeddings::Mode::Output,
+                                                         model_.config_->model.embedding.outputs.per_layer_inputs, per_layer_dim);
+    per_layer_inputs->Add();
+    aux_feature_outputs_.push_back(std::move(per_layer_inputs));
+  }
+  for (const auto& ds_name : model_.config_->model.embedding.outputs.deepstack) {
+    auto ds = std::make_unique<Embeddings>(*this, Embeddings::Mode::Output, ds_name);
+    ds->Add();
+    aux_feature_outputs_.push_back(std::move(ds));
   }
 }
 
@@ -664,18 +673,13 @@ void EmbeddingState::SetExtraInputs(const int64_t num_images, const int64_t num_
                                                            num_images, num_image_tokens_);
     image_features_->Add();
   }
-  // Qwen3-VL DeepStack: per-token feature inputs (from vision) and full-length scattered outputs
-  // (to decoder). Both are declared per deepstack_visual_index in genai_config.
+  // Qwen3-VL DeepStack: per-token feature inputs from the vision model (mirror image_features_).
+  // The scattered full-length outputs to the decoder are aux_feature_outputs_ (built in the ctor).
   for (const auto& ds_name : model_.config_->model.embedding.inputs.deepstack_features) {
     auto ds = std::make_unique<MultiModalFeatures>(*this, MultiModalFeatures::Mode::Input,
                                                    ds_name, num_images, num_image_tokens_);
     ds->Add();
     deepstack_features_in_.push_back(std::move(ds));
-  }
-  for (const auto& ds_name : model_.config_->model.embedding.outputs.deepstack) {
-    auto ds = std::make_unique<Embeddings>(*this, Embeddings::Mode::Output, ds_name);
-    ds->Add();
-    deepstack_out_.push_back(std::move(ds));
   }
   if (model_.speech_session_) {
     audio_features_ = std::make_unique<MultiModalFeatures>(*this, MultiModalFeatures::Mode::Input,  // Optional model input
@@ -716,21 +720,23 @@ DecoderState::DecoderState(const MultiModalLanguageModel& model, DeviceSpan<int3
       recurrent_state_{CreateRecurrentState(*this)} {
   inputs_embeds_.Add();
 
-  // Qwen3-VL DeepStack: full-length feature inputs injected after decoder layers 0/1/2. Allocated
-  // here (owning buffer); the embedding model's matching outputs reuse these buffers each step.
-  for (const auto& ds_name : model_.config_->model.decoder.inputs.deepstack) {
-    auto ds = std::make_unique<Embeddings>(*this, Embeddings::Mode::Input, ds_name);
-    ds->Add();
-    deepstack_in_.push_back(std::move(ds));
-  }
-
-  // Gemma4: decoder accepts per_layer_inputs from the embedding model
+  // Auxiliary per-token feature inputs injected into the decoder, paired by construction order
+  // with EmbeddingState::aux_feature_outputs_. Build per_layer_inputs first (Gemma4, if present),
+  // then one DeepStack input per deepstack_visual_index (Qwen3-VL, added after layers 0/1/2). These
+  // are allocated here (owning buffers); the embedding model's matching outputs reuse them each
+  // step. A model has at most one of these families, so the ordering is unambiguous.
   if (!model_.config_->model.decoder.inputs.per_layer_inputs.empty()) {
     auto shape = model_.session_info_.GetInputShape(model_.config_->model.decoder.inputs.per_layer_inputs);
     int64_t per_layer_dim = shape.size() >= 3 ? shape.back() : 0;
-    per_layer_inputs_ = std::make_unique<Embeddings>(*this, Embeddings::Mode::Input,
-                                                     model_.config_->model.decoder.inputs.per_layer_inputs, per_layer_dim);
-    per_layer_inputs_->Add();
+    auto per_layer_inputs = std::make_unique<Embeddings>(*this, Embeddings::Mode::Input,
+                                                         model_.config_->model.decoder.inputs.per_layer_inputs, per_layer_dim);
+    per_layer_inputs->Add();
+    aux_feature_inputs_.push_back(std::move(per_layer_inputs));
+  }
+  for (const auto& ds_name : model_.config_->model.decoder.inputs.deepstack) {
+    auto ds = std::make_unique<Embeddings>(*this, Embeddings::Mode::Input, ds_name);
+    ds->Add();
+    aux_feature_inputs_.push_back(std::move(ds));
   }
 
   // Some multimodal decoders (e.g., Gemma4) require input_ids alongside inputs_embeds.
@@ -789,8 +795,7 @@ void DecoderState::PrepareEmbeddingsForPrefill(size_t new_length) {
   // Allocate the embeddings buffers for the whole prompt. The embedding model writes into these
   // buffers in one run; the decoder then consumes them chunk by chunk.
   inputs_embeds_.UpdateSequenceLength(new_length);
-  if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
-  for (auto& ds : deepstack_in_) ds->UpdateSequenceLength(new_length);
+  for (auto& f : aux_feature_inputs_) f->UpdateSequenceLength(new_length);
 }
 
 DeviceSpan<float> DecoderState::RunPrefillWithChunking(int current_length, DeviceSpan<int32_t>& next_tokens,
@@ -817,8 +822,7 @@ DeviceSpan<float> DecoderState::RunPrefillWithChunking(int current_length, Devic
 
     // Feed only this chunk's slice of the pre-computed embeddings to the decoder.
     inputs_embeds_.UseChunkView(processed_tokens, current_chunk_size);
-    if (per_layer_inputs_) per_layer_inputs_->UseChunkView(processed_tokens, current_chunk_size);
-    for (auto& ds : deepstack_in_) ds->UseChunkView(processed_tokens, current_chunk_size);
+    for (auto& f : aux_feature_inputs_) f->UseChunkView(processed_tokens, current_chunk_size);
 
     // Graph capture is disabled during prefill chunking.
     State::Run(*model_.decoder_session_, /*graph_capture_this_run=*/false);
@@ -827,7 +831,7 @@ DeviceSpan<float> DecoderState::RunPrefillWithChunking(int current_length, Devic
   }
 
   inputs_embeds_.RestoreFullView();
-  if (per_layer_inputs_) per_layer_inputs_->RestoreFullView();
+  for (auto& f : aux_feature_inputs_) f->RestoreFullView();
 
   // Logits of the last chunk contain the logits for the last prompt token.
   return logits_.Get();
@@ -844,8 +848,7 @@ void DecoderState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int tot
     recurrent_state_->Update();
   logits_.Update(next_tokens, new_length);
   inputs_embeds_.UpdateSequenceLength(new_length);
-  if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
-  for (auto& ds : deepstack_in_) ds->UpdateSequenceLength(new_length);
+  for (auto& f : aux_feature_inputs_) f->UpdateSequenceLength(new_length);
 }
 
 // Overload for pipeline to call
@@ -857,8 +860,7 @@ void DecoderState::UpdateInputsOutputs(DeviceSpan<int32_t>& next_tokens, int tot
     recurrent_state_->Update();
   logits_.Update(next_tokens, new_length);
   inputs_embeds_.UpdateSequenceLength(new_length);
-  if (per_layer_inputs_) per_layer_inputs_->UpdateSequenceLength(new_length);
-  for (auto& ds : deepstack_in_) ds->UpdateSequenceLength(new_length);
+  for (auto& f : aux_feature_inputs_) f->UpdateSequenceLength(new_length);
 }
 
 MultiModalPipelineState::MultiModalPipelineState(const MultiModalLanguageModel& model, DeviceSpan<int32_t> sequence_lengths, const GeneratorParams& params)
@@ -914,6 +916,22 @@ void MultiModalPipelineState::SetExtraInputs(const std::vector<ExtraInput>& extr
     if (img_grid || vid_grid) {
       qwen_pos_inputs->SetGridTensors(img_grid, vid_grid, sec_grid);
     }
+  }
+}
+
+void MultiModalPipelineState::BindAuxFeatureBuffers() {
+  // Gemma4 per_layer_inputs and Qwen3-VL DeepStack both flow embedding-output -> decoder-input as
+  // per-token feature tensors; they are built in the same order on both sides, so pair by index.
+  auto& outputs = embedding_state_->aux_feature_outputs_;
+  auto& inputs = decoder_state_->aux_feature_inputs_;
+  if (outputs.size() != inputs.size()) {
+    throw std::runtime_error("Auxiliary decoder feature mismatch: embedding produces " +
+                             std::to_string(outputs.size()) + " feature output(s) but the decoder expects " +
+                             std::to_string(inputs.size()) +
+                             " (check per_layer_inputs / deepstack entries in genai_config).");
+  }
+  for (size_t k = 0; k < outputs.size(); ++k) {
+    outputs[k]->ReuseEmbeddingsBuffer(*inputs[k]);
   }
 }
 
@@ -977,19 +995,7 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
       embedding_state_->audio_features_->AllocateEmptyFeatures();
     }
     embedding_state_->inputs_embeds_.ReuseEmbeddingsBuffer(decoder_state_->inputs_embeds_);
-    if (embedding_state_->per_layer_inputs_ && decoder_state_->per_layer_inputs_) {
-      embedding_state_->per_layer_inputs_->ReuseEmbeddingsBuffer(*decoder_state_->per_layer_inputs_);
-    }
-    // Qwen3-VL DeepStack: bind embedding's full-length scattered outputs to the decoder's inputs.
-    if (embedding_state_->deepstack_out_.size() != decoder_state_->deepstack_in_.size()) {
-      throw std::runtime_error("DeepStack config mismatch: embedding.outputs.deepstack count (" +
-                               std::to_string(embedding_state_->deepstack_out_.size()) +
-                               ") must match decoder.inputs.deepstack count (" +
-                               std::to_string(decoder_state_->deepstack_in_.size()) + ").");
-    }
-    for (size_t k = 0; k < embedding_state_->deepstack_out_.size(); ++k) {
-      embedding_state_->deepstack_out_[k]->ReuseEmbeddingsBuffer(*decoder_state_->deepstack_in_[k]);
-    }
+    BindAuxFeatureBuffers();
     embedding_state_->Run(current_length, next_tokens, next_indices);
 
     auto logits = chunk_prefill
@@ -1004,20 +1010,9 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
   }
 
   embedding_state_->inputs_embeds_.ReuseEmbeddingsBuffer(decoder_state_->inputs_embeds_);
-  if (embedding_state_->per_layer_inputs_ && decoder_state_->per_layer_inputs_) {
-    embedding_state_->per_layer_inputs_->ReuseEmbeddingsBuffer(*decoder_state_->per_layer_inputs_);
-  }
-  // Qwen3-VL DeepStack: rebind embedding's full-length outputs (all zeros in generation, no image
-  // tokens) to the decoder's inputs so the per-layer Adds become no-ops.
-  if (embedding_state_->deepstack_out_.size() != decoder_state_->deepstack_in_.size()) {
-    throw std::runtime_error("DeepStack config mismatch: embedding.outputs.deepstack count (" +
-                             std::to_string(embedding_state_->deepstack_out_.size()) +
-                             ") must match decoder.inputs.deepstack count (" +
-                             std::to_string(decoder_state_->deepstack_in_.size()) + ").");
-  }
-  for (size_t k = 0; k < embedding_state_->deepstack_out_.size(); ++k) {
-    embedding_state_->deepstack_out_[k]->ReuseEmbeddingsBuffer(*decoder_state_->deepstack_in_[k]);
-  }
+  // In generation there are no image tokens, so embedding.onnx emits all-zeros for any DeepStack
+  // outputs and the decoder's per-layer Adds become no-ops.
+  BindAuxFeatureBuffers();
   embedding_state_->Run(current_length, next_tokens, next_indices);
   return decoder_state_->Run(current_length, next_tokens, next_indices);
 }

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -57,6 +57,9 @@ struct VisionState : State {
   int64_t num_images_{};
   ExtraInputs extra_inputs_{*this};  // Model inputs
   std::unique_ptr<MultiModalFeatures> image_features_;
+  // Qwen3-VL DeepStack: extra per-token vision outputs (one per deepstack_visual_index).
+  // Same shape/type as image_features; consumed by the embedding model.
+  std::vector<std::unique_ptr<MultiModalFeatures>> deepstack_features_;
 };
 
 // QwenVisionState: per-image slicing loop for Qwen2.5-VL / Qwen3-VL.
@@ -168,6 +171,10 @@ struct EmbeddingState : State {
   Embeddings inputs_embeds_{*this, Embeddings::Mode::Output,  // Model output
                             model_.config_->model.embedding.outputs.embeddings};
   std::unique_ptr<Embeddings> per_layer_inputs_;  // Optional model output (Gemma4)
+  // Qwen3-VL DeepStack: per-token features in (from vision), full-length scattered features out
+  // (to decoder). The scatter (input_ids==image_token) is done inside embedding.onnx.
+  std::vector<std::unique_ptr<MultiModalFeatures>> deepstack_features_in_;  // Optional model inputs
+  std::vector<std::unique_ptr<Embeddings>> deepstack_out_;                  // Model outputs
 };
 
 struct DecoderState : State {
@@ -197,6 +204,8 @@ struct DecoderState : State {
                             model_.config_->model.decoder.inputs.embeddings};
   std::unique_ptr<Embeddings> per_layer_inputs_;        // Optional model input (Gemma4: per-layer conditioning)
   std::unique_ptr<DefaultInputIDs> decoder_input_ids_;  // Optional model input (e.g., Gemma4 decoder needs input_ids)
+  // Qwen3-VL DeepStack: full-length scattered features injected after decoder layers 0/1/2.
+  std::vector<std::unique_ptr<Embeddings>> deepstack_in_;  // Model inputs
   std::unique_ptr<PositionInputs> position_inputs_;     // Model input
   std::unique_ptr<KeyValueCache> kv_cache_;             // Model input
   std::unique_ptr<RecurrentState> recurrent_state_;     // Model input (for hybrid models)

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -206,10 +206,10 @@ struct DecoderState : State {
   std::unique_ptr<DefaultInputIDs> decoder_input_ids_;  // Optional model input (e.g., Gemma4 decoder needs input_ids)
   // Qwen3-VL DeepStack: full-length scattered features injected after decoder layers 0/1/2.
   std::vector<std::unique_ptr<Embeddings>> deepstack_in_;  // Model inputs
-  std::unique_ptr<PositionInputs> position_inputs_;     // Model input
-  std::unique_ptr<KeyValueCache> kv_cache_;             // Model input
-  std::unique_ptr<RecurrentState> recurrent_state_;     // Model input (for hybrid models)
-  Logits logits_{*this};                                // Model output
+  std::unique_ptr<PositionInputs> position_inputs_;        // Model input
+  std::unique_ptr<KeyValueCache> kv_cache_;                // Model input
+  std::unique_ptr<RecurrentState> recurrent_state_;        // Model input (for hybrid models)
+  Logits logits_{*this};                                   // Model output
 };
 
 struct MultiModalPipelineState : State {

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -170,11 +170,13 @@ struct EmbeddingState : State {
   std::unique_ptr<MultiModalFeatures> audio_features_;        // Optional model input
   Embeddings inputs_embeds_{*this, Embeddings::Mode::Output,  // Model output
                             model_.config_->model.embedding.outputs.embeddings};
-  std::unique_ptr<Embeddings> per_layer_inputs_;  // Optional model output (Gemma4)
-  // Qwen3-VL DeepStack: per-token features in (from vision), full-length scattered features out
-  // (to decoder). The scatter (input_ids==image_token) is done inside embedding.onnx.
+  // Auxiliary per-token feature outputs produced alongside inputs_embeds and injected into the
+  // decoder: Gemma4 per_layer_inputs (1) and Qwen3-VL DeepStack (one per deepstack_visual_index).
+  // Paired by construction order with DecoderState::aux_feature_inputs_.
+  std::vector<std::unique_ptr<Embeddings>> aux_feature_outputs_;  // Optional model outputs
+  // Qwen3-VL DeepStack per-token feature inputs (from vision); mirror image_features_. The scatter
+  // to full length (input_ids==image_token) happens inside embedding.onnx.
   std::vector<std::unique_ptr<MultiModalFeatures>> deepstack_features_in_;  // Optional model inputs
-  std::vector<std::unique_ptr<Embeddings>> deepstack_out_;                  // Model outputs
 };
 
 struct DecoderState : State {
@@ -202,14 +204,15 @@ struct DecoderState : State {
   const MultiModalLanguageModel& model_;
   Embeddings inputs_embeds_{*this, Embeddings::Mode::Input,  // Model input
                             model_.config_->model.decoder.inputs.embeddings};
-  std::unique_ptr<Embeddings> per_layer_inputs_;        // Optional model input (Gemma4: per-layer conditioning)
-  std::unique_ptr<DefaultInputIDs> decoder_input_ids_;  // Optional model input (e.g., Gemma4 decoder needs input_ids)
-  // Qwen3-VL DeepStack: full-length scattered features injected after decoder layers 0/1/2.
-  std::vector<std::unique_ptr<Embeddings>> deepstack_in_;  // Model inputs
-  std::unique_ptr<PositionInputs> position_inputs_;        // Model input
-  std::unique_ptr<KeyValueCache> kv_cache_;                // Model input
-  std::unique_ptr<RecurrentState> recurrent_state_;        // Model input (for hybrid models)
-  Logits logits_{*this};                                   // Model output
+  // Auxiliary per-token feature inputs produced by the embedding model and injected into the
+  // decoder: Gemma4 per_layer_inputs (1) and Qwen3-VL DeepStack (one per deepstack_visual_index,
+  // added after layers 0/1/2). Paired by construction order with EmbeddingState::aux_feature_outputs_.
+  std::vector<std::unique_ptr<Embeddings>> aux_feature_inputs_;  // Optional model inputs
+  std::unique_ptr<DefaultInputIDs> decoder_input_ids_;           // Optional model input (e.g., Gemma4 decoder needs input_ids)
+  std::unique_ptr<PositionInputs> position_inputs_;              // Model input
+  std::unique_ptr<KeyValueCache> kv_cache_;                      // Model input
+  std::unique_ptr<RecurrentState> recurrent_state_;              // Model input (for hybrid models)
+  Logits logits_{*this};                                         // Model output
 };
 
 struct MultiModalPipelineState : State {
@@ -230,6 +233,10 @@ struct MultiModalPipelineState : State {
  private:
   void UpdateInputsOutputs(const DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices,
                            int current_length);
+
+  // Bind each embedding auxiliary feature output to the matching decoder input, paired by index
+  // (Gemma4 per_layer_inputs and/or Qwen3-VL DeepStack). Throws on a count mismatch.
+  void BindAuxFeatureBuffers();
 
   const MultiModalLanguageModel& model_;
   int64_t num_image_tokens_{};

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -83,6 +83,43 @@ class Qwen3VLTextModel(Qwen25VLTextModel):
         # Qwen3-VL uses the Interleaved MRotaryEmbedding layout.
         self.rope_attrs["mrope_layout"] = 1
 
+        # DeepStack: the vision encoder emits len(deepstack_visual_indexes) extra feature
+        # tensors (3 for the 4B model, from vision layers [5, 11, 17]). These are scattered to
+        # full length (batch, seq, hidden) by embedding.onnx and injected into the residual
+        # stream after decoder layers 0/1/2 (feature i -> layer i), matching HF's
+        # Qwen3VLTextModel._deepstack_process. We declare them as extra decoder inputs and add
+        # them in make_layer. During generation there are no image tokens, so embedding.onnx
+        # emits all-zeros and the Adds become no-ops.
+        vision_config = getattr(config, "vision_config", None)
+        ds_indexes = getattr(vision_config, "deepstack_visual_indexes", None) if vision_config else None
+        self.num_deepstack = len(ds_indexes) if ds_indexes else 3
+        # Full-length (batch, seq, hidden) scattered features produced by embedding.onnx are
+        # named "deepstack_{i}" (the per-token vision->embedding tensors are named
+        # "deepstack_features_{i}"). This matches genai_config decoder.inputs.deepstack.
+        for i in range(self.num_deepstack):
+            name = f"deepstack_{i}"
+            self.input_names[name] = name
+            self.input_types[name] = self.io_dtype
+            self.input_shapes[name] = ["batch_size", "sequence_length", self.hidden_size]
+
+    def make_layer(self, layer_id, layer):
+        # Build the standard decoder layer, then inject the DeepStack feature for this layer
+        # (layers 0..num_deepstack-1) into the residual stream. After make_layer the
+        # layernorm "skip_input" points at this layer's MLP down_proj output, which the next
+        # layer's input SkipLayerNorm adds to the residual (output_3 = root_input + skip_input).
+        # Adding deepstack_{layer_id} to that skip_input makes the next layer's residual (and its
+        # normalized input) include the DeepStack feature -- exactly HF's
+        # "hidden_states[image_positions] += visual_embeds after layer i".
+        super().make_layer(layer_id, layer)
+        if layer_id < self.num_deepstack:
+            skip_input = self.layernorm_attrs["skip_input"]
+            ds_name = f"deepstack_{layer_id}"
+            add_name = f"/model/layers.{layer_id}/deepstack/Add"
+            add_output = f"{add_name}/output_0"
+            self.make_node("Add", inputs=[skip_input, ds_name], outputs=[add_output], name=add_name)
+            self.make_value(add_output, self.io_dtype, shape=["batch_size", "sequence_length", self.hidden_size])
+            self.layernorm_attrs["skip_input"] = add_output
+
     def make_qk_norm(self, layer_id, attention):
         # Before: SimplifiedLayerNorm --> Cast from FP32 to io_dtype --> Reshape --> Cast from io_dtype to FP32 --> MRotaryEmbedding
         # After:  SimplifiedLayerNorm --> Reshape --> MRotaryEmbedding

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -87,12 +87,14 @@ class Qwen3VLTextModel(Qwen25VLTextModel):
         # tensors (3 for the 4B model, from vision layers [5, 11, 17]). These are scattered to
         # full length (batch, seq, hidden) by embedding.onnx and injected into the residual
         # stream after decoder layers 0/1/2 (feature i -> layer i), matching HF's
-        # Qwen3VLTextModel._deepstack_process. We declare them as extra decoder inputs and add
-        # them in make_layer. During generation there are no image tokens, so embedding.onnx
-        # emits all-zeros and the Adds become no-ops.
+        # Qwen3VLTextModel._deepstack_process. We declare them as extra decoder inputs (in
+        # make_inputs_and_outputs) and add them in make_layer. During generation there are no
+        # image tokens, so embedding.onnx emits all-zeros and the Adds become no-ops.
         vision_config = getattr(config, "vision_config", None)
         ds_indexes = getattr(vision_config, "deepstack_visual_indexes", None) if vision_config else None
         self.num_deepstack = len(ds_indexes) if ds_indexes else 3
+
+    def make_inputs_and_outputs(self):
         # Full-length (batch, seq, hidden) scattered features produced by embedding.onnx are
         # named "deepstack_{i}" (the per-token vision->embedding tensors are named
         # "deepstack_features_{i}"). This matches genai_config decoder.inputs.deepstack.
@@ -101,6 +103,7 @@ class Qwen3VLTextModel(Qwen25VLTextModel):
             self.input_names[name] = name
             self.input_types[name] = self.io_dtype
             self.input_shapes[name] = ["batch_size", "sequence_length", self.hidden_size]
+        super().make_inputs_and_outputs()
 
     def make_layer(self, layer_id, layer):
         # Build the standard decoder layer, then inject the DeepStack feature for this layer

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -83,16 +83,19 @@ class Qwen3VLTextModel(Qwen25VLTextModel):
         # Qwen3-VL uses the Interleaved MRotaryEmbedding layout.
         self.rope_attrs["mrope_layout"] = 1
 
-        # DeepStack: the vision encoder emits len(deepstack_visual_indexes) extra feature
-        # tensors (3 for the 4B model, from vision layers [5, 11, 17]). These are scattered to
-        # full length (batch, seq, hidden) by embedding.onnx and injected into the residual
-        # stream after decoder layers 0/1/2 (feature i -> layer i), matching HF's
-        # Qwen3VLTextModel._deepstack_process. We declare them as extra decoder inputs (in
-        # make_inputs_and_outputs) and add them in make_layer. During generation there are no
-        # image tokens, so embedding.onnx emits all-zeros and the Adds become no-ops.
+        # DeepStack: when the vision config declares deepstack_visual_indexes, the vision encoder
+        # emits one extra feature tensor per index (3 for the 4B model, from vision layers
+        # [5, 11, 17]). These are scattered to full length (batch, seq, hidden) by embedding.onnx
+        # and injected into the residual stream after decoder layers 0/1/2 (feature i -> layer i),
+        # matching HF's Qwen3VLTextModel._deepstack_process. We declare them as extra decoder
+        # inputs (in make_inputs_and_outputs) and add them in make_layer; during generation there
+        # are no image tokens so embedding.onnx emits all-zeros and the Adds become no-ops.
+        # DeepStack is opt-in from config: a vision config without deepstack_visual_indexes
+        # (missing or empty) yields num_deepstack == 0, so both hooks no-op and the graph is the
+        # plain Qwen3-VL decoder.
         vision_config = getattr(config, "vision_config", None)
         ds_indexes = getattr(vision_config, "deepstack_visual_indexes", None) if vision_config else None
-        self.num_deepstack = len(ds_indexes) if ds_indexes else 3
+        self.num_deepstack = len(ds_indexes) if ds_indexes is not None else 0
 
     def make_inputs_and_outputs(self):
         # Full-length (batch, seq, hidden) scattered features produced by embedding.onnx are

--- a/test/python/builder/test_qwen_vl.py
+++ b/test/python/builder/test_qwen_vl.py
@@ -160,12 +160,73 @@ def test_qwen_vl_uses_separate_qkv_and_mrope(monkeypatch, model_class):
 def test_qwen_vl_decoder_uses_3d_position_ids(monkeypatch, model_class):
     model = model_class.__new__(model_class)
     model.use_paged_attention = False
+    model.io_dtype = ir.DataType.FLOAT16
+    model.hidden_size = 2048
+    model.num_deepstack = 3
+    model.input_names = {}
+    model.input_types = {}
     model.input_shapes = {"position_ids": ["batch_size", "sequence_length"]}
     monkeypatch.setattr(Model, "make_inputs_and_outputs", lambda self: None)
 
     model.make_inputs_and_outputs()
 
     assert model.input_shapes["position_ids"] == [3, "batch_size", "sequence_length"]
+
+
+def test_qwen3_vl_declares_deepstack_decoder_inputs(monkeypatch):
+    model = Qwen3VLTextModel.__new__(Qwen3VLTextModel)
+    model.use_paged_attention = False
+    model.io_dtype = ir.DataType.FLOAT16
+    model.hidden_size = 2048
+    model.num_deepstack = 3
+    model.input_names = {}
+    model.input_types = {}
+    model.input_shapes = {"position_ids": ["batch_size", "sequence_length"]}
+    monkeypatch.setattr(Model, "make_inputs_and_outputs", lambda self: None)
+
+    model.make_inputs_and_outputs()
+
+    for i in range(3):
+        name = f"deepstack_{i}"
+        assert model.input_names[name] == name
+        assert model.input_types[name] == ir.DataType.FLOAT16
+        assert model.input_shapes[name] == ["batch_size", "sequence_length", 2048]
+
+
+def test_qwen3_vl_make_layer_injects_deepstack_into_skip_input(monkeypatch):
+    model = Qwen3VLTextModel.__new__(Qwen3VLTextModel)
+    model.io_dtype = ir.DataType.FLOAT16
+    model.hidden_size = 2048
+    model.num_deepstack = 3
+    nodes = []
+    values = []
+
+    def base_make_layer(self, layer_id, layer):
+        self.layernorm_attrs["skip_input"] = f"/model/layers.{layer_id}/mlp/down_proj/output_0"
+
+    monkeypatch.setattr(Qwen25VLTextModel, "make_layer", base_make_layer)
+    model.make_node = lambda op_type, inputs, outputs, name: nodes.append((op_type, inputs, outputs, name))
+    model.make_value = lambda name, dtype, shape: values.append((name, dtype, shape))
+
+    # Layer 1 is within the deepstack range -> an Add is inserted and skip_input is rewired.
+    model.layernorm_attrs = {}
+    model.make_layer(1, object())
+    assert nodes == [
+        (
+            "Add",
+            ["/model/layers.1/mlp/down_proj/output_0", "deepstack_1"],
+            ["/model/layers.1/deepstack/Add/output_0"],
+            "/model/layers.1/deepstack/Add",
+        )
+    ]
+    assert model.layernorm_attrs["skip_input"] == "/model/layers.1/deepstack/Add/output_0"
+
+    # Layer 3 is outside the deepstack range -> no Add, skip_input untouched.
+    nodes.clear()
+    model.layernorm_attrs = {}
+    model.make_layer(3, object())
+    assert nodes == []
+    assert model.layernorm_attrs["skip_input"] == "/model/layers.3/mlp/down_proj/output_0"
 
 
 def test_qwen35_paged_decoder_uses_packed_3d_position_ids(monkeypatch):

--- a/test/python/builder/test_qwen_vl.py
+++ b/test/python/builder/test_qwen_vl.py
@@ -103,7 +103,7 @@ def test_qwen35_moe_loads_moe_transformers_model(monkeypatch):
     assert calls[0][0] is FakeMoEModel
 
 
-def _initialize_qwen_model(monkeypatch, model_class):
+def _initialize_qwen_model(monkeypatch, model_class, config=None):
     def initialize_base(self, *_args, **_kwargs):
         self.layernorm_attrs = {
             "cast": {
@@ -121,7 +121,25 @@ def _initialize_qwen_model(monkeypatch, model_class):
         self.attention_attrs = {"q_norm": False, "k_norm": False}
 
     monkeypatch.setattr(Model, "__init__", initialize_base)
-    return model_class(types.SimpleNamespace(), ir.DataType.FLOAT16, ir.DataType.FLOAT16, "cuda", "", {})
+    config = types.SimpleNamespace() if config is None else config
+    return model_class(config, ir.DataType.FLOAT16, ir.DataType.FLOAT16, "cuda", "", {})
+
+
+@pytest.mark.parametrize(
+    "vision_config,expected_num_deepstack",
+    [
+        (None, 0),  # no vision_config -> DeepStack disabled
+        (types.SimpleNamespace(), 0),  # vision_config present but no deepstack_visual_indexes
+        (types.SimpleNamespace(deepstack_visual_indexes=None), 0),
+        (types.SimpleNamespace(deepstack_visual_indexes=[]), 0),  # empty -> disabled
+        (types.SimpleNamespace(deepstack_visual_indexes=[5, 11, 17]), 3),
+    ],
+)
+def test_qwen3_vl_deepstack_count_follows_vision_config(monkeypatch, vision_config, expected_num_deepstack):
+    config = types.SimpleNamespace() if vision_config is None else types.SimpleNamespace(vision_config=vision_config)
+    model = _initialize_qwen_model(monkeypatch, Qwen3VLTextModel, config=config)
+
+    assert model.num_deepstack == expected_num_deepstack
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds **DeepStack** support for **Qwen3-VL** to the multi-model (vision → embedding → decoder) pipeline.

Qwen3-VL does not rely solely on a single merged vision embedding. Its vision encoder also emits a small number of **intermediate hidden-state feature maps** ("DeepStack" features, one per entry in `deepstack_visual_indexes` — 3 for the 4B model, from ViT layers `[5, 11, 17]`). These are scattered back onto the image-token positions and **added into the decoder residual stream after the first few decoder layers** (feature `i` → after layer `i`), matching Hugging Face's `Qwen3VLTextModel._deepstack_process`.

Without this, the model keeps only the final merged vision embedding and loses the fine-grained visual detail DeepStack carries, which significantly degrades OCR/grounding accuracy. This PR wires DeepStack end to end through config parsing, the C++ runtime, and the ONNX model builder.

## Motivation

DeepStack is required for Qwen3-VL to reach its expected accuracy on detail-sensitive tasks (OCR, document/diagram understanding, grounding). The existing Qwen3-VL path builds and runs, but silently drops the DeepStack features, so accuracy is well below the reference PyTorch model. This change closes that gap.

Design reference: microsoft/onnxruntime-genai#1989.

## How it works

The three sub-models exchange DeepStack tensors as follows:

```
vision.onnx      ->  deepstack_features_{i}   (per-token, image-token length)
embedding.onnx   ->  scatters them to full (batch, seq, hidden) -> deepstack_{i}
decoder.onnx     ->  adds deepstack_{i} into the residual after layer i
```

- The **scatter** (place per-token features at `input_ids == image_token` positions) happens inside `embedding.onnx`, so the runtime only has to move buffers, not compute indices.
- During **generation** there are no image tokens, so `embedding.onnx` emits all-zeros for `deepstack_{i}` and the decoder's per-layer `Add`s become no-ops. No special-casing in the runtime.

## Changes

**`src/config.h` / `src/config.cpp`** — parse the DeepStack tensor-name arrays from `genai_config.json`:
- `model.vision.outputs.deepstack_features`
- `model.embedding.inputs.deepstack_features`
- `model.embedding.outputs.deepstack`
- `model.decoder.inputs.deepstack`

Each is parsed via an `OnArray` hook backed by `StringArray_Element`. `StringArray_Element` is moved earlier in the file so `DecoderInputs_Element` (declared before its previous definition) can use it.

**`src/models/multi_modal.{h,cpp}`** — runtime wiring:
- `VisionState`: allocate the extra DeepStack outputs (`outputs_[1..N]`) and, in the `QwenVisionState` per-image loop, slice them at the same offsets as `image_features` and restore them after the loop.
- `EmbeddingState`: allocate the per-token DeepStack inputs (from vision) and the full-length DeepStack outputs (to decoder); update them each step.
- `DecoderState`: allocate the full-length DeepStack inputs (owning buffers) and size them alongside `inputs_embeds` / `per_layer_inputs`, including the **prefill-chunking** path (`PrepareEmbeddingsForPrefill` / `RunPrefillWithChunking`).
- `MultiModalPipelineState::Run`: bind vision → embedding (`ReuseFeaturesBuffer`) and embedding → decoder (`ReuseEmbeddingsBuffer`) DeepStack buffers in both the prompt and generation paths.

**`src/python/py/models/builders/qwen.py`** — `Qwen3VLTextModel`:
- Declares `deepstack_{i}` decoder graph inputs of shape `[batch, seq, hidden]` (count from `vision_config.deepstack_visual_indexes`, defaulting to 3).
- Overrides `make_layer` to add `deepstack_{layer_id}` into the layer's residual (`skip_input`) for `layer_id < num_deepstack`, so the next layer's `SkipLayerNorm` folds the feature into the residual — exactly HF's "add visual features after layer i".

## Validation

Validated on **Qwen3-VL-4B** (INT4 AWQ vision-fp32 / text) exported as the 3-model split:

- **End-to-end runtime smoke test**: the full vision → embedding → decoder DeepStack path runs and produces correct, grounded output (e.g. an image of a cat yields *"A fluffy Ragdoll cat with striking blue eyes and a white and brown coat rests peacefully, gazing directly at the camera…"*).
- **Accuracy (AI2D, 100 samples)**: **81%** (ONNX INT4) vs **83%** (PyTorch FP32) — a −2 pp gap that is within run-to-run noise, confirming no accuracy regression from the ONNX/runtime path.

## Build / test

- Builds cleanly (DirectML config): C++ compiles and links, Python bindings build.
- `src/python/py/models/builders/qwen.py` passes byte-compilation and existing lint.

## Scope / notes

- Feature is fully **opt-in**: with no `deepstack*` entries in `genai_config.json`, all the new loops iterate zero times and behavior is unchanged for every other model.
- The genai_config `deepstack*` arrays are produced by the export/optimize tooling; this PR is the runtime + builder side that consumes and emits them.
- DeepStack is also wired through the prefill-chunking path so it stays correct when `search.chunk_size` is set.
