### PR TITLE
Fix shared memory race in warp merge sort write-back

### DIFF
--- a/src/ep/cuda/cuda_topk_warp_sort_helper.cuh
+++ b/src/ep/cuda/cuda_topk_warp_sort_helper.cuh
@@ -77,6 +77,10 @@ struct Greater {
  * is highly efficient for small sort sizes that fit within a single warp's processing capacity.
  * It is designed to be called by a full thread block, where only the first warp performs work.
  * The caller might need call __syncthreads() before and after this function.
+ *
+ * `temp_storage_ptr` may alias `smem_scores`/`smem_indices`: callers union the CUB temp storage
+ * with the score/index buffers to save shared memory, so the write-back below is fenced against
+ * CUB's final reads of that storage.
  */
 template <int BufferSize>
 __device__ void WarpMergeSort(float* smem_scores, int* smem_indices, void* temp_storage_ptr, int num_valid_items) {
@@ -108,6 +112,8 @@ __device__ void WarpMergeSort(float* smem_scores, int* smem_indices, void* temp_
 
   // Sort descending using a "greater than" comparator.
   WarpSortT(temp_storage).Sort(thread_keys, Greater<uint64_t>());
+  // CUB's merge loop ends on a read of its temp storage with no trailing sync.
+  __syncwarp();
 
   // Unpack and write back to the full buffer.
   for (int i = 0; i < kItemsPerThread; ++i) {
@@ -139,6 +145,8 @@ __device__ void WarpMergeSort(float* smem_scores, int* smem_indices, void* temp_
 
   // Sort descending using a "greater than" comparator.
   WarpSortT(temp_storage).Sort(thread_scores, thread_indices, Greater<float>());
+  // CUB's merge loop ends on a read of its temp storage with no trailing sync.
+  __syncwarp();
 
   // Write back to the full buffer.
   for (int i = 0; i < kItemsPerThread; ++i) {


### PR DESCRIPTION
Fixes a latent shared-memory race in the single-warp CUB merge sort used by the top-k reduction cascade.

## Problem

`topk_common::WarpMergeSort` takes the score/index buffers and the CUB temp storage as separate parameters, but every caller passes two members of the *same* union. `hybrid_sort`, `cascaded_sort` and `iterative_sort` all declare:

```cuda
union SharedStorage {
  typename cub::WarpMergeSort<uint64_t, (kMaxSortSize + 31) / 32, 32>::TempStorage cub_warp_storage;
  ...
  struct {
    __align__(128) float scores[kMaxSortSize];
    __align__(128) int   indices[kMaxSortSize];
  } stage2_storage;
};
```

and the single call site in `cuda_topk_common.cuh` passes both halves:

```cuda
topk_common::WarpMergeSort<kSortSizePo2>(smem.stage2_storage.scores, smem.stage2_storage.indices,
                                         &smem.cub_warp_storage, num_elements_to_sort);
```

So `smem_scores`, `smem_indices` and `temp_storage` are the same bytes.

CUB's `BlockMergeSortStrategy::StableSort` merge loop **ends on a read** of its temp storage — `SerialMerge(&temp_storage.keys_shared[0], ...)` in the keys-only path, or the `items_shared` gather otherwise — with no trailing `Sync()`. On return from `Sort()`, one lane can therefore begin the write-back into `smem_scores`/`smem_indices` while another lane is still reading that same memory inside the merge.

In the stable path `scores[]` (float) overlays the first half of `keys_shared` (uint64_t), which is exactly the range `SerialMerge` reads, so the overlap is real rather than theoretical.

Since Volta, lanes in a warp are not guaranteed to advance in lockstep, so nothing prevents the skew. The caller's `__syncthreads()` after the call does not help — the race is intra-warp and happens before that barrier.

## Fix

Add `__syncwarp()` between the sort and the write-back, in both the `STABLE_TOPK` and the key-value paths. Placing it in the shared helper covers hybrid, cascaded and iterative at once.

The loads *before* the sort need no extra barrier: CUB calls `Sync()` (which is `__syncwarp(member_mask)` for `WarpMergeSort`) before its first write to `keys_shared`, so every lane's loads are complete before any lane writes scratch.

## Impact

Silent, low-probability wrong results (incorrect top-k ordering or values) on Volta and newer. Not reproducible on pre-Volta hardware, where warp lockstep hides it.

## Testing

Compile-only change in behavior terms — no API or layout change. Existing top-k correctness tests cover the affected paths (`hybrid_sort`, `cascaded_sort`, `iterative_sort`). The race is timing-dependent, so it does not reproduce deterministically in a unit test; the fix is justified by the CUB source ordering described above.
