### PR TITLE
Fix Nemotron streaming mel tensor validation

### DIFF
--- a/src/models/nemotron_speech.cpp
+++ b/src/models/nemotron_speech.cpp
@@ -526,8 +526,7 @@ void NemotronSpeechState::RunEncoder() {
 
   OrtValue* mel_tensor = current_mel_->ort_tensor_.get();
   auto mel_shape = mel_tensor->GetTensorTypeAndShapeInfo()->GetShape();
-  ValidateNemotronMelInputShape(mel_shape, nemotron_config_.num_mels);
-  int64_t total_mel_frames = mel_shape[2];
+  const auto total_mel_frames = GetValidatedNemotronMelFrameCount(mel_shape, nemotron_config_.num_mels);
 
   encoder_state_->SetMelInput(mel_tensor, total_mel_frames);
   encoder_state_->UpdateCacheInputs();

--- a/src/models/nemotron_speech.h
+++ b/src/models/nemotron_speech.h
@@ -15,19 +15,21 @@
 
 namespace Generators {
 
-inline void ValidateNemotronMelInputShape(const std::vector<int64_t>& mel_shape, int64_t expected_num_mels) {
+inline int64_t GetValidatedNemotronMelFrameCount(const std::vector<int64_t>& mel_shape, int64_t expected_num_mels) {
   if (mel_shape.size() != 3) {
-    throw std::runtime_error("mel input must have rank 3 [batch, mels, frames], got rank " + std::to_string(mel_shape.size()));
+    throw std::runtime_error("mel input must have rank 3 [batch, frames, mels], got rank " + std::to_string(mel_shape.size()));
   }
 
   if (mel_shape[0] != 1) {
     throw std::runtime_error("mel input batch dimension must be 1, got " + std::to_string(mel_shape[0]));
   }
 
-  if (mel_shape[1] != expected_num_mels) {
-    throw std::runtime_error("mel input mels dimension (" + std::to_string(mel_shape[1]) +
+  if (mel_shape[2] != expected_num_mels) {
+    throw std::runtime_error("mel input mels dimension (" + std::to_string(mel_shape[2]) +
                              ") does not match expected num_mels (" + std::to_string(expected_num_mels) + ")");
   }
+
+  return mel_shape[1];
 }
 
 inline void ValidateNemotronEncoderOutputRank(const std::vector<int64_t>& encoder_shape) {

--- a/test/cpp/audio_speech_validation_test.cpp
+++ b/test/cpp/audio_speech_validation_test.cpp
@@ -32,19 +32,23 @@ TEST(AudioSpeechValidationTests, WhisperAudioFeaturesRankValidation) {
 }
 
 TEST(AudioSpeechValidationTests, NemotronMelTensorRankValidation) {
-  EXPECT_NO_THROW(Generators::ValidateNemotronMelInputShape({1, 80, 1234}, 80));
-
   const std::string rank_error = GetExceptionMessage([] {
-    Generators::ValidateNemotronMelInputShape({80, 1234}, 80);
+    Generators::GetValidatedNemotronMelFrameCount({304, 128}, 128);
   });
   EXPECT_NE(rank_error.find("rank 3"), std::string::npos);
 }
 
+TEST(AudioSpeechValidationTests, NemotronMelShapeValidationReturnsFrameCountFromMiddleDimension) {
+  EXPECT_EQ(Generators::GetValidatedNemotronMelFrameCount({1, 304, 128}, 128), 304);
+}
+
 TEST(AudioSpeechValidationTests, NemotronMelDimensionValidation) {
   const std::string mels_error = GetExceptionMessage([] {
-    Generators::ValidateNemotronMelInputShape({1, 79, 1234}, 80);
+    Generators::GetValidatedNemotronMelFrameCount({1, 128, 304}, 128);
   });
   EXPECT_NE(mels_error.find("expected num_mels"), std::string::npos);
+  EXPECT_NE(mels_error.find("304"), std::string::npos);
+  EXPECT_NE(mels_error.find("128"), std::string::npos);
 }
 
 TEST(AudioSpeechValidationTests, NemotronEncoderOutputRankValidation) {
@@ -76,14 +80,14 @@ TEST(AudioSpeechValidationTests, ParakeetDecoderDimensionValidation) {
 
 TEST(AudioSpeechValidationTests, Rank1TensorsRejected) {
   EXPECT_THROW(Generators::ValidateWhisperAudioFeaturesShape({3000}, 3000), std::runtime_error);
-  EXPECT_THROW(Generators::ValidateNemotronMelInputShape({3000}, 80), std::runtime_error);
+  EXPECT_THROW(Generators::GetValidatedNemotronMelFrameCount({3000}, 80), std::runtime_error);
   EXPECT_THROW(Generators::ValidateParakeetEncoderOutputShape({512}, 512), std::runtime_error);
   EXPECT_THROW(Generators::ValidateParakeetDecoderOutputShape({1024}, 1024), std::runtime_error);
 }
 
 TEST(AudioSpeechValidationTests, DimensionMismatchesCaught) {
   EXPECT_THROW(Generators::ValidateWhisperAudioFeaturesShape({1, 80, 2999}, 3000), std::runtime_error);
-  EXPECT_THROW(Generators::ValidateNemotronMelInputShape({2, 80, 3000}, 80), std::runtime_error);
+  EXPECT_THROW(Generators::GetValidatedNemotronMelFrameCount({2, 304, 128}, 128), std::runtime_error);
   EXPECT_THROW(Generators::ValidateParakeetEncoderOutputShape({1, 256, 64}, 512), std::runtime_error);
   EXPECT_THROW(Generators::ValidateParakeetDecoderOutputShape({2, 1024, 1}, 1024), std::runtime_error);
 }


### PR DESCRIPTION
## Summary
- validate Nemotron streaming mel tensors using the produced `[batch, frames, mels]` layout
- derive encoder frame count from the validated middle dimension
- add asymmetric regression coverage for frame extraction and transposed inputs

## Context

microsoft/onnxruntime-genai#2382 added shape validation assuming `[batch, mels, frames]`, but `NemotronStreamingProcessor` produces `[batch, frames, mels]`. Real tensors such as `[1, 65, 128]` therefore failed with `mels dimension (65) does not match expected num_mels (128)`.

The fix preserves the security validation while making validation and frame-count extraction share one strict tensor contract.

## Validation
- 261 GenAI CPU unit tests: 239 passed, 22 expected platform/model skips
- `StreamingAudioFixture.StreamRecordingInChunksAndValidateTranscription` passed
- `StreamingAudioFixture.StreamRecordingWithInitialData` passed
- `StreamingAudioFixture.StreamingCallbackReceivesTokens` passed

Three independent reviews approved the final patch with no blocking findings.