### PR TITLE
Fix feature leakage across Qwen multi-image inputs

### DIFF
--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -300,10 +300,7 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
                           total_hw > 0 && total_patches % total_hw == 0);
   int64_t hw_multiplier = temporal_padded ? (total_patches / total_hw) : 0;
 
-  if (total_patches != total_grid_tokens && padded_image_stride == 0 && !temporal_padded)
-    throw std::runtime_error("pixel_values patch count (" + std::to_string(total_patches) +
-                             ") does not match image_grid_thw patch count (" +
-                             std::to_string(total_grid_tokens) + ")");
+  ValidateQwenPatchLayout(total_patches, total_grid_tokens, padded_image_stride, temporal_padded);
 
   // Validate that the pre-allocated output buffer is large enough for all images
   int64_t expected_total_feats = total_grid_tokens / merge_sq;

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -5,6 +5,7 @@
 #include "multi_modal.h"
 #include "models/io/default_position_inputs.h"
 #include "models/io/qwen_vl_position_inputs.h"
+#include "qwen_vl_state.h"
 #include <cstring>
 #include <algorithm>
 #include <numeric>
@@ -46,51 +47,21 @@ int64_t GetNumAudioTokens(const std::vector<ExtraInput>& extra_inputs,
   return 0;
 }
 
-// Returns the number of images in the current batch.
-//
-// Two strategies are tried in order:
-//
-// 1. pixel_values rank-3 path (Phi, Gemma, and legacy Qwen processors):
-//    The extension returns pixel_values as [N, patches_per_image, patch_dim], so
-//    the batch size is simply shape[0].
-//
-// 2. image_grid_thw fallback (Qwen2.5-VL / Qwen3-VL after the multi-image flatten fix):
-//    QwenImageProcessor flattens pixel_values to rank 2 [total_patches, patch_dim]
-//    so that vision.onnx—which is exported for a single image and loops per-image in
-//    VisionState::Run—always receives a 2-D input regardless of image count.
-//    Rank-2 pixel_values carries no image-count information, so we fall through and
-//    read num_images from image_grid_thw.shape[0] ([num_images, 3]).
+// Returns the number of images in the current batch. Most processors retain an
+// image batch dimension; model-specific flattened layouts provide metadata.
 int64_t GetImageFeatureBatchSize(const std::vector<ExtraInput>& extra_inputs) {
   for (size_t i = 0; i < extra_inputs.size(); ++i) {
     if (extra_inputs[i].name == Config::Defaults::PixelValuesName) {
       assert(extra_inputs[i].tensor->ort_tensor_);
       const auto num_dims = extra_inputs[i].tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetShape().size();
-      if (num_dims < 3) {
-        // Qwen flattens pixel_values to [total_patches, patch_dim] (rank 2) so that
-        // vision.onnx always receives a single-image-shaped input; num_images cannot
-        // be inferred from pixel_values alone — fall through to image_grid_thw.
-        break;
+      if (num_dims >= 3) {
+        return extra_inputs[i].tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetShape().front();
       }
-      // Rank ≥ 3: batch size is the leading dimension (Phi, Gemma, legacy Qwen).
-      return extra_inputs[i].tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetShape().front();
+      break;
     }
   }
 
-  // Fallback for Qwen2.5-VL / Qwen3-VL: image_grid_thw has shape [num_images, 3]
-  // so its leading dimension directly gives the image count.
-  // This tensor is Qwen-specific; for Phi and Gemma it is absent and we return 0.
-  for (size_t i = 0; i < extra_inputs.size(); ++i) {
-    if (extra_inputs[i].name == Config::Defaults::ImageGridThwName) {
-      assert(extra_inputs[i].tensor->ort_tensor_);
-      const auto shape = extra_inputs[i].tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetShape();
-      const int64_t num_images = shape.empty() ? 0 : shape[0];
-      const size_t elem_count = extra_inputs[i].tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetElementCount();
-      ValidateImageGridThwLayoutAndCount(shape, elem_count, num_images, "image_grid_thw");
-      return num_images;
-    }
-  }
-
-  return 0;
+  return GetQwenImageCount(extra_inputs);
 }
 
 }  // namespace
@@ -151,224 +122,6 @@ DeviceSpan<float> VisionState::Run(int current_length, DeviceSpan<int32_t>& next
   }
 
   State::Run(*model_.vision_session_);
-  return {};
-}
-
-// ---------------------------------------------------------------------------
-// QwenVisionState: per-image slicing loop
-// ---------------------------------------------------------------------------
-
-DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices) {
-  if (model_.config_->model.vision.run_options.has_value()) {
-    State::SetRunOptions(model_.config_->model.vision.run_options.value());
-  }
-
-  // Single image (or no image data): run the ONNX session directly.
-  if (num_images_ <= 1) {
-    State::Run(*model_.vision_session_);
-    return {};
-  }
-
-  // Multi-image: vision.onnx is exported for exactly one image at a time.
-  //
-  // Dynamo unrolls Python for-loops at export time, so an N-image dummy
-  // input would produce a graph that only works for that exact N.  To
-  // support a variable number of images we export with N=1 and iterate
-  // here in C++, slicing out per-image views of pixel_values and
-  // image_grid_thw and writing each result directly into the correct
-  // offset of the pre-allocated image_features output buffer.
-  const std::string& pv_name = model_.config_->model.vision.inputs.pixel_values;
-  const std::string& grid_name = model_.config_->model.vision.inputs.image_grid_thw;
-
-  size_t pv_idx = SIZE_MAX;
-  size_t grid_idx = SIZE_MAX;
-  for (size_t i = 0; i < input_names_.size(); ++i) {
-    if (input_names_[i] == pv_name) {
-      pv_idx = i;
-    }
-    if (input_names_[i] == grid_name) {
-      grid_idx = i;
-    }
-  }
-
-  if (pv_idx == SIZE_MAX || grid_idx == SIZE_MAX) {
-    // Couldn't find expected inputs – fall back to single Run.
-    State::Run(*model_.vision_session_);
-    return {};
-  }
-
-  OrtValue* grid_full = inputs_[grid_idx];
-  const int64_t* grid_data = grid_full->GetTensorData<int64_t>();
-
-  const auto grid_shape = grid_full->GetTensorTypeAndShapeInfo()->GetShape();
-  const size_t grid_elem_count = grid_full->GetTensorTypeAndShapeInfo()->GetElementCount();
-  ValidateImageGridThwLayoutAndCount(grid_shape, grid_elem_count, num_images_, "image_grid_thw");
-
-  // Check if the ONNX model accepts dynamic num_images.
-  // A non-positive dim-0 (0 or -1) in the model's input shape = dynamic/symbolic.
-  bool model_supports_batch = false;
-  {
-    auto session_input_names = model_.vision_session_->GetInputNames();
-    for (size_t si = 0; si < session_input_names.size(); ++si) {
-      if (session_input_names[si] == grid_name) {
-        auto grid_input_info = model_.vision_session_->GetInputTypeInfo(si);
-        auto grid_expected_shape = grid_input_info->GetTensorTypeAndShapeInfo().GetShape();
-        if (!grid_expected_shape.empty() && grid_expected_shape[0] <= 0) {
-          model_supports_batch = true;  // dim-0 is symbolic — accepts any N
-        }
-        break;
-      }
-    }
-  }
-
-  // Check if all images share the same (t, h, w) grid.
-  bool uniform_grid = true;
-  if (num_images_ > 1) {
-    int64_t t0 = grid_data[0], h0 = grid_data[1], w0 = grid_data[2];
-    for (int64_t img = 1; img < num_images_; ++img) {
-      if (grid_data[img * 3] != t0 || grid_data[img * 3 + 1] != h0 || grid_data[img * 3 + 2] != w0) {
-        uniform_grid = false;
-        break;
-      }
-    }
-  }
-
-  // --- Batched single-call path (like HuggingFace) ---
-  if (model_supports_batch && uniform_grid) {
-    // The model has dynamic image_grid_thw dim-0 and all images share the
-    // same grid.  Pass all N images' pixel_values and the full [N, 3]
-    // grid_thw in one call — the ONNX graph was vectorized to handle this.
-    State::Run(*model_.vision_session_);
-    return {};
-  }
-
-  // --- Per-image loop path (fallback for different-sized images or static models) ---
-  OrtValue* pv_full = inputs_[pv_idx];
-  OrtValue* feat_full = outputs_[0];  // pre-allocated image_features output
-
-  // Shapes: pixel_values[total_patches, patch_dim], image_features[total_logical_patches, hidden_size]
-  auto pv_info = pv_full->GetTensorTypeAndShapeInfo();
-  auto feat_info = feat_full->GetTensorTypeAndShapeInfo();
-  auto pv_shape = pv_info->GetShape();
-  auto feat_shape = feat_info->GetShape();
-  auto pv_type = pv_info->GetElementType();
-  auto feat_type = feat_info->GetElementType();
-  int64_t patch_dim = pv_shape[1];
-  int64_t hidden_size = feat_shape[1];
-
-  // Map ONNX element type to byte size.
-  auto element_size = [](ONNXTensorElementDataType type) -> size_t {
-    switch (type) {
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
-        return 4;
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
-        return 2;
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
-        return 2;
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
-        return 8;
-      default:
-        throw std::runtime_error("Unsupported pixel_values element type in multi-image vision loop");
-    }
-  };
-  size_t pv_element_size = element_size(pv_type);
-  size_t feat_element_size = element_size(feat_type);
-
-  void* pv_raw = pv_full->GetTensorMutableRawData();
-  void* feat_raw = feat_full->GetTensorMutableRawData();
-  int64_t spatial_merge_size = model_.config_->model.vision.spatial_merge_size;
-
-  auto cpu_mem = OrtMemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
-
-  int64_t total_patches = pv_shape[0];
-  int64_t total_feats = feat_shape[0];
-  int64_t merge_sq = spatial_merge_size * spatial_merge_size;
-
-  // Detect temporal padding: processor may produce more rows than sum(t*h*w)
-  int64_t total_grid_tokens = 0;
-  int64_t total_hw = 0;
-  int64_t max_grid_tokens = 0;
-  for (int64_t img = 0; img < num_images_; ++img) {
-    int64_t grid_tokens = grid_data[img * 3] * grid_data[img * 3 + 1] * grid_data[img * 3 + 2];
-    total_grid_tokens += grid_tokens;
-    total_hw += grid_data[img * 3 + 1] * grid_data[img * 3 + 2];
-    max_grid_tokens = std::max(max_grid_tokens, grid_tokens);
-  }
-  const QwenPatchLayout patch_layout =
-      ResolveQwenPatchLayout(total_patches, total_grid_tokens, total_hw, max_grid_tokens, num_images_);
-
-  // Validate that the pre-allocated output buffer is large enough for all images
-  int64_t expected_total_feats = total_grid_tokens / merge_sq;
-  if (total_feats < expected_total_feats)
-    throw std::runtime_error("pre-allocated image_features dim 0 (" + std::to_string(total_feats) +
-                             ") is smaller than expected (" + std::to_string(expected_total_feats) +
-                             ") for " + std::to_string(num_images_) + " images");
-
-  int64_t patch_offset = 0;
-  int64_t feat_offset = 0;
-  for (int64_t img = 0; img < num_images_; ++img) {
-    int64_t t = grid_data[img * 3];
-    int64_t h = grid_data[img * 3 + 1];
-    int64_t w = grid_data[img * 3 + 2];
-    int64_t grid_tokens = t * h * w;
-    int64_t num_patches = patch_layout.ImagePatchCount(grid_tokens, h, w);
-    int64_t num_feats = grid_tokens / merge_sq;
-    int64_t image_patch_offset = patch_layout.ImagePatchOffset(img, patch_offset);
-
-    if (grid_tokens % merge_sq != 0)
-      throw std::runtime_error("grid tokens (" + std::to_string(grid_tokens) +
-                               ") is not divisible by spatial_merge_size^2 (" +
-                               std::to_string(merge_sq) + ") for image " + std::to_string(img));
-    if (image_patch_offset + num_patches > total_patches)
-      throw std::runtime_error("patch_offset (" + std::to_string(image_patch_offset) + ") + num_patches (" +
-                               std::to_string(num_patches) + ") exceeds pixel_values dim 0 (" +
-                               std::to_string(total_patches) + ")");
-    if (feat_offset + num_feats > total_feats)
-      throw std::runtime_error("feat_offset (" + std::to_string(feat_offset) + ") + num_feats (" +
-                               std::to_string(num_feats) + ") exceeds image_features dim 0 (" +
-                               std::to_string(total_feats) + ")");
-
-    // Create non-owning sub-tensors (zero-copy views into the original buffers).
-    std::vector<int64_t> sub_pv_shape = {num_patches, patch_dim};
-    std::vector<int64_t> sub_grid_shape = {1LL, 3LL};  // vision.onnx expects [1, 3] per image
-    std::vector<int64_t> sub_feat_shape = {num_feats, hidden_size};
-
-    auto sub_pv = OrtValue::CreateTensor(
-        *cpu_mem,
-        static_cast<uint8_t*>(pv_raw) + static_cast<size_t>(image_patch_offset * patch_dim) * pv_element_size,
-        static_cast<size_t>(num_patches * patch_dim) * pv_element_size,
-        std::span<const int64_t>(sub_pv_shape), pv_type);
-
-    auto sub_grid = OrtValue::CreateTensor(
-        *cpu_mem,
-        const_cast<void*>(static_cast<const void*>(grid_data + img * 3)),
-        3 * sizeof(int64_t),
-        std::span<const int64_t>(sub_grid_shape),
-        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
-
-    auto sub_feat = OrtValue::CreateTensor(
-        *cpu_mem,
-        static_cast<uint8_t*>(feat_raw) + static_cast<size_t>(feat_offset * hidden_size) * feat_element_size,
-        static_cast<size_t>(num_feats * hidden_size) * feat_element_size,
-        std::span<const int64_t>(sub_feat_shape), feat_type);
-
-    // Temporarily point the State's inputs/output to the per-image slices,
-    // run the session, then advance offsets.
-    inputs_[pv_idx] = sub_pv.get();
-    inputs_[grid_idx] = sub_grid.get();
-    outputs_[0] = sub_feat.get();
-
-    State::Run(*model_.vision_session_);
-
-    patch_offset += num_patches;
-    feat_offset += num_feats;
-  }
-
-  // Restore original pointers so the State remains valid after this call.
-  inputs_[pv_idx] = pv_full;
-  inputs_[grid_idx] = grid_full;
-  outputs_[0] = feat_full;
-
   return {};
 }
 

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -294,13 +294,8 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
     total_hw += grid_data[img * 3 + 1] * grid_data[img * 3 + 2];
     max_grid_tokens = std::max(max_grid_tokens, grid_tokens);
   }
-  int64_t padded_image_stride = 0;
-  if (total_patches != total_grid_tokens && total_patches % num_images_ == 0) {
-    int64_t candidate_stride = total_patches / num_images_;
-    if (candidate_stride >= max_grid_tokens) {
-      padded_image_stride = candidate_stride;
-    }
-  }
+  int64_t padded_image_stride =
+      GetQwenPaddedImageStride(total_patches, total_grid_tokens, max_grid_tokens, num_images_);
   bool temporal_padded = (padded_image_stride == 0 && total_patches != total_grid_tokens &&
                           total_hw > 0 && total_patches % total_hw == 0);
   int64_t hw_multiplier = temporal_padded ? (total_patches / total_hw) : 0;
@@ -348,7 +343,7 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
 
     auto sub_pv = OrtValue::CreateTensor(
         *cpu_mem,
-      static_cast<uint8_t*>(pv_raw) + static_cast<size_t>(image_patch_offset * patch_dim) * pv_element_size,
+        static_cast<uint8_t*>(pv_raw) + static_cast<size_t>(image_patch_offset * patch_dim) * pv_element_size,
         static_cast<size_t>(num_patches * patch_dim) * pv_element_size,
         std::span<const int64_t>(sub_pv_shape), pv_type);
 

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -287,12 +287,28 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
   // Detect temporal padding: processor may produce more rows than sum(t*h*w)
   int64_t total_grid_tokens = 0;
   int64_t total_hw = 0;
+  int64_t max_grid_tokens = 0;
   for (int64_t img = 0; img < num_images_; ++img) {
-    total_grid_tokens += grid_data[img * 3] * grid_data[img * 3 + 1] * grid_data[img * 3 + 2];
+    int64_t grid_tokens = grid_data[img * 3] * grid_data[img * 3 + 1] * grid_data[img * 3 + 2];
+    total_grid_tokens += grid_tokens;
     total_hw += grid_data[img * 3 + 1] * grid_data[img * 3 + 2];
+    max_grid_tokens = std::max(max_grid_tokens, grid_tokens);
   }
-  bool temporal_padded = (total_patches != total_grid_tokens && total_hw > 0 && total_patches % total_hw == 0);
+  int64_t padded_image_stride = 0;
+  if (total_patches != total_grid_tokens && total_patches % num_images_ == 0) {
+    int64_t candidate_stride = total_patches / num_images_;
+    if (candidate_stride >= max_grid_tokens) {
+      padded_image_stride = candidate_stride;
+    }
+  }
+  bool temporal_padded = (padded_image_stride == 0 && total_patches != total_grid_tokens &&
+                          total_hw > 0 && total_patches % total_hw == 0);
   int64_t hw_multiplier = temporal_padded ? (total_patches / total_hw) : 0;
+
+  if (total_patches != total_grid_tokens && padded_image_stride == 0 && !temporal_padded)
+    throw std::runtime_error("pixel_values patch count (" + std::to_string(total_patches) +
+                             ") does not match image_grid_thw patch count (" +
+                             std::to_string(total_grid_tokens) + ")");
 
   // Validate that the pre-allocated output buffer is large enough for all images
   int64_t expected_total_feats = total_grid_tokens / merge_sq;
@@ -310,13 +326,14 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
     int64_t grid_tokens = t * h * w;
     int64_t num_patches = temporal_padded ? (hw_multiplier * h * w) : grid_tokens;
     int64_t num_feats = grid_tokens / merge_sq;
+    int64_t image_patch_offset = padded_image_stride > 0 ? img * padded_image_stride : patch_offset;
 
     if (grid_tokens % merge_sq != 0)
       throw std::runtime_error("grid tokens (" + std::to_string(grid_tokens) +
                                ") is not divisible by spatial_merge_size^2 (" +
                                std::to_string(merge_sq) + ") for image " + std::to_string(img));
-    if (patch_offset + num_patches > total_patches)
-      throw std::runtime_error("patch_offset (" + std::to_string(patch_offset) + ") + num_patches (" +
+    if (image_patch_offset + num_patches > total_patches)
+      throw std::runtime_error("patch_offset (" + std::to_string(image_patch_offset) + ") + num_patches (" +
                                std::to_string(num_patches) + ") exceeds pixel_values dim 0 (" +
                                std::to_string(total_patches) + ")");
     if (feat_offset + num_feats > total_feats)
@@ -331,7 +348,7 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
 
     auto sub_pv = OrtValue::CreateTensor(
         *cpu_mem,
-        static_cast<uint8_t*>(pv_raw) + static_cast<size_t>(patch_offset * patch_dim) * pv_element_size,
+      static_cast<uint8_t*>(pv_raw) + static_cast<size_t>(image_patch_offset * patch_dim) * pv_element_size,
         static_cast<size_t>(num_patches * patch_dim) * pv_element_size,
         std::span<const int64_t>(sub_pv_shape), pv_type);
 

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -294,13 +294,8 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
     total_hw += grid_data[img * 3 + 1] * grid_data[img * 3 + 2];
     max_grid_tokens = std::max(max_grid_tokens, grid_tokens);
   }
-  int64_t padded_image_stride =
-      GetQwenPaddedImageStride(total_patches, total_grid_tokens, max_grid_tokens, num_images_);
-  bool temporal_padded = (padded_image_stride == 0 && total_patches != total_grid_tokens &&
-                          total_hw > 0 && total_patches % total_hw == 0);
-  int64_t hw_multiplier = temporal_padded ? (total_patches / total_hw) : 0;
-
-  ValidateQwenPatchLayout(total_patches, total_grid_tokens, padded_image_stride, temporal_padded);
+  const QwenPatchLayout patch_layout =
+      ResolveQwenPatchLayout(total_patches, total_grid_tokens, total_hw, max_grid_tokens, num_images_);
 
   // Validate that the pre-allocated output buffer is large enough for all images
   int64_t expected_total_feats = total_grid_tokens / merge_sq;
@@ -316,9 +311,9 @@ DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& 
     int64_t h = grid_data[img * 3 + 1];
     int64_t w = grid_data[img * 3 + 2];
     int64_t grid_tokens = t * h * w;
-    int64_t num_patches = temporal_padded ? (hw_multiplier * h * w) : grid_tokens;
+    int64_t num_patches = patch_layout.ImagePatchCount(grid_tokens, h, w);
     int64_t num_feats = grid_tokens / merge_sq;
-    int64_t image_patch_offset = padded_image_stride > 0 ? img * padded_image_stride : patch_offset;
+    int64_t image_patch_offset = patch_layout.ImagePatchOffset(img, patch_offset);
 
     if (grid_tokens % merge_sq != 0)
       throw std::runtime_error("grid tokens (" + std::to_string(grid_tokens) +

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -59,20 +59,6 @@ struct VisionState : State {
   std::unique_ptr<MultiModalFeatures> image_features_;
 };
 
-// QwenVisionState: per-image slicing loop for Qwen2.5-VL / Qwen3-VL.
-//
-// vision.onnx is exported for exactly one image (Dynamo unrolls Python
-// for-loops at trace time, so an N-image dummy produces a graph that only
-// works for that exact N).  This subclass iterates over images in C++,
-// creating zero-copy sub-tensor views of pixel_values / image_grid_thw and
-// writing each result into the correct offset of the pre-allocated
-// image_features output buffer.
-struct QwenVisionState : VisionState {
-  using VisionState::VisionState;  // inherit constructor
-
-  DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens, DeviceSpan<int32_t> next_indices = {}) override;
-};
-
 // PixtralVisionState: per-image vision loop for Pixtral / Mistral3.
 //
 // Each image is independently smart_resize'd to a different resolution.
@@ -90,82 +76,6 @@ struct PixtralVisionState : VisionState {
   std::vector<int64_t> image_heights_;
   std::vector<int64_t> image_widths_;
 };
-
-inline void ValidateImageGridThwLayoutAndCount(const std::vector<int64_t>& shape,
-                                               size_t elem_count,
-                                               int64_t num_images,
-                                               const char* tensor_name) {
-  if (num_images < 0) {
-    throw std::runtime_error(std::string(tensor_name) + " num_images must be non-negative");
-  }
-
-  if (shape.size() != 2) {
-    throw std::runtime_error(std::string(tensor_name) + " must have rank 2 [num_images, 3]");
-  }
-
-  if (shape[0] < 0 || shape[1] < 0) {
-    throw std::runtime_error(std::string(tensor_name) + " dimensions must be non-negative");
-  }
-
-  if (shape[1] != 3) {
-    throw std::runtime_error(std::string(tensor_name) + " second dimension must be 3");
-  }
-
-  const size_t shape_image_count = static_cast<size_t>(shape[0]);
-  const size_t expected_image_count = static_cast<size_t>(num_images);
-  if (shape_image_count < expected_image_count) {
-    throw std::runtime_error(std::string(tensor_name) + " shape[0] (" + std::to_string(shape_image_count) +
-                             ") is less than required image count (" + std::to_string(expected_image_count) + ")");
-  }
-
-  if (elem_count % 3 != 0 || elem_count / 3 < expected_image_count) {
-    throw std::runtime_error(std::string(tensor_name) + " element count (" + std::to_string(elem_count) +
-                             ") is less than required for " + std::to_string(num_images) +
-                             " images (need at least 3 values per image)");
-  }
-}
-
-struct QwenPatchLayout {
-  int64_t padded_image_stride{};
-  int64_t temporal_multiplier{};
-
-  int64_t ImagePatchCount(int64_t grid_tokens, int64_t height, int64_t width) const {
-    return temporal_multiplier > 0 ? temporal_multiplier * height * width : grid_tokens;
-  }
-
-  int64_t ImagePatchOffset(int64_t image_index, int64_t packed_offset) const {
-    return padded_image_stride > 0 ? image_index * padded_image_stride : packed_offset;
-  }
-};
-
-inline QwenPatchLayout ResolveQwenPatchLayout(int64_t total_patches,
-                                              int64_t total_grid_tokens,
-                                              int64_t total_hw,
-                                              int64_t max_grid_tokens,
-                                              int64_t num_images) {
-  if (total_patches == total_grid_tokens) {
-    return {};
-  }
-
-  const bool temporal_padded = total_patches > 0 && total_hw > 0 && total_patches % total_hw == 0;
-  const int64_t candidate_stride =
-      num_images > 0 && total_patches % num_images == 0 ? total_patches / num_images : 0;
-  const bool stride_padded = candidate_stride > 0 && candidate_stride >= max_grid_tokens;
-
-  if (stride_padded && temporal_padded) {
-    throw std::runtime_error("pixel_values patch layout is ambiguous between per-image stride padding and temporal padding");
-  }
-  if (stride_padded) {
-    return {.padded_image_stride = candidate_stride};
-  }
-  if (temporal_padded) {
-    return {.temporal_multiplier = total_patches / total_hw};
-  }
-
-  throw std::runtime_error("pixel_values patch count (" + std::to_string(total_patches) +
-                           ") does not match image_grid_thw patch count (" +
-                           std::to_string(total_grid_tokens) + ")");
-}
 
 // Factory: pick the right VisionState subclass based on model type.
 std::unique_ptr<VisionState> CreateVisionState(const MultiModalLanguageModel& model, const GeneratorParams& params);

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -125,28 +125,46 @@ inline void ValidateImageGridThwLayoutAndCount(const std::vector<int64_t>& shape
   }
 }
 
-inline int64_t GetQwenPaddedImageStride(int64_t total_patches,
-                                        int64_t total_grid_tokens,
-                                        int64_t max_grid_tokens,
-                                        int64_t num_images) {
-  if (num_images > 0 && total_patches != total_grid_tokens && total_patches % num_images == 0) {
-    const int64_t candidate_stride = total_patches / num_images;
-    if (candidate_stride >= max_grid_tokens) {
-      return candidate_stride;
-    }
-  }
-  return 0;
-}
+struct QwenPatchLayout {
+  int64_t padded_image_stride{};
+  int64_t temporal_multiplier{};
 
-inline void ValidateQwenPatchLayout(int64_t total_patches,
-                                    int64_t total_grid_tokens,
-                                    int64_t padded_image_stride,
-                                    bool temporal_padded) {
-  if (total_patches != total_grid_tokens && padded_image_stride == 0 && !temporal_padded) {
-    throw std::runtime_error("pixel_values patch count (" + std::to_string(total_patches) +
-                             ") does not match image_grid_thw patch count (" +
-                             std::to_string(total_grid_tokens) + ")");
+  int64_t ImagePatchCount(int64_t grid_tokens, int64_t height, int64_t width) const {
+    return temporal_multiplier > 0 ? temporal_multiplier * height * width : grid_tokens;
   }
+
+  int64_t ImagePatchOffset(int64_t image_index, int64_t packed_offset) const {
+    return padded_image_stride > 0 ? image_index * padded_image_stride : packed_offset;
+  }
+};
+
+inline QwenPatchLayout ResolveQwenPatchLayout(int64_t total_patches,
+                                              int64_t total_grid_tokens,
+                                              int64_t total_hw,
+                                              int64_t max_grid_tokens,
+                                              int64_t num_images) {
+  if (total_patches == total_grid_tokens) {
+    return {};
+  }
+
+  const bool temporal_padded = total_patches > 0 && total_hw > 0 && total_patches % total_hw == 0;
+  const int64_t candidate_stride =
+      num_images > 0 && total_patches % num_images == 0 ? total_patches / num_images : 0;
+  const bool stride_padded = candidate_stride > 0 && candidate_stride >= max_grid_tokens;
+
+  if (stride_padded && temporal_padded) {
+    throw std::runtime_error("pixel_values patch layout is ambiguous between per-image stride padding and temporal padding");
+  }
+  if (stride_padded) {
+    return {.padded_image_stride = candidate_stride};
+  }
+  if (temporal_padded) {
+    return {.temporal_multiplier = total_patches / total_hw};
+  }
+
+  throw std::runtime_error("pixel_values patch count (" + std::to_string(total_patches) +
+                           ") does not match image_grid_thw patch count (" +
+                           std::to_string(total_grid_tokens) + ")");
 }
 
 // Factory: pick the right VisionState subclass based on model type.

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -138,6 +138,17 @@ inline int64_t GetQwenPaddedImageStride(int64_t total_patches,
   return 0;
 }
 
+inline void ValidateQwenPatchLayout(int64_t total_patches,
+                                    int64_t total_grid_tokens,
+                                    int64_t padded_image_stride,
+                                    bool temporal_padded) {
+  if (total_patches != total_grid_tokens && padded_image_stride == 0 && !temporal_padded) {
+    throw std::runtime_error("pixel_values patch count (" + std::to_string(total_patches) +
+                             ") does not match image_grid_thw patch count (" +
+                             std::to_string(total_grid_tokens) + ")");
+  }
+}
+
 // Factory: pick the right VisionState subclass based on model type.
 std::unique_ptr<VisionState> CreateVisionState(const MultiModalLanguageModel& model, const GeneratorParams& params);
 

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -125,6 +125,19 @@ inline void ValidateImageGridThwLayoutAndCount(const std::vector<int64_t>& shape
   }
 }
 
+inline int64_t GetQwenPaddedImageStride(int64_t total_patches,
+                                        int64_t total_grid_tokens,
+                                        int64_t max_grid_tokens,
+                                        int64_t num_images) {
+  if (num_images > 0 && total_patches != total_grid_tokens && total_patches % num_images == 0) {
+    const int64_t candidate_stride = total_patches / num_images;
+    if (candidate_stride >= max_grid_tokens) {
+      return candidate_stride;
+    }
+  }
+  return 0;
+}
+
 // Factory: pick the right VisionState subclass based on model type.
 std::unique_ptr<VisionState> CreateVisionState(const MultiModalLanguageModel& model, const GeneratorParams& params);
 

--- a/src/models/qwen_vl_state.cpp
+++ b/src/models/qwen_vl_state.cpp
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "qwen_vl_state.h"
+
+#include <algorithm>
+#include <cstdint>
+
+#include "generator/generators.h"
+
+namespace Generators {
+
+namespace {
+
+void ValidateImageGridThwLayoutAndCount(const std::vector<int64_t>& shape,
+                                        size_t elem_count,
+                                        int64_t num_images,
+                                        const char* tensor_name) {
+  if (num_images < 0) {
+    throw std::runtime_error(std::string(tensor_name) + " num_images must be non-negative");
+  }
+  if (shape.size() != 2) {
+    throw std::runtime_error(std::string(tensor_name) + " must have rank 2 [num_images, 3]");
+  }
+  if (shape[0] < 0 || shape[1] < 0) {
+    throw std::runtime_error(std::string(tensor_name) + " dimensions must be non-negative");
+  }
+  if (shape[1] != 3) {
+    throw std::runtime_error(std::string(tensor_name) + " second dimension must be 3");
+  }
+
+  const size_t shape_image_count = static_cast<size_t>(shape[0]);
+  const size_t expected_image_count = static_cast<size_t>(num_images);
+  if (shape_image_count < expected_image_count) {
+    throw std::runtime_error(std::string(tensor_name) + " shape[0] (" + std::to_string(shape_image_count) +
+                             ") is less than required image count (" + std::to_string(expected_image_count) + ")");
+  }
+  if (elem_count % 3 != 0 || elem_count / 3 < expected_image_count) {
+    throw std::runtime_error(std::string(tensor_name) + " element count (" + std::to_string(elem_count) +
+                             ") is less than required for " + std::to_string(num_images) +
+                             " images (need at least 3 values per image)");
+  }
+}
+
+}  // namespace
+
+int64_t GetQwenImageCount(const std::vector<ExtraInput>& extra_inputs) {
+  for (const auto& input : extra_inputs) {
+    if (input.name == Config::Defaults::ImageGridThwName) {
+      assert(input.tensor->ort_tensor_);
+      const auto shape = input.tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetShape();
+      const int64_t num_images = shape.empty() ? 0 : shape[0];
+      const size_t elem_count = input.tensor->ort_tensor_->GetTensorTypeAndShapeInfo()->GetElementCount();
+      ValidateImageGridThwLayoutAndCount(shape, elem_count, num_images, "image_grid_thw");
+      return num_images;
+    }
+  }
+  return 0;
+}
+
+DeviceSpan<float> QwenVisionState::Run(int current_length, DeviceSpan<int32_t>& next_tokens,
+                                       DeviceSpan<int32_t> next_indices) {
+  if (model_.config_->model.vision.run_options.has_value()) {
+    State::SetRunOptions(model_.config_->model.vision.run_options.value());
+  }
+
+  if (num_images_ <= 1) {
+    State::Run(*model_.vision_session_);
+    return {};
+  }
+
+  const std::string& pv_name = model_.config_->model.vision.inputs.pixel_values;
+  const std::string& grid_name = model_.config_->model.vision.inputs.image_grid_thw;
+
+  size_t pv_idx = SIZE_MAX;
+  size_t grid_idx = SIZE_MAX;
+  for (size_t i = 0; i < input_names_.size(); ++i) {
+    if (input_names_[i] == pv_name) {
+      pv_idx = i;
+    }
+    if (input_names_[i] == grid_name) {
+      grid_idx = i;
+    }
+  }
+
+  if (pv_idx == SIZE_MAX || grid_idx == SIZE_MAX) {
+    State::Run(*model_.vision_session_);
+    return {};
+  }
+
+  OrtValue* grid_full = inputs_[grid_idx];
+  const int64_t* grid_data = grid_full->GetTensorData<int64_t>();
+
+  const auto grid_shape = grid_full->GetTensorTypeAndShapeInfo()->GetShape();
+  const size_t grid_elem_count = grid_full->GetTensorTypeAndShapeInfo()->GetElementCount();
+  ValidateImageGridThwLayoutAndCount(grid_shape, grid_elem_count, num_images_, "image_grid_thw");
+
+  bool model_supports_batch = false;
+  {
+    auto session_input_names = model_.vision_session_->GetInputNames();
+    for (size_t si = 0; si < session_input_names.size(); ++si) {
+      if (session_input_names[si] == grid_name) {
+        auto grid_input_info = model_.vision_session_->GetInputTypeInfo(si);
+        auto grid_expected_shape = grid_input_info->GetTensorTypeAndShapeInfo().GetShape();
+        if (!grid_expected_shape.empty() && grid_expected_shape[0] <= 0) {
+          model_supports_batch = true;
+        }
+        break;
+      }
+    }
+  }
+
+  bool uniform_grid = true;
+  if (num_images_ > 1) {
+    int64_t t0 = grid_data[0], h0 = grid_data[1], w0 = grid_data[2];
+    for (int64_t img = 1; img < num_images_; ++img) {
+      if (grid_data[img * 3] != t0 || grid_data[img * 3 + 1] != h0 || grid_data[img * 3 + 2] != w0) {
+        uniform_grid = false;
+        break;
+      }
+    }
+  }
+
+  if (model_supports_batch && uniform_grid) {
+    State::Run(*model_.vision_session_);
+    return {};
+  }
+
+  OrtValue* pv_full = inputs_[pv_idx];
+  OrtValue* feat_full = outputs_[0];
+
+  auto pv_info = pv_full->GetTensorTypeAndShapeInfo();
+  auto feat_info = feat_full->GetTensorTypeAndShapeInfo();
+  auto pv_shape = pv_info->GetShape();
+  auto feat_shape = feat_info->GetShape();
+  auto pv_type = pv_info->GetElementType();
+  auto feat_type = feat_info->GetElementType();
+  int64_t patch_dim = pv_shape[1];
+  int64_t hidden_size = feat_shape[1];
+
+  auto element_size = [](ONNXTensorElementDataType type) -> size_t {
+    switch (type) {
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+        return 4;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+        return 2;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+        return 8;
+      default:
+        throw std::runtime_error("Unsupported pixel_values element type in multi-image vision loop");
+    }
+  };
+  size_t pv_element_size = element_size(pv_type);
+  size_t feat_element_size = element_size(feat_type);
+
+  void* pv_raw = pv_full->GetTensorMutableRawData();
+  void* feat_raw = feat_full->GetTensorMutableRawData();
+  int64_t spatial_merge_size = model_.config_->model.vision.spatial_merge_size;
+
+  auto cpu_mem = OrtMemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+
+  int64_t total_patches = pv_shape[0];
+  int64_t total_feats = feat_shape[0];
+  int64_t merge_sq = spatial_merge_size * spatial_merge_size;
+
+  int64_t total_grid_tokens = 0;
+  int64_t total_hw = 0;
+  int64_t max_grid_tokens = 0;
+  for (int64_t img = 0; img < num_images_; ++img) {
+    int64_t grid_tokens = grid_data[img * 3] * grid_data[img * 3 + 1] * grid_data[img * 3 + 2];
+    total_grid_tokens += grid_tokens;
+    total_hw += grid_data[img * 3 + 1] * grid_data[img * 3 + 2];
+    max_grid_tokens = std::max(max_grid_tokens, grid_tokens);
+  }
+  const QwenPatchLayout patch_layout =
+      ResolveQwenPatchLayout(total_patches, total_grid_tokens, total_hw, max_grid_tokens, num_images_);
+
+  int64_t expected_total_feats = total_grid_tokens / merge_sq;
+  if (total_feats < expected_total_feats)
+    throw std::runtime_error("pre-allocated image_features dim 0 (" + std::to_string(total_feats) +
+                             ") is smaller than expected (" + std::to_string(expected_total_feats) +
+                             ") for " + std::to_string(num_images_) + " images");
+
+  int64_t patch_offset = 0;
+  int64_t feat_offset = 0;
+  for (int64_t img = 0; img < num_images_; ++img) {
+    int64_t t = grid_data[img * 3];
+    int64_t h = grid_data[img * 3 + 1];
+    int64_t w = grid_data[img * 3 + 2];
+    int64_t grid_tokens = t * h * w;
+    int64_t num_patches = patch_layout.ImagePatchCount(grid_tokens, h, w);
+    int64_t num_feats = grid_tokens / merge_sq;
+    int64_t image_patch_offset = patch_layout.ImagePatchOffset(img, patch_offset);
+
+    if (grid_tokens % merge_sq != 0)
+      throw std::runtime_error("grid tokens (" + std::to_string(grid_tokens) +
+                               ") is not divisible by spatial_merge_size^2 (" +
+                               std::to_string(merge_sq) + ") for image " + std::to_string(img));
+    if (image_patch_offset + num_patches > total_patches)
+      throw std::runtime_error("patch_offset (" + std::to_string(image_patch_offset) + ") + num_patches (" +
+                               std::to_string(num_patches) + ") exceeds pixel_values dim 0 (" +
+                               std::to_string(total_patches) + ")");
+    if (feat_offset + num_feats > total_feats)
+      throw std::runtime_error("feat_offset (" + std::to_string(feat_offset) + ") + num_feats (" +
+                               std::to_string(num_feats) + ") exceeds image_features dim 0 (" +
+                               std::to_string(total_feats) + ")");
+
+    std::vector<int64_t> sub_pv_shape = {num_patches, patch_dim};
+    std::vector<int64_t> sub_grid_shape = {1LL, 3LL};
+    std::vector<int64_t> sub_feat_shape = {num_feats, hidden_size};
+
+    auto sub_pv = OrtValue::CreateTensor(
+        *cpu_mem,
+        static_cast<uint8_t*>(pv_raw) + static_cast<size_t>(image_patch_offset * patch_dim) * pv_element_size,
+        static_cast<size_t>(num_patches * patch_dim) * pv_element_size,
+        std::span<const int64_t>(sub_pv_shape), pv_type);
+
+    auto sub_grid = OrtValue::CreateTensor(
+        *cpu_mem,
+        const_cast<void*>(static_cast<const void*>(grid_data + img * 3)),
+        3 * sizeof(int64_t),
+        std::span<const int64_t>(sub_grid_shape),
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+
+    auto sub_feat = OrtValue::CreateTensor(
+        *cpu_mem,
+        static_cast<uint8_t*>(feat_raw) + static_cast<size_t>(feat_offset * hidden_size) * feat_element_size,
+        static_cast<size_t>(num_feats * hidden_size) * feat_element_size,
+        std::span<const int64_t>(sub_feat_shape), feat_type);
+
+    inputs_[pv_idx] = sub_pv.get();
+    inputs_[grid_idx] = sub_grid.get();
+    outputs_[0] = sub_feat.get();
+
+    State::Run(*model_.vision_session_);
+
+    patch_offset += num_patches;
+    feat_offset += num_feats;
+  }
+
+  inputs_[pv_idx] = pv_full;
+  inputs_[grid_idx] = grid_full;
+  outputs_[0] = feat_full;
+
+  return {};
+}
+
+}  // namespace Generators

--- a/src/models/qwen_vl_state.h
+++ b/src/models/qwen_vl_state.h
@@ -43,11 +43,8 @@ inline QwenPatchLayout ResolveQwenPatchLayout(int64_t total_patches,
   const bool temporal_padded = total_patches > 0 && total_hw > 0 && total_patches % total_hw == 0;
   const int64_t candidate_stride =
       num_images > 0 && total_patches % num_images == 0 ? total_patches / num_images : 0;
-  const bool stride_padded = candidate_stride > 0 && candidate_stride >= max_grid_tokens;
+  const bool stride_padded = candidate_stride > 0 && candidate_stride == max_grid_tokens;
 
-  if (stride_padded && temporal_padded) {
-    throw std::runtime_error("pixel_values patch layout is ambiguous between per-image stride padding and temporal padding");
-  }
   if (stride_padded) {
     return {.padded_image_stride = candidate_stride};
   }

--- a/src/models/qwen_vl_state.h
+++ b/src/models/qwen_vl_state.h
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "multi_modal.h"
+
+namespace Generators {
+
+// Qwen vision graphs exported with a single-image dummy input require one run
+// per image. This state slices flattened pixel values and concatenates outputs.
+struct QwenVisionState : VisionState {
+  using VisionState::VisionState;
+
+  DeviceSpan<float> Run(int current_length, DeviceSpan<int32_t>& next_tokens,
+                        DeviceSpan<int32_t> next_indices = {}) override;
+};
+
+int64_t GetQwenImageCount(const std::vector<ExtraInput>& extra_inputs);
+
+struct QwenPatchLayout {
+  int64_t padded_image_stride{};
+  int64_t temporal_multiplier{};
+
+  int64_t ImagePatchCount(int64_t grid_tokens, int64_t height, int64_t width) const {
+    return temporal_multiplier > 0 ? temporal_multiplier * height * width : grid_tokens;
+  }
+
+  int64_t ImagePatchOffset(int64_t image_index, int64_t packed_offset) const {
+    return padded_image_stride > 0 ? image_index * padded_image_stride : packed_offset;
+  }
+};
+
+inline QwenPatchLayout ResolveQwenPatchLayout(int64_t total_patches,
+                                              int64_t total_grid_tokens,
+                                              int64_t total_hw,
+                                              int64_t max_grid_tokens,
+                                              int64_t num_images) {
+  if (total_patches == total_grid_tokens) {
+    return {};
+  }
+
+  const bool temporal_padded = total_patches > 0 && total_hw > 0 && total_patches % total_hw == 0;
+  const int64_t candidate_stride =
+      num_images > 0 && total_patches % num_images == 0 ? total_patches / num_images : 0;
+  const bool stride_padded = candidate_stride > 0 && candidate_stride >= max_grid_tokens;
+
+  if (stride_padded && temporal_padded) {
+    throw std::runtime_error("pixel_values patch layout is ambiguous between per-image stride padding and temporal padding");
+  }
+  if (stride_padded) {
+    return {.padded_image_stride = candidate_stride};
+  }
+  if (temporal_padded) {
+    return {.temporal_multiplier = total_patches / total_hw};
+  }
+
+  throw std::runtime_error("pixel_values patch count (" + std::to_string(total_patches) +
+                           ") does not match image_grid_thw patch count (" +
+                           std::to_string(total_grid_tokens) + ")");
+}
+
+}  // namespace Generators

--- a/test/cpp/qwen_multi_image_vision_test.cpp
+++ b/test/cpp/qwen_multi_image_vision_test.cpp
@@ -103,29 +103,62 @@ TEST(QwenVisionMultiImageTest, AcceptsValidGridThroughPublicInputValidation) {
 TEST(QwenVisionMultiImageTest, UsesPaddedStrideForDifferentImageGridSizes) {
   constexpr int64_t total_patches = 27520;
   constexpr int64_t total_grid_tokens = 20004;
+  constexpr int64_t total_hw = 20004;
   constexpr int64_t max_grid_tokens = 6880;
   constexpr int64_t num_images = 4;
 
-  const int64_t stride = Generators::GetQwenPaddedImageStride(
-      total_patches, total_grid_tokens, max_grid_tokens, num_images);
+  const auto layout = Generators::ResolveQwenPatchLayout(
+      total_patches, total_grid_tokens, total_hw, max_grid_tokens, num_images);
 
-  EXPECT_EQ(stride, 6880);
-  EXPECT_EQ(2 * stride, 13760);
-  EXPECT_NE(2 * stride, 5624 + 6880);
+  EXPECT_EQ(layout.padded_image_stride, 6880);
+  EXPECT_EQ(layout.temporal_multiplier, 0);
+  EXPECT_EQ(layout.ImagePatchOffset(2, 5624 + 6880), 13760);
+  EXPECT_EQ(layout.ImagePatchCount(1900, 38, 50), 1900);
 }
 
 TEST(QwenVisionMultiImageTest, KeepsPackedLayoutWhenPatchCountsMatchGrid) {
-  EXPECT_EQ(Generators::GetQwenPaddedImageStride(20004, 20004, 6880, 4), 0);
+  const auto layout = Generators::ResolveQwenPatchLayout(20004, 20004, 20004, 6880, 4);
+  EXPECT_EQ(layout.padded_image_stride, 0);
+  EXPECT_EQ(layout.temporal_multiplier, 0);
+  EXPECT_EQ(layout.ImagePatchOffset(2, 12504), 12504);
 }
 
 TEST(QwenVisionMultiImageTest, RejectsUnsupportedPatchLayout) {
   const std::string message = CaptureRuntimeErrorMessage([] {
-    Generators::ValidateQwenPatchLayout(
+    Generators::ResolveQwenPatchLayout(
         /*total_patches=*/20005,
         /*total_grid_tokens=*/20004,
-        /*padded_image_stride=*/0,
-        /*temporal_padded=*/false);
+        /*total_hw=*/20004,
+        /*max_grid_tokens=*/6880,
+        /*num_images=*/4);
   });
 
   EXPECT_EQ(message, "pixel_values patch count (20005) does not match image_grid_thw patch count (20004)");
+}
+
+TEST(QwenVisionMultiImageTest, PreservesUnambiguousTemporalPadding) {
+  const auto layout = Generators::ResolveQwenPatchLayout(
+      /*total_patches=*/27,
+      /*total_grid_tokens=*/18,
+      /*total_hw=*/9,
+      /*max_grid_tokens=*/10,
+      /*num_images=*/2);
+
+  EXPECT_EQ(layout.padded_image_stride, 0);
+  EXPECT_EQ(layout.temporal_multiplier, 3);
+  EXPECT_EQ(layout.ImagePatchOffset(1, 12), 12);
+  EXPECT_EQ(layout.ImagePatchCount(10, 1, 5), 15);
+}
+
+TEST(QwenVisionMultiImageTest, RejectsAmbiguousStrideAndTemporalPadding) {
+  const std::string message = CaptureRuntimeErrorMessage([] {
+    Generators::ResolveQwenPatchLayout(
+        /*total_patches=*/24,
+        /*total_grid_tokens=*/12,
+        /*total_hw=*/12,
+        /*max_grid_tokens=*/8,
+        /*num_images=*/2);
+  });
+
+  EXPECT_EQ(message, "pixel_values patch layout is ambiguous between per-image stride padding and temporal padding");
 }

--- a/test/cpp/qwen_multi_image_vision_test.cpp
+++ b/test/cpp/qwen_multi_image_vision_test.cpp
@@ -8,6 +8,8 @@
 
 #include <gtest/gtest.h>
 
+#include "models/multi_modal.h"
+
 #define OGA_USE_SPAN 1
 #include "ort_genai.h"
 
@@ -96,4 +98,22 @@ TEST(QwenVisionMultiImageTest, AcceptsValidGridThroughPublicInputValidation) {
   auto harness = QwenVisionHarness::Create();
   harness.inputs->Delete("input_ids");
   EXPECT_NO_THROW(harness.generator->SetInputs(*harness.inputs));
+}
+
+TEST(QwenVisionMultiImageTest, UsesPaddedStrideForDifferentImageGridSizes) {
+  constexpr int64_t total_patches = 27520;
+  constexpr int64_t total_grid_tokens = 20004;
+  constexpr int64_t max_grid_tokens = 6880;
+  constexpr int64_t num_images = 4;
+
+  const int64_t stride = Generators::GetQwenPaddedImageStride(
+      total_patches, total_grid_tokens, max_grid_tokens, num_images);
+
+  EXPECT_EQ(stride, 6880);
+  EXPECT_EQ(2 * stride, 13760);
+  EXPECT_NE(2 * stride, 5624 + 6880);
+}
+
+TEST(QwenVisionMultiImageTest, KeepsPackedLayoutWhenPatchCountsMatchGrid) {
+  EXPECT_EQ(Generators::GetQwenPaddedImageStride(20004, 20004, 6880, 4), 0);
 }

--- a/test/cpp/qwen_multi_image_vision_test.cpp
+++ b/test/cpp/qwen_multi_image_vision_test.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-#include "models/multi_modal.h"
+#include "models/qwen_vl_state.h"
 
 #define OGA_USE_SPAN 1
 #include "ort_genai.h"

--- a/test/cpp/qwen_multi_image_vision_test.cpp
+++ b/test/cpp/qwen_multi_image_vision_test.cpp
@@ -117,3 +117,15 @@ TEST(QwenVisionMultiImageTest, UsesPaddedStrideForDifferentImageGridSizes) {
 TEST(QwenVisionMultiImageTest, KeepsPackedLayoutWhenPatchCountsMatchGrid) {
   EXPECT_EQ(Generators::GetQwenPaddedImageStride(20004, 20004, 6880, 4), 0);
 }
+
+TEST(QwenVisionMultiImageTest, RejectsUnsupportedPatchLayout) {
+  const std::string message = CaptureRuntimeErrorMessage([] {
+    Generators::ValidateQwenPatchLayout(
+        /*total_patches=*/20005,
+        /*total_grid_tokens=*/20004,
+        /*padded_image_stride=*/0,
+        /*temporal_padded=*/false);
+  });
+
+  EXPECT_EQ(message, "pixel_values patch count (20005) does not match image_grid_thw patch count (20004)");
+}

--- a/test/cpp/qwen_multi_image_vision_test.cpp
+++ b/test/cpp/qwen_multi_image_vision_test.cpp
@@ -150,15 +150,30 @@ TEST(QwenVisionMultiImageTest, PreservesUnambiguousTemporalPadding) {
   EXPECT_EQ(layout.ImagePatchCount(10, 1, 5), 15);
 }
 
-TEST(QwenVisionMultiImageTest, RejectsAmbiguousStrideAndTemporalPadding) {
-  const std::string message = CaptureRuntimeErrorMessage([] {
-    Generators::ResolveQwenPatchLayout(
-        /*total_patches=*/24,
-        /*total_grid_tokens=*/12,
-        /*total_hw=*/12,
-        /*max_grid_tokens=*/8,
-        /*num_images=*/2);
-  });
+TEST(QwenVisionMultiImageTest, UsesPaddedStrideWhenTotalIsAlsoDivisibleByTotalHw) {
+  const auto layout = Generators::ResolveQwenPatchLayout(
+      /*total_patches=*/768,
+      /*total_grid_tokens=*/384,
+      /*total_hw=*/384,
+      /*max_grid_tokens=*/256,
+      /*num_images=*/3);
 
-  EXPECT_EQ(message, "pixel_values patch layout is ambiguous between per-image stride padding and temporal padding");
+  EXPECT_EQ(layout.padded_image_stride, 256);
+  EXPECT_EQ(layout.temporal_multiplier, 0);
+  EXPECT_EQ(layout.ImagePatchOffset(2, 320), 512);
+  EXPECT_EQ(layout.ImagePatchCount(64, 8, 8), 64);
+}
+
+TEST(QwenVisionMultiImageTest, PreservesTemporalPaddingWhenStrideDoesNotMatchMaximumGrid) {
+  const auto layout = Generators::ResolveQwenPatchLayout(
+      /*total_patches=*/24,
+      /*total_grid_tokens=*/12,
+      /*total_hw=*/12,
+      /*max_grid_tokens=*/8,
+      /*num_images=*/2);
+
+  EXPECT_EQ(layout.padded_image_stride, 0);
+  EXPECT_EQ(layout.temporal_multiplier, 2);
+  EXPECT_EQ(layout.ImagePatchOffset(1, 8), 8);
+  EXPECT_EQ(layout.ImagePatchCount(8, 2, 4), 16);
 }

--- a/test/cpp/virtual_dispatch_test.cpp
+++ b/test/cpp/virtual_dispatch_test.cpp
@@ -13,6 +13,7 @@
 #include <type_traits>
 
 #include "models/multi_modal.h"
+#include "models/qwen_vl_state.h"
 
 namespace Generators::test {
 


### PR DESCRIPTION
## Summary

Fix Qwen multi-image inference when images produce different patch-grid sizes.

ORT Extensions pads each image to a common patch stride before flattening the batch. The Qwen vision loop previously treated this tensor as tightly packed, causing later images to read patches from earlier images.

## Changes

- Detect per-image padded patch layout.
- Use the padded stride when calculating image offsets.
- Continue passing only each image's logical patches to the vision model.
- Reject unsupported patch layouts instead of silently mixing features.

## Validation

- Verified inference with 2, 3, 4, and 8 images.
- Confirmed later images no longer contain features from earlier images.
- Passed `QwenVisionMultiImageTest.*`.
- Built and linked the native runtime successfully.