### PR TITLE
Support stop strings during speculative decoding

### DIFF
--- a/docs/SpeculativeDecoding.md
+++ b/docs/SpeculativeDecoding.md
@@ -316,7 +316,7 @@ acceptance must be considered together.
 | `interrupted_rounds` | Rounds invalidated by an external operation before normal completion |
 | `active_rounds` | `1` while a round has buffered output, otherwise `0` |
 | `draft_tokens_proposed` | Tokens produced by the active proposer; for n-gram decoding these are lookup proposals |
-| `draft_tokens_evaluated` | Proposed tokens examined before acceptance stopped |
+| `draft_tokens_evaluated` | Proposed token positions logically resolved before the committed output boundary: the accepted prefix plus the first rejected proposal when rejection ends verification. Engine stops counting at a stop string or token limit, so later proposal positions are not counted. |
 | `draft_tokens_accepted` | Proposed tokens accepted directly |
 | `correction_tokens` | Target-selected tokens committed after a rejection |
 | `bonus_tokens` | Target-selected trailing tokens committed after full proposal acceptance |
@@ -328,7 +328,8 @@ acceptance must be considered together.
 | `target_forward_passes` | All target verification, re-anchor, and lifecycle reconciliation executions |
 
 `acceptance_rate` is `draft_tokens_accepted / draft_tokens_evaluated`. It is zero until at least
-one proposed token has been evaluated.
+one proposed token has been evaluated. An Engine round truncated by a stop string or token limit can
+have an acceptance rate of `1.0` even when later proposed tokens were not evaluated.
 
 ### Round and target execution breakdown
 

--- a/docs/engine_c_api_spec.md
+++ b/docs/engine_c_api_spec.md
@@ -120,7 +120,7 @@ Initial implementation status:
 | --- | --- |
 | `max_generated_tokens` | Implemented end to end; zero uses the configured/default limit |
 | `temperature`, `top_p`, `top_k`, `seed` | Setter returns an explicit not-implemented error |
-| UTF-8 stop strings | Implemented end to end for ordinary (non-speculative) dynamic Engine turns; see "Stop strings" below. A null collection is rejected; an empty collection clears/disables stop strings |
+| UTF-8 stop strings | Implemented end to end for dynamic Engine turns, including speculative draft verification (manual `OgaRequestSetDraftTokens` and automatic in-Engine drafters such as MTP); see "Stop strings" below. A null collection is rejected; an empty collection clears/disables stop strings |
 | guidance | Setter returns an explicit not-implemented error and does not retain/dereference input |
 
 Unsupported requested behavior must never be accepted and ignored. `OgaTurnOptions` may be reused,
@@ -173,11 +173,11 @@ disturb ordinary EOS termination.
 Stop strings require an Engine configured for dynamic batching: `OgaRequestBeginTurn` rejects a
 stop-enabled turn on a static-batching Engine before any Request mutation, because static batching
 completes generation through a non-transactional path that cannot stage, roll back, or replay a
-match. Stop strings are also incompatible with speculative draft verification for the Request whose
-turn enables them: `OgaRequestSetDraftTokens` (and every automatic in-Engine drafter, e.g. MTP)
-rejects/skips that Request rather than proposing drafts, while other Requests on the same Engine
-keep using speculative decoding normally. A stop-enabled turn therefore always runs the plain
-one-token-per-step path, request-locally.
+match. A stop-enabled turn drafts and verifies with speculative decoding exactly like any other
+turn: `OgaRequestSetDraftTokens` and every automatic in-Engine drafter (e.g. MTP) accept and verify
+drafts normally, observing target-accepted tokens through the same stop-string matcher the ordinary
+one-token path uses, in exact committed order, truncating at the first completed match and
+discarding every later draft.
 
 Turn admission itself is transactional with respect to stop strings, symmetrically for both
 directions: a `BeginTurn` that would enable, change, or clear the Request's stop-string

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -864,29 +864,135 @@ replay its full current-turn token history, so one retryable abort's recovery co
 stop-string component alone is `O(active stop-enabled requests in the batch x each request's
 generated current-turn token count)` -- linear in the number of such requests, and, per request,
 linear in how deep into the turn it already is. This follows from the required per-request replay;
-this repository does not include a replay benchmark or publish a measured per-token constant. A
-Request many thousands of tokens into a long turn pays a proportionally larger replay on every
-retryable abort that touches it, and a batch with several such requests pays that cost once per
-request, every time. No batching or amortization across requests exists for this replay today.
-Rollout qualification for stop strings at scale should measure this cost with representative
-tokenizers and turn depths, and monitor observed abort frequency alongside typical current-turn
-depth rather than assuming replay cost is negligible.
+speculative draft verification can observe up to `kMaxGeneratedTokensPerStep` tokens for one
+request in a single step rather than the ordinary path's one, but this does not change the bound
+above: it is already stated in terms of the replayed turn depth (the checkpoint the step began at),
+not the number of tokens observed within the failing step itself. This repository does not include
+a replay benchmark or publish a measured per-token constant. A Request many thousands of tokens
+into a long turn pays a proportionally larger replay on every retryable abort that touches it, and
+a batch with several such requests pays that cost once per request, every time. No batching or
+amortization across requests exists for this replay today. Rollout qualification for stop strings
+at scale should measure this cost with representative tokenizers and turn depths, and monitor
+observed abort frequency alongside typical current-turn depth rather than assuming replay cost is
+negligible.
 
 Stop strings require an Engine configured for dynamic batching. Static batching completes generation
 through `ScheduledRequests::GenerateNextTokens`, a non-transactional path that cannot stage, roll
 back, or replay a match, so `Engine::BeginTurn` rejects a stop-enabled turn on a static-batching
 Engine before any Request mutation.
 
-Stop strings are incompatible with speculative draft verification for the specific Request whose
-turn enables them, but this Engine capability is not disabled for other Requests. Every draft
-producer -- manual `Request::SetDraftTokens` callers and the automatic in-Engine MTP drafter alike
--- converges on `Request::DraftTokenValidationError()`, which returns a rejection reason whenever
-the request has an active stop controller. A manual caller sees this as a thrown error;
-`Engine::PrepareMtpStep`'s existing per-request skip check (already used for guidance and other
-per-request draft-ineligibility reasons) uses the same function to silently exclude the request from
-receiving automatic drafts, so its target step keeps running the plain one-token-per-step path while
-every other Request on the same Engine continues to use speculative decoding normally. See
-"Speculative drafts" above for the shared verification path this reuses.
+Speculative draft verification observes target-accepted tokens through the same
+`StopStringController` a stop-enabled Request already uses for its ordinary one-token path, so a
+stop-enabled turn drafts and verifies exactly like any other request; no producer needs any special
+casing for stop strings. Greedy verification
+(`Request::CommitAcceptedDraftsForTransaction`) observes each accepted draft in commit order, but
+only the ones that actually append -- an accepted draft that turns out to be EOS commits without
+appending (`GreedySearch_Cpu::CommitToken` marks the search done, leaving the sequence length
+unchanged), and that gate excludes it from the controller exactly like `StageGeneration`'s
+`token_appended` check excludes an unappended EOS on the ordinary path; a match stops verification
+(and discards every later draft, including the trailing bonus/replacement row) the instant one
+completes; `Request::StageDraftCompletionForTransaction` then reports `StopString` ahead of the
+ordinary `TurnLimit`/`ContextLimit` checks for that same round, mirroring `StageGeneration`'s own
+precedence. Because greedy's loop increments `accepted_draft_count_` before checking for a match, a
+matching draft is always included in it -- it is a genuinely target-confirmed draft, indistinguishable
+from any earlier accepted one, whatever ends the round.
+
+Sampled and batched-sampler verification (`ScheduledRequests::GenerateNextTokensForTransaction`'s
+per-stage loop) reuses `StageGenerationForTransaction`/`StageGeneration` unchanged, one stage at a
+time: `Request::AppendAcceptedSampledToken` incrementally records every stage before the one that
+completes a match (or the round's natural last stage) so `accepted_draft_count_` reflects "prior
+stages only" while that call runs, which is what lets the per-stage baseline stay a single, uniform
+formula (`plan.sequence_length_before + accepted_draft_count_`) regardless of which stage turns out
+to match. Once a stage's own `StageGenerationForTransaction()` result is in hand, though, the caller
+still needs to decide whether *that* stage's own token is itself a genuinely confirmed draft (as
+opposed to a trailing replacement/bonus token, which is never one of the proposed drafts) before
+handing the result to `CommitStep`: `SelectSampledRows`'s `confirmed_draft_counts` output (the
+sequential draw loop's own confirmed-prefix length, computed independently of any stop string) tells
+the caller which case applies. When the finishing stage is a confirmed draft, `Request::
+PromoteFinalStageAsAcceptedDraft` folds it into `accepted_draft_count_` (reusing
+`AppendAcceptedSampledToken`) and clears the result's `token_appended` so `CommitStep` does not also
+append the same token a second time. This applies whether the round ends via a stop match or, with
+no stop strings at all, the turn/context limit landing exactly on a confirmed draft with no bonus
+token ever drawn -- both cases would otherwise under-count `AcceptedDraftTokenCount()` (and, since
+`RunDynamic()`'s target-reservation `CommitPrefix` and `Engine::RecordSpeculativeCommit`'s telemetry
+read it before `CommitStep` resets it, under-retain the confirmed draft's own KV slot in the paged
+cache and under-report it in `SpeculativeStats`). A match found mid-round also
+truncates that request's `selected_tokens` to the matching stage, so later stages simply never
+iterate it again -- no separate discard step is needed. Because a committed `StopString` result
+always has `done == true`, it structurally prevents a subsequent draft block for that request
+without any stop-specific check: `Engine::PrepareMtpStep`'s existing
+`result.done` gate already skips proposing a new automatic draft, and `Request::SetDraftTokens`'s
+existing `IsExecuting(status_)` check already rejects a manual proposal once the request is
+`TurnComplete`. The controller's per-token observation, wherever it runs inside a step, is covered by
+the same whole-step transaction checkpoint/replay described above, so rollback and retry work
+identically whether the observed token came from the ordinary path or from draft verification.
+Static batching's rejection of a stop-enabled turn (above) is unrelated and unaffected.
+
+**RNG fidelity for a stop-truncated sampled round.** `SelectSampledRows`'s sequential draw loop
+samples every candidate token for a randomly-sampled request's whole proposed draft (and its
+trailing bonus/replacement, if reached) up front, before the later per-stage loop can possibly know
+that a stop match will truncate the round early. Left alone, this would permanently advance
+the host verification `rng_` for tokens beyond the match that never become visible. To avoid this,
+`SelectSampledRows` checkpoints a plain copy of `rng_` after every draw, but only for a request with
+an active stop controller (`stop_controller_ != nullptr`) -- this
+is an intentional, reserved-up-front allocation and copy for that request's checkpoints (that
+request's own inner vector is `reserve()`d to the call's exact upper bound, `draft_count + 1`,
+before any draws happen, so growing it never reallocates or re-copies an already-captured
+checkpoint). The outer checkpoint vector itself is left completely empty -- no allocation at all --
+unless a pre-scan finds at least one random-sampled drafted request in the whole step that needs it;
+only then is it sized once, to the request count. A step with no drafts, no random sampling, or no
+stop-enabled request among them never allocates either the outer vector or any inner one, so the
+no-stop, greedy, and non-drafted paths pay nothing for this. When the per-stage loop truncates a
+request's `selected_tokens` at a stop match, it also restores `rng_` to the checkpoint captured
+right after that stage's own draw, discarding the effect of every later draw the sequential loop
+made for a now-invisible token. This is unrelated to, and layered on top of, the pre-existing
+whole-step `rng_`/`transaction_rng_` checkpoint a retryable batch abort already restores
+unconditionally (see "Recoverable rollback"
+below); that mechanism alone already undoes every draw a failed attempt made, stop strings or not.
+
+**Telemetry: `draft_tokens_evaluated`.** `Request::EvaluatedDraftTokenCount()` tracks, directly in
+the verification commit path, how many of this round's *proposed* draft positions were logically
+resolved as accepted or rejected before the round's terminal boundary -- never inferred afterward
+in `Engine::RecordSpeculativeCommit` from
+`accepted`/`finish_reason`/`token_appended`, and never counting a trailing replacement/bonus token
+itself (which is not one of the proposed drafts). It is always `>= AcceptedDraftTokenCount()`, reset
+and advanced at exactly the same transaction boundaries, and read before `CommitStep()` resets it,
+the same way `AcceptedDraftTokenCount()` is. Greedy target comparisons may have been precomputed
+for later proposal rows, but rows beyond a committed stop/limit boundary are not part of this
+logical evaluated count.
+
+Greedy verification (`CommitAcceptedDraftsForTransaction`) increments it once per loop iteration,
+regardless of that iteration's append/match/turn-limit outcome; if the loop completes normally (no
+match, EOS, or turn/context limit interrupted it) and the caller proposed more drafts than were
+confirmed, the rejected position beyond the confirmed prefix is counted too, even though the loop
+itself never processes it (that comparison already happened in the caller). Sampled/batched
+verification advances it identically to `accepted_draft_count_` for every non-finishing stage
+(`AppendAcceptedSampledToken`) and for a finishing stage that is itself a confirmed draft
+(`PromoteFinalStageAsAcceptedDraft`); a finishing stage that is instead a logically resolved but
+non-accepted proposal (a rejection with a replacement, or EOS without an append) advances only
+this count, via `MarkFinalStageAsEvaluatedNonAcceptedDraft`, never `accepted_draft_count_`. A
+finishing stage beyond the whole proposed range (a trailing bonus token after full acceptance)
+advances neither.
+
+This gives exactly: an ordinary rejection after `k` accepted drafts evaluates `k + 1`; full
+acceptance (with or without a bonus token) evaluates the full proposed count; a stop match that
+completes on a genuinely confirmed draft evaluates exactly the retained confirmed prefix; a stop
+match on the ordinary replacement following a rejected draft evaluates `accepted + 1`, identically
+to a non-stop rejection; and, critically, a round the turn/context limit (not a rejection) truncates
+before any further proposal can enter the committed logical result -- e.g. 5 proposed drafts,
+budget for 2, both confirmed -- evaluates exactly 2, not `accepted + 1 = 3`: no third proposal
+position belongs to that result. The counters are advanced while verification resolves each
+proposal because `token_appended` and `finish_reason` alone cannot distinguish budget exhaustion
+from a confirmed final draft or a rejected proposal.
+
+**CUDA batched-commit qualification gap.** The per-stage loop's `can_batch_commits` branch (used
+when every active request's `Search` supports device-side batched commit) uses the same counters,
+checkpoints, and promotion rules as the non-batched fallback branch. The two finalization blocks are
+duplicated implementations that are presently equivalent, not shared code. The CPU test doubles
+this document's tests run against cannot produce a `Search` that supports batched commit, so no
+automated test in this repository actually exercises the `can_batch_commits == true` branch for
+decoded stop strings. Treat that branch as requiring real CUDA qualification before relying on it
+in production; structural equivalence is not evidence that it has been tested.
 
 ## Rollback and failure handling
 

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -986,13 +986,13 @@ proposal because `token_appended` and `finish_reason` alone cannot distinguish b
 from a confirmed final draft or a rejected proposal.
 
 **CUDA batched-commit qualification gap.** The per-stage loop's `can_batch_commits` branch (used
-when every active request's `Search` supports device-side batched commit) uses the same counters,
-checkpoints, and promotion rules as the non-batched fallback branch. The two finalization blocks are
-duplicated implementations that are presently equivalent, not shared code. The CPU test doubles
+when every active request's `Search` supports device-side batched commit) and the non-batched
+fallback use different token-commit mechanisms, then call the same stage-finalization code for
+counters, checkpoints, promotion, stop truncation, and result publication. The CPU test doubles
 this document's tests run against cannot produce a `Search` that supports batched commit, so no
-automated test in this repository actually exercises the `can_batch_commits == true` branch for
-decoded stop strings. Treat that branch as requiring real CUDA qualification before relying on it
-in production; structural equivalence is not evidence that it has been tested.
+automated test in this repository actually exercises the device-side commit mechanism with decoded
+stop strings. Treat that branch as requiring real CUDA qualification before relying on it in
+production; shared finalization does not prove that the preceding device commit has been tested.
 
 ## Rollback and failure handling
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -917,8 +917,7 @@ void Engine::PublishMtpDrafts(MtpStep& step) {
 }
 
 void Engine::RecordSpeculativeCommit(const StepPlan& plan) noexcept {
-  for (size_t i = 0; i < plan.requests.size(); ++i) {
-    const auto& entry = plan.requests[i];
+  for (const auto& entry : plan.requests) {
     if (entry.draft_token_count == 0) {
       continue;
     }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -489,6 +489,14 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
                                                 remaining_turn_tokens_after_step > 1
                                                     ? remaining_turn_tokens_after_step - 1
                                                     : size_t{0}});
+      // A stop-enabled request is intentionally not excluded here: generic target verification
+      // (Request::CommitAcceptedDraftsForTransaction for greedy, the per-stage loop in
+      // ScheduledRequests::GenerateNextTokensForTransaction for sampled/batched) truncates it
+      // transactionally through the same StopStringController the ordinary path uses, so it can
+      // draft and verify normally. result.done still does the work of preventing a redraft after a
+      // match: it is true for any committed StopString result exactly like any other finish
+      // reason, so this check below already skips proposing a new draft block for it with no
+      // stop-specific condition needed.
       if (!result.token_appended || result.done ||
           entry.request->DraftTokenValidationError() ||
           max_draft_tokens == 0) {
@@ -909,17 +917,28 @@ void Engine::PublishMtpDrafts(MtpStep& step) {
 }
 
 void Engine::RecordSpeculativeCommit(const StepPlan& plan) noexcept {
-  for (const auto& entry : plan.requests) {
+  for (size_t i = 0; i < plan.requests.size(); ++i) {
+    const auto& entry = plan.requests[i];
     if (entry.draft_token_count == 0) {
       continue;
     }
 
     const size_t accepted = entry.request->AcceptedDraftTokenCount();
+    // EvaluatedDraftTokenCount() is tracked directly at the actual verification source (the
+    // greedy loop in Request::CommitAcceptedDraftsForTransaction, and the sampled/batched stage
+    // loop's AppendAcceptedSampledToken/PromoteFinalStageAsAcceptedDraft/
+    // MarkFinalStageAsEvaluatedNonAcceptedDraft in
+    // ScheduledRequests::GenerateNextTokensForTransaction),
+    // not inferred here from accepted/finish_reason/token_appended after the fact. It counts draft
+    // positions logically resolved before the committed terminal boundary; greedy comparisons may
+    // have been precomputed for later positions. The old inference overcounted a limit-truncated
+    // round -- e.g. 5 proposed, budget for 2, both confirmed: the logical evaluated prefix is 2,
+    // not accepted + 1 = 3.
+    const size_t evaluated = entry.request->EvaluatedDraftTokenCount();
     ++speculative_stats_.rounds;
     ++speculative_stats_.completed_rounds;
     speculative_stats_.draft_tokens_proposed += entry.draft_token_count;
-    speculative_stats_.draft_tokens_evaluated +=
-        std::min(accepted + 1, entry.draft_token_count);
+    speculative_stats_.draft_tokens_evaluated += evaluated;
     speculative_stats_.draft_tokens_accepted += accepted;
     ++speculative_stats_.acceptance_length_histogram[accepted];
     if (accepted == 0) {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -277,7 +277,9 @@ void Request::MarkClosedFromEngine(const Engine& engine) noexcept {
   std::vector<int32_t>{}.swap(draft_tokens_);
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
+  evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_stop_match_index_ = -1;
 }
 
 void Request::CompleteCloseFromEngine(const Engine& engine) noexcept {
@@ -350,7 +352,9 @@ void Request::CompleteClose() noexcept {
   std::vector<int32_t>{}.swap(draft_tokens_);
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
+  evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_stop_match_index_ = -1;
   std::vector<int32_t>{}.swap(tokens_host_);
 }
 
@@ -385,15 +389,10 @@ int64_t Request::CommittedSequenceLength() const {
 }
 
 const char* Request::DraftTokenValidationError() const noexcept {
-  if (stop_controller_) {
-    // The shared boundary every draft producer converges on: manual Request::SetDraftTokens
-    // callers get this as a thrown error, and Engine::PrepareMtpStep's identical check silently
-    // excludes the request from automatic MTP drafting instead (see its use there). Either way, a
-    // stop-enabled turn always runs the plain one-token-per-step path, request-locally, without
-    // disabling draft verification for any other request on this Engine.
-    return "Speculative draft tokens are not supported while stop strings are enabled for the "
-           "active turn.";
-  }
+  // A stop-enabled turn is not excluded here: draft verification observes target-accepted tokens
+  // through stop_controller_ in exactly the same committed order the ordinary one-token path uses
+  // (CommitAcceptedDraftsForTransaction for greedy verification, StageGenerationForTransaction for
+  // sampled/batched verification), so it drafts and verifies normally.
   if (guidance_logits_processor_) {
     return "Speculative draft tokens are not supported with guidance.";
   }
@@ -470,7 +469,9 @@ void Request::AppendDraftsForTransaction(size_t draft_count) {
   tokens_host_.insert(tokens_host_.end(), drafts.begin(), drafts.end());
   staged_draft_count_ = draft_count;
   accepted_draft_count_ = 0;
+  evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_stop_match_index_ = -1;
 }
 
 void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
@@ -484,9 +485,16 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
   search_->RewindTo(committed_length);
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
+  evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_stop_match_index_ = -1;
 
   for (size_t offset = 0; offset < accepted_count; ++offset) {
+    // Every iteration examines exactly one proposed draft position's target acceptance, whether or
+    // not it turns out to append/match/end the round below -- this is what lets
+    // Engine::RecordSpeculativeCommit read an exact "rows examined" count instead of inferring one
+    // from token_appended/finish_reason after the fact.
+    ++evaluated_draft_count_;
     const int32_t token = draft_tokens_[offset];
     const int64_t sequence_length_before = CurrentSequenceLength();
     search_->CommitToken(token);
@@ -495,6 +503,17 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
       tokens_host_.push_back(token);
       ++staged_draft_count_;
       ++accepted_draft_count_;
+      // Only an actually-appended token reaches the matcher here, exactly mirroring the ordinary
+      // one-token path's token_appended gate in StageGeneration(): an accepted draft that turns out
+      // to be EOS commits (GreedySearch_Cpu::CommitToken marks the search done) without appending,
+      // so its bytes must never reach the controller or be able to produce a StopString result.
+      if (stop_controller_) {
+        if (const auto& match = stop_controller_->ObserveToken(token)) {
+          draft_verification_stop_match_index_ = static_cast<int32_t>(match->index);
+          draft_verification_completed_generation_ = true;
+          break;
+        }
+      }
     } else if (sequence_length_after != sequence_length_before ||
                !search_->IsDone()) {
       throw std::logic_error(
@@ -509,6 +528,16 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
       break;
     }
   }
+  // The loop above only ever runs offsets 0..accepted_count-1 (all already argmax-confirmed by the
+  // caller): a genuinely rejected draft at offset accepted_count, if any, is never processed by it
+  // at all -- that comparison already happened in the caller (ScheduledRequests::SelectSampledRows)
+  // before this function was even called. If the loop completed normally (no stop match, EOS, or
+  // turn/context limit interrupted it) and the caller proposed more drafts than were confirmed,
+  // that rejected position was examined (compared against the target's own argmax and found not to
+  // match) even though it is not processed here, so it counts too.
+  if (!draft_verification_completed_generation_ && accepted_count < proposed_count) {
+    ++evaluated_draft_count_;
+  }
 }
 
 void Request::RewindDraftsForTransaction(size_t accepted_count) {
@@ -517,6 +546,7 @@ void Request::RewindDraftsForTransaction(size_t accepted_count) {
   }
   const size_t rejected_count = staged_draft_count_ - accepted_count;
   accepted_draft_count_ = accepted_count;
+  evaluated_draft_count_ = accepted_count;
   if (rejected_count == 0) {
     return;
   }
@@ -526,14 +556,32 @@ void Request::RewindDraftsForTransaction(size_t accepted_count) {
   search_->RewindTo(static_cast<size_t>(CurrentSequenceLength()) - rejected_count);
 }
 
-void Request::RecordSampledDraftAcceptance(size_t accepted_count) {
-  if (staged_draft_count_ != 0 || accepted_count > draft_tokens_.size()) {
-    throw std::logic_error("Sampled verification recorded an invalid accepted draft prefix.");
+void Request::AppendAcceptedSampledToken(int32_t token) {
+  if (accepted_draft_count_ >= draft_tokens_.size()) {
+    throw std::logic_error("Sampled verification accepted more tokens than were proposed as drafts.");
   }
-  tokens_host_.insert(tokens_host_.end(), draft_tokens_.begin(),
-                      draft_tokens_.begin() + static_cast<ptrdiff_t>(accepted_count));
-  staged_draft_count_ = accepted_count;
-  accepted_draft_count_ = accepted_count;
+  tokens_host_.push_back(token);
+  ++staged_draft_count_;
+  ++accepted_draft_count_;
+  ++evaluated_draft_count_;
+}
+
+void Request::PromoteFinalStageAsAcceptedDraft(RequestStepResult& result) {
+  // Reuses the exact same push/increment AppendAcceptedSampledToken performs for an earlier stage;
+  // the only difference is that this token is the one StageGeneration() just staged as this
+  // result's own token_appended token, so CommitStep() must not also append it a second time.
+  //
+  // A confirmed draft this promotes must have actually been appended by StageGeneration() this
+  // stage (mirroring the ordinary path's own token_appended semantics): if it were not, the token
+  // this mirrors into tokens_host_ below would never have genuinely extended Search's own
+  // sequence, silently diverging Request's host mirror from Search. Enforce the
+  // confirmed_draft_counts/token_appended invariant before mutating the host mirror.
+  if (!result.token_appended) {
+    throw std::logic_error(
+        "PromoteFinalStageAsAcceptedDraft was called for a stage that never appended a token.");
+  }
+  AppendAcceptedSampledToken(result.token);
+  result.token_appended = false;
 }
 
 void Request::DiscardStagedDrafts() noexcept {
@@ -542,7 +590,9 @@ void Request::DiscardStagedDrafts() noexcept {
     staged_draft_count_ = 0;
   }
   accepted_draft_count_ = 0;
+  evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_stop_match_index_ = -1;
 }
 
 RequestStateSnapshot Request::Snapshot() const {
@@ -801,17 +851,26 @@ RequestStepResult Request::StageDraftCompletionForTransaction() {
   }
 
   GenerationFinishReason finish_reason = GenerationFinishReason::ContextLimit;
-  const bool turn_limit_reached =
-      turn_max_generated_tokens_ &&
-      turn_generated_tokens_ + accepted_draft_count_ >=
-          *turn_max_generated_tokens_;
-  if (turn_limit_reached) {
-    finish_reason = GenerationFinishReason::TurnLimit;
+  int32_t matched_stop_string_index = -1;
+  // Stop-string precedence over the turn/context limit was already decided when this token was
+  // observed, immediately after it was accepted in CommitAcceptedDraftsForTransaction()'s loop --
+  // mirroring StageGeneration()'s identical precedence for the ordinary one-token path.
+  if (draft_verification_stop_match_index_ >= 0) {
+    finish_reason = GenerationFinishReason::StopString;
+    matched_stop_string_index = draft_verification_stop_match_index_;
   } else {
-    const auto next_tokens = search_->GetNextTokens().CpuSpan();
-    if (search_->IsDone() && !next_tokens.empty() &&
-        contains(params_->config.model.eos_token_id, next_tokens.back())) {
-      finish_reason = GenerationFinishReason::EosToken;
+    const bool turn_limit_reached =
+        turn_max_generated_tokens_ &&
+        turn_generated_tokens_ + accepted_draft_count_ >=
+            *turn_max_generated_tokens_;
+    if (turn_limit_reached) {
+      finish_reason = GenerationFinishReason::TurnLimit;
+    } else {
+      const auto next_tokens = search_->GetNextTokens().CpuSpan();
+      if (search_->IsDone() && !next_tokens.empty() &&
+          contains(params_->config.model.eos_token_id, next_tokens.back())) {
+        finish_reason = GenerationFinishReason::EosToken;
+      }
     }
   }
   RequestStepResult result{
@@ -819,6 +878,7 @@ RequestStepResult Request::StageDraftCompletionForTransaction() {
       false,
       true,
       finish_reason,
+      matched_stop_string_index,
   };
   StageVisibleTokens(result, accepted_draft_count_, std::nullopt);
   return result;
@@ -831,8 +891,10 @@ void Request::RestoreStateForTransaction() {
   tokens_host_.resize(transaction_tokens_host_size_);
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
+  evaluated_draft_count_ = 0;
   scheduled_token_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_stop_match_index_ = -1;
   if (guidance_transaction_checkpoint_) {
     guidance_logits_processor_ = std::move(guidance_transaction_checkpoint_);
   }
@@ -851,8 +913,10 @@ void Request::QueueStateRestoreForTransaction() {
   tokens_host_.resize(transaction_tokens_host_size_);
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
+  evaluated_draft_count_ = 0;
   scheduled_token_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_stop_match_index_ = -1;
   // Deliberately does not replay the stop controller yet: like the guidance checkpoint swap below,
   // that work is deferred to CompleteStateRestoreForTransaction() so this stays lightweight
   // bookkeeping that cannot itself allocate, decode, or throw.
@@ -901,7 +965,9 @@ void Request::CommitStep(const RequestStepPlan& plan,
   draft_tokens_.clear();
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
+  evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_stop_match_index_ = -1;
 }
 
 // Records the tokens this step makes externally visible, in sequence order. Accepted drafts are
@@ -977,10 +1043,6 @@ RequestStepResult Request::StageGeneration(int64_t sequence_length_before) {
   // registering EOS as a special, zero-byte-decoding token by default. Prompt/continuation tokens
   // also never reach this point, and stop_controller_ is null on the no-stop fast path.
   if (token_appended && stop_controller_) {
-    if (accepted_draft_count_ != 0) {
-      throw std::logic_error(
-          "Stop-string matching cannot observe accepted draft tokens.");
-    }
     if (const auto& match = stop_controller_->ObserveToken(token)) {
       finish_reason = GenerationFinishReason::StopString;
       matched_stop_string_index = static_cast<int32_t>(match->index);

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -177,9 +177,10 @@ struct Request : std::enable_shared_from_this<Request>,
    * This is the single request-local check every speculative draft producer converges on: manual
    * Request::SetDraftTokens callers get the returned reason as a thrown error, and every automatic
    * in-Engine drafter (e.g. MTP's Engine::PrepareMtpStep) uses the same check to silently skip
-   * proposing drafts for this request instead. An active decoded stop-string configuration is one
-   * such reason, so a stop-enabled turn always runs the plain one-token-per-step path -- without
-   * disabling draft verification for any other request on the same Engine.
+   * proposing drafts for this request instead. An active decoded stop-string configuration is not
+   * one of these reasons: draft verification observes target-accepted tokens through the request's
+   * StopStringController in exactly the same committed order as the ordinary one-token path, so a
+   * stop-enabled turn drafts and verifies normally.
    */
   const char* DraftTokenValidationError() const noexcept;
 
@@ -242,6 +243,15 @@ struct Request : std::enable_shared_from_this<Request>,
   size_t AcceptedDraftTokenCount() const noexcept { return accepted_draft_count_; }
 
   /**
+   * @brief Proposed draft positions logically resolved before this step's terminal boundary.
+   *
+   * This is the confirmed prefix plus, when applicable, one non-accepted proposal that ended
+   * verification through rejection or EOS. It never counts a trailing replacement/bonus token,
+   * which is not one of the proposed drafts. Always >= AcceptedDraftTokenCount().
+   */
+  size_t EvaluatedDraftTokenCount() const noexcept { return evaluated_draft_count_; }
+
+  /**
    * @brief Sequence length excluding any drafts staged by the step in flight.
    */
   int64_t CommittedSequenceLength() const;
@@ -254,7 +264,34 @@ struct Request : std::enable_shared_from_this<Request>,
   }
   bool IsStopToken(int32_t token) const;
   void RewindDraftsForTransaction(size_t accepted_count);
-  void RecordSampledDraftAcceptance(size_t accepted_count);
+  // Incrementally records one more sampled-path token that is not this round's finishing stage.
+  // Called once per stage, strictly after that stage's StageGenerationForTransaction() call, for
+  // every stage except the one that turns out to end the round (a stop match, the turn/context
+  // limit, or the request's natural last stage) -- so accepted_draft_count_ always reflects prior
+  // stages only, and the following stage's token_appended check (and any stop-string observation
+  // nested in it) sees exactly one newly appended token, regardless of which stage that turns out
+  // to be. Every stage recorded here is both accepted and evaluated (a non-finishing stage is
+  // always a genuinely confirmed draft), so this advances accepted_draft_count_ and
+  // evaluated_draft_count_ together. The finishing stage itself is never passed here, whether it is
+  // a trailing replacement/bonus token (not one of the proposed drafts) or, when the turn/context
+  // limit or a stop match lands exactly on the last proposed draft with no room left for a
+  // replacement/bonus token, a genuinely confirmed draft -- see PromoteFinalStageAsAcceptedDraft
+  // for that case.
+  void AppendAcceptedSampledToken(int32_t token);
+  // Called instead of AppendAcceptedSampledToken when the stage that turns out to end this round
+  // (a stop-string match, the turn/context limit, or ordinary exhaustion of the proposed drafts) is
+  // itself a genuinely target-confirmed draft rather than a trailing replacement/bonus token: folds
+  // it into accepted_draft_count_/evaluated_draft_count_/tokens_host_ exactly like an earlier
+  // accepted stage would, and suppresses CommitStep()'s own token_appended append of the same token
+  // so it is recorded exactly once. Never called for a trailing replacement/bonus token, which
+  // stays excluded from both counts exactly as it always has been.
+  void PromoteFinalStageAsAcceptedDraft(RequestStepResult& result);
+  // Called instead when the finishing stage is a proposed draft position that was logically
+  // resolved but not accepted, either because it was rejected (and this stage contains its
+  // replacement) or because it is EOS and ends without appending. A trailing bonus token past the
+  // proposed range is not a proposal and must not call this. Advances only evaluated_draft_count_;
+  // any appended replacement is committed normally through the ordinary token_appended path.
+  void MarkFinalStageAsEvaluatedNonAcceptedDraft() noexcept { ++evaluated_draft_count_; }
 
   void ValidateEngineCompatibility() const;
   void SaveStateForTransaction();
@@ -456,7 +493,34 @@ struct Request : std::enable_shared_from_this<Request>,
   std::vector<int32_t> draft_tokens_;
   size_t staged_draft_count_{};
   size_t accepted_draft_count_{};
+  // Proposed draft positions whose target acceptance verification has actually examined this
+  // round, independent of accept/reject outcome and always >= accepted_draft_count_. Reset and
+  // advanced at exactly the same transaction boundaries as accepted_draft_count_ (see the reset
+  // sites for that field); read by Engine::RecordSpeculativeCommit before CommitStep() resets it,
+  // the same way accepted_draft_count_ is. See EvaluatedDraftTokenCount()'s doc comment above for
+  // the exact semantics, and AppendAcceptedSampledToken/PromoteFinalStageAsAcceptedDraft/
+  // MarkFinalStageAsEvaluatedNonAcceptedDraft/CommitAcceptedDraftsForTransaction for how each path
+  // advances it.
+  size_t evaluated_draft_count_{};
   bool draft_verification_completed_generation_{};
+  // Set by CommitAcceptedDraftsForTransaction() when a stop-string match ends greedy draft
+  // verification early, giving StopString precedence over the turn/context limit for the same
+  // completing token. -1 when verification completed generation for any other reason (or has not
+  // completed yet). The sampled/batched path never sets this: it observes stop matches through
+  // the same StageGenerationForTransaction()/StageGeneration() path the ordinary one-token step
+  // uses, one stage at a time, so it needs no separate bookkeeping here.
+  //
+  // StageDraftCompletionForTransaction() only ever reads this field (and accepted_draft_count_,
+  // and Search's own state) to compute its result; it never resets or otherwise mutates it. Only
+  // CommitStep()/RestoreStateForTransaction()/QueueStateRestoreForTransaction()/
+  // DiscardStagedDrafts()/AppendDraftsForTransaction() reset it, at their own well-defined
+  // transaction boundaries -- never in response to StageDraftCompletionForTransaction() being
+  // called. This is deliberate: ScheduledRequests::GenerateNextTokensForTransaction() can call
+  // StageDraftCompletionForTransaction() for the same request twice in one step when the
+  // transaction also uses the batched sampler (once from the batched-sampling setup loop, once
+  // unconditionally from the final per-request loop), and both calls must produce the exact same
+  // result.
+  int32_t draft_verification_stop_match_index_{-1};
   std::shared_ptr<GeneratorParams> params_;
   std::mt19937 rng_;
   std::mt19937 transaction_rng_;

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -775,6 +775,48 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
     if (can_batch_commits)
       committed_tokens = model_->p_device_->Allocate<int32_t>(sampled_request_count);
 
+    const auto commit_sampled_stage = [&](size_t request_index, size_t stage) {
+      auto& request = requests_[request_index];
+      // The plan's original sequence_length_before, plus accepted_draft_count_ (prior stages
+      // only -- never this one), always equals CurrentSequenceLength() just before this stage's
+      // own append. Every earlier stage advanced Search and accepted_draft_count_ by exactly one,
+      // so the unmodified plan works for every stage.
+      const auto& stage_plan = plan.requests[request_index];
+      const auto stage_result = request->StageGenerationForTransaction(stage_plan);
+      const bool is_natural_last_stage =
+          stage + 1 == selected_tokens[request_index].size();
+      const bool stopped =
+          stage_result.finish_reason == GenerationFinishReason::StopString;
+      if (stopped || is_natural_last_stage) {
+        if (stopped && !is_natural_last_stage &&
+            (request_index >= rng_checkpoints.size() ||
+             stage >= rng_checkpoints[request_index].size())) {
+          throw std::logic_error(
+              "A stop-truncated sampled round is missing its RNG checkpoint.");
+        }
+        auto final_result = stage_result;
+        // A target-confirmed final draft contributes to both the accepted and evaluated counts.
+        // A final stage within the proposed range but beyond the confirmed prefix is evaluated
+        // but not accepted. A trailing bonus token was never proposed and contributes to neither.
+        if (stage < confirmed_draft_counts[request_index]) {
+          request->PromoteFinalStageAsAcceptedDraft(final_result);
+        } else if (stage < stage_plan.draft_token_count) {
+          request->MarkFinalStageAsEvaluatedNonAcceptedDraft();
+        }
+        results[request_index] = final_result;
+        if (stopped && !is_natural_last_stage) {
+          // Later selected tokens are never committed. Restore the RNG checkpoint immediately
+          // after the retained token so discarded samples do not affect future decoding.
+          selected_tokens[request_index].resize(stage + 1);
+          request->rng_ = rng_checkpoints[request_index][stage];
+        }
+      } else if (!stage_result.token_appended || stage_result.done) {
+        throw std::logic_error("An accepted sampled draft unexpectedly ended the request.");
+      } else {
+        request->AppendAcceptedSampledToken(stage_result.token);
+      }
+    };
+
     for (size_t stage = 0; stage < max_selected_tokens; ++stage) {
       std::vector<size_t> active;
       active.reserve(sampled_request_count);
@@ -803,97 +845,12 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
         }
         stage_tokens.CopyDeviceToCpu();
         for (size_t row = 0; row < active.size(); ++row) {
-          const size_t request_index = active[row];
-          auto& request = requests_[request_index];
-          // The plan's original sequence_length_before, plus accepted_draft_count_ (prior stages
-          // only -- never this one), always equals CurrentSequenceLength() just before this
-          // stage's own append: every earlier stage's StageGeneration() advanced Search by exactly
-          // one token, and AppendAcceptedSampledToken() below advances accepted_draft_count_ by
-          // exactly one to match. So this same unmodified plan works for every stage, whether or
-          // not it turns out to be the request's last, and StageGeneration()'s stop-string
-          // observation -- reused unchanged from the ordinary one-token path -- always sees
-          // exactly one newly appended token.
-          const auto& stage_plan = plan.requests[request_index];
-          const auto stage_result = request->StageGenerationForTransaction(stage_plan);
-          const bool is_natural_last_stage =
-              stage + 1 == selected_tokens[request_index].size();
-          const bool stopped =
-              stage_result.finish_reason == GenerationFinishReason::StopString;
-          if (stopped || is_natural_last_stage) {
-            auto final_result = stage_result;
-            // This stage is a genuinely target-confirmed draft (not a trailing replacement/bonus
-            // token) whenever it falls within the request's own confirmed prefix -- fold it into
-            // accepted_draft_count_ so CommitStep, cache/fixed-state CommitPrefix, and speculative
-            // telemetry all count it as accepted, exactly like an earlier accepted stage. When it
-            // instead falls at or beyond the confirmed prefix but still within the proposed draft
-            // range, it is a logically resolved but non-accepted proposal (either rejected, with
-            // its replacement in this result, or EOS without an append) -- count it as evaluated
-            // but not accepted. A stage beyond the whole proposed range (a trailing bonus token
-            // after full acceptance) is neither: it was never one of the proposed drafts.
-            if (stage < confirmed_draft_counts[request_index]) {
-              request->PromoteFinalStageAsAcceptedDraft(final_result);
-            } else if (stage < stage_plan.draft_token_count) {
-              request->MarkFinalStageAsEvaluatedNonAcceptedDraft();
-            }
-            results[request_index] = final_result;
-            if (stopped && !is_natural_last_stage) {
-              // A stop match ends verification here: every later staged draft (and any trailing
-              // bonus/replacement token) is discarded by simply never being iterated again --
-              // active[] excludes this request from every subsequent stage once its
-              // selected_tokens shrink to this point. Undo every RNG draw this round made for
-              // those now-invisible tokens by restoring the state captured right after this
-              // stage's own draw (a no-op for a request with no active stop controller, which
-              // never populated a checkpoint here).
-              selected_tokens[request_index].resize(stage + 1);
-              // rng_checkpoints itself is only ever sized when at least one request in this step
-              // needed it (see SelectSampledRows); a request whose own stop match reaches here
-              // always was one of them, but this stays a bounds check rather than an implicit
-              // invariant.
-              if (request_index < rng_checkpoints.size() &&
-                  stage < rng_checkpoints[request_index].size()) {
-                request->rng_ = rng_checkpoints[request_index][stage];
-              }
-            }
-          } else if (!stage_result.token_appended || stage_result.done) {
-            throw std::logic_error("An accepted sampled draft unexpectedly ended the request.");
-          } else {
-            request->AppendAcceptedSampledToken(stage_result.token);
-          }
+          commit_sampled_stage(active[row], stage);
         }
       } else {
         for (size_t request_index : active) {
-          auto& request = requests_[request_index];
-          request->search_->CommitToken(selected_tokens[request_index][stage]);
-          const auto& stage_plan = plan.requests[request_index];
-          const auto stage_result = request->StageGenerationForTransaction(stage_plan);
-          const bool is_natural_last_stage =
-              stage + 1 == selected_tokens[request_index].size();
-          const bool stopped =
-              stage_result.finish_reason == GenerationFinishReason::StopString;
-          if (stopped || is_natural_last_stage) {
-            auto final_result = stage_result;
-            if (stage < confirmed_draft_counts[request_index]) {
-              request->PromoteFinalStageAsAcceptedDraft(final_result);
-            } else if (stage < stage_plan.draft_token_count) {
-              request->MarkFinalStageAsEvaluatedNonAcceptedDraft();
-            }
-            results[request_index] = final_result;
-            if (stopped && !is_natural_last_stage) {
-              selected_tokens[request_index].resize(stage + 1);
-              // rng_checkpoints itself is only ever sized when at least one request in this step
-              // needed it (see SelectSampledRows); a request whose own stop match reaches here
-              // always was one of them, but this stays a bounds check rather than an implicit
-              // invariant.
-              if (request_index < rng_checkpoints.size() &&
-                  stage < rng_checkpoints[request_index].size()) {
-                request->rng_ = rng_checkpoints[request_index][stage];
-              }
-            }
-          } else if (!stage_result.token_appended || stage_result.done) {
-            throw std::logic_error("An accepted sampled draft unexpectedly ended the request.");
-          } else {
-            request->AppendAcceptedSampledToken(stage_result.token);
-          }
+          requests_[request_index]->search_->CommitToken(selected_tokens[request_index][stage]);
+          commit_sampled_stage(request_index, stage);
         }
       }
     }

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -295,11 +295,17 @@ Tensor* ScheduledRequests::AuxHiddenStates() const {
 std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
     std::vector<DeviceSpan<float>>& verify_rows,
     std::vector<std::vector<int32_t>>& selected_tokens,
-    std::vector<size_t>& accepted_draft_counts) {
+    std::vector<size_t>& confirmed_draft_counts,
+    std::vector<std::vector<std::mt19937>>& rng_checkpoints) {
   std::vector<DeviceSpan<float>> sampled_rows;
   sampled_rows.reserve(requests_.size());
   selected_tokens.resize(requests_.size());
-  accepted_draft_counts.assign(requests_.size(), 0);
+  confirmed_draft_counts.assign(requests_.size(), 0);
+  // Left completely empty (no allocation at all) unless the pre-scan below finds at least one
+  // random-sampled drafted request with an active stop controller; only then is it sized once, to
+  // requests_.size() so per-request indexing below stays simple. A step with no drafts, no random
+  // sampling, or no stop-enabled request among them never allocates or grows this at all.
+  rng_checkpoints.clear();
 
   // Verification only needs each draft row's argmax. Reading a whole vocabulary row back to the host
   // costs about a megabyte and a stream synchronization per draft, which on a large-vocabulary model
@@ -330,9 +336,15 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
     }
   }
   int max_sampling_top_k = 0;
+  bool any_checkpoint_needed = false;
   for (size_t i = 0; i < requests_.size(); ++i) {
-    if (draft_token_counts_[i] != 0 && UsesRandomSampling(requests_[i]->SearchOptions()))
+    if (draft_token_counts_[i] != 0 && UsesRandomSampling(requests_[i]->SearchOptions())) {
       max_sampling_top_k = std::max(max_sampling_top_k, requests_[i]->SearchOptions().top_k);
+      any_checkpoint_needed = any_checkpoint_needed || requests_[i]->stop_controller_ != nullptr;
+    }
+  }
+  if (any_checkpoint_needed) {
+    rng_checkpoints.resize(requests_.size());
   }
   const TopKScores topk = TryDeviceTopKScoresPerRow(
       *model_->p_device_inputs_, verify_rows, max_sampling_top_k);
@@ -353,6 +365,24 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
       // BatchedSamplerState. search.random_seed consequently reproduces a given decode path, not
       // output across decode paths, because whether drafts are admitted depends on batch
       // composition. See "Seeded sampling" in docs/paged_attention_engine.md.
+      //
+      // A stop-enabled request additionally checkpoints rng_ right after every draw here (a plain
+      // copy of the fixed-size std::mt19937 state, intentionally allocated/copied). The outer
+      // rng_checkpoints vector itself is left completely empty (see above) unless at least one
+      // random-sampled drafted request in this whole step needs it, and each such request's own
+      // inner vector is reserved once up front for this call's exact upper bound, draft_count + 1,
+      // so growing it below never reallocates or re-copies already-captured checkpoints. If a
+      // later stop match truncates this round before its natural end, the caller restores rng_ to
+      // the checkpoint captured after the retained match, undoing every draw made for a now-
+      // discarded, never-visible token so those candidates do not advance the host verification
+      // RNG beyond the retained prefix. A
+      // request with no active stop controller never checkpoints (no reservation, no copies, no
+      // vector growth) and a step with no such request at all never even allocates the outer
+      // vector, so this adds no cost to the existing no-stop/greedy/non-drafted paths.
+      const bool checkpoint_rng = requests_[i]->stop_controller_ != nullptr;
+      if (checkpoint_rng) {
+        rng_checkpoints[i].reserve(draft_count + 1);
+      }
       const auto drafts = requests_[i]->StagedDraftTokens();
       const size_t token_budget = requests_[i]->RemainingTurnTokenBudget();
       requests_[i]->RewindDraftsForTransaction(0);
@@ -364,6 +394,9 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
             requests_[i]->SearchOptions(), topk, sampling_scratch);
         const int32_t token = SampleTargetToken(selection, requests_[i]->rng_);
         selected_tokens[i].push_back(token);
+        if (checkpoint_rng) {
+          rng_checkpoints[i].push_back(requests_[i]->rng_);
+        }
         if (token != drafts[accepted_count] || requests_[i]->IsStopToken(token))
           break;
         ++accepted_count;
@@ -375,8 +408,11 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
             requests_[i]->SearchOptions(), topk, sampling_scratch);
         selected_tokens[i].push_back(
             SampleTargetToken(selection, requests_[i]->rng_));
+        if (checkpoint_rng) {
+          rng_checkpoints[i].push_back(requests_[i]->rng_);
+        }
       }
-      accepted_draft_counts[i] = accepted_count;
+      confirmed_draft_counts[i] = accepted_count;
       sampled_rows.push_back({});
       row += draft_count + 1;
       continue;
@@ -657,8 +693,10 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
 
   auto verify_rows = ProcessLogits();
   std::vector<std::vector<int32_t>> selected_tokens;
-  std::vector<size_t> accepted_draft_counts;
-  auto logits = SelectSampledRows(verify_rows, selected_tokens, accepted_draft_counts);
+  std::vector<size_t> confirmed_draft_counts;
+  std::vector<std::vector<std::mt19937>> rng_checkpoints;
+  auto logits = SelectSampledRows(verify_rows, selected_tokens, confirmed_draft_counts,
+                                  rng_checkpoints);
   const bool guidance_applied = TryApplyBatchedGuidanceMasks(logits);
   results.assign(requests_.size(), RequestStepResult{});
   std::vector<bool> sampled_by_batched_sampler(requests_.size(), false);
@@ -744,6 +782,12 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
         if (stage < selected_tokens[i].size())
           active.push_back(i);
       }
+      // Every request that had selected_tokens this round has already finalized (a stop match or
+      // its own natural end) by the time none remain active for a later stage: skip the batched
+      // buffer round-trip entirely rather than transferring and synchronizing an empty span.
+      if (active.empty()) {
+        break;
+      }
 
       if (can_batch_commits) {
         auto stage_tokens = committed_tokens.subspan(0, active.size());
@@ -760,39 +804,95 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
         stage_tokens.CopyDeviceToCpu();
         for (size_t row = 0; row < active.size(); ++row) {
           const size_t request_index = active[row];
-          auto stage_plan = plan.requests[request_index];
-          if (stage + 1 == selected_tokens[request_index].size()) {
-            requests_[request_index]->RecordSampledDraftAcceptance(
-                accepted_draft_counts[request_index]);
-          } else {
-            stage_plan.sequence_length_before =
-                requests_[request_index]->CurrentSequenceLength() - 1;
-          }
-          const auto stage_result =
-              requests_[request_index]->StageGenerationForTransaction(stage_plan);
-          if (stage + 1 == selected_tokens[request_index].size()) {
-            results[request_index] = stage_result;
+          auto& request = requests_[request_index];
+          // The plan's original sequence_length_before, plus accepted_draft_count_ (prior stages
+          // only -- never this one), always equals CurrentSequenceLength() just before this
+          // stage's own append: every earlier stage's StageGeneration() advanced Search by exactly
+          // one token, and AppendAcceptedSampledToken() below advances accepted_draft_count_ by
+          // exactly one to match. So this same unmodified plan works for every stage, whether or
+          // not it turns out to be the request's last, and StageGeneration()'s stop-string
+          // observation -- reused unchanged from the ordinary one-token path -- always sees
+          // exactly one newly appended token.
+          const auto& stage_plan = plan.requests[request_index];
+          const auto stage_result = request->StageGenerationForTransaction(stage_plan);
+          const bool is_natural_last_stage =
+              stage + 1 == selected_tokens[request_index].size();
+          const bool stopped =
+              stage_result.finish_reason == GenerationFinishReason::StopString;
+          if (stopped || is_natural_last_stage) {
+            auto final_result = stage_result;
+            // This stage is a genuinely target-confirmed draft (not a trailing replacement/bonus
+            // token) whenever it falls within the request's own confirmed prefix -- fold it into
+            // accepted_draft_count_ so CommitStep, cache/fixed-state CommitPrefix, and speculative
+            // telemetry all count it as accepted, exactly like an earlier accepted stage. When it
+            // instead falls at or beyond the confirmed prefix but still within the proposed draft
+            // range, it is a logically resolved but non-accepted proposal (either rejected, with
+            // its replacement in this result, or EOS without an append) -- count it as evaluated
+            // but not accepted. A stage beyond the whole proposed range (a trailing bonus token
+            // after full acceptance) is neither: it was never one of the proposed drafts.
+            if (stage < confirmed_draft_counts[request_index]) {
+              request->PromoteFinalStageAsAcceptedDraft(final_result);
+            } else if (stage < stage_plan.draft_token_count) {
+              request->MarkFinalStageAsEvaluatedNonAcceptedDraft();
+            }
+            results[request_index] = final_result;
+            if (stopped && !is_natural_last_stage) {
+              // A stop match ends verification here: every later staged draft (and any trailing
+              // bonus/replacement token) is discarded by simply never being iterated again --
+              // active[] excludes this request from every subsequent stage once its
+              // selected_tokens shrink to this point. Undo every RNG draw this round made for
+              // those now-invisible tokens by restoring the state captured right after this
+              // stage's own draw (a no-op for a request with no active stop controller, which
+              // never populated a checkpoint here).
+              selected_tokens[request_index].resize(stage + 1);
+              // rng_checkpoints itself is only ever sized when at least one request in this step
+              // needed it (see SelectSampledRows); a request whose own stop match reaches here
+              // always was one of them, but this stays a bounds check rather than an implicit
+              // invariant.
+              if (request_index < rng_checkpoints.size() &&
+                  stage < rng_checkpoints[request_index].size()) {
+                request->rng_ = rng_checkpoints[request_index][stage];
+              }
+            }
           } else if (!stage_result.token_appended || stage_result.done) {
             throw std::logic_error("An accepted sampled draft unexpectedly ended the request.");
+          } else {
+            request->AppendAcceptedSampledToken(stage_result.token);
           }
         }
       } else {
         for (size_t request_index : active) {
           auto& request = requests_[request_index];
-          auto stage_plan = plan.requests[request_index];
-          stage_plan.sequence_length_before = request->CurrentSequenceLength();
           request->search_->CommitToken(selected_tokens[request_index][stage]);
-          if (stage + 1 == selected_tokens[request_index].size()) {
-            request->RecordSampledDraftAcceptance(
-                accepted_draft_counts[request_index]);
-            stage_plan = plan.requests[request_index];
-          }
-          const auto stage_result =
-              request->StageGenerationForTransaction(stage_plan);
-          if (stage + 1 == selected_tokens[request_index].size()) {
-            results[request_index] = stage_result;
+          const auto& stage_plan = plan.requests[request_index];
+          const auto stage_result = request->StageGenerationForTransaction(stage_plan);
+          const bool is_natural_last_stage =
+              stage + 1 == selected_tokens[request_index].size();
+          const bool stopped =
+              stage_result.finish_reason == GenerationFinishReason::StopString;
+          if (stopped || is_natural_last_stage) {
+            auto final_result = stage_result;
+            if (stage < confirmed_draft_counts[request_index]) {
+              request->PromoteFinalStageAsAcceptedDraft(final_result);
+            } else if (stage < stage_plan.draft_token_count) {
+              request->MarkFinalStageAsEvaluatedNonAcceptedDraft();
+            }
+            results[request_index] = final_result;
+            if (stopped && !is_natural_last_stage) {
+              selected_tokens[request_index].resize(stage + 1);
+              // rng_checkpoints itself is only ever sized when at least one request in this step
+              // needed it (see SelectSampledRows); a request whose own stop match reaches here
+              // always was one of them, but this stays a bounds check rather than an implicit
+              // invariant.
+              if (request_index < rng_checkpoints.size() &&
+                  stage < rng_checkpoints[request_index].size()) {
+                request->rng_ = rng_checkpoints[request_index][stage];
+              }
+            }
           } else if (!stage_result.token_appended || stage_result.done) {
             throw std::logic_error("An accepted sampled draft unexpectedly ended the request.");
+          } else {
+            request->AppendAcceptedSampledToken(stage_result.token);
           }
         }
       }

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -116,11 +116,15 @@ struct ScheduledRequests {
   // Verifies each drafted request's proposal against the target model's own rows, rewinds the
   // rejected tail, and returns the one row per request that the sampler must select from. For a
   // randomly sampled request, selected_tokens holds the accepted deterministic proposal prefix
-  // plus the target-distributed correction or bonus token to commit.
+  // plus the target-distributed correction or bonus token to commit; confirmed_draft_counts[i] is
+  // that same request's confirmed prefix length alone (excluding the trailing correction/bonus),
+  // used by the caller to tell a confirmed final draft apart from a replacement/bonus token when a
+  // stop match or the turn/context limit ends verification on the request's last staged token.
   std::vector<DeviceSpan<float>> SelectSampledRows(
       std::vector<DeviceSpan<float>>& verify_rows,
       std::vector<std::vector<int32_t>>& selected_tokens,
-      std::vector<size_t>& accepted_draft_counts);
+      std::vector<size_t>& confirmed_draft_counts,
+      std::vector<std::vector<std::mt19937>>& rng_checkpoints);
 
   std::vector<std::shared_ptr<Request>> requests_;
   // Drafts the transaction stages onto each request's sequence, in scheduled row order. Empty

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <random>
+
 #include "execution_context.h"
 #include "request.h"
 

--- a/test/cpp/engine/engine_test_doubles.h
+++ b/test/cpp/engine/engine_test_doubles.h
@@ -388,6 +388,7 @@ struct ScriptedDecoderIO : DecoderIO {
                     bool fail_process_logits = false,
                     const StepPlan* plan = nullptr,
                     std::span<const int32_t> row_tokens = {},
+                    std::span<const int32_t> sampling_candidate_tokens = {},
                     int64_t hidden_size = 0,
                     ONNXTensorElementDataType hidden_type = Ort::TypeToTensorType<float>)
       : DecoderIO(model, scheduled_requests, cache_manager),
@@ -405,6 +406,9 @@ struct ScriptedDecoderIO : DecoderIO {
     if (!row_tokens.empty() && row_tokens.size() != rows) {
       throw std::runtime_error("ScriptedDecoderIO: row token script does not cover every row.");
     }
+    if (!row_tokens.empty() && !sampling_candidate_tokens.empty()) {
+      throw std::runtime_error("ScriptedDecoderIO: row tokens and sampling candidates are mutually exclusive.");
+    }
     row_count_ = rows;
     logits_ = std::make_unique<Tensor>(model->p_device_inputs_, Ort::TypeToTensorType<float>);
     const std::array<int64_t, 2> shape{static_cast<int64_t>(rows), vocab_size_};
@@ -413,6 +417,15 @@ struct ScriptedDecoderIO : DecoderIO {
     auto cpu_span = device_span.CpuSpan();
     std::fill(cpu_span.begin(), cpu_span.end(), 0.0f);
     for (size_t row = 0; row < rows; ++row) {
+      if (!sampling_candidate_tokens.empty()) {
+        for (const int32_t token : sampling_candidate_tokens) {
+          if (token < 0 || token >= vocab_size_) {
+            throw std::runtime_error("ScriptedDecoderIO: sampling candidate out of vocabulary range");
+          }
+          cpu_span[static_cast<int64_t>(row) * vocab_size_ + token] = 100.0f;
+        }
+        continue;
+      }
       const int32_t token = row_tokens.empty() ? forced_token : row_tokens[row];
       if (token < 0 || token >= vocab_size_) {
         throw std::runtime_error("ScriptedDecoderIO: scripted row token out of vocabulary range");
@@ -517,7 +530,8 @@ struct RecordingModelExecutor : ModelExecutor {
         std::make_unique<ScriptedDecoderIO>(
             model_, scheduled_requests, cache_manager_, forced_token_,
             failure == ScriptedExecutionFailure::PostProcessing,
-            context.plan, verify_row_tokens_, hidden_size_, hidden_type_));
+            context.plan, verify_row_tokens_, sampling_candidate_tokens_,
+            hidden_size_, hidden_type_));
     static_cast<void>(context);
   }
 
@@ -528,6 +542,9 @@ struct RecordingModelExecutor : ModelExecutor {
   }
   void SetVerifyRowTokens(std::vector<int32_t> tokens) {
     verify_row_tokens_ = std::move(tokens);
+  }
+  void SetSamplingCandidateTokens(std::vector<int32_t> tokens) {
+    sampling_candidate_tokens_ = std::move(tokens);
   }
   bool SupportsDraftVerification() const override {
     return supports_draft_verification_;
@@ -557,6 +574,7 @@ struct RecordingModelExecutor : ModelExecutor {
   ScriptedExecutionFailure next_failure_{ScriptedExecutionFailure::None};
   std::function<void(ExecutionContext&)> on_execute_;
   std::vector<int32_t> verify_row_tokens_;
+  std::vector<int32_t> sampling_candidate_tokens_;
   bool supports_draft_verification_{true};
   int64_t hidden_size_{};
   ONNXTensorElementDataType hidden_type_{Ort::TypeToTensorType<float>};

--- a/test/cpp/engine/stop_string_engine_tests.cpp
+++ b/test/cpp/engine/stop_string_engine_tests.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Component-contract tests for ordinary (non-speculative) dynamic Engine decoded stop strings.
-// These wire an Engine with the recording cache-manager and model-executor doubles over the
+// Component-contract tests for dynamic Engine decoded stop strings, covering both the ordinary
+// one-token-per-step path and speculative draft verification (manual SetDraftTokens and automatic
+// MTP). These wire an Engine with the recording cache-manager and model-executor doubles over the
 // synthetic-paged fixture model, which carries a tiny checked-in tokenizer (see
 // test/models/engine/synthetic-paged/tokenizer.json) whose vocabulary is designed for exact,
 // deterministic stop-string scenarios:
@@ -248,7 +249,6 @@ TEST_F(StopStringEngineTest, TurnResetClearsMatchAndControllerForTheNextTurn) {
   ASSERT_EQ(engine.engine->Run(storage), 1u);
   ASSERT_EQ(request->FinishReason(), GenerationFinishReason::StopString);
   ASSERT_EQ(request->MatchedStopStringIndex(), 0);
-  EXPECT_EQ(request->DraftTokenValidationError(), nullptr);
 
   // The next turn resets the finish reason and matched index immediately at admission, before any
   // new generation, and starts a fresh matcher/tokenizer stream even when it reuses the exact same
@@ -709,12 +709,19 @@ TEST_F(StopStringEngineTest, StaticBatchingEngineRejectsStopEnabledTurnBeforeMut
   EXPECT_NO_THROW(request->BeginTurn(Prompt()));
 }
 
-TEST_F(StopStringEngineTest, ManualDraftTokensAreRejectedForAStopEnabledTurn) {
+// ---------------------------------------------------------------------------------------------
+// Speculative draft verification: a stop-enabled turn drafts and verifies exactly like an ordinary
+// one, for both manual SetDraftTokens callers and the automatic MTP drafter. Only static batching's
+// own rejection (above) still excludes a stop-enabled turn before mutation.
+// ---------------------------------------------------------------------------------------------
+
+TEST_F(StopStringEngineTest, ManualDraftTokensAreAcceptedAndVerifiedForAStopEnabledTurn) {
   auto cache = std::make_shared<RecordingCacheManager>(model_, /*capacity=*/8);
   cache->SetMaxDraftTokensPerStep(3);
   auto scheduler = Scheduler::Create(model_, cache);
-  auto executor = std::make_unique<RecordingModelExecutor>(model_, cache, /*forced_token=*/2);
+  auto executor = std::make_unique<RecordingModelExecutor>(model_, cache, /*forced_token=*/11);
   executor->SetSupportsDraftVerification(true);
+  auto* executor_observer = executor.get();
   EngineDependencies dependencies{cache, std::move(scheduler), std::move(executor)};
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
   ASSERT_GT(engine->MaxDraftTokensPerStep(), 0u);
@@ -726,9 +733,1118 @@ TEST_F(StopStringEngineTest, ManualDraftTokensAreRejectedForAStopEnabledTurn) {
   ASSERT_EQ(engine->Run(storage), 1u);  // past prefill, ready to decode
   ASSERT_FALSE(request->IsPrefill());
 
-  EXPECT_NE(request->DraftTokenValidationError(), nullptr);
-  EXPECT_THROW(
-      request->SetDraftTokens(std::array<int32_t, 1>{2}), std::runtime_error);
+  // A stop-enabled turn no longer excludes draft verification: the request is ready to decode, so
+  // proposing drafts succeeds exactly as it would without stop strings, and every non-matching
+  // draft commits and is emitted normally.
+  EXPECT_EQ(request->DraftTokenValidationError(), nullptr);
+  EXPECT_NO_THROW(request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 13}));
+  executor_observer->SetVerifyRowTokens({11, 12, 13, 14});
+
+  ASSERT_EQ(engine->Run(storage), 4u);
+  for (size_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(storage[i].flags, EngineEventFlagToken);
+  }
+  EXPECT_EQ(request->AcceptedDraftTokenCount(), 0u);  // cleared by CommitStep after the round
+  EXPECT_TRUE(ValidateRequestInvariants(request->Snapshot()).empty());
+}
+
+TEST_F(StopStringEngineTest, GreedyDraftMatchAtTheFirstPositionDiscardsLaterDraftsAndTruncatesCache) {
+  // Drafts "STOPX", "t11", "t12"; the target agrees with all three, but the match completes on the
+  // very first committed draft, so verification must never even look at the later two.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{7, 11, 12});
+  engine.executor->SetVerifyRowTokens({7, 11, 12, 13});
+
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].token, 7);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::StopString);
+  EXPECT_EQ(storage[0].matched_stop_string_index, 0);
+  EXPECT_EQ(request->AcceptedDraftTokenCount(), 0u);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  // Only the one matching draft is kept in the paged cache; the two later drafts, though the
+  // target agreed with them too, were never committed. kept_tokens also counts the one always-
+  // consumed continuation token that seeded this round's first draft logits.
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 2u);
+  EXPECT_TRUE(ValidateRequestInvariants(request->Snapshot()).empty());
+}
+
+TEST_F(StopStringEngineTest, GreedyDraftMatchAtAMiddlePositionEmitsThePriorAcceptedTokenFirst) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 7, 12});
+  engine.executor->SetVerifyRowTokens({11, 7, 12, 13});
+
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+  EXPECT_EQ(storage[0].token, 11);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken);
+  EXPECT_EQ(storage[1].token, 7);
+  EXPECT_EQ(storage[1].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 3u);
+}
+
+TEST_F(StopStringEngineTest, GreedyDraftMatchAtTheLastDraftPositionDiscardsTheBonusRow) {
+  // All three drafts are accepted, and the match completes on the last one -- the row after it
+  // (the bonus/replacement row the target would otherwise have contributed) is never reached.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 7});
+  engine.executor->SetVerifyRowTokens({11, 12, 7, 13});
+
+  ASSERT_EQ(engine.engine->Run(storage), 3u);
+  EXPECT_EQ(storage[0].token, 11);
+  EXPECT_EQ(storage[1].token, 12);
+  EXPECT_EQ(storage[2].token, 7);
+  EXPECT_EQ(storage[2].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[2].finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 4u);
+}
+
+TEST_F(StopStringEngineTest, GreedyBonusTokenCanCompleteAMatchAfterAllDraftsAccepted) {
+  // None of the three drafts individually match; verification accepts all of them and, since
+  // there was no early stop, falls through to the ordinary one-token bonus row, which does match.
+  // This exercises the ordinary ApplyLogitsForTransaction path rather than the greedy draft loop's
+  // own observation, confirming the bonus token needs no special handling.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 12, 13, 7});
+
+  ASSERT_EQ(engine.engine->Run(storage), 4u);
+  EXPECT_EQ(storage[3].token, 7);
+  EXPECT_EQ(storage[3].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[3].finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 4u);
+}
+
+TEST_F(StopStringEngineTest, GreedyRejectedDraftNeverReachesTheMatcherButItsReplacementCan) {
+  // Draft position 0 ("t11") is rejected -- the target predicts "STOPX" instead. The matcher never
+  // sees the rejected draft at all; it observes only the target's own replacement, which matches.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({7, 12, 13, 14});  // row 0 disagrees with draft 0
+
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].token, 7);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 1u);
+}
+
+TEST_F(StopStringEngineTest, GreedyMatchCanBeginInPriorCommittedOutputAndFinishInADraft) {
+  // The ordinary first generated token ("ST") only partially matches; the very next round proposes
+  // a draft whose first token ("OP") completes the match using the controller's carried-over
+  // partial state, not anything reseeded from the draft proposal itself.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].flags & EngineEventFlagTurnFinished, 0u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{6, 11, 12});  // "OP", filler, filler
+  engine.executor->SetVerifyRowTokens({6, 11, 12, 13});
+
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].token, 6);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::StopString);
+  EXPECT_EQ(storage[0].matched_stop_string_index, 0);
+  EXPECT_EQ(request->TurnGeneratedTokens(), 2u);
+}
+
+TEST_F(StopStringEngineTest, GreedyDraftVerificationNeverObservesAnAcceptedEosDraftThatDoesNotAppend) {
+  // GreedySearch_Cpu::CommitToken(eos) marks the search done without appending (sequence length
+  // unchanged): draft position 1 is EOS, argmax-accepted, but must never reach the controller or be
+  // able to produce a StopString result, exactly like an unappended EOS on the ordinary one-token
+  // path. Verification must also stop there -- draft position 2 and the bonus/replacement row are
+  // never reached.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11 /* filler */);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);  // commits "t11" (token 11)
+
+  const int32_t eos = EosToken(*model_);
+  request->SetDraftTokens(std::array<int32_t, 3>{11, eos, 12});
+  engine.executor->SetVerifyRowTokens({11, eos, 12, 13});  // argmax accepts all three positions
+
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].token, 11);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::EosToken);
+  EXPECT_EQ(storage[0].matched_stop_string_index, -1);
+  EXPECT_EQ(request->FinishReason(), GenerationFinishReason::EosToken);
+  EXPECT_EQ(request->MatchedStopStringIndex(), -1);
+
+  // Only the appended draft is retained. The non-appended EOS, draft position 2, and the
+  // bonus/replacement row are excluded from the public sequence and cache commit.
+  EXPECT_EQ(request->AcceptedDraftTokenCount(), 0u);
+  EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 2u);  // 1 base + 1 appended draft
+  EXPECT_TRUE(ValidateRequestInvariants(request->Snapshot()).empty());
+}
+
+TEST_F(StopStringEngineTest, SampledDraftMatchAtTheFirstAcceptedPositionTruncates) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{7, 12, 13});
+  engine.executor->SetVerifyRowTokens({7, 12, 13, 14});
+
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].token, 7);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  // The matching draft is itself target-confirmed (the target's own sample equals the proposed
+  // draft), so it counts as accepted -- 1 confirmed draft plus the always-kept prior slot.
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 2u);
+}
+
+TEST_F(StopStringEngineTest, SampledDraftMatchAtAMiddleAcceptedPositionEmitsThePriorTokenFirst) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 7, 13});
+  engine.executor->SetVerifyRowTokens({11, 7, 13, 14});
+
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+  EXPECT_EQ(storage[0].token, 11);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken);
+  EXPECT_EQ(storage[1].token, 7);
+  EXPECT_EQ(storage[1].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  // 2 confirmed drafts (the prior one plus the matching one) plus the always-kept prior slot.
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 3u);
+}
+
+TEST_F(StopStringEngineTest, SampledDraftMatchAtTheLastAcceptedPositionDiscardsTheTrailingBonus) {
+  // All three drafts are accepted and a bonus token is drawn too, but the match completes on the
+  // last *draft* position -- the trailing bonus token must never be committed or emitted.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 7});
+  engine.executor->SetVerifyRowTokens({11, 12, 7, 14});
+
+  ASSERT_EQ(engine.engine->Run(storage), 3u);
+  EXPECT_EQ(storage[2].token, 7);
+  EXPECT_EQ(storage[2].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[2].finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  // All 3 drafts are confirmed (including the matching one, which ends verification but was still
+  // itself target-confirmed) plus the always-kept prior slot; the drawn-but-discarded bonus token
+  // (14) is not part of this count.
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 4u);
+}
+
+TEST_F(StopStringEngineTest, SampledFullyAcceptedBonusTokenCanCompleteAMatch) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 12, 13, 7});
+
+  ASSERT_EQ(engine.engine->Run(storage), 4u);
+  EXPECT_EQ(storage[3].token, 7);
+  EXPECT_EQ(storage[3].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[3].finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 4u);
+}
+
+TEST_F(StopStringEngineTest, SampledRejectedDraftReplacementCanCompleteAMatch) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({7, 12, 13, 14});  // target replaces draft 0 with "STOPX"
+
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].token, 7);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 1u);
+}
+
+TEST_F(StopStringEngineTest, SampledDraftVerificationNeverObservesAnAcceptedEosDraftThatDoesNotAppend) {
+  // Mirrors GreedyDraftVerificationNeverObservesAnAcceptedEosDraftThatDoesNotAppend for the sampled
+  // path: an EOS draft never reaches the matcher and never gets promoted as an accepted draft,
+  // because StageGeneration()'s own token_appended gate (shared unchanged with the ordinary path)
+  // already excludes it -- both stage-loop branches reuse that same function unmodified for this.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);  // commits "t11"
+
+  const int32_t eos = EosToken(*model_);
+  request->SetDraftTokens(std::array<int32_t, 3>{11, eos, 12});
+  engine.executor->SetVerifyRowTokens({11, eos, 12, 13});
+
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].token, 11);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::EosToken);
+  EXPECT_EQ(storage[0].matched_stop_string_index, -1);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 2u);  // 1 base + 1 appended draft
+}
+
+TEST_F(StopStringEngineTest, PromoteFinalStageAsAcceptedDraftRejectsAResultThatNeverAppended) {
+  // Direct unit coverage for PromoteFinalStageAsAcceptedDraft's own precondition: it must never
+  // silently mirror a token into tokens_host_ for a stage StageGeneration() itself reports as not
+  // appended (which would diverge Request's host mirror from Search's own sequence). This can only
+  // be reached today by a caller bug -- the stage loop only ever calls it when confirmed_draft_
+  // counts and token_appended already agree -- so this exercises the guard directly rather than
+  // trying to contrive a real end-to-end scenario that violates the invariant.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt());
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  RequestStepResult result{};
+  result.token = 42;
+  result.token_appended = false;
+  EXPECT_THROW(request->PromoteFinalStageAsAcceptedDraft(result), std::logic_error);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Accepted/telemetry accounting: a sampled draft that itself completes the match is genuinely
+// target-confirmed and must count as accepted -- for cache/fixed-state CommitPrefix (already
+// covered by the kept_tokens assertions above) and for speculative telemetry.
+// ---------------------------------------------------------------------------------------------
+
+TEST_F(StopStringEngineTest, SampledAcceptedTelemetryCountsAMatchAtTheFirstPosition) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{7, 12, 13});
+  engine.executor->SetVerifyRowTokens({7, 12, 13, 14});
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.draft_tokens_proposed, 3u);
+  // The match ends verification without evaluating (and rejecting) anything beyond the confirmed
+  // prefix: evaluated is exactly the accepted count, not accepted + 1.
+  EXPECT_EQ(stats.draft_tokens_evaluated, 1u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[1], 1u);
+  EXPECT_EQ(stats.partial_accept_rounds, 1u);
+  EXPECT_EQ(stats.zero_accept_rounds, 0u);
+  EXPECT_EQ(stats.full_accept_rounds, 0u);
+}
+
+TEST_F(StopStringEngineTest, SampledAcceptedTelemetryCountsAMatchAtAMiddlePosition) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 7, 13});
+  engine.executor->SetVerifyRowTokens({11, 7, 13, 14});
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.draft_tokens_proposed, 3u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 2u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 2u);
+  EXPECT_EQ(stats.acceptance_length_histogram[2], 1u);
+  EXPECT_EQ(stats.partial_accept_rounds, 1u);
+}
+
+TEST_F(StopStringEngineTest, SampledAcceptedTelemetryCountsAFullyConfirmedMatchAtTheLastPosition) {
+  // All 3 drafts are genuinely confirmed and the match completes on the last one; a bonus token is
+  // drawn (then discarded) but never counted. This is "full acceptance" for telemetry purposes --
+  // every proposed draft was confirmed -- even though the round ended via a match, not a bonus.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 7});
+  engine.executor->SetVerifyRowTokens({11, 12, 7, 14});
+  ASSERT_EQ(engine.engine->Run(storage), 3u);
+
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.draft_tokens_proposed, 3u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 3u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 3u);
+  EXPECT_EQ(stats.acceptance_length_histogram[3], 1u);
+  EXPECT_EQ(stats.full_accept_rounds, 1u);
+  EXPECT_EQ(stats.partial_accept_rounds, 0u);
+}
+
+TEST_F(StopStringEngineTest, NoStopBudgetExhaustedNaturalLastGenuineDraftKeepsValidAcceptedCacheWork) {
+  // Regression coverage for the no-stop case review item 2 calls out explicitly: the turn token
+  // budget (not a stop match) ends verification exactly on the last genuinely confirmed draft, with
+  // no bonus/replacement token ever drawn. AcceptedDraftTokenCount() and cache kept_tokens must
+  // still count that final draft as accepted -- this request has no stop controller at all.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), std::optional<size_t>{3});  // no stop strings
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  ASSERT_EQ(request->TurnGeneratedTokens(), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, 12, 13, 25});
+
+  // Budget allows exactly 2 more tokens (3 total): the sequential draw loop confirms drafts 0 and
+  // 1, then its own budget check (not a rejection) stops it before drawing a bonus/replacement.
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::TurnLimit);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  // Both confirmed drafts (11, 12) plus the always-kept prior slot -- not 2, which would silently
+  // under-count the final genuine draft as though it were an unconfirmed replacement/bonus.
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 3u);
+}
+
+TEST_F(StopStringEngineTest, ManualDraftCountFarExceedingTheBudgetStillCountsTheFinalAcceptedDraftOnce) {
+  // A manual SetDraftTokens caller proposes far more drafts (5) than the turn's remaining budget
+  // (2) can ever use. The natural last selected stage this produces is still a genuinely confirmed
+  // draft, not a replacement/bonus (there is no room left to draw one) -- the fix must not infer
+  // "last stage => not accepted" from the stage index alone. Every stage must be counted exactly
+  // once: the two prior/confirmed stages via AppendAcceptedSampledToken, and the final one via
+  // PromoteFinalStageAsAcceptedDraft, never both for the same stage and never zero times.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(5);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), std::optional<size_t>{3});  // no stop strings; budget for 2 more
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  const auto length_after_prefill = request->CurrentSequenceLength();
+  const auto processed_after_prefill = request->ProcessedSequenceLength();
+
+  request->SetDraftTokens(std::array<int32_t, 5>{11, 12, 13, 14, 15});
+  engine.executor->SetVerifyRowTokens({11, 12, 13, 14, 15, 25});
+
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+  EXPECT_EQ(storage[0].token, 11);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken);
+  EXPECT_EQ(storage[1].token, 12);
+  EXPECT_EQ(storage[1].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::TurnLimit);
+
+  // Retained sequence/telemetry reflect exactly 2 accepted drafts out of 5 proposed -- partial,
+  // not full, acceptance -- even though the budget (not a target rejection) is what stopped it.
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 2);
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.draft_tokens_proposed, 5u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 2u);
+  // Exactly 2 proposal positions were logically resolved before the budget boundary (the
+  // sequential sampled loop stops before a 3rd draw), not accepted + 1 = 3.
+  EXPECT_EQ(stats.draft_tokens_evaluated, 2u);
+  EXPECT_EQ(stats.partial_accept_rounds, 1u);
+  EXPECT_EQ(stats.full_accept_rounds, 0u);
+  EXPECT_EQ(stats.acceptance_length_histogram[2], 1u);
+
+  // Cache/ProcessedSequenceLength count both confirmed drafts (11, 12), not just the first one:
+  // the final stage is promoted exactly once, neither silently dropped nor double-counted.
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 3u);  // 1 base + 2 confirmed drafts
+  EXPECT_EQ(request->ProcessedSequenceLength(), processed_after_prefill + 3);
+  // Unlike an ordinary one-token round (which always leaves its own freshly sampled output 1 token
+  // behind processed_sequence_length_, since that output's own KV is computed only when it becomes
+  // a future round's input), a draft round's retained final token was itself one of this round's
+  // fed positions, so its KV is already computed: processed catches all the way up to current here,
+  // not merely close to it. Either way, processed must never exceed current.
+  EXPECT_EQ(request->CurrentSequenceLength(), request->ProcessedSequenceLength());
+
+  // A further continuation with new input succeeds as an ordinary decode -- it does not need to
+  // reprocess "11" or "12" themselves, only the fresh token it is given, proving the sequence and
+  // cache bookkeeping this round left behind is coherent, not a hidden divergence forcing a larger
+  // re-prefill than an ordinary continuation would ever need.
+  EXPECT_NO_THROW(request->BeginTurn(std::array<int32_t, 1>{25}));
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+}
+
+TEST_F(StopStringEngineTest, GreedyDraftCountFarExceedingTheBudgetEvaluatesOnlyTheCommittedPrefix) {
+  // Greedy counterpart: the turn/context-limit check inside CommitAcceptedDraftsForTransaction's
+  // own loop (not a target rejection) breaks it after 2 of 5 argmax-confirmed drafts. Later target
+  // comparisons may already be available, but only these 2 positions are logically resolved into
+  // the committed outcome, so evaluated is 2 rather than an inferred accepted + 1 = 3.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(5);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), std::optional<size_t>{3});  // no stop strings; budget for 2 more
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 5>{11, 12, 13, 14, 15});
+  engine.executor->SetVerifyRowTokens({11, 12, 13, 14, 15, 25});  // all 5 argmax-confirmed
+
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::TurnLimit);
+
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.draft_tokens_proposed, 5u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 2u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 2u);
+  EXPECT_EQ(stats.partial_accept_rounds, 1u);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Rollback/retry and RNG fidelity for sampled draft verification.
+// ---------------------------------------------------------------------------------------------
+
+TEST_F(StopStringEngineTest, DirectRollbackDuringSampledDraftVerificationRestoresControllerAndDrafts) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  const auto generated_before = request->TurnGeneratedTokens();
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 7, 12});
+  engine.executor->SetVerifyRowTokens({11, 7, 12, 13});
+  engine.executor->SetNextFailure(ScriptedExecutionFailure::PostProcessing);
+
+  EXPECT_EQ(RunOne(*engine.engine).flags, EngineEventFlagRetryable);
+  EXPECT_EQ(request->TurnGeneratedTokens(), generated_before);
+  EXPECT_EQ(request->PendingDraftTokenCount(), 3u);
+  EXPECT_EQ(request->AcceptedDraftTokenCount(), 0u);
+  EXPECT_TRUE(engine.cache->prefix_commits.empty());
+
+  // Retry: re-feeding the exact same draft/verify script must reproduce the exact same match.
+  engine.executor->SetVerifyRowTokens({11, 7, 12, 13});
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+  EXPECT_EQ(storage[1].token, 7);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::StopString);
+  EXPECT_EQ(storage[1].matched_stop_string_index, 0);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 3u);  // both confirmed drafts counted
+}
+
+TEST_F(StopStringEngineTest, SampledStopTruncationPreservesFutureSampleSequence) {
+  // A stop match on draft position 0 discards 3 later, already-drawn-but-now-invisible tokens (2
+  // more drafts plus a bonus). The retained request's RNG state after rollback must exactly equal
+  // a reference request's, which only ever drew the same 2 tokens (1 prefill token, 1 draft) via
+  // the very same draft-verification sampling path -- not "advanced as if 4 draws happened".
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+
+  // Reference: prefill's own sampled token, then exactly one more draft draw with no bonus (the
+  // turn's budget is set to end exactly there), and no stop configured at all.
+  auto engine_ref = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine_ref.cache->SetMaxDraftTokensPerStep(3);
+  auto ref = CreateEngineRequest(engine_ref.engine, *params);
+  ref->BeginTurn(Prompt(), std::optional<size_t>{2});
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine_ref.engine->Run(storage), 1u);
+
+  // Speculative: the same seed and prefill token, then a 3-draft proposal whose first token
+  // completes a stop match, discarding 3 later draws made before the match was detected.
+  auto engine_spec = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine_spec.cache->SetMaxDraftTokensPerStep(3);
+  auto spec = CreateEngineRequest(engine_spec.engine, *params);
+  spec->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  ASSERT_EQ(engine_spec.engine->Run(storage), 1u);
+
+  ref->SetDraftTokens(std::array<int32_t, 1>{7});
+  engine_ref.executor->SetVerifyRowTokens({7, 14});
+  ASSERT_EQ(engine_ref.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::TurnLimit);
+
+  spec->SetDraftTokens(std::array<int32_t, 3>{7, 7, 7});
+  engine_spec.executor->SetVerifyRowTokens({7, 7, 7, 7});
+  ASSERT_EQ(engine_spec.engine->Run(storage), 1u);
+  EXPECT_EQ(storage[0].token, 7);
+  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::StopString);
+
+  // Continue both requests through the public Engine API with an injected three-way sampling
+  // distribution. Equal future token streams demonstrate that discarded speculative candidates
+  // did not advance the stop-truncated request's RNG beyond the retained prefix.
+  const auto sample_continuation = [&](DoublesEngine& engine,
+                                       const std::shared_ptr<Request>& request) {
+    engine.executor->SetVerifyRowTokens({});
+    engine.executor->SetSamplingCandidateTokens({20, 21, 22});
+    request->BeginTurn(std::array<int32_t, 1>{2}, std::optional<size_t>{16});
+    std::vector<int32_t> tokens;
+    bool done = false;
+    while (!done) {
+      const size_t count = engine.engine->Run(storage);
+      for (size_t i = 0; i < count; ++i) {
+        if (storage[i].request != request) continue;
+        if (storage[i].flags & EngineEventFlagToken) tokens.push_back(storage[i].token);
+        done = (storage[i].flags & EngineEventFlagTurnFinished) != 0;
+      }
+    }
+    return tokens;
+  };
+
+  const auto reference_tokens = sample_continuation(engine_ref, ref);
+  const auto speculative_tokens = sample_continuation(engine_spec, spec);
+  EXPECT_EQ(speculative_tokens, reference_tokens);
+  EXPECT_EQ(speculative_tokens.size(), 16u);
+}
+
+TEST_F(StopStringEngineTest, MixedBatchBothSampledRequestsMatchAtStageZeroTerminatesTheStageLoopEarly) {
+  // Both requests originally propose 3 drafts (so max_selected_tokens would reach 4 if either had
+  // continued to a natural bonus), but both match on their very first draft, truncating both to
+  // size 1. Every stage beyond 0 therefore has an empty active[] -- the loop must still produce
+  // correct results for both requests despite breaking (or, on this CPU-only fallback branch,
+  // simply never entering the per-row loop body) well before the original max_selected_tokens. The
+  // can_batch_commits branch is CUDA-only and not reachable from these CPU test doubles, so this
+  // does not itself demonstrate the avoided device transfer/sync the early break exists for; that
+  // is a structural code-reasoning claim (see the loop's own comment), not something a CPU test can
+  // observe directly.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  auto make_request = [&](unsigned int seed) {
+    auto p = MakeGreedyParams(*model_);
+    p->search.do_sample = true;
+    p->search.top_k = 3;
+    p->search.temperature = 0.01f;
+    p->search.random_seed = seed;
+    auto r = CreateEngineRequest(engine.engine, *p);
+    r->BeginTurn(Prompt(), StopOptions({"STOP"}));
+    return r;
+  };
+  auto first = make_request(1234);
+  auto second = make_request(5678);
+  std::array<EngineEvent, 2> prefill;
+  ASSERT_EQ(engine.engine->Run(prefill), 2u);
+
+  first->SetDraftTokens(std::array<int32_t, 3>{7, 11, 12});
+  second->SetDraftTokens(std::array<int32_t, 3>{7, 13, 14});
+  engine.executor->SetVerifyRowTokens({7, 11, 12, 15, 7, 13, 14, 16});
+
+  std::array<EngineEvent, 4> events;
+  ASSERT_EQ(engine.engine->Run(events), 2u);
+  EXPECT_EQ(events[0].request, first);
+  EXPECT_EQ(events[0].token, 7);
+  EXPECT_EQ(events[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(events[0].finish_reason, GenerationFinishReason::StopString);
+  EXPECT_EQ(events[1].request, second);
+  EXPECT_EQ(events[1].token, 7);
+  EXPECT_EQ(events[1].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(events[1].finish_reason, GenerationFinishReason::StopString);
+}
+
+TEST_F(StopStringEngineTest, StopStringPrecedesTurnLimitForTheSameCompletingDraftToken) {
+  // The matching draft is also the exact token that would otherwise exhaust the turn's generated-
+  // token budget; StopString must still be reported, not TurnLimit.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}, std::optional<size_t>{3}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);  // 1 of 3 generated tokens used
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 7, 12});
+  engine.executor->SetVerifyRowTokens({11, 7, 12, 13});
+
+  // Committing "OP" (offset 1) both completes "STOP" and would independently exhaust the 3-token
+  // budget (1 prior + this round's 2 accepted so far == 3); the stop check runs first in the
+  // greedy loop and breaks before the turn-limit check for this same token is ever reached.
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+  EXPECT_EQ(storage[1].token, 7);
+  EXPECT_EQ(storage[1].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::StopString);
+  EXPECT_NE(storage[1].finish_reason, GenerationFinishReason::TurnLimit);
+}
+
+TEST_F(StopStringEngineTest, SampledStopStringPrecedesTurnLimitForTheSameCompletingDraftToken) {
+  // Sampled-path regression coverage for the same precedence: this reuses StageGeneration()'s own,
+  // unchanged stop-before-turn-limit ordering (the same mechanism the ordinary and greedy paths
+  // already rely on), so this specifically guards against a bookkeeping change to
+  // accepted_draft_count_/confirmed_draft_counts/PromoteFinalStageAsAcceptedDraft accidentally
+  // disturbing that ordering rather than exercising new precedence logic of its own.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}, std::optional<size_t>{3}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);  // 1 of 3 generated tokens used
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 7, 12});
+  engine.executor->SetVerifyRowTokens({11, 7, 12, 13});
+
+  // Stage 1 ("OP", token 7) both completes "STOP" and would independently exhaust the 3-token
+  // budget (1 prior + 2 accepted this round == 3); stop precedence must still win.
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+  EXPECT_EQ(storage[1].token, 7);
+  EXPECT_EQ(storage[1].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::StopString);
+  EXPECT_NE(storage[1].finish_reason, GenerationFinishReason::TurnLimit);
+  ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
+  EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 3u);  // both confirmed drafts counted
+}
+
+TEST_F(StopStringEngineTest, MixedBatchStopEnabledSpeculativeRequestTruncatesWhileSiblingCommitsNormally) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto stopping = CreateEngineRequest(engine.engine, *model_);
+  stopping->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto plain = CreateEngineRequest(engine.engine, *model_);
+  plain->BeginTurn(Prompt());
+
+  std::array<EngineEvent, 2> prefill;
+  ASSERT_EQ(engine.engine->Run(prefill), 2u);
+
+  stopping->SetDraftTokens(std::array<int32_t, 3>{11, 7, 12});
+  plain->SetDraftTokens(std::array<int32_t, 1>{14});
+  engine.executor->SetVerifyRowTokens({11, 7, 12, 13, 14, 25});
+
+  std::array<EngineEvent, 4> events;
+  ASSERT_EQ(engine.engine->Run(events), 4u);
+  EXPECT_EQ(events[0].request, stopping);
+  EXPECT_EQ(events[0].token, 11);
+  EXPECT_EQ(events[0].flags, EngineEventFlagToken);
+  EXPECT_EQ(events[1].request, stopping);
+  EXPECT_EQ(events[1].token, 7);
+  EXPECT_EQ(events[1].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(events[1].finish_reason, GenerationFinishReason::StopString);
+  EXPECT_EQ(events[2].request, plain);
+  EXPECT_EQ(events[2].token, 14);
+  EXPECT_EQ(events[2].flags, EngineEventFlagToken);
+  EXPECT_EQ(events[3].request, plain);
+  EXPECT_EQ(events[3].token, 25);
+  EXPECT_EQ(events[3].flags, EngineEventFlagToken);
+  EXPECT_EQ(plain->Status(), RequestStatus::Active);
+  EXPECT_EQ(stopping->Status(), RequestStatus::TurnComplete);
+}
+
+TEST_F(StopStringEngineTest, AcceptedDraftTokenCountAndTelemetryReflectATruncatedGreedyMatch) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 7, 12});
+  engine.executor->SetVerifyRowTokens({11, 7, 12, 13});
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+
+  // The proposed count (3) and evaluated count still reflect the round the target actually saw.
+  // Both the greedy and sampled/batched paths count the matching draft itself as accepted -- it
+  // is genuinely target-confirmed (the argmax/sample agreed with it) -- just via different
+  // mechanisms: greedy's loop increments accepted_draft_count_ before checking for a match, so the
+  // match is already included the instant it is observed; the sampled/batched stage loop instead
+  // promotes it after the fact via Request::PromoteFinalStageAsAcceptedDraft, once the caller knows
+  // this stage is both the round's end and within the confirmed prefix. Because the match completes
+  // on this confirmed draft (token_appended == false, from StageDraftCompletionForTransaction's
+  // hardcoded result), evaluated is exactly the accepted count, not accepted + 1.
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.draft_tokens_proposed, 3u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 2u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 2u);
+}
+
+TEST_F(StopStringEngineTest, GreedyRejectedDraftReplacementStopTelemetryCountsTheEvaluatedRejection) {
+  // Mirrors GreedyRejectedDraftNeverReachesTheMatcherButItsReplacementCan's setup, adding the
+  // telemetry assertions review correction #3 calls out: unlike a match on a confirmed draft, a
+  // match on the ordinary replacement following a rejected draft still has token_appended == true
+  // (it flows through the ordinary ApplyLogitsForTransaction path, not
+  // StageDraftCompletionForTransaction), so verification genuinely evaluated and rejected one
+  // draft to reach it -- evaluated must be accepted + 1 (= 1), not accepted (= 0).
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({7, 12, 13, 14});  // row 0 disagrees with draft 0
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.draft_tokens_proposed, 3u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 0u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 1u);
+  EXPECT_EQ(stats.zero_accept_rounds, 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[0], 1u);
+  // The aggregate acceptance-rate denominator (evaluated, not proposed) reflects the same fix.
+  EXPECT_FLOAT_EQ(stats.acceptance_rate, 0.0f);
+}
+
+TEST_F(StopStringEngineTest, SampledRejectedDraftReplacementStopTelemetryCountsTheEvaluatedRejection) {
+  // Sampled-path counterpart: the replacement token flows through StageGeneration() with
+  // token_appended == true (the stage loop never calls PromoteFinalStageAsAcceptedDraft for it,
+  // since it falls outside confirmed_draft_counts), so the same accepted + 1 rule applies.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto params = MakeGreedyParams(*model_);
+  params->search.do_sample = true;
+  params->search.top_k = 3;
+  params->search.temperature = 0.01f;
+  params->search.random_seed = 1234;
+  auto request = CreateEngineRequest(engine.engine, *params);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({7, 12, 13, 14});  // target replaces draft 0 with "STOPX"
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+
+  const auto stats = engine.engine->GetSpeculativeStats();
+  EXPECT_EQ(stats.draft_tokens_proposed, 3u);
+  EXPECT_EQ(stats.draft_tokens_accepted, 0u);
+  EXPECT_EQ(stats.draft_tokens_evaluated, 1u);
+  EXPECT_EQ(stats.zero_accept_rounds, 1u);
+  EXPECT_EQ(stats.acceptance_length_histogram[0], 1u);
+  EXPECT_FLOAT_EQ(stats.acceptance_rate, 0.0f);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Rollback and replay of draft verification: the request-local StopStringController checkpoint
+// taken at BeginTransaction() covers whatever the draft loop or sampled stage loop observed, so a
+// rolled-back step must restore both the draft proposal and the controller for an identical retry.
+// ---------------------------------------------------------------------------------------------
+
+TEST_F(StopStringEngineTest, DirectRollbackDuringGreedyDraftVerificationRestoresControllerAndDrafts) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  const auto generated_before = request->TurnGeneratedTokens();
+
+  request->SetDraftTokens(std::array<int32_t, 3>{11, 7, 12});
+  engine.executor->SetVerifyRowTokens({11, 7, 12, 13});
+  engine.executor->SetNextFailure(ScriptedExecutionFailure::PostProcessing);
+
+  EXPECT_EQ(RunOne(*engine.engine).flags, EngineEventFlagRetryable);
+  EXPECT_EQ(request->TurnGeneratedTokens(), generated_before);
+  EXPECT_EQ(request->PendingDraftTokenCount(), 3u);
+  EXPECT_EQ(request->AcceptedDraftTokenCount(), 0u);
+  EXPECT_TRUE(engine.cache->prefix_commits.empty());
+
+  // Retry: re-feeding the exact same draft/verify script must reproduce the exact same match.
+  engine.executor->SetVerifyRowTokens({11, 7, 12, 13});
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
+  EXPECT_EQ(storage[1].token, 7);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::StopString);
+  EXPECT_EQ(storage[1].matched_stop_string_index, 0);
+}
+
+TEST_F(StopStringEngineTest, QueuedRollbackDuringGreedyDraftVerificationRestoresControllerAndDrafts) {
+  // Mirrors QueuedRollbackReplaysTheControllerInTheCompletionPhase, but drives the draft loop
+  // directly at the Request level so it stays independent of Engine::Run's multi-request queued-
+  // restore machinery while still exercising Queue*/Complete* (not Restore*) for the draft path.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+  auto request = CreateEngineRequest(engine.engine, *model_);
+  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 4> storage;
+  ASSERT_EQ(engine.engine->Run(storage), 1u);  // commits "ST"
+
+  const auto before = request->Snapshot();
+  request->SetDraftTokens(std::array<int32_t, 1>{6});  // "OP": completes "STOP"
+  RequestStepPlan plan;
+  plan.request = request;
+  plan.request_id = request.get();
+  plan.sequence_length_before = before.current_sequence_length;
+  plan.target_cache_slots = static_cast<size_t>(before.current_sequence_length) + 1;
+  plan.draft_token_count = 1;
+  PrepareRequestStep(model_, plan);
+
+  request->SaveStateForTransaction();
+  request->AppendDraftsForTransaction(1);
+  request->CommitAcceptedDraftsForTransaction(1);
+  ASSERT_TRUE(request->DraftVerificationCompletedGeneration());
+  const auto staged = request->StageDraftCompletionForTransaction();
+  ASSERT_EQ(staged.finish_reason, GenerationFinishReason::StopString);
+
+  request->QueueStateRestoreForTransaction();
+  request->CompleteStateRestoreForTransaction();
+  EXPECT_EQ(request->PendingDraftTokenCount(), 1u);
+  EXPECT_EQ(request->AcceptedDraftTokenCount(), 0u);
+
+  // Retry: re-stage and commit the same draft; the match must reappear identically.
+  request->SaveStateForTransaction();
+  request->AppendDraftsForTransaction(1);
+  request->CommitAcceptedDraftsForTransaction(1);
+  ASSERT_TRUE(request->DraftVerificationCompletedGeneration());
+  const auto retried = request->StageDraftCompletionForTransaction();
+  ASSERT_EQ(retried.finish_reason, GenerationFinishReason::StopString);
+  ASSERT_EQ(retried.matched_stop_string_index, 0);
+  request->CommitStateForTransaction();
+  request->CommitStep(plan, retried);
+
+  EXPECT_EQ(request->TurnGeneratedTokens(), 2u);
+  EXPECT_EQ(request->FinishReason(), GenerationFinishReason::StopString);
+  EXPECT_EQ(request->MatchedStopStringIndex(), 0);
+}
+
+TEST(StopStringMtpSpeculativeTest, AutomaticMtpDraftsAreProposedForAStopEnabledRequestNotYetDone) {
+  auto model = LoadSyntheticPagedMtpModel();
+  const int32_t eos = EosToken(*model);
+  const int32_t filler = eos == 5 ? 6 : 5;  // never EOS, never matches "UNREACHABLE"
+  auto engine = MakeMtpDoublesEngine(model, filler);
+
+  auto stop_request = CreateEngineRequest(engine.engine, *model);
+  stop_request->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
+  auto plain_request = CreateRequestWithPrompt(engine.engine, *model, Prompt());
+
+  std::array<EngineEvent, 8> storage;
+  ASSERT_GT(engine.engine->Run(storage), 0u);
+
+  // Both requests receive an MTP shadow now: a stop-enabled turn that has not yet matched is no
+  // longer excluded from automatic drafting, and it drafts and verifies request-locally without
+  // needing any producer-specific carve-out.
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 2u);
+}
+
+TEST(StopStringMtpSpeculativeTest, StopEnabledRequestThatJustMatchedIsExcludedFromTheNextMtpDraftBlock) {
+  auto model = LoadSyntheticPagedMtpModel();
+  auto engine = MakeMtpDoublesEngine(model, /*forced_token=*/5 /* "ST" */);
+
+  auto stop_request = CreateEngineRequest(engine.engine, *model);
+  stop_request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  std::array<EngineEvent, 8> storage;
+  ASSERT_GT(engine.engine->Run(storage), 0u);
+  ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);  // "ST": no match yet, drafts normally
+
+  engine.executor->SetForcedToken(6);  // "OP": completes "STOP"
+  const size_t drained = engine.engine->Run(storage);
+  ASSERT_GT(drained, 0u);
+  bool saw_stop_finish = false;
+  for (size_t i = 0; i < drained; ++i) {
+    if (storage[i].request == stop_request &&
+        (storage[i].flags & EngineEventFlagTurnFinished)) {
+      EXPECT_EQ(storage[i].finish_reason, GenerationFinishReason::StopString);
+      saw_stop_finish = true;
+    }
+  }
+  EXPECT_TRUE(saw_stop_finish);
+  EXPECT_EQ(stop_request->Status(), RequestStatus::TurnComplete);
+  // A terminal target result -- this StopString match -- prevents a subsequent draft block: no
+  // new MTP shadow is created for it once it is done, exactly like any other finish reason.
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+}
+
+// End-to-end: unlike the test above (where the MTP-proposed draft is rejected and the target's own
+// replacement happens to complete the match), this one controls the MTP head's own forced token so
+// the *proposed draft itself* is genuinely accepted and completes the match through
+// Request::CommitAcceptedDraftsForTransaction()'s greedy loop -- the same generic path a manual
+// SetDraftTokens caller uses, exercised here through the fully automatic producer. The doubles'
+// CPU device still chains the MTP head to this Engine's full 3-token draft budget (chaining beyond
+// one token is not itself CUDA-gated the way the batched device-stage path is), so the proposal is
+// "STOPX","STOPX","STOPX"; the match completes on the very first of the three, mid-draft.
+TEST(StopStringMtpSpeculativeTest, AutomaticMtpProposedDraftItselfCompletesAMidDraftMatchAndIsNotRedrafted) {
+  auto model = LoadSyntheticPagedMtpModel();
+  auto engine = MakeMtpDoublesEngine(model, /*forced_token=*/11 /* filler, never matches "STOP" */);
+  // Every MTP proposal from here on predicts "STOPX" (token 7).
+  engine.mtp_executor->SetForcedToken(7);
+
+  auto stop_request = CreateEngineRequest(engine.engine, *model);
+  stop_request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+
+  std::array<EngineEvent, 8> storage;
+  ASSERT_GT(engine.engine->Run(storage), 0u);  // prefill + "t11"; MTP proposes 3 "STOPX" drafts
+  ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+  ASSERT_EQ(stop_request->PendingDraftTokenCount(), 3u);
+  ASSERT_EQ(stop_request->FinishReason(), GenerationFinishReason::None);
+
+  // The target's own argmax agrees with the proposed draft at position 0 (accepting it, not
+  // replacing it), so the draft is genuinely committed through the greedy verification loop; the
+  // match completes there and the loop never even looks at positions 1, 2, or the bonus row.
+  engine.executor->SetVerifyRowTokens({7, 25, 26, 27});
+  const size_t drained = engine.engine->Run(storage);
+  ASSERT_GT(drained, 0u);
+  bool saw_stop_finish = false;
+  for (size_t i = 0; i < drained; ++i) {
+    if (storage[i].request == stop_request && (storage[i].flags & EngineEventFlagTurnFinished)) {
+      EXPECT_EQ(storage[i].token, 7);
+      EXPECT_EQ(storage[i].finish_reason, GenerationFinishReason::StopString);
+      EXPECT_EQ(storage[i].matched_stop_string_index, 0);
+      saw_stop_finish = true;
+    }
+  }
+  EXPECT_TRUE(saw_stop_finish);
+  EXPECT_EQ(stop_request->Status(), RequestStatus::TurnComplete);
+  EXPECT_EQ(stop_request->FinishReason(), GenerationFinishReason::StopString);
+
+  // No redraft: the terminal target result this round (result.done == true) makes
+  // Engine::PrepareMtpStep skip proposing a new draft block for it entirely.
+  EXPECT_EQ(stop_request->PendingDraftTokenCount(), 0u);
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
+
+  // A further Run() neither drafts nor otherwise touches the now-terminal request again.
+  ASSERT_EQ(engine.engine->Run(storage), 0u);
+  EXPECT_EQ(stop_request->PendingDraftTokenCount(), 0u);
+}
+
+// The sibling-keeps-drafting half of the same claim: AutomaticMtpDraftsAreProposedForAStopEnabled-
+// RequestNotYetDone above already proves both a stop-enabled and a plain request receive an MTP
+// shadow from the same automatic drafter with no producer-specific carve-out; this extends it one
+// more round to prove the plain sibling's own drafting keeps working normally, undisturbed by the
+// other request's stop configuration. Exact interleaved-row control for a second automatic MTP
+// verification round on the *stop-enabled* request's own sibling would require duplicating the
+// packed-row bookkeeping above per request; this instead exercises the sibling directly, which is
+// the actual property being verified.
+TEST(StopStringMtpSpeculativeTest, PlainSiblingContinuesAutomaticMtpDraftingAcrossRounds) {
+  auto model = LoadSyntheticPagedMtpModel();
+  auto engine = MakeMtpDoublesEngine(model, /*forced_token=*/11);
+  engine.mtp_executor->SetForcedToken(12);
+
+  auto stop_request = CreateEngineRequest(engine.engine, *model);
+  stop_request->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
+  auto plain_request = CreateRequestWithPrompt(engine.engine, *model, Prompt());
+
+  std::array<EngineEvent, 8> storage;
+  ASSERT_GT(engine.engine->Run(storage), 0u);
+  ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 2u);
+  ASSERT_EQ(plain_request->PendingDraftTokenCount(), 3u);
+  ASSERT_EQ(stop_request->PendingDraftTokenCount(), 3u);
+
+  // Neither request's proposed draft ("t12") matches "UNREACHABLE"; both continue normally
+  // (draft0/1/2 accepted, plus a bonus token that also decodes to unreachable filler text), and
+  // the plain sibling keeps receiving fresh automatic drafts round after round.
+  engine.executor->SetVerifyRowTokens({12, 12, 12, 13, 12, 12, 12, 14});
+  ASSERT_GT(engine.engine->Run(storage), 0u);
+  EXPECT_EQ(plain_request->Status(), RequestStatus::Active);
+  EXPECT_EQ(stop_request->Status(), RequestStatus::Active);
+  EXPECT_EQ(plain_request->PendingDraftTokenCount(), 3u);
+  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 2u);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -767,7 +1883,6 @@ TEST_F(StopStringEngineTest, CancelMergesIntoARetainedTokenEventWithoutLeakingAS
   EXPECT_EQ(drain_storage[0].finish_reason, GenerationFinishReason::Canceled);
   EXPECT_EQ(drain_storage[0].matched_stop_string_index, -1);
   EXPECT_EQ(stopping->MatchedStopStringIndex(), -1);
-  EXPECT_EQ(stopping->DraftTokenValidationError(), nullptr);
 }
 
 // A fatal engine failure only forcibly fails requests that are still executable
@@ -799,7 +1914,6 @@ TEST_F(StopStringEngineTest, FatalFailurePreservesAnAlreadyCommittedStopMatchOnA
   EXPECT_EQ(failure.flags, EngineEventFlagTurnFinished | EngineEventFlagFailed);
   EXPECT_EQ(failure.finish_reason, GenerationFinishReason::Failed);
   EXPECT_EQ(failure.matched_stop_string_index, -1);
-  EXPECT_EQ(executing->DraftTokenValidationError(), nullptr);
 
   // The Engine is now unhealthy, but `completed` was not part of the failing batch: its own
   // committed stop-match state must be completely unaffected.
@@ -807,11 +1921,10 @@ TEST_F(StopStringEngineTest, FatalFailurePreservesAnAlreadyCommittedStopMatchOnA
   EXPECT_EQ(completed->MatchedStopStringIndex(), 0);
 }
 
-TEST_F(StopStringEngineTest, UnserviceableFailureReleasesStopControllerState) {
+TEST_F(StopStringEngineTest, UnserviceableStopEnabledRequestPublishesFailure) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/2);
   auto request = CreateEngineRequest(engine.engine, *model_);
   request->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
-  ASSERT_NE(request->DraftTokenValidationError(), nullptr);
   engine.cache->SetUnserviceableRequest(request);
 
   const auto failure = RunOne(*engine.engine);
@@ -820,27 +1933,6 @@ TEST_F(StopStringEngineTest, UnserviceableFailureReleasesStopControllerState) {
   EXPECT_EQ(failure.error_code, EngineErrorCode::RequestUnserviceable);
   EXPECT_EQ(request->Status(), RequestStatus::TurnComplete);
   EXPECT_EQ(request->FinishReason(), GenerationFinishReason::Failed);
-  EXPECT_EQ(request->DraftTokenValidationError(), nullptr);
-}
-
-TEST(StopStringMtpExclusionTest,
-     StopEnabledRequestIsExcludedFromAutomaticMtpButEngineKeepsSpeculativeCapability) {
-  auto model = LoadSyntheticPagedMtpModel();
-  const int32_t eos = EosToken(*model);
-  const int32_t filler = eos == 5 ? 6 : 5;  // never EOS, never matches "UNREACHABLE"
-  auto engine = MakeMtpDoublesEngine(model, filler);
-
-  auto stop_request = CreateEngineRequest(engine.engine, *model);
-  stop_request->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
-  auto plain_request = CreateRequestWithPrompt(engine.engine, *model, Prompt());
-
-  std::array<EngineEvent, 8> storage;
-  ASSERT_GT(engine.engine->Run(storage), 0u);
-
-  // Only the plain request receives an MTP shadow: the stop-enabled request is excluded request-
-  // locally (via the same DraftTokenValidationError() check SetDraftTokens uses), without
-  // disabling speculative drafting for the rest of the Engine.
-  EXPECT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
 }
 
 // ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extend Engine stop-string handling through speculative target verification so MTP, DFlash2/DSpark, manually supplied drafts, and future draft producers share the same decoded-text termination behavior.

- Observe target-verified tokens in order and stop at the first decoded stop-string match.
- Retain, emit, cache, and count the token that completes the match while discarding the remaining speculative suffix.
- Keep Search state, host token history, paged and fixed-state cache commits, generated-token usage, and speculative telemetry aligned with the retained prefix.
- Restore sampled host RNG state to the retained boundary when candidates after a match are discarded.
- Prevent automatic drafters from proposing another block after the target request has completed.

The stop logic remains in the generic target-verification path rather than in individual draft producers. Matching semantics and public Engine behavior are unchanged from #2527.

## Correctness

Greedy and sampled verification now track accepted and evaluated draft counts explicitly. This distinguishes retained accepted tokens from proposals that were evaluated but rejected or discarded after a terminal boundary, ensuring cache accounting and telemetry describe the transaction that was actually committed.

Sampled verification records lightweight RNG checkpoints only for stop-enabled requests with active drafts. If a match truncates the speculative round, the request restores the checkpoint immediately after the retained matching token, so discarded candidates do not alter future sampling.