### PR TITLE
stamps onnx model files with genai commit

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -130,6 +130,16 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${python_srcs})
 if(BUILD_WHEEL)
   set(WHEEL_FILES_DIR "${CMAKE_BINARY_DIR}/wheel")
   message("Setting up wheel files in : ${WHEEL_FILES_DIR}")
+  execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY "${REPO_ROOT}"
+    RESULT_VARIABLE GENAI_COMMIT_RESULT
+    OUTPUT_VARIABLE GENAI_COMMIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+  if(NOT GENAI_COMMIT_RESULT EQUAL 0)
+    set(GENAI_COMMIT "")
+  endif()
   if(USE_TRT_RTX)
     set(TARGET_NAME "onnxruntime-genai-trt-rtx")
   elseif(USE_WINML)

--- a/src/python/__init__.py.in
+++ b/src/python/__init__.py.in
@@ -4,6 +4,7 @@
 from onnxruntime_genai import _dll_directory
 
 __version__ = "@VERSION_INFO@"
+__commit__ = "@GENAI_COMMIT@"
 __id__ = "@TARGET_NAME@"
 
 _dll_directory.add_onnxruntime_dependency(__id__)

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -1639,19 +1639,23 @@ class Model:
     @classmethod
     def get_genai_version(cls) -> str | None:
         """Return the GenAI package version when source metadata is available."""
-        try:
-            # Attempt to read the version information from the VERSION_INFO file in the repository root.
-            repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
-            with open(os.path.join(repo_root, "VERSION_INFO"), encoding="utf-8") as version_info:
-                return version_info.read().strip()
-        except OSError:
+        # Attempt to read the version information from the VERSION_INFO file in the repository root.
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
+        version_info_path = os.path.join(repo_root, "VERSION_INFO")
+        if os.path.exists(version_info_path):
             try:
-                # If VERSION_INFO file is missing, we are installing from whl package. Use the version from the package metadata.
-                from onnxruntime_genai import __version__
+                with open(version_info_path, encoding="utf-8") as version_info:
+                    return version_info.read().strip()
+            except OSError:
+                pass
 
-                return __version__ or None
-            except ImportError:
-                return None
+        try:
+            # If VERSION_INFO file is missing, we are installing from whl package. Use the version from the package metadata.
+            from onnxruntime_genai import __version__
+
+            return __version__ or None
+        except ImportError:
+            return None
 
     @classmethod
     def get_genai_commit(cls) -> str | None:

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import ast
 import json
 import os
-from pathlib import Path
 import subprocess
 from collections.abc import Sequence
 
@@ -43,49 +42,6 @@ from quantization import CudaQuantizer, QuantConfig, resolve_dtype
 
 
 class Model:
-    def get_genai_version(self) -> str | None:
-        """Return the GenAI package version when source metadata is available."""
-        try:
-            # Attempt to read the version information from the VERSION_INFO file in the repository root.
-            return (Path(__file__).resolve().parents[5] / "VERSION_INFO").read_text(encoding="utf-8").strip()
-        except OSError:
-            try:
-                # If VERSION_INFO file is missing, we are installing from whl package. Use the version from the package metadata.
-                from onnxruntime_genai import __version__
-
-                return __version__ or None
-            except ImportError:
-                return None
-
-    def get_genai_commit(self) -> str | None:
-        """Return the current GenAI source revision when Git metadata is available."""
-        repo_root = Path(__file__).resolve().parents[5]
-        try:
-            # Attempt to get the current Git commit hash from the repository root.
-            result = subprocess.run(
-                ["git", "rev-parse", "HEAD"],
-                cwd=repo_root,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            return result.stdout.strip()
-        except (OSError, subprocess.CalledProcessError):
-            try:
-                # If Git metadata is unavailable, we are installing from whl package. Use the commit information from the package metadata.
-                from onnxruntime_genai import __commit__
-
-                return __commit__ or None
-            except ImportError:
-                return None
-
-    def stamp_build_metadata(self, model: ir.Model) -> None:
-        """Add GenAI version and source revision to an exported ONNX graph."""
-        if version := self.get_genai_version():
-            model.producer_version = version
-        if commit := self.get_genai_commit():
-            model.metadata_props["producer_commit"] = commit
-
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
         self.extra_options = extra_options
         self.make_config_init(config)
@@ -1680,6 +1636,53 @@ class Model:
             init.CopyFrom(numpy_helper.from_array(np.ascontiguousarray(packed), init.name))
             node.attribute.append(onnx_helper.make_attribute("weight_prepacked", prepack_mode))
 
+    @classmethod
+    def get_genai_version(cls) -> str | None:
+        """Return the GenAI package version when source metadata is available."""
+        try:
+            # Attempt to read the version information from the VERSION_INFO file in the repository root.
+            repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
+            with open(os.path.join(repo_root, "VERSION_INFO"), encoding="utf-8") as version_info:
+                return version_info.read().strip()
+        except OSError:
+            try:
+                # If VERSION_INFO file is missing, we are installing from whl package. Use the version from the package metadata.
+                from onnxruntime_genai import __version__
+
+                return __version__ or None
+            except ImportError:
+                return None
+
+    @classmethod
+    def get_genai_commit(cls) -> str | None:
+        """Return the current GenAI source revision when Git metadata is available."""
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
+        try:
+            # Attempt to get the current Git commit hash from the repository root.
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo_root,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return result.stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            try:
+                # If Git metadata is unavailable, we are installing from whl package. Use the commit information from the package metadata.
+                from onnxruntime_genai import __commit__
+
+                return __commit__ or None
+            except ImportError:
+                return None
+
+    @classmethod
+    def stamp_build_metadata(cls, model: ir.Model) -> None:
+        """Add GenAI version and an optional abbreviated source revision to an exported ONNX graph."""
+        if version := cls.get_genai_version():
+            commit_suffix = f"+{commit[:7]}" if (commit := cls.get_genai_commit()) else ""
+            model.producer_version = f"{version}{commit_suffix}"
+
     def save_model(self, out_dir):
         print(f"Saving ONNX model in {out_dir}")
 
@@ -1715,7 +1718,7 @@ class Model:
                 pbar.update()
                 pbar.set_description(f"Saving {tensor.name} ({tensor.dtype.short_name()}, {tensor.shape})")
 
-            self.stamp_build_metadata(model)
+            Model.stamp_build_metadata(model)
             ir.save(
                 model,
                 out_path,

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 import ast
-import functools
 import json
 import os
 from pathlib import Path
@@ -44,12 +43,25 @@ from quantization import CudaQuantizer, QuantConfig, resolve_dtype
 
 
 class Model:
-    @classmethod
-    @functools.cache
-    def get_genai_commit(cls) -> str | None:
+    def get_genai_version(self) -> str | None:
+        """Return the GenAI package version when source metadata is available."""
+        try:
+            # Attempt to read the version information from the VERSION_INFO file in the repository root.
+            return (Path(__file__).resolve().parents[5] / "VERSION_INFO").read_text(encoding="utf-8").strip()
+        except OSError:
+            try:
+                # If VERSION_INFO file is missing, we are installing from whl package. Use the version from the package metadata.
+                from onnxruntime_genai import __version__
+
+                return __version__ or None
+            except ImportError:
+                return None
+
+    def get_genai_commit(self) -> str | None:
         """Return the current GenAI source revision when Git metadata is available."""
         repo_root = Path(__file__).resolve().parents[5]
         try:
+            # Attempt to get the current Git commit hash from the repository root.
             result = subprocess.run(
                 ["git", "rev-parse", "HEAD"],
                 cwd=repo_root,
@@ -59,13 +71,20 @@ class Model:
             )
             return result.stdout.strip()
         except (OSError, subprocess.CalledProcessError):
-            return None
+            try:
+                # If Git metadata is unavailable, we are installing from whl package. Use the commit information from the package metadata.
+                from onnxruntime_genai import __commit__
 
-    @classmethod
-    def stamp_build_metadata(cls, model: ir.Model) -> None:
-        """Add the GenAI source revision to an exported ONNX graph."""
-        if commit := cls.get_genai_commit():
-            model.producer_version = commit
+                return __commit__ or None
+            except ImportError:
+                return None
+
+    def stamp_build_metadata(self, model: ir.Model) -> None:
+        """Add GenAI version and source revision to an exported ONNX graph."""
+        if version := self.get_genai_version():
+            model.producer_version = version
+        if commit := self.get_genai_commit():
+            model.metadata_props["producer_commit"] = commit
 
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
         self.extra_options = extra_options

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -43,30 +43,30 @@ from transformers import (
 from quantization import CudaQuantizer, QuantConfig, resolve_dtype
 
 
-@functools.cache
-def get_genai_commit() -> str | None:
-    """Return the current GenAI source revision when Git metadata is available."""
-    repo_root = Path(__file__).resolve().parents[5]
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=repo_root,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        return result.stdout.strip()
-    except (OSError, subprocess.CalledProcessError):
-        return None
-
-
-def stamp_build_metadata(model: ir.Model) -> None:
-    """Add the GenAI source revision to an exported ONNX graph."""
-    if commit := get_genai_commit():
-        model.producer_version = commit
-
-
 class Model:
+    @classmethod
+    @functools.cache
+    def get_genai_commit(cls) -> str | None:
+        """Return the current GenAI source revision when Git metadata is available."""
+        repo_root = Path(__file__).resolve().parents[5]
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo_root,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return result.stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            return None
+
+    @classmethod
+    def stamp_build_metadata(cls, model: ir.Model) -> None:
+        """Add the GenAI source revision to an exported ONNX graph."""
+        if commit := cls.get_genai_commit():
+            model.producer_version = commit
+
     def __init__(self, config, io_dtype, onnx_dtype, ep, cache_dir, extra_options):
         self.extra_options = extra_options
         self.make_config_init(config)
@@ -1696,7 +1696,7 @@ class Model:
                 pbar.update()
                 pbar.set_description(f"Saving {tensor.name} ({tensor.dtype.short_name()}, {tensor.shape})")
 
-            stamp_build_metadata(model)
+            self.stamp_build_metadata(model)
             ir.save(
                 model,
                 out_path,

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -9,8 +9,11 @@
 from __future__ import annotations
 
 import ast
+import functools
 import json
 import os
+from pathlib import Path
+import subprocess
 from collections.abc import Sequence
 
 import numpy as np
@@ -38,6 +41,29 @@ from transformers import (
 )
 
 from quantization import CudaQuantizer, QuantConfig, resolve_dtype
+
+
+@functools.cache
+def get_genai_commit() -> str | None:
+    """Return the current GenAI source revision when Git metadata is available."""
+    repo_root = Path(__file__).resolve().parents[5]
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def stamp_build_metadata(model: ir.Model) -> None:
+    """Add the GenAI source revision to an exported ONNX graph."""
+    if commit := get_genai_commit():
+        model.producer_version = commit
 
 
 class Model:
@@ -1670,6 +1696,7 @@ class Model:
                 pbar.update()
                 pbar.set_description(f"Saving {tensor.name} ({tensor.dtype.short_name()}, {tensor.shape})")
 
+            stamp_build_metadata(model)
             ir.save(
                 model,
                 out_path,

--- a/src/python/py/models/builders/dflash2.py
+++ b/src/python/py/models/builders/dflash2.py
@@ -42,7 +42,7 @@ import torch
 from onnx_ir.tensor_adapters import TorchTensor, to_torch_dtype
 from tqdm import tqdm
 
-from builders.base import stamp_build_metadata
+from builders.base import Model
 
 
 class DFlash2Builder:
@@ -930,7 +930,7 @@ class DFlash2Builder:
                 pbar.update()
                 pbar.set_description(f"Saving {tensor.name} ({tensor.dtype.short_name()}, {tensor.shape})")
 
-            stamp_build_metadata(self.model)
+            Model.stamp_build_metadata(self.model)
             ir.save(
                 self.model,
                 out_path,

--- a/src/python/py/models/builders/dflash2.py
+++ b/src/python/py/models/builders/dflash2.py
@@ -930,7 +930,7 @@ class DFlash2Builder:
                 pbar.update()
                 pbar.set_description(f"Saving {tensor.name} ({tensor.dtype.short_name()}, {tensor.shape})")
 
-            Model.__new__(Model).stamp_build_metadata(self.model)
+            Model.stamp_build_metadata(self.model)
             ir.save(
                 self.model,
                 out_path,

--- a/src/python/py/models/builders/dflash2.py
+++ b/src/python/py/models/builders/dflash2.py
@@ -42,6 +42,8 @@ import torch
 from onnx_ir.tensor_adapters import TorchTensor, to_torch_dtype
 from tqdm import tqdm
 
+from builders.base import stamp_build_metadata
+
 
 class DFlash2Builder:
     """Emits ``dflash2.onnx`` from a DFlash 2 draft checkpoint plus the target's
@@ -928,6 +930,7 @@ class DFlash2Builder:
                 pbar.update()
                 pbar.set_description(f"Saving {tensor.name} ({tensor.dtype.short_name()}, {tensor.shape})")
 
+            stamp_build_metadata(self.model)
             ir.save(
                 self.model,
                 out_path,

--- a/src/python/py/models/builders/dflash2.py
+++ b/src/python/py/models/builders/dflash2.py
@@ -930,7 +930,7 @@ class DFlash2Builder:
                 pbar.update()
                 pbar.set_description(f"Saving {tensor.name} ({tensor.dtype.short_name()}, {tensor.shape})")
 
-            Model.stamp_build_metadata(self.model)
+            Model.__new__(Model).stamp_build_metadata(self.model)
             ir.save(
                 self.model,
                 out_path,

--- a/test/python/builder/test_build_metadata.py
+++ b/test/python/builder/test_build_metadata.py
@@ -59,6 +59,7 @@ def test_stamp_build_metadata_uses_version_when_commit_is_unavailable(monkeypatc
 
     monkeypatch.setattr(base_module.subprocess, "run", missing_git)
     monkeypatch.setattr(base_module.Model, "get_genai_version", classmethod(lambda cls: GENAI_VERSION))
+    monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__commit__=""))
     model = _make_empty_onnx_model()
 
     Model.stamp_build_metadata(model)

--- a/test/python/builder/test_build_metadata.py
+++ b/test/python/builder/test_build_metadata.py
@@ -6,24 +6,26 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 import types
-from pathlib import Path
 
 import onnx_ir as ir
 
-MODELS_DIR = Path(__file__).parents[3] / "src" / "python" / "py" / "models"
-BUILDERS_DIR = MODELS_DIR / "builders"
-GENAI_VERSION = (Path(__file__).parents[3] / "VERSION_INFO").read_text(encoding="utf-8").strip()
-sys.path.insert(0, str(MODELS_DIR))
+TEST_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+MODELS_DIR = os.path.join(TEST_ROOT, "src", "python", "py", "models")
+BUILDERS_DIR = os.path.join(MODELS_DIR, "builders")
+with open(os.path.join(TEST_ROOT, "VERSION_INFO"), encoding="utf-8") as version_info:
+    GENAI_VERSION = version_info.read().strip()
+sys.path.insert(0, MODELS_DIR)
 
 
 def _load_base_module():
     sys.modules.setdefault("models", types.ModuleType("models"))
     builders_package = sys.modules.setdefault("models.builders", types.ModuleType("models.builders"))
-    builders_package.__path__ = [str(BUILDERS_DIR)]
+    builders_package.__path__ = [BUILDERS_DIR]
 
-    spec = importlib.util.spec_from_file_location("models.builders.base", BUILDERS_DIR / "base.py")
+    spec = importlib.util.spec_from_file_location("models.builders.base", os.path.join(BUILDERS_DIR, "base.py"))
     module = importlib.util.module_from_spec(spec)
     sys.modules["models.builders.base"] = module
     spec.loader.exec_module(module)
@@ -39,53 +41,40 @@ def _make_empty_onnx_model():
     return ir.Model(graph, ir_version=10, producer_name="onnxruntime-genai")
 
 
-def test_stamp_build_metadata_sets_genai_version_and_commit(monkeypatch):
+def test_stamp_build_metadata_embeds_commit_in_producer_version(monkeypatch):
     result = types.SimpleNamespace(stdout="0123456789abcdef\n")
     monkeypatch.setattr(base_module.subprocess, "run", lambda *args, **kwargs: result)
-    monkeypatch.setattr(base_module.Model, "get_genai_version", lambda self: GENAI_VERSION)
-    builder = Model.__new__(Model)
+    monkeypatch.setattr(base_module.Model, "get_genai_version", classmethod(lambda cls: GENAI_VERSION))
     model = _make_empty_onnx_model()
 
-    builder.stamp_build_metadata(model)
+    Model.stamp_build_metadata(model)
 
-    assert model.producer_version == GENAI_VERSION
-    assert model.metadata_props["producer_commit"] == "0123456789abcdef"
+    assert model.producer_version == f"{GENAI_VERSION}+0123456"
+    assert not model.metadata_props
 
 
-def test_stamp_build_metadata_handles_missing_git(monkeypatch):
+def test_stamp_build_metadata_uses_version_when_commit_is_unavailable(monkeypatch):
     def missing_git(*args, **kwargs):
         raise FileNotFoundError
 
     monkeypatch.setattr(base_module.subprocess, "run", missing_git)
-    monkeypatch.setattr(base_module.Model, "get_genai_version", lambda self: GENAI_VERSION)
-    builder = Model.__new__(Model)
+    monkeypatch.setattr(base_module.Model, "get_genai_version", classmethod(lambda cls: GENAI_VERSION))
     model = _make_empty_onnx_model()
 
-    builder.stamp_build_metadata(model)
+    Model.stamp_build_metadata(model)
 
     assert model.producer_version == GENAI_VERSION
-    assert "producer_commit" not in model.metadata_props
+    assert not model.metadata_props
 
 
 def test_get_genai_version_uses_installed_package_metadata(monkeypatch):
-    class MissingVersionInfo:
-        def resolve(self):
-            return self
+    def missing_version_info(*args, **kwargs):
+        raise FileNotFoundError
 
-        @property
-        def parents(self):
-            return [self] * 6
-
-        def __truediv__(self, _):
-            return self
-
-        def read_text(self, **_):
-            raise FileNotFoundError
-
-    monkeypatch.setattr(base_module, "Path", lambda _: MissingVersionInfo())
+    monkeypatch.setattr(base_module, "open", missing_version_info, raising=False)
     monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__version__=GENAI_VERSION))
 
-    assert Model.__new__(Model).get_genai_version() == GENAI_VERSION
+    assert Model.get_genai_version() == GENAI_VERSION
 
 
 def test_get_genai_commit_uses_installed_package_metadata(monkeypatch):
@@ -95,4 +84,4 @@ def test_get_genai_commit_uses_installed_package_metadata(monkeypatch):
     monkeypatch.setattr(base_module.subprocess, "run", missing_git)
     monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__commit__="0123456789abcdef"))
 
-    assert Model.__new__(Model).get_genai_commit() == "0123456789abcdef"
+    assert Model.get_genai_commit() == "0123456789abcdef"

--- a/test/python/builder/test_build_metadata.py
+++ b/test/python/builder/test_build_metadata.py
@@ -68,10 +68,7 @@ def test_stamp_build_metadata_uses_version_when_commit_is_unavailable(monkeypatc
 
 
 def test_get_genai_version_uses_installed_package_metadata(monkeypatch):
-    def missing_version_info(*args, **kwargs):
-        raise FileNotFoundError
-
-    monkeypatch.setattr(base_module, "open", missing_version_info, raising=False)
+    monkeypatch.setattr(base_module.os.path, "exists", lambda _: False)
     monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__version__=GENAI_VERSION))
 
     assert Model.get_genai_version() == GENAI_VERSION

--- a/test/python/builder/test_build_metadata.py
+++ b/test/python/builder/test_build_metadata.py
@@ -1,0 +1,98 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License
+
+"""Tests for ONNX export provenance stamped by the model builder."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import onnx_ir as ir
+
+MODELS_DIR = Path(__file__).parents[3] / "src" / "python" / "py" / "models"
+BUILDERS_DIR = MODELS_DIR / "builders"
+GENAI_VERSION = (Path(__file__).parents[3] / "VERSION_INFO").read_text(encoding="utf-8").strip()
+sys.path.insert(0, str(MODELS_DIR))
+
+
+def _load_base_module():
+    sys.modules.setdefault("models", types.ModuleType("models"))
+    builders_package = sys.modules.setdefault("models.builders", types.ModuleType("models.builders"))
+    builders_package.__path__ = [str(BUILDERS_DIR)]
+
+    spec = importlib.util.spec_from_file_location("models.builders.base", BUILDERS_DIR / "base.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["models.builders.base"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+base_module = _load_base_module()
+Model = base_module.Model
+
+
+def _make_empty_onnx_model():
+    graph = ir.Graph(inputs=(), outputs=(), nodes=(), opset_imports={"": 22})
+    return ir.Model(graph, ir_version=10, producer_name="onnxruntime-genai")
+
+
+def test_stamp_build_metadata_sets_genai_version_and_commit(monkeypatch):
+    result = types.SimpleNamespace(stdout="0123456789abcdef\n")
+    monkeypatch.setattr(base_module.subprocess, "run", lambda *args, **kwargs: result)
+    monkeypatch.setattr(base_module.Model, "get_genai_version", lambda self: GENAI_VERSION)
+    builder = Model.__new__(Model)
+    model = _make_empty_onnx_model()
+
+    builder.stamp_build_metadata(model)
+
+    assert model.producer_version == GENAI_VERSION
+    assert model.metadata_props["producer_commit"] == "0123456789abcdef"
+
+
+def test_stamp_build_metadata_handles_missing_git(monkeypatch):
+    def missing_git(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(base_module.subprocess, "run", missing_git)
+    monkeypatch.setattr(base_module.Model, "get_genai_version", lambda self: GENAI_VERSION)
+    builder = Model.__new__(Model)
+    model = _make_empty_onnx_model()
+
+    builder.stamp_build_metadata(model)
+
+    assert model.producer_version == GENAI_VERSION
+    assert "producer_commit" not in model.metadata_props
+
+
+def test_get_genai_version_uses_installed_package_metadata(monkeypatch):
+    class MissingVersionInfo:
+        def resolve(self):
+            return self
+
+        @property
+        def parents(self):
+            return [self] * 6
+
+        def __truediv__(self, _):
+            return self
+
+        def read_text(self, **_):
+            raise FileNotFoundError
+
+    monkeypatch.setattr(base_module, "Path", lambda _: MissingVersionInfo())
+    monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__version__=GENAI_VERSION))
+
+    assert Model.__new__(Model).get_genai_version() == GENAI_VERSION
+
+
+def test_get_genai_commit_uses_installed_package_metadata(monkeypatch):
+    def missing_git(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(base_module.subprocess, "run", missing_git)
+    monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__commit__="0123456789abcdef"))
+
+    assert Model.__new__(Model).get_genai_commit() == "0123456789abcdef"

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -22,7 +22,6 @@ import pytest
 
 MODELS_DIR = Path(__file__).parents[3] / "src" / "python" / "py" / "models"
 BUILDERS_DIR = MODELS_DIR / "builders"
-GENAI_VERSION = (Path(__file__).parents[3] / "VERSION_INFO").read_text(encoding="utf-8").strip()
 sys.path.insert(0, str(MODELS_DIR))
 
 
@@ -463,70 +462,6 @@ def test_qwen35_moe_architecture_selects_composite_builder(monkeypatch, tmp_path
     assert captured["args"][5]["config_only"] is True
     assert captured["genai_config"][0] is config
     assert captured["processing"][0] == "fake-model"
-
-
-def _make_empty_onnx_model():
-    graph = ir.Graph(inputs=(), outputs=(), nodes=(), opset_imports={"": 22})
-    return ir.Model(graph, ir_version=10, producer_name="onnxruntime-genai")
-
-
-def test_stamp_build_metadata_sets_genai_version_and_commit(monkeypatch):
-    result = types.SimpleNamespace(stdout="0123456789abcdef\n")
-    monkeypatch.setattr(base_module.subprocess, "run", lambda *args, **kwargs: result)
-    monkeypatch.setattr(base_module.Model, "get_genai_version", lambda self: GENAI_VERSION)
-    builder = Model.__new__(Model)
-    model = _make_empty_onnx_model()
-
-    builder.stamp_build_metadata(model)
-
-    assert model.producer_version == GENAI_VERSION
-    assert model.metadata_props["producer_commit"] == "0123456789abcdef"
-
-
-def test_stamp_build_metadata_handles_missing_git(monkeypatch):
-    def missing_git(*args, **kwargs):
-        raise FileNotFoundError
-
-    monkeypatch.setattr(base_module.subprocess, "run", missing_git)
-    monkeypatch.setattr(base_module.Model, "get_genai_version", lambda self: GENAI_VERSION)
-    builder = Model.__new__(Model)
-    model = _make_empty_onnx_model()
-
-    builder.stamp_build_metadata(model)
-
-    assert model.producer_version == GENAI_VERSION
-    assert "producer_commit" not in model.metadata_props
-
-
-def test_get_genai_version_uses_installed_package_metadata(monkeypatch):
-    class MissingVersionInfo:
-        def resolve(self):
-            return self
-
-        @property
-        def parents(self):
-            return [self] * 6
-
-        def __truediv__(self, _):
-            return self
-
-        def read_text(self, **_):
-            raise FileNotFoundError
-
-    monkeypatch.setattr(base_module, "Path", lambda _: MissingVersionInfo())
-    monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__version__=GENAI_VERSION))
-
-    assert Model.__new__(Model).get_genai_version() == GENAI_VERSION
-
-
-def test_get_genai_commit_uses_installed_package_metadata(monkeypatch):
-    def missing_git(*args, **kwargs):
-        raise FileNotFoundError
-
-    monkeypatch.setattr(base_module.subprocess, "run", missing_git)
-    monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__commit__="0123456789abcdef"))
-
-    assert Model.__new__(Model).get_genai_commit() == "0123456789abcdef"
 
 
 def test_state_window_must_be_non_negative(monkeypatch):

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -472,10 +472,10 @@ def _make_empty_onnx_model():
 def test_stamp_build_metadata_sets_genai_commit(monkeypatch):
     result = types.SimpleNamespace(stdout="0123456789abcdef\n")
     monkeypatch.setattr(base_module.subprocess, "run", lambda *args, **kwargs: result)
-    base_module.get_genai_commit.cache_clear()
+    Model.get_genai_commit.__func__.cache_clear()
     model = _make_empty_onnx_model()
 
-    base_module.stamp_build_metadata(model)
+    Model.stamp_build_metadata(model)
 
     assert model.producer_version == "0123456789abcdef"
 
@@ -485,10 +485,10 @@ def test_stamp_build_metadata_handles_missing_git(monkeypatch):
         raise FileNotFoundError
 
     monkeypatch.setattr(base_module.subprocess, "run", missing_git)
-    base_module.get_genai_commit.cache_clear()
+    Model.get_genai_commit.__func__.cache_clear()
     model = _make_empty_onnx_model()
 
-    base_module.stamp_build_metadata(model)
+    Model.stamp_build_metadata(model)
 
     assert model.producer_version is None
 

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -464,6 +464,35 @@ def test_qwen35_moe_architecture_selects_composite_builder(monkeypatch, tmp_path
     assert captured["processing"][0] == "fake-model"
 
 
+def _make_empty_onnx_model():
+    graph = ir.Graph(inputs=(), outputs=(), nodes=(), opset_imports={"": 22})
+    return ir.Model(graph, ir_version=10, producer_name="onnxruntime-genai")
+
+
+def test_stamp_build_metadata_sets_genai_commit(monkeypatch):
+    result = types.SimpleNamespace(stdout="0123456789abcdef\n")
+    monkeypatch.setattr(base_module.subprocess, "run", lambda *args, **kwargs: result)
+    base_module.get_genai_commit.cache_clear()
+    model = _make_empty_onnx_model()
+
+    base_module.stamp_build_metadata(model)
+
+    assert model.producer_version == "0123456789abcdef"
+
+
+def test_stamp_build_metadata_handles_missing_git(monkeypatch):
+    def missing_git(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(base_module.subprocess, "run", missing_git)
+    base_module.get_genai_commit.cache_clear()
+    model = _make_empty_onnx_model()
+
+    base_module.stamp_build_metadata(model)
+
+    assert model.producer_version is None
+
+
 def test_state_window_must_be_non_negative(monkeypatch):
     with pytest.raises(ValueError, match="non-negative integer"):
         _run_check_extra_options(monkeypatch, {"state_window": "-1"})

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -22,6 +22,7 @@ import pytest
 
 MODELS_DIR = Path(__file__).parents[3] / "src" / "python" / "py" / "models"
 BUILDERS_DIR = MODELS_DIR / "builders"
+GENAI_VERSION = (Path(__file__).parents[3] / "VERSION_INFO").read_text(encoding="utf-8").strip()
 sys.path.insert(0, str(MODELS_DIR))
 
 
@@ -469,15 +470,17 @@ def _make_empty_onnx_model():
     return ir.Model(graph, ir_version=10, producer_name="onnxruntime-genai")
 
 
-def test_stamp_build_metadata_sets_genai_commit(monkeypatch):
+def test_stamp_build_metadata_sets_genai_version_and_commit(monkeypatch):
     result = types.SimpleNamespace(stdout="0123456789abcdef\n")
     monkeypatch.setattr(base_module.subprocess, "run", lambda *args, **kwargs: result)
-    Model.get_genai_commit.__func__.cache_clear()
+    monkeypatch.setattr(base_module.Model, "get_genai_version", lambda self: GENAI_VERSION)
+    builder = Model.__new__(Model)
     model = _make_empty_onnx_model()
 
-    Model.stamp_build_metadata(model)
+    builder.stamp_build_metadata(model)
 
-    assert model.producer_version == "0123456789abcdef"
+    assert model.producer_version == GENAI_VERSION
+    assert model.metadata_props["producer_commit"] == "0123456789abcdef"
 
 
 def test_stamp_build_metadata_handles_missing_git(monkeypatch):
@@ -485,12 +488,45 @@ def test_stamp_build_metadata_handles_missing_git(monkeypatch):
         raise FileNotFoundError
 
     monkeypatch.setattr(base_module.subprocess, "run", missing_git)
-    Model.get_genai_commit.__func__.cache_clear()
+    monkeypatch.setattr(base_module.Model, "get_genai_version", lambda self: GENAI_VERSION)
+    builder = Model.__new__(Model)
     model = _make_empty_onnx_model()
 
-    Model.stamp_build_metadata(model)
+    builder.stamp_build_metadata(model)
 
-    assert model.producer_version is None
+    assert model.producer_version == GENAI_VERSION
+    assert "producer_commit" not in model.metadata_props
+
+
+def test_get_genai_version_uses_installed_package_metadata(monkeypatch):
+    class MissingVersionInfo:
+        def resolve(self):
+            return self
+
+        @property
+        def parents(self):
+            return [self] * 6
+
+        def __truediv__(self, _):
+            return self
+
+        def read_text(self, **_):
+            raise FileNotFoundError
+
+    monkeypatch.setattr(base_module, "Path", lambda _: MissingVersionInfo())
+    monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__version__=GENAI_VERSION))
+
+    assert Model.__new__(Model).get_genai_version() == GENAI_VERSION
+
+
+def test_get_genai_commit_uses_installed_package_metadata(monkeypatch):
+    def missing_git(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(base_module.subprocess, "run", missing_git)
+    monkeypatch.setitem(sys.modules, "onnxruntime_genai", types.SimpleNamespace(__commit__="0123456789abcdef"))
+
+    assert Model.__new__(Model).get_genai_commit() == "0123456789abcdef"
 
 
 def test_state_window_must_be_non_negative(monkeypatch):


### PR DESCRIPTION
GenAI commit id used to build onnx models via model builder can now be surfaced by inspecting the onnx model:

```python
import onnx

model = onnx.load(r'C:\path\to\model.onnx', load_external_data=False)

print('producer:', model.producer_name)
print('GenAI version:', model.producer_version)
```

Expected Output:
```
producer: onnxruntime-genai
GenAI version: 0.16.0-dev+3ca2c97
```