### PR TITLE
Fix atomic reference lock for pre-iOS 14 targets

### DIFF
--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -396,7 +396,7 @@ struct ExternalRefCounted {
  private:
   void LockExternalReferences() const noexcept {
     while (external_reference_lock_.test_and_set(std::memory_order_acquire)) {
-#if defined(USE_CXX17)
+#if defined(USE_CXX17) || defined(__APPLE__)
       std::this_thread::yield();
 #else
       external_reference_lock_.wait(true, std::memory_order_relaxed);
@@ -406,7 +406,7 @@ struct ExternalRefCounted {
 
   void UnlockExternalReferences() const noexcept {
     external_reference_lock_.clear(std::memory_order_release);
-#if !defined(USE_CXX17)
+#if !defined(USE_CXX17) && !defined(__APPLE__)
     external_reference_lock_.notify_one();
 #endif
   }


### PR DESCRIPTION
## Summary
- use the existing yield-based atomic flag lock path on Apple platforms
- retain C++20 atomic wait/notify on supported non-Apple platforms
- avoid raising the iOS deployment target after #2448

## Validation
- compiled src/smartptrs.h through both the Apple fallback and non-Apple C++20 paths
- passed clang-format 20.1.8 dry-run with warnings treated as errors