### PR TITLE
Address unreplied DFlash 2 review threads from #2496

### DIFF
--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -1122,8 +1122,16 @@ call, so `model.dflash2.run_options` cannot disable execution-provider synchroni
 The direct drafter session also uses graph id `-1`: its variable-shaped proposal tensors are
 allocated per call and therefore cannot be captured safely. If this optional post-commit drafter
 run fails, the Engine discards any partial proposal and still publishes the already committed target
-events. A transient failure is retried on the next step; three consecutive failures disable DFlash 2
-for the Engine. `dflash2_failures` and `dflash2_disables` report those events.
+events. A recoverable failure also makes the drafter forget every request it is currently tracking,
+because the step whose rows it failed to ingest leaves its cached context no longer contiguous with
+the target. Those in-flight requests finish without DFlash 2 drafts while requests admitted
+afterwards still get them, and the retry budget is therefore spent on real drafter failures: three
+consecutive failures disable DFlash 2 for the Engine, and a proposal contract violation disables it
+at once. `dflash2_failures` and `dflash2_disables` report those events.
+
+Automatic DFlash 2 drafting is greedy-only. A request that uses random sampling (`do_sample` with
+`top_k != 1` and a non-zero temperature) can never take a DFlash 2 block, so it is never fed to the
+drafter and never claims a ring.
 
 The drafter keeps a fixed sliding-window ring per request from that request's first decode step
 until it is closed, so its pool is sized for `max_batch_size` rings. A request that first decodes

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -1119,8 +1119,8 @@ steps remain eager. Engine construction validates the output's rank, element typ
 against the drafter input before allocating cache resources.
 The drafter run is synchronous because its packed inputs and outputs are owned by one proposal
 call, so `model.dflash2.run_options` cannot disable execution-provider synchronization.
-The direct drafter session also uses graph id `-1`: its variable-shaped proposal tensors are
-allocated per call and therefore cannot be captured safely. If this optional post-commit drafter
+The direct drafter session also uses graph id `-1`: it reuses proposal tensor allocations but
+reshapes them for each step, so they cannot be captured safely. If this optional post-commit drafter
 run fails, the Engine discards any partial proposal and still publishes the already committed target
 events. A recoverable failure also makes the drafter forget every request it is currently tracking,
 because the step whose rows it failed to ingest leaves its cached context no longer contiguous with

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -341,9 +341,8 @@ Dflash2Drafter::Dflash2Drafter(std::shared_ptr<Dflash2Model> model, size_t paged
   run_options_->AddConfigEntry("gpu_graph_id", "-1");
 }
 
-Tensor& Dflash2Drafter::StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device,
-                                   ONNXTensorElementDataType type,
-                                   const std::vector<int64_t>& shape) {
+Tensor& Dflash2StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device,
+                          ONNXTensorElementDataType type, const std::vector<int64_t>& shape) {
   size_t elements = 1;
   for (const int64_t dimension : shape) {
     elements = CheckedMultiply(elements, static_cast<size_t>(dimension), "DFlash 2 proposal tensor");
@@ -585,7 +584,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     span.CopyCpuToDevice();
   };
 
-  auto& packed_aux = StepTensor(step_tensors_.packed_aux, device, aux_type_,
+  auto& packed_aux = Dflash2StepTensor(step_tensors_.packed_aux, device, aux_type_,
                                 {static_cast<int64_t>(num_ctx_rows),
                                  static_cast<int64_t>(aux_hidden_size_)});
   const size_t aux_row_bytes =
@@ -603,7 +602,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     destination_row += ingest_count[i];
   }
 
-  auto& input_ids = StepTensor(step_tensors_.input_ids, device, Ort::TypeToTensorType<int64_t>,
+  auto& input_ids = Dflash2StepTensor(step_tensors_.input_ids, device, Ort::TypeToTensorType<int64_t>,
                                {static_cast<int64_t>(num_block_rows)});
   {
     auto span = input_ids.GetDeviceSpan<int64_t>();
@@ -619,23 +618,23 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   }
 
   constexpr auto int32_type = Ort::TypeToTensorType<int32_t>;
-  auto& q_row_map = StepTensor(step_tensors_.q_row_map, device, int32_type,
+  auto& q_row_map = Dflash2StepTensor(step_tensors_.q_row_map, device, int32_type,
                                {static_cast<int64_t>(num_tokens)});
   fill_int32(q_row_map, layout.q_row_map);
-  auto& qkv_row_map = StepTensor(step_tensors_.qkv_row_map, device, int32_type,
+  auto& qkv_row_map = Dflash2StepTensor(step_tensors_.qkv_row_map, device, int32_type,
                                  {static_cast<int64_t>(num_tokens)});
   fill_int32(qkv_row_map, layout.qkv_row_map);
-  auto& block_row_index = StepTensor(step_tensors_.block_row_index, device, int32_type,
+  auto& block_row_index = Dflash2StepTensor(step_tensors_.block_row_index, device, int32_type,
                                      {static_cast<int64_t>(num_block_rows)});
   fill_int32(block_row_index, layout.block_row_index);
-  auto& cumulative = StepTensor(step_tensors_.cumulative_sequence_lengths, device, int32_type,
+  auto& cumulative = Dflash2StepTensor(step_tensors_.cumulative_sequence_lengths, device, int32_type,
                                 {static_cast<int64_t>(served.size() + 1)});
   fill_int32(cumulative, layout.cumulative_sequence_lengths);
-  auto& past_lengths = StepTensor(step_tensors_.past_sequence_lengths, device, int32_type,
+  auto& past_lengths = Dflash2StepTensor(step_tensors_.past_sequence_lengths, device, int32_type,
                                   {static_cast<int64_t>(served.size())});
   fill_int32(past_lengths, layout.past_sequence_lengths);
 
-  auto& block_table = StepTensor(
+  auto& block_table = Dflash2StepTensor(
       step_tensors_.block_table, device, int32_type,
       {static_cast<int64_t>(served.size()), static_cast<int64_t>(max_blocks)});
   {
@@ -660,7 +659,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     span.CopyCpuToDevice();
   }
 
-  auto& metadata = StepTensor(step_tensors_.attention_metadata, GetDeviceInterface(DeviceType::CPU),
+  auto& metadata = Dflash2StepTensor(step_tensors_.attention_metadata, GetDeviceInterface(DeviceType::CPU),
                               int32_type, {3});
   {
     auto span = metadata.GetDeviceSpan<int32_t>();
@@ -671,10 +670,10 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   }
 
   const size_t batch = block_feed_indices.size();
-  auto& candidate_ids = StepTensor(step_tensors_.candidate_ids, device, int32_type,
+  auto& candidate_ids = Dflash2StepTensor(step_tensors_.candidate_ids, device, int32_type,
                                    {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
                                     static_cast<int64_t>(top_k)});
-  auto& scores = StepTensor(step_tensors_.scores, device, Ort::TypeToTensorType<float>,
+  auto& scores = Dflash2StepTensor(step_tensors_.scores, device, Ort::TypeToTensorType<float>,
                             {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
                              static_cast<int64_t>(top_k), static_cast<int64_t>(top_k)});
 

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -337,8 +337,25 @@ Dflash2Drafter::Dflash2Drafter(std::shared_ptr<Dflash2Model> model, size_t paged
       }
     }
   }
-  // Proposal tensors are rebuilt for every packed batch, so their addresses are not capturable.
+  // Proposal tensors keep a stable address but not a stable shape, so they are not capturable.
   run_options_->AddConfigEntry("gpu_graph_id", "-1");
+}
+
+Tensor& Dflash2Drafter::StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device,
+                                   ONNXTensorElementDataType type,
+                                   const std::vector<int64_t>& shape) {
+  size_t elements = 1;
+  for (const int64_t dimension : shape) {
+    elements = CheckedMultiply(elements, static_cast<size_t>(dimension), "DFlash 2 proposal tensor");
+  }
+  const size_t bytes = CheckedMultiply(elements, Ort::SizeOf(type), "DFlash 2 proposal tensor");
+  // A static Tensor rejects a shape larger than the buffer it already owns, so a step that needs
+  // more room starts a new buffer. Every other step reshapes a view over the buffer it kept.
+  if (!slot || slot->bytes_ < bytes) {
+    slot = std::make_unique<Tensor>(device, type);
+  }
+  slot->CreateTensor(shape, /*make_static=*/true, std::max<size_t>(bytes, 1));
+  return *slot;
 }
 
 void Dflash2Drafter::AllocateCache() {
@@ -562,23 +579,19 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   const size_t num_tokens = layout.q_row_map.size();
   auto device = model_->p_device_inputs_;
 
-  auto make = [&](ONNXTensorElementDataType type, std::vector<int64_t> shape) {
-    auto tensor = std::make_unique<Tensor>(device, type);
-    tensor->CreateTensor(shape);
-    return tensor;
-  };
   auto fill_int32 = [](Tensor& tensor, const std::vector<int32_t>& values) {
     auto span = tensor.GetDeviceSpan<int32_t>();
     std::copy(values.begin(), values.end(), span.CpuSpan().begin());
     span.CopyCpuToDevice();
   };
 
-  auto packed_aux = make(aux_type_, {static_cast<int64_t>(num_ctx_rows),
-                                     static_cast<int64_t>(aux_hidden_size_)});
+  auto& packed_aux = StepTensor(step_tensors_.packed_aux, device, aux_type_,
+                                {static_cast<int64_t>(num_ctx_rows),
+                                 static_cast<int64_t>(aux_hidden_size_)});
   const size_t aux_row_bytes =
       CheckedMultiply(aux_hidden_size_, Ort::SizeOf(aux_type_), "DFlash 2 auxiliary row bytes");
   auto source_bytes = aux_hidden_states.GetByteSpan();
-  auto destination_bytes = packed_aux->GetByteSpan();
+  auto destination_bytes = packed_aux.GetByteSpan();
   size_t destination_row = 0;
   for (const size_t i : served) {
     if (ingest_count[i] == 0) {
@@ -590,9 +603,10 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     destination_row += ingest_count[i];
   }
 
-  auto input_ids = make(Ort::TypeToTensorType<int64_t>, {static_cast<int64_t>(num_block_rows)});
+  auto& input_ids = StepTensor(step_tensors_.input_ids, device, Ort::TypeToTensorType<int64_t>,
+                               {static_cast<int64_t>(num_block_rows)});
   {
-    auto span = input_ids->GetDeviceSpan<int64_t>();
+    auto span = input_ids.GetDeviceSpan<int64_t>();
     auto cpu = span.CpuSpan();
     for (size_t slot = 0; slot < block_feed_indices.size(); ++slot) {
       const auto& feed = feeds[block_feed_indices[slot]];
@@ -604,43 +618,52 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     span.CopyCpuToDevice();
   }
 
-  auto q_row_map = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(num_tokens)});
-  fill_int32(*q_row_map, layout.q_row_map);
-  auto qkv_row_map = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(num_tokens)});
-  fill_int32(*qkv_row_map, layout.qkv_row_map);
-  auto block_row_index = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(num_block_rows)});
-  fill_int32(*block_row_index, layout.block_row_index);
-  auto cumulative = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(served.size() + 1)});
-  fill_int32(*cumulative, layout.cumulative_sequence_lengths);
-  auto past_lengths = make(Ort::TypeToTensorType<int32_t>, {static_cast<int64_t>(served.size())});
-  fill_int32(*past_lengths, layout.past_sequence_lengths);
+  constexpr auto int32_type = Ort::TypeToTensorType<int32_t>;
+  auto& q_row_map = StepTensor(step_tensors_.q_row_map, device, int32_type,
+                               {static_cast<int64_t>(num_tokens)});
+  fill_int32(q_row_map, layout.q_row_map);
+  auto& qkv_row_map = StepTensor(step_tensors_.qkv_row_map, device, int32_type,
+                                 {static_cast<int64_t>(num_tokens)});
+  fill_int32(qkv_row_map, layout.qkv_row_map);
+  auto& block_row_index = StepTensor(step_tensors_.block_row_index, device, int32_type,
+                                     {static_cast<int64_t>(num_block_rows)});
+  fill_int32(block_row_index, layout.block_row_index);
+  auto& cumulative = StepTensor(step_tensors_.cumulative_sequence_lengths, device, int32_type,
+                                {static_cast<int64_t>(served.size() + 1)});
+  fill_int32(cumulative, layout.cumulative_sequence_lengths);
+  auto& past_lengths = StepTensor(step_tensors_.past_sequence_lengths, device, int32_type,
+                                  {static_cast<int64_t>(served.size())});
+  fill_int32(past_lengths, layout.past_sequence_lengths);
 
-  auto block_table = make(Ort::TypeToTensorType<int32_t>,
-                          {static_cast<int64_t>(served.size()), static_cast<int64_t>(max_blocks)});
+  auto& block_table = StepTensor(
+      step_tensors_.block_table, device, int32_type,
+      {static_cast<int64_t>(served.size()), static_cast<int64_t>(max_blocks)});
   {
-    auto span = block_table->GetDeviceSpan<int32_t>();
+    auto span = block_table.GetDeviceSpan<int32_t>();
     auto cpu = span.CpuSpan();
-    std::fill(cpu.begin(), cpu.end(), int32_t{-1});
     for (size_t row = 0; row < served.size(); ++row) {
       const auto& blocks = requests_[feeds[served[row]].request].blocks;
+      auto columns = cpu.subspan(row * max_blocks, max_blocks);
       if (ring_blocks_ == 0) {
-        std::copy(blocks.begin(), blocks.end(), cpu.begin() + row * max_blocks);
+        const size_t used = std::min(blocks.size(), max_blocks);
+        std::copy_n(blocks.begin(), used, columns.begin());
+        std::fill(columns.begin() + used, columns.end(), int32_t{-1});
         continue;
       }
       // A windowed drafter repeats its ring across every column: column j holds the block that
-      // owns position j * block_size, which is ring[j % ring_blocks].
+      // owns position j * block_size, which is ring[j % ring_blocks]. Every column is written, so
+      // the reused buffer never exposes a stale id.
       for (size_t column = 0; column < max_blocks; ++column) {
-        cpu[row * max_blocks + column] = blocks[column % blocks.size()];
+        columns[column] = blocks[column % blocks.size()];
       }
     }
     span.CopyCpuToDevice();
   }
 
-  auto metadata = std::make_unique<Tensor>(GetDeviceInterface(DeviceType::CPU),
-                                           Ort::TypeToTensorType<int32_t>);
-  metadata->CreateTensor(std::vector<int64_t>{3});
+  auto& metadata = StepTensor(step_tensors_.attention_metadata, GetDeviceInterface(DeviceType::CPU),
+                              int32_type, {3});
   {
-    auto span = metadata->GetDeviceSpan<int32_t>();
+    auto span = metadata.GetDeviceSpan<int32_t>();
     auto cpu = span.CpuSpan();
     cpu[0] = layout.max_query_len;
     cpu[1] = layout.max_kv_len;
@@ -648,12 +671,12 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   }
 
   const size_t batch = block_feed_indices.size();
-  auto candidate_ids = make(Ort::TypeToTensorType<int32_t>,
+  auto& candidate_ids = StepTensor(step_tensors_.candidate_ids, device, int32_type,
+                                   {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
+                                    static_cast<int64_t>(top_k)});
+  auto& scores = StepTensor(step_tensors_.scores, device, Ort::TypeToTensorType<float>,
                             {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
-                             static_cast<int64_t>(top_k)});
-  auto scores = make(Ort::TypeToTensorType<float>,
-                     {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
-                      static_cast<int64_t>(top_k), static_cast<int64_t>(top_k)});
+                             static_cast<int64_t>(top_k), static_cast<int64_t>(top_k)});
 
   std::vector<const char*> input_names{
       config_.inputs.aux_hidden_states.c_str(), config_.inputs.input_ids.c_str(),
@@ -661,14 +684,14 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
       config_.inputs.block_row_index.c_str(), config_.inputs.cumulative_sequence_lengths.c_str(),
       config_.inputs.past_sequence_lengths.c_str(), config_.inputs.block_table.c_str(),
       config_.inputs.attention_metadata.c_str()};
-  std::vector<OrtValue*> inputs{packed_aux->GetOrtTensor(), input_ids->GetOrtTensor(),
-                                q_row_map->GetOrtTensor(), qkv_row_map->GetOrtTensor(),
-                                block_row_index->GetOrtTensor(), cumulative->GetOrtTensor(),
-                                past_lengths->GetOrtTensor(), block_table->GetOrtTensor(),
-                                metadata->GetOrtTensor()};
+  std::vector<OrtValue*> inputs{packed_aux.GetOrtTensor(), input_ids.GetOrtTensor(),
+                                q_row_map.GetOrtTensor(), qkv_row_map.GetOrtTensor(),
+                                block_row_index.GetOrtTensor(), cumulative.GetOrtTensor(),
+                                past_lengths.GetOrtTensor(), block_table.GetOrtTensor(),
+                                metadata.GetOrtTensor()};
   std::vector<const char*> output_names{config_.outputs.candidate_ids.c_str(),
                                         config_.outputs.scores.c_str()};
-  std::vector<OrtValue*> outputs{candidate_ids->GetOrtTensor(), scores->GetOrtTensor()};
+  std::vector<OrtValue*> outputs{candidate_ids.GetOrtTensor(), scores.GetOrtTensor()};
   for (size_t i = 0; i < caches_.size(); ++i) {
     input_names.push_back(cache_input_names_[i].c_str());
     inputs.push_back(caches_[i]->GetOrtTensor());
@@ -690,8 +713,8 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   }
 
   // The spans own the host mirrors these point into, so they must outlive the reads below.
-  auto candidate_span = candidate_ids->GetDeviceSpan<int32_t>();
-  auto scores_span = scores->GetDeviceSpan<float>();
+  auto candidate_span = candidate_ids.GetDeviceSpan<int32_t>();
+  auto scores_span = scores.GetDeviceSpan<float>();
   auto candidate_cpu = candidate_span.CopyDeviceToCpu();
   auto scores_cpu = scores_span.CopyDeviceToCpu();
   for (size_t slot = 0; slot < block_feed_indices.size(); ++slot) {

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -348,13 +348,18 @@ Tensor& Dflash2StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device
     elements = CheckedMultiply(elements, static_cast<size_t>(dimension), "DFlash 2 proposal tensor");
   }
   const size_t bytes = CheckedMultiply(elements, Ort::SizeOf(type), "DFlash 2 proposal tensor");
-  // A static Tensor rejects a shape larger than the buffer it already owns, so a step that needs
-  // more room starts a new buffer. Every other step reshapes a view over the buffer it kept.
-  if (!slot || slot->bytes_ < bytes) {
+  // A static Tensor rejects a shape larger than the buffer it already owns, and it keeps the element
+  // type it was constructed with, so either one changing has to start a new buffer. Every other step
+  // reshapes a view over the buffer it kept.
+  if (!slot || slot->type_ != type || slot->bytes_ < bytes) {
     slot = std::make_unique<Tensor>(device, type);
   }
   slot->CreateTensor(shape, /*make_static=*/true, std::max<size_t>(bytes, 1));
   return *slot;
+}
+
+bool Dflash2CanDraft(const Config::Search& search) {
+  return !search.do_sample || search.top_k == 1 || search.temperature == 0;
 }
 
 void Dflash2Drafter::AllocateCache() {
@@ -585,8 +590,8 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   };
 
   auto& packed_aux = Dflash2StepTensor(step_tensors_.packed_aux, device, aux_type_,
-                                {static_cast<int64_t>(num_ctx_rows),
-                                 static_cast<int64_t>(aux_hidden_size_)});
+                                       {static_cast<int64_t>(num_ctx_rows),
+                                        static_cast<int64_t>(aux_hidden_size_)});
   const size_t aux_row_bytes =
       CheckedMultiply(aux_hidden_size_, Ort::SizeOf(aux_type_), "DFlash 2 auxiliary row bytes");
   auto source_bytes = aux_hidden_states.GetByteSpan();
@@ -603,7 +608,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   }
 
   auto& input_ids = Dflash2StepTensor(step_tensors_.input_ids, device, Ort::TypeToTensorType<int64_t>,
-                               {static_cast<int64_t>(num_block_rows)});
+                                      {static_cast<int64_t>(num_block_rows)});
   {
     auto span = input_ids.GetDeviceSpan<int64_t>();
     auto cpu = span.CpuSpan();
@@ -619,19 +624,19 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
 
   constexpr auto int32_type = Ort::TypeToTensorType<int32_t>;
   auto& q_row_map = Dflash2StepTensor(step_tensors_.q_row_map, device, int32_type,
-                               {static_cast<int64_t>(num_tokens)});
+                                      {static_cast<int64_t>(num_tokens)});
   fill_int32(q_row_map, layout.q_row_map);
   auto& qkv_row_map = Dflash2StepTensor(step_tensors_.qkv_row_map, device, int32_type,
-                                 {static_cast<int64_t>(num_tokens)});
+                                        {static_cast<int64_t>(num_tokens)});
   fill_int32(qkv_row_map, layout.qkv_row_map);
   auto& block_row_index = Dflash2StepTensor(step_tensors_.block_row_index, device, int32_type,
-                                     {static_cast<int64_t>(num_block_rows)});
+                                            {static_cast<int64_t>(num_block_rows)});
   fill_int32(block_row_index, layout.block_row_index);
   auto& cumulative = Dflash2StepTensor(step_tensors_.cumulative_sequence_lengths, device, int32_type,
-                                {static_cast<int64_t>(served.size() + 1)});
+                                       {static_cast<int64_t>(served.size() + 1)});
   fill_int32(cumulative, layout.cumulative_sequence_lengths);
   auto& past_lengths = Dflash2StepTensor(step_tensors_.past_sequence_lengths, device, int32_type,
-                                  {static_cast<int64_t>(served.size())});
+                                         {static_cast<int64_t>(served.size())});
   fill_int32(past_lengths, layout.past_sequence_lengths);
 
   auto& block_table = Dflash2StepTensor(
@@ -660,7 +665,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   }
 
   auto& metadata = Dflash2StepTensor(step_tensors_.attention_metadata, GetDeviceInterface(DeviceType::CPU),
-                              int32_type, {3});
+                                     int32_type, {3});
   {
     auto span = metadata.GetDeviceSpan<int32_t>();
     auto cpu = span.CpuSpan();
@@ -671,11 +676,11 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
 
   const size_t batch = block_feed_indices.size();
   auto& candidate_ids = Dflash2StepTensor(step_tensors_.candidate_ids, device, int32_type,
-                                   {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
-                                    static_cast<int64_t>(top_k)});
+                                          {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
+                                           static_cast<int64_t>(top_k)});
   auto& scores = Dflash2StepTensor(step_tensors_.scores, device, Ort::TypeToTensorType<float>,
-                            {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
-                             static_cast<int64_t>(top_k), static_cast<int64_t>(top_k)});
+                                   {static_cast<int64_t>(batch), static_cast<int64_t>(num_spec),
+                                    static_cast<int64_t>(top_k), static_cast<int64_t>(top_k)});
 
   std::vector<const char*> input_names{
       config_.inputs.aux_hidden_states.c_str(), config_.inputs.input_ids.c_str(),

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -137,8 +137,11 @@ std::unique_ptr<Config> CreateDflash2Config(const Config& config) {
   }
   // Every non-anchor query row feeds this id straight into the drafter's embedding lookup, so an
   // out-of-range value is either a crash or silently meaningless drafts.
-  if (dflash2.mask_token_id < 0 ||
-      (config.model.vocab_size > 0 && dflash2.mask_token_id >= config.model.vocab_size)) {
+  if (config.model.vocab_size <= 0) {
+    throw std::runtime_error(
+        "model.vocab_size must be positive to validate model.dflash2.mask_token_id.");
+  }
+  if (dflash2.mask_token_id < 0 || dflash2.mask_token_id >= config.model.vocab_size) {
     throw std::runtime_error(
         "model.dflash2.mask_token_id must be a valid token id in [0, model.vocab_size).");
   }

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -135,6 +135,13 @@ std::unique_ptr<Config> CreateDflash2Config(const Config& config) {
   if (dflash2.num_draft_tokens != dflash2.block_size - 1) {
     throw std::runtime_error("model.dflash2.num_draft_tokens must be block_size - 1.");
   }
+  // Every non-anchor query row feeds this id straight into the drafter's embedding lookup, so an
+  // out-of-range value is either a crash or silently meaningless drafts.
+  if (dflash2.mask_token_id < 0 ||
+      (config.model.vocab_size > 0 && dflash2.mask_token_id >= config.model.vocab_size)) {
+    throw std::runtime_error(
+        "model.dflash2.mask_token_id must be a valid token id in [0, model.vocab_size).");
+  }
   if (dflash2.run_options) {
     for (const auto& [name, value] : *dflash2.run_options) {
       if (name == "disable_synchronize_execution_providers" && value == "1") {
@@ -400,6 +407,13 @@ void Dflash2Drafter::Release(const Request* request) {
   }
   free_blocks_.insert(free_blocks_.end(), entry->second.blocks.begin(), entry->second.blocks.end());
   requests_.erase(entry);
+}
+
+void Dflash2Drafter::ReleaseAll() {
+  for (const auto& [request, state] : requests_) {
+    free_blocks_.insert(free_blocks_.end(), state.blocks.begin(), state.blocks.end());
+  }
+  requests_.clear();
 }
 
 void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> feeds,

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -96,6 +96,12 @@ struct Dflash2Drafter {
   // Returns a request's blocks to the pool. Safe for requests the drafter never saw.
   void Release(const Request* request);
 
+  // Drops every tracked request's cache state and returns its blocks. Used after a recoverable
+  // proposal failure: the drafter's cached context is no longer contiguous with the target for any
+  // in-flight request, and a request can only rejoin from position zero, so those requests finish
+  // without drafts while requests admitted later still get them.
+  void ReleaseAll();
+
  private:
   struct RequestState {
     std::vector<int32_t> blocks;

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -24,6 +24,10 @@ size_t Dflash2DraftWidth(size_t capability_limit, size_t configured_limit,
 Tensor& Dflash2StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device,
                           ONNXTensorElementDataType type, const std::vector<int64_t>& shape);
 
+// Whether a request's search options can ever take a DFlash 2 block. Drafting is greedy-only, and
+// this is fixed when the request is created, so a request this rejects is never fed to the drafter.
+bool Dflash2CanDraft(const Config::Search& search);
+
 /**
  * @brief Hosts the ``dflash2.onnx`` session.
  *

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -19,6 +19,11 @@ size_t Dflash2DraftWidth(size_t capability_limit, size_t configured_limit,
                          size_t sequence_length_after_step, size_t sequence_limit,
                          size_t remaining_turn_tokens_after_step);
 
+// Reshapes a proposal tensor the drafter reuses between steps, replacing its buffer only when a
+// step needs more room than the one it kept.
+Tensor& Dflash2StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device,
+                          ONNXTensorElementDataType type, const std::vector<int64_t>& shape);
+
 /**
  * @brief Hosts the ``dflash2.onnx`` session.
  *
@@ -114,9 +119,6 @@ struct Dflash2Drafter {
   // gets a fixed ring instead, which its block table repeats across every column.
   void EnsureBlocks(RequestState& state, size_t positions);
   void AllocateCache();
-  // Reshapes a reused proposal tensor, replacing its buffer only when a step needs more room.
-  static Tensor& StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device,
-                            ONNXTensorElementDataType type, const std::vector<int64_t>& shape);
 
   std::shared_ptr<Dflash2Model> model_;
   const Config::Model::Dflash2& config_;

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -114,6 +114,9 @@ struct Dflash2Drafter {
   // gets a fixed ring instead, which its block table repeats across every column.
   void EnsureBlocks(RequestState& state, size_t positions);
   void AllocateCache();
+  // Reshapes a reused proposal tensor, replacing its buffer only when a step needs more room.
+  static Tensor& StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device,
+                            ONNXTensorElementDataType type, const std::vector<int64_t>& shape);
 
   std::shared_ptr<Dflash2Model> model_;
   const Config::Model::Dflash2& config_;
@@ -129,6 +132,21 @@ struct Dflash2Drafter {
 
   std::vector<std::unique_ptr<Tensor>> caches_;  // 2 * num_hidden_layers, key then value per layer
   std::vector<std::string> cache_input_names_, cache_output_names_;
+  // Proposal tensors, reused across steps and grown to the high-water mark of the batches served
+  // so far, so a steady-state decode step allocates none of them.
+  struct StepTensors {
+    std::unique_ptr<Tensor> packed_aux;
+    std::unique_ptr<Tensor> input_ids;
+    std::unique_ptr<Tensor> q_row_map;
+    std::unique_ptr<Tensor> qkv_row_map;
+    std::unique_ptr<Tensor> block_row_index;
+    std::unique_ptr<Tensor> cumulative_sequence_lengths;
+    std::unique_ptr<Tensor> past_sequence_lengths;
+    std::unique_ptr<Tensor> block_table;
+    std::unique_ptr<Tensor> attention_metadata;
+    std::unique_ptr<Tensor> candidate_ids;
+    std::unique_ptr<Tensor> scores;
+  } step_tensors_;
   std::vector<int32_t> free_blocks_;
   std::unordered_map<const Request*, RequestState> requests_;
   size_t admission_misses_{};

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -201,6 +201,13 @@ Engine::Engine(std::shared_ptr<Model> model, EngineDependencies dependencies)
   staged_events_.reserve(max_step_event_count_);
   fatal_events_.reserve(max_step_event_count_ + 1);
   mtp_requests_.reserve(max_batch_size);
+  if (dflash2_drafter_) {
+    // Sized here so a committed step never has to grow them, which would make an optional drafter
+    // able to fail the step with a bad_alloc.
+    dflash2_feeds_.reserve(max_batch_size);
+    dflash2_draft_widths_.reserve(max_batch_size);
+    dflash2_drafts_.reserve(max_batch_size);
+  }
 }
 
 Engine::~Engine() {
@@ -328,6 +335,14 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
   dflash2_draft_widths_.reserve(plan.requests.size());
   for (size_t i = 0; i < plan.requests.size(); ++i) {
     const auto& entry = plan.requests[i];
+    const auto& search = entry.request->SearchOptions();
+    // DFlash 2 drafting is greedy-only. A sampled request can never take this drafter's block, so
+    // feeding it would only burn a ring that an eligible request could use. Greediness is fixed
+    // when the request is created, so a request skipped here is skipped for its whole life and
+    // never joins the drafter's contiguity contract.
+    if (search.do_sample && search.top_k != 1 && search.temperature != 0) {
+      continue;
+    }
     const size_t accepted = entry.request->AcceptedDraftTokenCount();
     if (accepted > entry.draft_token_count) {
       throw std::logic_error("DFlash 2 observed more accepted drafts than the target planned.");
@@ -346,8 +361,6 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
     feed.aux_row_count = valid_rows;
     feed.first_position = first_position;
 
-    const auto& search = entry.request->SearchOptions();
-    const bool greedy = !search.do_sample || search.top_k == 1 || search.temperature == 0;
     // The committed length this step ends at: the accepted prefix plus the token just sampled.
     const int64_t length_after_step = static_cast<int64_t>(first_position + valid_rows) +
                                       (results[i].token_appended ? 1 : 0);
@@ -363,7 +376,7 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
         static_cast<size_t>(length_after_step), sequence_limit,
         remaining_turn_tokens_after_step);
     feed.wants_drafts = width > 0 && results[i].token_appended && !results[i].done &&
-                        greedy && !entry.request->DraftTokenValidationError();
+                        !entry.request->DraftTokenValidationError();
     feed.anchor_token = results[i].token;
     dflash2_feeds_.push_back(feed);
     dflash2_draft_widths_.push_back(width);
@@ -390,6 +403,48 @@ void Engine::PublishDflash2Drafts(ScheduledRequests& scheduled_requests) {
     // of the same greedy path.
     drafts.resize(std::min(drafts.size(), dflash2_draft_widths_[i]));
     dflash2_feeds_[i].request->SetDraftTokens(drafts);
+  }
+}
+
+void Engine::RecordDflash2Failure(std::exception_ptr error, bool contract_error) {
+  for (const auto& feed : dflash2_feeds_) {
+    if (feed.request) {
+      feed.request->SetDraftTokens({});
+    }
+  }
+  dflash2_feeds_.clear();
+  // The drafter's cached context stops being contiguous with the target the moment a step's rows
+  // are not ingested, and its contiguity check is a contract violation. Forget every in-flight
+  // request instead, so the retry budget below is spent on real drafter failures rather than on
+  // the bookkeeping gap the first failure left behind.
+  dflash2_drafter_->ReleaseAll();
+  ++speculative_stats_.standard_fallback_steps;
+  ++speculative_stats_.dflash2_failures;
+  ++dflash2_consecutive_failures_;
+  const bool disable_dflash2 = contract_error ||
+                               dflash2_consecutive_failures_ >= kDflash2FailureDisableThreshold;
+  dflash2_disabled_ = disable_dflash2;
+  if (disable_dflash2) {
+    ++speculative_stats_.dflash2_disables;
+  }
+  if (dflash2_consecutive_failures_ != 1 && !disable_dflash2) {
+    return;
+  }
+  // Log() asserts that logging is enabled, and an assertion abort is not catchable, so the guard
+  // has to come before the call rather than inside the try below.
+  if (!g_log.enabled || !g_log.warning) {
+    return;
+  }
+  try {
+    Log("warning", AddExceptionCause(
+                       contract_error
+                           ? "Disabling DFlash 2 after a proposal contract failure."
+                       : disable_dflash2
+                           ? "Disabling DFlash 2 after repeated proposal failures."
+                           : "DFlash 2 proposal failed; using target-only decoding for this step.",
+                       error));
+  } catch (...) {
+    // Diagnostics must not turn an optional drafter failure into a target failure.
   }
 }
 
@@ -1684,7 +1739,10 @@ void Engine::RunDynamic() {
         const bool disable_mtp =
             mtp_consecutive_failures_ >= kMtpFailureDisableThreshold;
         mtp_disabled_ = disable_mtp;
-        if (mtp_consecutive_failures_ == 1 || disable_mtp) {
+        if ((mtp_consecutive_failures_ == 1 || disable_mtp) &&
+            // Log() asserts that logging is enabled, and an assertion abort is not catchable, so
+            // the guard has to come before the call rather than inside the try below.
+            g_log.enabled && g_log.warning) {
           try {
             Log("warning", AddExceptionCause(
                                disable_mtp
@@ -1750,11 +1808,6 @@ void Engine::RunDynamic() {
       if (mtp_step) {
         mtp_step->reservation->PrepareCommit();
       }
-      if (dflash2_drafter_ && !dflash2_disabled_ && MaxDraftTokensPerStep() > 0) {
-        // Reads accepted-draft counts that CommitStep clears below. Keep this fallible work on the
-        // rollback side of the target transaction's commit boundary.
-        PrepareDflash2Feeds(step_plan_, step_results_);
-      }
     } catch (...) {
       const auto preparation_error = std::current_exception();
       rollback_transaction();
@@ -1764,6 +1817,35 @@ void Engine::RunDynamic() {
           nullptr,
           "Transaction preparation failed and the Engine is no longer healthy.",
           preparation_error);
+    }
+
+    bool dflash2_feeds_ready = false;
+    if (dflash2_drafter_ && !dflash2_disabled_ && MaxDraftTokensPerStep() > 0) {
+      // Reads accepted-draft counts that CommitStep clears below. Keep this fallible work on the
+      // rollback side of the target transaction's commit boundary. DFlash 2 is optional, so only a
+      // contract violation is fatal here; anything else falls back to a target-only commit.
+      std::exception_ptr fatal_preparation_error;
+      try {
+        PrepareDflash2Feeds(step_plan_, step_results_);
+        dflash2_feeds_ready = true;
+      } catch (const std::logic_error&) {
+        fatal_preparation_error = std::current_exception();
+      } catch (...) {
+        try {
+          RecordDflash2Failure(std::current_exception(), false);
+        } catch (...) {
+          fatal_preparation_error = std::current_exception();
+        }
+      }
+      if (fatal_preparation_error) {
+        rollback_transaction();
+        MarkUnhealthyAndThrow(
+            StepOutcomeKind::ExecutionContractFailure,
+            step_plan_.transaction_id,
+            nullptr,
+            "Transaction preparation failed and the Engine is no longer healthy.",
+            fatal_preparation_error);
+      }
     }
 
     try {
@@ -1785,20 +1867,12 @@ void Engine::RunDynamic() {
       if (mtp_step) {
         PublishMtpDrafts(*mtp_step);
       }
-      if (dflash2_drafter_ && !dflash2_disabled_ && MaxDraftTokensPerStep() > 0) {
+      if (dflash2_feeds_ready) {
         try {
           PublishDflash2Drafts(scheduled_requests);
           dflash2_consecutive_failures_ = 0;
         } catch (...) {
           const auto dflash2_error = std::current_exception();
-          for (const auto& feed : dflash2_feeds_) {
-            if (feed.request) {
-              feed.request->SetDraftTokens({});
-            }
-          }
-          ++speculative_stats_.standard_fallback_steps;
-          ++speculative_stats_.dflash2_failures;
-          ++dflash2_consecutive_failures_;
           bool contract_error = false;
           try {
             std::rethrow_exception(dflash2_error);
@@ -1806,25 +1880,7 @@ void Engine::RunDynamic() {
             contract_error = true;
           } catch (...) {
           }
-          const bool disable_dflash2 = contract_error ||
-                                       dflash2_consecutive_failures_ >= kDflash2FailureDisableThreshold;
-          dflash2_disabled_ = disable_dflash2;
-          if (disable_dflash2) {
-            ++speculative_stats_.dflash2_disables;
-          }
-          if (dflash2_consecutive_failures_ == 1 || disable_dflash2) {
-            try {
-              Log("warning", AddExceptionCause(
-                                 contract_error
-                                     ? "Disabling DFlash 2 after a proposal contract failure."
-                                 : disable_dflash2
-                                     ? "Disabling DFlash 2 after repeated proposal failures."
-                                     : "DFlash 2 proposal failed; using target-only decoding for this step.",
-                                 dflash2_error));
-            } catch (...) {
-              // Diagnostics must not turn an optional drafter failure into a target failure.
-            }
-          }
+          RecordDflash2Failure(dflash2_error, contract_error);
         }
       }
     } catch (...) {

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -336,11 +336,10 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
   for (size_t i = 0; i < plan.requests.size(); ++i) {
     const auto& entry = plan.requests[i];
     const auto& search = entry.request->SearchOptions();
-    // DFlash 2 drafting is greedy-only. A sampled request can never take this drafter's block, so
-    // feeding it would only burn a ring that an eligible request could use. Greediness is fixed
-    // when the request is created, so a request skipped here is skipped for its whole life and
-    // never joins the drafter's contiguity contract.
-    if (search.do_sample && search.top_k != 1 && search.temperature != 0) {
+    // Feeding a request that can never take a block would only burn a ring an eligible request
+    // could use, and a request skipped here is skipped for its whole life, so it never joins the
+    // drafter's contiguity contract.
+    if (!Dflash2CanDraft(search)) {
       continue;
     }
     const size_t accepted = entry.request->AcceptedDraftTokenCount();

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -232,6 +232,8 @@ struct Engine : std::enable_shared_from_this<Engine>,
   // feeds are captured before Request::CommitStep clears the accepted-draft counts they depend on.
   void PrepareDflash2Feeds(const StepPlan& plan, const std::vector<RequestStepResult>& results);
   void PublishDflash2Drafts(ScheduledRequests& scheduled_requests);
+  // Accounts for a recoverable DFlash 2 failure and decides whether the drafter stays enabled.
+  void RecordDflash2Failure(std::exception_ptr error, bool contract_error);
   void RecordSpeculativeCommit(const StepPlan& plan) noexcept;
   void CloseMtpRequest(const std::shared_ptr<Request>& request);
   [[noreturn]] void HandleContinuationRestoreFailure(

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -283,4 +283,49 @@ TEST(Dflash2ConfigTest, CapsDraftWidthBySessionAndTurnLimits) {
   EXPECT_EQ(Dflash2DraftWidth(7, 5, 9, 10, 9), 0u);
 }
 
+TEST(Dflash2ConfigTest, ReusesProposalBufferUntilAStepOutgrowsIt) {
+  auto* device = GetDeviceInterface(DeviceType::CPU);
+  constexpr auto type = Ort::TypeToTensorType<int32_t>;
+  std::unique_ptr<Tensor> slot;
+
+  Dflash2StepTensor(slot, device, type, {2, 4});
+  EXPECT_EQ(slot->GetElementCount(), 8u);
+  const void* buffer = slot->buffer_;
+  ASSERT_NE(buffer, nullptr);
+
+  // A narrower step reshapes a view over the same buffer instead of allocating.
+  Dflash2StepTensor(slot, device, type, {1, 3});
+  EXPECT_EQ(slot->GetElementCount(), 3u);
+  EXPECT_EQ(slot->GetShape(), (std::vector<int64_t>{1, 3}));
+  EXPECT_EQ(slot->buffer_, buffer);
+
+  // Tensor rejects a static shape larger than its buffer, so growth must start a new one.
+  EXPECT_NO_THROW(Dflash2StepTensor(slot, device, type, {4, 8}));
+  EXPECT_EQ(slot->GetElementCount(), 32u);
+  const void* grown = slot->buffer_;
+
+  Dflash2StepTensor(slot, device, type, {2, 4});
+  EXPECT_EQ(slot->buffer_, grown);
+}
+
+TEST(Dflash2ConfigTest, ReusesProposalBufferForAnEmptyStep) {
+  auto* device = GetDeviceInterface(DeviceType::CPU);
+  constexpr auto type = Ort::TypeToTensorType<int32_t>;
+  std::unique_ptr<Tensor> slot;
+
+  // A step can serve feeds that carry a query block but no context rows.
+  EXPECT_NO_THROW(Dflash2StepTensor(slot, device, type, {0, 64}));
+  EXPECT_EQ(slot->GetElementCount(), 0u);
+  EXPECT_NO_THROW(Dflash2StepTensor(slot, device, type, {2, 64}));
+  EXPECT_EQ(slot->GetElementCount(), 128u);
+}
+
+TEST(Dflash2ConfigTest, RejectsProposalShapesThatOverflow) {
+  auto* device = GetDeviceInterface(DeviceType::CPU);
+  std::unique_ptr<Tensor> slot;
+  const int64_t huge = std::numeric_limits<int64_t>::max();
+  EXPECT_THROW(Dflash2StepTensor(slot, device, Ort::TypeToTensorType<int32_t>, {huge, huge}),
+               std::runtime_error);
+}
+
 }  // namespace Generators::test

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -328,4 +328,35 @@ TEST(Dflash2ConfigTest, RejectsProposalShapesThatOverflow) {
                std::runtime_error);
 }
 
+TEST(Dflash2ConfigTest, ReplacesProposalBufferWhenTheElementTypeChanges) {
+  auto* device = GetDeviceInterface(DeviceType::CPU);
+  std::unique_ptr<Tensor> slot;
+
+  Dflash2StepTensor(slot, device, Ort::TypeToTensorType<int32_t>, {8});
+  // A static Tensor keeps the type it was constructed with, so reusing the buffer for another type
+  // would silently hand the session the wrong element type.
+  Dflash2StepTensor(slot, device, Ort::TypeToTensorType<float>, {4});
+  EXPECT_EQ(slot->GetType(), Ort::TypeToTensorType<float>);
+  EXPECT_EQ(slot->GetElementCount(), 4u);
+}
+
+TEST(Dflash2ConfigTest, DraftsOnlyForGreedyRequests) {
+  Config::Search search;
+  search.do_sample = false;
+  EXPECT_TRUE(Dflash2CanDraft(search));
+
+  search.do_sample = true;
+  search.top_k = 50;
+  search.temperature = 1.0f;
+  EXPECT_FALSE(Dflash2CanDraft(search));
+
+  // Sampling that can only ever pick the top logit is still greedy.
+  search.top_k = 1;
+  EXPECT_TRUE(Dflash2CanDraft(search));
+
+  search.top_k = 50;
+  search.temperature = 0.0f;
+  EXPECT_TRUE(Dflash2CanDraft(search));
+}
+
 }  // namespace Generators::test

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -234,6 +234,10 @@ TEST(Dflash2ConfigTest, RequiresOneDraftPerNonAnchorBlockRow) {
 
 TEST(Dflash2ConfigTest, RequiresMaskTokenInsideVocabulary) {
   auto config = MakeDflash2Config();
+  config.model.vocab_size = 0;
+  EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+
+  config.model.vocab_size = 128;
   config.model.dflash2.mask_token_id = -1;
   EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
 

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -15,6 +15,7 @@ namespace {
 
 Config MakeDflash2Config() {
   Config config;
+  config.model.vocab_size = 128;
   auto& decoder = config.model.decoder;
   decoder.filename = "target.onnx";
   decoder.sliding_window = Config::Model::Decoder::SlidingWindow{4096};
@@ -30,6 +31,7 @@ Config MakeDflash2Config() {
   dflash2.block_size = 4;
   dflash2.num_draft_tokens = 3;
   dflash2.selector_top_k = 2;
+  dflash2.mask_token_id = 31;
   dflash2.sliding_window = 17;
   return config;
 }
@@ -228,6 +230,21 @@ TEST(Dflash2ConfigTest, RequiresOneDraftPerNonAnchorBlockRow) {
   auto config = MakeDflash2Config();
   config.model.dflash2.num_draft_tokens = 2;
   EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+}
+
+TEST(Dflash2ConfigTest, RequiresMaskTokenInsideVocabulary) {
+  auto config = MakeDflash2Config();
+  config.model.dflash2.mask_token_id = -1;
+  EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+
+  config.model.dflash2.mask_token_id = config.model.vocab_size;
+  EXPECT_THROW(CreateDflash2Config(config), std::runtime_error);
+
+  config.model.dflash2.mask_token_id = 0;
+  EXPECT_NO_THROW(CreateDflash2Config(config));
+
+  config.model.dflash2.mask_token_id = config.model.vocab_size - 1;
+  EXPECT_NO_THROW(CreateDflash2Config(config));
 }
 
 TEST(Dflash2ConfigTest, ProjectsDrafterWithoutTargetState) {


### PR DESCRIPTION
Follow-up to #2496. Several review threads on that PR were resolved without a reply, and five of them turned out not to be addressed in the merged code. This fixes those, plus the proposal-tensor allocation the same review asked about.

## Key Changes

### A drafter failure could abort a Debug build

`Log()` starts with `assert(g_log.enabled)`, and logging is off by default. The MTP and DFlash 2 warning paths called it from inside a `try`/`catch`, which cannot catch an assertion abort, so the first drafter failure in a Debug build could take the process down. Both call sites are now guarded with `g_log.enabled && g_log.warning`, matching how the rest of the codebase gates warnings.

### The documented three-failure retry never happened

`Dflash2Drafter` advances `cached_positions` only after a successful run, and `Propose()` rejects a feed whose `first_position` does not match. So after any recoverable failure the target moved on while the drafter did not, and the *next* step raised the contiguity `logic_error` — a contract error, which disables DFlash 2 immediately. The retry budget was unreachable.

A recoverable failure now calls the new `Dflash2Drafter::ReleaseAll()`, which returns every ring to the pool and forgets the tracked requests. A request can only join the drafter from position zero, so those in-flight requests finish without drafts while requests admitted afterwards still get them. The retry budget is now spent on real drafter failures.

### An optional drafter could mark the Engine unhealthy

`PrepareDflash2Feeds()` sat inside the transaction-preparation `try`, so any allocation failure while growing its vectors rolled the step back and marked the Engine permanently unhealthy. It now has its own handler: only a `logic_error` is fatal, anything else counts as a DFlash 2 failure and the step commits target-only. The step vectors are also reserved to `max_batch_size` in the Engine constructor so a committed step never has to grow them.

### Sampled requests claimed drafter rings they could never use

DFlash 2 drafting is greedy-only, but non-greedy requests were still fed to the drafter, took a ring for their whole life, and ran their context through it. With enough of them the ring pool could be exhausted for eligible requests. The new `Dflash2CanDraft()` predicate is checked before the feed is built, and the greedy-only limitation is now documented.

### `mask_token_id` was unvalidated

Any integer was accepted and passed straight to the drafter's embedding lookup; a missing field silently meant token 0. `CreateDflash2Config()` now requires `0 <= mask_token_id < model.vocab_size`.

### Proposal tensors were rebuilt every token

Every `Propose()` call allocated eleven fresh tensors. They now live in a `StepTensors` member and reshape a view over a buffer the drafter keeps, via `Dflash2StepTensor()`, which replaces the buffer only when a step outgrows the high-water mark or changes element type. A steady-state decode step allocates none of them. The per-step block-table fill also no longer blanks the whole table first, since the windowed path writes every column anyway.

The block table's *width* still tracks absolute KV length, and that is deliberate: `PagedAttention` resolves slots as `block_table[b][(past_seqlens[b] + offset) / block_size]` and rotates K with that same absolute position before the cache write, so a window-relative table would need an operator change. This matches what `PagedKeyValueCache::FillBlockTables` already does for the main model's windowed layers.

## Testing Notes

`test/cpp/dflash2_config_test.cpp` gains eight tests (`engine_unit_tests`, no GPU or model needed):

| Test | Guards |
|---|---|
| `RequiresMaskTokenInsideVocabulary` | lower/upper bounds and both valid endpoints |
| `ReusesProposalBufferUntilAStepOutgrowsIt` | a narrower step keeps the buffer; a wider step starts a new one. `Tensor` throws on a static shape larger than its buffer, so dropping the growth check fails this test |
| `ReusesProposalBufferForAnEmptyStep` | the zero-context-row step and the capacity floor |
| `ReplacesProposalBufferWhenTheElementTypeChanges` | a static `Tensor` keeps its construction type, so a reused slot must not silently hand the session the wrong one |
| `RejectsProposalShapesThatOverflow` | the checked size arithmetic still throws |
| `DraftsOnlyForGreedyRequests` | the greedy-only rule, including `top_k == 1` and `temperature == 0` counting as greedy |

Run:

```bash
cmake --build build/<config> --target engine_unit_tests
build/<config>/engine_unit_tests --gtest_filter=Dflash2*
```

Full suite: 465/465 pass. `lintrunner` is clean.

## Not addressed

- **No `Propose()` or Engine-step test.** `engine_unit_tests` builds requests from a fixture model that never runs a graph, and `Dflash2Drafter`'s constructor needs a real session, so covering `Propose()`, ring reuse, admission, or the disable path needs either a drafter interface with a test double or a tiny executable `dflash2.onnx`. The pure host-side rules those paths depend on are unit-tested above.
- **Drafter scratch is still outside the cache budget.** Buffers now settle at the high-water mark rather than being allocated per step. Practically this is close to what already happened, since `p_device_inputs_` is an ORT arena that never returned the per-step allocations to the driver, but accounting it in `ComputeNumBlocks` is a separate cache-sizing change.
