### PR TITLE
Enable prefill chunking for text-only mRoPE models

### DIFF
--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -716,16 +716,21 @@ DeviceSpan<float> DecoderState::Run(int current_length, DeviceSpan<int32_t>& nex
   return logits_.Get();
 }
 
-bool DecoderState::SupportsPrefillChunking() const {
+bool DecoderState::SupportsPrefillChunking(bool has_multimodal_content) const {
   // Chunking slices the pre-computed embeddings along the sequence dimension, which is only
   // contiguous for a single sequence. Continuous decoding of position ids/attention mask in
   // DefaultPositionInputs is likewise restricted to a batch-beam size of one.
   if (params_->BatchBeamSize() != 1)
     return false;
 
-  // Qwen-VL's 3D mRoPE position ids are computed from the full prompt in a single pass, so they
-  // cannot be produced chunk by chunk. Fall back to a single prefill run for those models.
-  return dynamic_cast<const DefaultPositionInputs*>(position_inputs_.get()) != nullptr;
+  // DefaultPositionInputs produces position ids sequentially, so chunking is always safe.
+  if (dynamic_cast<const DefaultPositionInputs*>(position_inputs_.get()) != nullptr)
+    return true;
+
+  // Qwen-VL's 3D mRoPE position ids diverge from sequential positions only when vision/audio
+  // content shifts the rope deltas. A text-only prompt reduces to sequential positions, so
+  // chunking is safe; with multimodal content the ids must be produced in a single full pass.
+  return !has_multimodal_content;
 }
 
 void DecoderState::PrepareEmbeddingsForPrefill(size_t new_length) {
@@ -873,8 +878,9 @@ DeviceSpan<float> MultiModalPipelineState::Run(int current_length, DeviceSpan<in
   // prompt embeddings in several smaller runs to bound peak memory usage.
   const auto& chunk_size_opt = params_->search.chunk_size;
   const size_t num_tokens = next_tokens.size();
+  const bool has_multimodal_content = num_image_tokens_ != 0 || num_audio_tokens_ != 0;
   const bool chunk_prefill = is_prompt_ && chunk_size_opt.has_value() && chunk_size_opt.value() > 0 &&
-                             num_tokens > chunk_size_opt.value() && decoder_state_->SupportsPrefillChunking();
+                             num_tokens > chunk_size_opt.value() && decoder_state_->SupportsPrefillChunking(has_multimodal_content);
 
   if (chunk_prefill) {
     decoder_state_->PrepareEmbeddingsForPrefill(num_tokens);

--- a/src/models/multi_modal.cpp
+++ b/src/models/multi_modal.cpp
@@ -730,7 +730,12 @@ bool DecoderState::SupportsPrefillChunking(bool has_multimodal_content) const {
   // Qwen-VL's 3D mRoPE position ids diverge from sequential positions only when vision/audio
   // content shifts the rope deltas. A text-only prompt reduces to sequential positions, so
   // chunking is safe; with multimodal content the ids must be produced in a single full pass.
-  return !has_multimodal_content;
+  if (dynamic_cast<const Qwen2VLPositionInputs*>(position_inputs_.get()) != nullptr)
+    return !has_multimodal_content;
+
+  // Any other position-input type (e.g. WindowedPositionInputs) keeps the conservative
+  // single-pass prefill behavior.
+  return false;
 }
 
 void DecoderState::PrepareEmbeddingsForPrefill(size_t new_length) {

--- a/src/models/multi_modal.h
+++ b/src/models/multi_modal.h
@@ -182,7 +182,7 @@ struct DecoderState : State {
   // Prefill chunking (see search.chunk_size). The embedding model still runs once over the whole
   // prompt (it is a lookup/projection), while the decoder prefill is split into several runs so the
   // peak attention workspace scales with the chunk size instead of the full prompt length.
-  bool SupportsPrefillChunking() const;
+  bool SupportsPrefillChunking(bool has_multimodal_content) const;
   void PrepareEmbeddingsForPrefill(size_t new_length);
   DeviceSpan<float> RunPrefillWithChunking(int current_length, DeviceSpan<int32_t>& next_tokens,
                                            DeviceSpan<int32_t> next_indices, size_t chunk_size);


### PR DESCRIPTION
## Description

`DecoderState::SupportsPrefillChunking()` gated prefill chunking on the position-input type, returning `true` only for `DefaultPositionInputs`. This rejected every Qwen-VL 3D mRoPE model, forcing a single full-length prefill pass even for **text-only** prompts - so long-context text prompts on these models could not benefit from chunked prefill and paid the full peak-memory cost.

Qwen-VL's 3D mRoPE offsets position ids by `rope_deltas` (see `position_inputs.cpp`), which are non-zero **only** when vision/audio tokens are present. A text-only prompt therefore reduces to sequential positions and can be produced chunk-by-chunk safely. The correct condition is not "is this mRoPE?" but "does this prompt actually contain multimodal content?"

## Summary of Changes

- Change `SupportsPrefillChunking()` to take a `has_multimodal_content` flag and decide per position-input type:
    - `DefaultPositionInputs` → chunking always allowed (unchanged).
    - `Qwen2VLPositionInputs` (3D mRoPE) → allowed only when `has_multimodal_content` is `false` (text-only prompt).
    - Any other type (e.g. `WindowedPositionInputs`) → single-pass prefill, unchanged.
- At the sole caller (`MultiModalPipelineState::Run`), compute `has_multimodal_content` from `num_image_tokens_ != 0 || num_audio_tokens_ != 0` (both already available on `MultiModalPipelineState`) and pass it in.

The multimodal-content flag is a required parameter (no default) so a future caller cannot silently omit it and accidentally enable chunking for a genuine image/audio prompt.

## Behavior

- **`DefaultPositionInputs` (any prompt):** chunks — unchanged.
- **`Qwen2VLPositionInputs`, text-only prompt:** was single prefill → **now chunks**.
- **`Qwen2VLPositionInputs`, image/audio prompt:** single prefill — unchanged.
- **`WindowedPositionInputs` / other types:** single prefill — unchanged.

Chunking is still additionally gated by the existing conditions (`batch_beam_size == 1`, `chunk_size` set and exceeded), so this only relaxes the position-input-type restriction for text-only mRoPE prompts.

Updated after review feedback: the relaxation is now scoped specifically to `Qwen2VLPositionInputs` so sliding-window (`WindowedPositionInputs`) models keep their existing single-pass prefill behavior.