### PR TITLE
Enable per-turn generation options in the Engine

### DIFF
--- a/benchmark/engine/README.md
+++ b/benchmark/engine/README.md
@@ -125,12 +125,17 @@ Each config is a list of scenario entries:
 | `execution_provider_library` | Path to the provider plugin. Required for `cuda`, registered once per process. |
 | `generation_tokens` | Tokens generated per request. |
 
+`long_prefill` and `mixed_workload` truncate a RULER prompt that would leave no room for generation
+within the model-configured session limit, reporting both requested and actual token counts.
+`capacity_pressure` does not truncate; over-ceiling prompts are reported as rejected admissions.
+
 `mixed_workload` runs one long-prefill request alongside active decode requests. The full and
-focused matrices use a hardcoded 128K prefill at concurrency 4 and 8; the smoke test uses the
-smallest 0.5B, concurrency-4 entry. In this scenario, the long-prefill request is intentionally
-capped to one generated token while decode requests keep `generation_tokens`; this keeps the
-prefill request from pushing max-length/context usage into unstable CUDA/KV-pressure territory
-while still measuring prefill-vs-decode interference.
+focused matrices request a 128K prefill at concurrency 4 and 8; the prompt is capped to leave room
+for generation within the model's configured session limit. The smoke test uses the smallest 0.5B,
+concurrency-4 entry. In this scenario, the long-prefill request is intentionally capped to one
+generated token while decode requests keep `generation_tokens`; this keeps the prefill request from
+pushing max-length/context usage into unstable CUDA/KV-pressure territory while still measuring
+prefill-vs-decode interference.
 
 `continuation` runs three appended turns for each logical request. Each turn submits the previous
 turn's generated tokens as part of the next prompt, so the benchmark measures session-cache reuse

--- a/benchmark/engine/scenarios/capacity_pressure.cpp
+++ b/benchmark/engine/scenarios/capacity_pressure.cpp
@@ -79,7 +79,8 @@ ScenarioExecutionOutput CapacityPressureScenario::Execute(const ScenarioConfig& 
 
   for (int run = 0; run < total_runs; ++run) {
     const bool is_warmup = run < config.warmup_runs;
-    std::vector<std::unique_ptr<OgaGeneratorParams>> params;
+    std::vector<std::unique_ptr<OgaRequestOptions>> request_options;
+    std::vector<std::unique_ptr<OgaTurnOptions>> turn_options;
     std::vector<std::unique_ptr<OgaRequest>> requests(
         static_cast<size_t>(config.concurrency));
     std::vector<std::vector<int32_t>> request_tokens(static_cast<size_t>(config.concurrency));
@@ -88,7 +89,8 @@ ScenarioExecutionOutput CapacityPressureScenario::Execute(const ScenarioConfig& 
     std::vector<bool> admitted(static_cast<size_t>(config.concurrency), false);
     std::vector<bool> rejected(static_cast<size_t>(config.concurrency), false);
     std::unordered_map<const OgaRequest*, size_t> request_indices;
-    params.reserve(static_cast<size_t>(config.concurrency));
+    request_options.reserve(static_cast<size_t>(config.concurrency));
+    turn_options.reserve(static_cast<size_t>(config.concurrency));
 
     const auto run_start = std::chrono::steady_clock::now();
     int admitted_count = 0;
@@ -103,14 +105,19 @@ ScenarioExecutionOutput CapacityPressureScenario::Execute(const ScenarioConfig& 
       const auto& prompt = pressure_prompts[request_index];
       const size_t prompt_count = prompt->SequenceCount(0);
       prompt_counts[request_index] = prompt_count;
-      params.emplace_back(OgaGeneratorParams::Create(*engineResources.model));
-      params.back()->SetSearchOption("max_length", static_cast<double>(prompt_count + config.generation_tokens));
-      params.back()->SetSearchOption("random_seed", kRandomSeed);
+      request_options.emplace_back(OgaRequestOptions::Create());
+      request_options.back()->SetMaxSessionTokens(prompt_count + config.generation_tokens);
       request_tokens[request_index].assign(prompt->SequenceData(0), prompt->SequenceData(0) + prompt_count);
 
       try {
-        auto request = engineResources.engine->CreateRequest(*params.back());
-        request->BeginTurn(prompt->SequenceData(0), prompt_count);
+        auto request =
+            engineResources.engine->CreateRequest(request_options.back().get());
+        turn_options.push_back(request->CreateTurnOptions());
+        if (engineResources.uses_dynamic_batching) {
+          turn_options.back()->SetSeed(kRandomSeed);
+        }
+        request->BeginTurn(prompt->SequenceData(0), prompt_count,
+                           turn_options.back().get());
         request_indices.emplace(request.get(), request_index);
         requests[request_index] = std::move(request);
       } catch (const std::exception& ex) {

--- a/benchmark/engine/scenarios/continuation.cpp
+++ b/benchmark/engine/scenarios/continuation.cpp
@@ -74,12 +74,12 @@ ScenarioExecutionOutput ContinuationScenario::Execute(const ScenarioConfig& conf
   for (int run = 0; run < total_runs; ++run) {
     const bool is_warmup = run < config.warmup_runs;
 
-    std::vector<std::unique_ptr<OgaGeneratorParams>> params;
+    std::vector<std::unique_ptr<OgaRequestOptions>> request_options;
     std::vector<std::unique_ptr<OgaRequest>> requests;
     std::vector<std::unique_ptr<OgaTurnOptions>> turn_options;
     std::vector<std::vector<int32_t>> request_tokens(static_cast<size_t>(config.concurrency));
     std::unordered_map<const OgaRequest*, size_t> request_indices;
-    params.reserve(static_cast<size_t>(config.concurrency));
+    request_options.reserve(static_cast<size_t>(config.concurrency));
     requests.reserve(static_cast<size_t>(config.concurrency));
     turn_options.reserve(static_cast<size_t>(config.concurrency));
 
@@ -88,15 +88,19 @@ ScenarioExecutionOutput ContinuationScenario::Execute(const ScenarioConfig& conf
     for (int i = 0; i < config.concurrency; ++i) {
       const size_t request_index = static_cast<size_t>(i);
       request_tokens[request_index].assign(base_prompt->SequenceData(0), base_prompt->SequenceData(0) + base_prompt_count);
-      params.emplace_back(OgaGeneratorParams::Create(*engineResources.model));
-      params.back()->SetSearchOption("max_length", static_cast<double>(max_session_tokens));
-      params.back()->SetSearchOption("random_seed", kRandomSeed + i);
+      request_options.emplace_back(OgaRequestOptions::Create());
+      request_options.back()->SetMaxSessionTokens(max_session_tokens);
       requests.emplace_back(
-          engineResources.engine->CreateRequest(*params.back()));
+          engineResources.engine->CreateRequest(request_options.back().get()));
       request_indices.emplace(requests.back().get(), request_index);
       turn_options.push_back(requests.back()->CreateTurnOptions());
       turn_options.back()->SetMaxGeneratedTokens(
           static_cast<uint64_t>(config.generation_tokens));
+      if (engineResources.uses_dynamic_batching) {
+        // Seed only the first turn; continuation turns reuse the same options object, so the seed
+        // is cleared below to keep the request on one continuous random stream.
+        turn_options.back()->SetSeed(static_cast<uint64_t>(kRandomSeed + i));
+      }
       requests.back()->BeginTurn(
           base_prompt->SequenceData(0), base_prompt_count,
           turn_options.back().get());
@@ -187,6 +191,7 @@ ScenarioExecutionOutput ContinuationScenario::Execute(const ScenarioConfig& conf
       if (turn + 1 < kContinuationTurns) {
         for (int i = 0; i < config.concurrency; ++i) {
           const size_t request_index = static_cast<size_t>(i);
+          turn_options[request_index]->ClearSeed();
           if (generated_segments[request_index].empty()) {
             throw std::runtime_error(Name() + ": no generated tokens available for continuation");
           }

--- a/benchmark/engine/scenarios/decode_baseline.cpp
+++ b/benchmark/engine/scenarios/decode_baseline.cpp
@@ -87,13 +87,15 @@ ScenarioExecutionOutput DecodeBaselineScenario::Execute(const ScenarioConfig& co
   for (int run = 0; run < total_runs; ++run) {
     const bool is_warmup = run < config.warmup_runs;
 
-    std::vector<std::unique_ptr<OgaGeneratorParams>> params;
+    std::vector<std::unique_ptr<OgaRequestOptions>> request_options;
+    std::vector<std::unique_ptr<OgaTurnOptions>> turn_options;
     std::vector<RequestRunState> request_states(static_cast<size_t>(config.concurrency));
     std::vector<std::unique_ptr<OgaRequest>> requests;
     std::unordered_map<const OgaRequest*, RequestRunState*>
         request_states_by_request;
 
-    params.reserve(static_cast<size_t>(config.concurrency));
+    request_options.reserve(static_cast<size_t>(config.concurrency));
+    turn_options.reserve(static_cast<size_t>(config.concurrency));
     requests.reserve(static_cast<size_t>(config.concurrency));
 
     // Start timing before submission so TTFT captures arrival-to-first-token, including admission.
@@ -101,21 +103,26 @@ ScenarioExecutionOutput DecodeBaselineScenario::Execute(const ScenarioConfig& co
     size_t generated_tokens = 0;
 
     for (int i = 0; i < config.concurrency; ++i) {
-      params.emplace_back(OgaGeneratorParams::Create(*engineResources.model));
-      const size_t max_length = prompt_token_count + static_cast<size_t>(config.generation_tokens);
-      params.back()->SetSearchOption(
-          "max_length", static_cast<double>(max_length));
-      params.back()->SetSearchOption("random_seed", kRandomSeed);
+      request_options.emplace_back(OgaRequestOptions::Create());
+      const size_t max_session_tokens =
+          prompt_token_count + static_cast<size_t>(config.generation_tokens);
+      request_options.back()->SetMaxSessionTokens(max_session_tokens);
 
       auto& request_state = request_states[static_cast<size_t>(i)];
       request_state.tokens.assign(
           prompt_tokens->SequenceData(0), prompt_tokens->SequenceData(0) + prompt_token_count);
 
-      requests.emplace_back(engineResources.engine->CreateRequest(*params.back()));
+      requests.emplace_back(
+          engineResources.engine->CreateRequest(request_options.back().get()));
       request_states_by_request.emplace(
           requests.back().get(), &request_state);
+      turn_options.push_back(requests.back()->CreateTurnOptions());
+      if (engineResources.uses_dynamic_batching) {
+        turn_options.back()->SetSeed(kRandomSeed);
+      }
       requests.back()->BeginTurn(
-          prompt_tokens->SequenceData(0), prompt_token_count);
+          prompt_tokens->SequenceData(0), prompt_token_count,
+          turn_options.back().get());
     }
 
     auto event_buffer = engineResources.engine->CreateEventBuffer(

--- a/benchmark/engine/scenarios/long_prefill.cpp
+++ b/benchmark/engine/scenarios/long_prefill.cpp
@@ -63,7 +63,15 @@ ScenarioExecutionOutput LongPrefillScenario::Execute(const ScenarioConfig& confi
 
   std::mt19937 prompt_random(kRandomSeed);
   auto prompt_tokens = BuildRulerPromptTokens(prompt_length_k, *engineResources.tokenizer, prompt_random);
-  const size_t prompt_token_count = prompt_tokens->SequenceCount(0);
+  const size_t requested_prompt_token_count = prompt_tokens->SequenceCount(0);
+  const size_t prompt_token_count = FitPromptToSessionLimit(
+      requested_prompt_token_count, static_cast<size_t>(config.generation_tokens),
+      engineResources.model_max_session_tokens);
+  if (prompt_token_count != requested_prompt_token_count) {
+    std::cout << tag << "Prompt truncated from " << requested_prompt_token_count
+              << " to " << prompt_token_count
+              << " tokens to fit the model session limit" << std::endl;
+  }
 
   ScenarioExecutionOutput output;
   std::vector<double> ttft_values;
@@ -74,13 +82,18 @@ ScenarioExecutionOutput LongPrefillScenario::Execute(const ScenarioConfig& confi
 
   for (int run = 0; run < total_runs; ++run) {
     const bool is_warmup = run < config.warmup_runs;
-    auto params = OgaGeneratorParams::Create(*engineResources.model);
-    params->SetSearchOption("max_length", static_cast<double>(prompt_token_count + static_cast<size_t>(config.generation_tokens)));
-    params->SetSearchOption("random_seed", kRandomSeed);
+    auto request_options = OgaRequestOptions::Create();
+    request_options->SetMaxSessionTokens(
+        prompt_token_count + static_cast<size_t>(config.generation_tokens));
 
-    auto request = engineResources.engine->CreateRequest(*params);
+    auto request = engineResources.engine->CreateRequest(request_options.get());
+    auto turn_options = request->CreateTurnOptions();
+    if (engineResources.uses_dynamic_batching) {
+      turn_options->SetSeed(kRandomSeed);
+    }
     request->BeginTurn(
-        prompt_tokens->SequenceData(0), prompt_token_count);
+        prompt_tokens->SequenceData(0), prompt_token_count,
+        turn_options.get());
 
     const auto start = std::chrono::steady_clock::now();
     auto event_buffer = engineResources.engine->CreateEventBuffer(1);
@@ -133,7 +146,9 @@ ScenarioExecutionOutput LongPrefillScenario::Execute(const ScenarioConfig& confi
   output.scenario_metrics = {
       {"prefill_ms", std::move(prefill_ms_values)},
       {"prompt_processing_tps", std::move(prompt_processing_tps_values)},
+      {"requested_prompt_tokens", requested_prompt_token_count},
       {"prompt_tokens", prompt_token_count},
+      {"prompt_truncated", prompt_token_count != requested_prompt_token_count},
       {"peak_host_memory_mb", BytesToMb(memory.PeakHostBytes())},
   };
 

--- a/benchmark/engine/scenarios/mixed_workload.cpp
+++ b/benchmark/engine/scenarios/mixed_workload.cpp
@@ -64,8 +64,21 @@ ScenarioExecutionOutput MixedWorkloadScenario::Execute(const ScenarioConfig& con
   std::mt19937 prompt_random(kRandomSeed);
   auto decode_prompt = BuildRulerPromptTokens(prompt_length_k, *engineResources.tokenizer, prompt_random);
   auto prefill_prompt = BuildRulerPromptTokens(kPrefillPromptLengthK, *engineResources.tokenizer, prompt_random);
-  const size_t decode_prompt_count = decode_prompt->SequenceCount(0);
-  const size_t prefill_prompt_count = prefill_prompt->SequenceCount(0);
+  const size_t requested_decode_prompt_count = decode_prompt->SequenceCount(0);
+  const size_t requested_prefill_prompt_count = prefill_prompt->SequenceCount(0);
+  const size_t decode_prompt_count = FitPromptToSessionLimit(
+      requested_decode_prompt_count, static_cast<size_t>(config.generation_tokens),
+      engineResources.model_max_session_tokens);
+  const size_t prefill_prompt_count = FitPromptToSessionLimit(
+      requested_prefill_prompt_count, static_cast<size_t>(kPrefillGenerationTokens),
+      engineResources.model_max_session_tokens);
+  if (decode_prompt_count != requested_decode_prompt_count ||
+      prefill_prompt_count != requested_prefill_prompt_count) {
+    std::cout << tag << "Prompts fitted to the model session limit: decode "
+              << requested_decode_prompt_count << " -> " << decode_prompt_count
+              << ", prefill " << requested_prefill_prompt_count << " -> "
+              << prefill_prompt_count << " tokens" << std::endl;
+  }
 
   ScenarioExecutionOutput output;
   std::vector<double> decode_ttft_values;
@@ -79,8 +92,9 @@ ScenarioExecutionOutput MixedWorkloadScenario::Execute(const ScenarioConfig& con
   for (int run = 0; run < total_runs; ++run) {
     const bool is_warmup = run < config.warmup_runs;
 
-    // Co-schedule one 128K prefill with active decode requests in the same engine workload.
-    std::vector<std::unique_ptr<OgaGeneratorParams>> params;
+    // Co-schedule one long prefill with active decode requests in the same engine workload.
+    std::vector<std::unique_ptr<OgaRequestOptions>> request_options;
+    std::vector<std::unique_ptr<OgaTurnOptions>> turn_options;
     std::vector<std::unique_ptr<OgaRequest>> requests;
     std::vector<std::vector<int32_t>> request_tokens(static_cast<size_t>(config.concurrency));
     std::vector<size_t> prompt_counts(static_cast<size_t>(config.concurrency), decode_prompt_count);
@@ -89,7 +103,8 @@ ScenarioExecutionOutput MixedWorkloadScenario::Execute(const ScenarioConfig& con
     std::vector<std::chrono::steady_clock::time_point> last_token_time(static_cast<size_t>(config.concurrency));
     std::vector<std::vector<double>> request_itl_ms(static_cast<size_t>(config.concurrency));
     std::unordered_map<const OgaRequest*, size_t> request_indices;
-    params.reserve(static_cast<size_t>(config.concurrency));
+    request_options.reserve(static_cast<size_t>(config.concurrency));
+    turn_options.reserve(static_cast<size_t>(config.concurrency));
     requests.reserve(static_cast<size_t>(config.concurrency));
 
     const auto run_start = std::chrono::steady_clock::now();
@@ -102,14 +117,18 @@ ScenarioExecutionOutput MixedWorkloadScenario::Execute(const ScenarioConfig& con
       const int generation_tokens = i == 0 ? kPrefillGenerationTokens : config.generation_tokens;
       prompt_counts[static_cast<size_t>(i)] = prompt_count;
       target_generation_tokens[static_cast<size_t>(i)] = generation_tokens;
-      params.emplace_back(OgaGeneratorParams::Create(*engineResources.model));
-      params.back()->SetSearchOption("max_length", static_cast<double>(prompt_count + generation_tokens));
-      params.back()->SetSearchOption("random_seed", kRandomSeed);
+      request_options.emplace_back(OgaRequestOptions::Create());
+      request_options.back()->SetMaxSessionTokens(prompt_count + generation_tokens);
       request_tokens[static_cast<size_t>(i)].assign(prompt->SequenceData(0), prompt->SequenceData(0) + prompt_count);
       requests.emplace_back(
-          engineResources.engine->CreateRequest(*params.back()));
+          engineResources.engine->CreateRequest(request_options.back().get()));
       request_indices.emplace(requests.back().get(), static_cast<size_t>(i));
-      requests.back()->BeginTurn(prompt->SequenceData(0), prompt_count);
+      turn_options.push_back(requests.back()->CreateTurnOptions());
+      if (engineResources.uses_dynamic_batching) {
+        turn_options.back()->SetSeed(kRandomSeed);
+      }
+      requests.back()->BeginTurn(prompt->SequenceData(0), prompt_count,
+                                 turn_options.back().get());
     }
 
     // Measure whether the long prefill delays decode first-token and inter-token latency.
@@ -210,8 +229,12 @@ ScenarioExecutionOutput MixedWorkloadScenario::Execute(const ScenarioConfig& con
       {"e2e_ms", std::move(e2e_ms_values)},
       {"tokens_per_s", std::move(tokens_per_s_values)},
       {"prefill_ttft_ms", std::move(prefill_ttft_ms_values)},
+      {"requested_decode_prompt_tokens", requested_decode_prompt_count},
       {"decode_prompt_tokens", decode_prompt_count},
+      {"requested_prefill_prompt_tokens", requested_prefill_prompt_count},
       {"prefill_prompt_tokens", prefill_prompt_count},
+      {"prompt_truncated", decode_prompt_count != requested_decode_prompt_count ||
+                               prefill_prompt_count != requested_prefill_prompt_count},
       {"prefill_generation_tokens", kPrefillGenerationTokens},
       {"peak_host_memory_mb", BytesToMb(memory.PeakHostBytes())},
   };

--- a/benchmark/engine/scenarios/utils.cpp
+++ b/benchmark/engine/scenarios/utils.cpp
@@ -179,6 +179,24 @@ std::string ResolveModelPath(const std::string& model_path) {
 
 EngineResources::EngineResources(const ScenarioConfig& config) {
   const std::string resolved_model_path = ResolveModelPath(config.model_path);
+  std::ifstream config_file(fs::path(resolved_model_path) / "genai_config.json");
+  if (!config_file) {
+    throw std::runtime_error("Unable to open genai_config.json in model_path: " + resolved_model_path);
+  }
+  nlohmann::json model_config;
+  config_file >> model_config;
+  const auto context_length = model_config.at("model").at("context_length").get<int64_t>();
+  const auto search = model_config.value("search", nlohmann::json::object());
+  const auto configured_max_length = search.value("max_length", int64_t{0});
+  const auto max_length = configured_max_length == 0 ? context_length : configured_max_length;
+  if (max_length <= 0) {
+    throw std::runtime_error("The model's session token limit must be greater than zero");
+  }
+  model_max_session_tokens = static_cast<size_t>(max_length);
+  const auto engine_config = model_config.value("engine", nlohmann::json::object());
+  uses_dynamic_batching =
+      engine_config.contains("dynamic_batching") &&
+      !engine_config.contains("static_batching");
 
   oga_config = OgaConfig::Create(resolved_model_path.c_str());
   oga_config->ClearProviders();
@@ -213,6 +231,14 @@ std::unique_ptr<OgaSequences> BuildRulerPromptTokens(
   const std::string prompt = prompts.at(distribution(random)).get<std::string>();
   tokenizer.Encode(prompt.c_str(), *prompt_tokens);
   return prompt_tokens;
+}
+
+size_t FitPromptToSessionLimit(
+    size_t prompt_tokens, size_t generated_tokens, size_t max_session_tokens) {
+  if (generated_tokens >= max_session_tokens) {
+    throw std::invalid_argument("The model's session token limit leaves no room for the benchmark prompt");
+  }
+  return std::min(prompt_tokens, max_session_tokens - generated_tokens);
 }
 
 MemorySampler::MemorySampler(std::chrono::milliseconds interval) : interval_(interval) {}

--- a/benchmark/engine/scenarios/utils.h
+++ b/benchmark/engine/scenarios/utils.h
@@ -105,6 +105,8 @@ class MemorySampler {
 struct EngineResources {
   explicit EngineResources(const ScenarioConfig& config);
 
+  size_t model_max_session_tokens{};
+  bool uses_dynamic_batching{};
   std::unique_ptr<OgaConfig> oga_config;
   std::unique_ptr<OgaModel> model;
   std::unique_ptr<OgaTokenizer> tokenizer;
@@ -163,5 +165,7 @@ std::string ResolveModelPath(const std::string& model_path);
 EngineResources CreateEngineResources(const ScenarioConfig& config);
 std::unique_ptr<OgaSequences> BuildRulerPromptTokens(
     int prompt_length_k, const OgaTokenizer& tokenizer, std::mt19937& random);
+size_t FitPromptToSessionLimit(
+    size_t prompt_tokens, size_t generated_tokens, size_t max_session_tokens);
 
 }  // namespace engine_benchmark

--- a/benchmark/python/benchmark_engine_guidance.py
+++ b/benchmark/python/benchmark_engine_guidance.py
@@ -118,16 +118,20 @@ def validate_output(output):
 
 def run_once(engine, model, tokenizer, prompt_tokens, max_length, guided):
     setup_started = time.perf_counter()
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=max_length)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(max_length)
+    request = engine.create_request(options=request_options)
+    turn_options = og.TurnOptions(request)
+    # Benchmark output must be deterministic, so every turn selects the top logit explicitly rather
+    # than inheriting whatever the model's search defaults are.
+    turn_options.set_do_sample(False)
     if guided:
-        params.set_guidance("lark_grammar", f"start: %json {json.dumps(SCHEMA)}\n")
-    request = engine.create_request(params)
+        turn_options.set_guidance("lark_grammar", f"start: %json {json.dumps(SCHEMA)}\n")
     setup_ms = (time.perf_counter() - setup_started) * 1000
 
     try:
         admission_started = time.perf_counter()
-        request.begin_turn(np.asarray(prompt_tokens, dtype=np.int32))
+        request.begin_turn(np.asarray(prompt_tokens, dtype=np.int32), turn_options)
         admission_ms = (time.perf_counter() - admission_started) * 1000
         output, metrics = generate(engine, request, tokenizer, setup_started)
     finally:

--- a/docs/ConstrainedDecoding.md
+++ b/docs/ConstrainedDecoding.md
@@ -23,4 +23,5 @@ generation.
 
 Builds created without guidance support reject a request that supplies guidance instead of silently
 generating unconstrained output. Configure the build with `USE_GUIDANCE=ON` (or the corresponding
-build-script option) before enabling guidance in `GeneratorParams`.
+build-script option) before enabling guidance in `GeneratorParams` (classic Generator) or in
+`OgaTurnOptions` (Engine, where guidance is scoped to one turn).

--- a/docs/engine_c_api_spec.md
+++ b/docs/engine_c_api_spec.md
@@ -168,7 +168,9 @@ Rules:
   empty grammar are meaningful values rather than "unset".
 - `min_generated_tokens` masks the end-of-sequence token until the turn has generated that many
   tokens. It does not prevent stop strings, turn or session limits, cancellation, failure, or
-  guidance termination.
+  guidance termination. An extendable accepting grammar continues under the minimum, but once
+  guidance permits EOS and no continuation token, its termination takes precedence rather than
+  leaving the turn with no legal token.
 - Admission rejects an explicitly set distribution scalar that contradicts a resolved greedy policy,
   so a caller never believes a turn sampled when it selected the top logit. A `temperature` other
   than 0 or 1, a nucleus `top_p` strictly between 0 and 1, and a `top_k` above 1 all contradict

--- a/docs/engine_c_api_spec.md
+++ b/docs/engine_c_api_spec.md
@@ -2,9 +2,9 @@
 
 > **Status:** Implemented experimental contract.
 >
-> This specification describes the experimental Engine C API. It is
-> deliberately independent of the classic Generator API except where retaining
-> `OgaGeneratorParams` avoids an unnecessary runtime refactor.
+> This specification describes the experimental Engine C API. It is independent of the classic
+> Generator API: Engine Request creation does not accept `OgaGeneratorParams`, and the classic
+> Generator surface is unchanged.
 
 ## Goals
 
@@ -19,8 +19,9 @@ Model
 
 The redesign must:
 
-- preserve the supported request-level `OgaGeneratorParams` configuration for one-sequence,
-  one-beam Engine Requests; unsupported modes remain rejected;
+- keep ownership of configuration at the level that owns the state: model/Engine configuration for
+  the runtime, `OgaRequestOptions` for resident-session policy, and `OgaTurnOptions` for one turn's
+  generation policy;
 - make Request and Turn limits explicit;
 - identify every Turn;
 - cancel only the intended Turn;
@@ -48,9 +49,9 @@ setters without public field-presence rules. `OgaEngineEvent` and `OgaTurnUsage`
 through getters, so the API publishes no layout, size, alignment, version, or stride contract.
 `OgaEngineEventBuffer` owns the event objects and exposes borrowed views.
 
-`OgaGeneratorParams` remains in Request creation initially. Internally, `Search`, RNG, sampling,
-guidance, allocation limits, and model execution currently consume `GeneratorParams`. Replacing it
-with an Engine-bound opaque `OgaRequestParams` is deferred until that ownership is refactored.
+Request creation takes no generation parameters. The Engine derives each Request's private search
+configuration from its own model, forcing a single sequence and a single beam, so no caller-supplied
+`GeneratorParams` field can reach the Engine and be silently ignored.
 
 ### Request options
 
@@ -68,10 +69,11 @@ Rules:
 
 - `OgaRequestOptions` is an opaque, reusable, caller-owned handle.
 - Conversion from `uint64_t` to internal sizes is checked before mutation.
-- Null options or zero `max_session_tokens` use the Request's snapshotted
-  `OgaGeneratorParams.search.max_length`. That search value normally defaults from the model context
-  length, but the caller may set it lower before Request creation.
-- A nonzero `max_session_tokens` may not exceed that snapshotted `search.max_length`.
+- Null options or zero `max_session_tokens` use the model-configured `search.max_length`, which
+  normally defaults from the model context length.
+- A nonzero `max_session_tokens` may not exceed that model-configured ceiling.
+- This is the Request's one session limit: Search completion, cache sizing, speculative bounds, and
+  the `MaxSessionTokens` finish reason all use it.
 - The value counts the initial input, generated tokens, and continuation input over the complete
   resident Request.
 
@@ -88,6 +90,14 @@ OgaResult* OgaTurnOptionsSetMaxGeneratedTokens(
     OgaTurnOptions* options,
     uint64_t max_generated_tokens);
 
+OgaResult* OgaTurnOptionsSetMinGeneratedTokens(
+    OgaTurnOptions* options,
+    uint64_t min_generated_tokens);
+
+OgaResult* OgaTurnOptionsSetDoSample(
+    OgaTurnOptions* options,
+    bool do_sample);
+
 OgaResult* OgaTurnOptionsSetTemperature(
     OgaTurnOptions* options,
     float temperature);
@@ -100,9 +110,19 @@ OgaResult* OgaTurnOptionsSetTopK(
     OgaTurnOptions* options,
     int32_t top_k);
 
+OgaResult* OgaTurnOptionsSetRepetitionPenalty(
+    OgaTurnOptions* options,
+    float repetition_penalty);
+
+OgaResult* OgaTurnOptionsSetNoRepeatNgramSize(
+    OgaTurnOptions* options,
+    int32_t no_repeat_ngram_size);
+
 OgaResult* OgaTurnOptionsSetSeed(
     OgaTurnOptions* options,
     uint64_t seed);
+
+OgaResult* OgaTurnOptionsClearSeed(OgaTurnOptions* options);
 
 OgaResult* OgaTurnOptionsSetStopStrings(
     OgaTurnOptions* options,
@@ -112,21 +132,111 @@ OgaResult* OgaTurnOptionsSetGuidance(
     OgaTurnOptions* options,
     const char* guidance_type,
     const char* guidance_data);
+
+OgaResult* OgaTurnOptionsClearGuidance(OgaTurnOptions* options);
+
+OgaResult* OgaTurnOptionsReset(OgaTurnOptions* options);
 ```
 
-Initial implementation status:
+Every option is unset by default, and an unset option means "use the model-configured default for
+this turn" -- never "keep what the previous turn used". Policy is resolved anew for every
+`OgaRequestBeginTurn`:
 
-| Setting | Initial behavior |
+| Setting | Unset behavior |
 | --- | --- |
-| `max_generated_tokens` | Implemented end to end; zero uses the configured/default limit |
-| `temperature`, `top_p`, `top_k`, `seed` | Setter returns an explicit not-implemented error |
-| UTF-8 stop strings | Implemented end to end for dynamic Engine turns, including speculative draft verification (manual `OgaRequestSetDraftTokens` and automatic in-Engine drafters such as MTP); see "Stop strings" below. A null collection is rejected; an empty collection clears/disables stop strings |
-| guidance | Setter returns an explicit not-implemented error and does not retain/dereference input |
+| `do_sample`, `temperature`, `top_p`, `top_k` | Model `search` defaults |
+| `repetition_penalty`, `no_repeat_ngram_size` | Model `search` defaults, subject to scoring-device capability |
+| `min_generated_tokens` | Zero; the model's session-absolute `search.min_length` is never reinterpreted as a per-turn value |
+| `max_generated_tokens` | Unlimited except for the Request's session limit |
+| `seed` | Continue the Request's existing host and device random streams |
+| stop strings | Disabled |
+| guidance | Disabled |
 
-Unsupported requested behavior must never be accepted and ignored. `OgaTurnOptions` may be reused,
-but `OgaRequestBeginTurn` snapshots all supported values before returning. An options object is
-bound to the Request that created it; passing it to another Request is rejected. The options object does not
-keep the Request alive. Using it after the bound Request is closed or destroyed returns an error.
+Rules:
+
+- Zero unsets `max_generated_tokens` and `min_generated_tokens`: a turn cannot generate zero tokens,
+  and a zero floor is the same thing as no floor.
+- Zero `no_repeat_ngram_size` does *not* unset the option. It explicitly disables n-gram blocking
+  for the turn, which is also what an unset value resolves to whenever the model's
+  `search.no_repeat_ngram_size` is zero. On a model that configures a nonzero size, setting zero is
+  how a turn opts out of it.
+- Zero is a valid deterministic *seed*, so `OgaTurnOptionsClearSeed` is the only way to remove a
+  pending reseed; it means "continue the existing stream", not "randomize again".
+- `OgaTurnOptionsReset` is the whole-object unset mechanism: it restores every option, including
+  `no_repeat_ngram_size`, to unset. There are deliberately no per-scalar clear entry points beyond
+  `OgaTurnOptionsClearSeed` and `OgaTurnOptionsClearGuidance`, which exist only because zero and the
+  empty grammar are meaningful values rather than "unset".
+- `min_generated_tokens` masks the end-of-sequence token until the turn has generated that many
+  tokens. It does not prevent stop strings, turn or session limits, cancellation, failure, or
+  guidance termination.
+- Admission rejects an explicitly set distribution scalar that contradicts a resolved greedy policy,
+  so a caller never believes a turn sampled when it selected the top logit. A `temperature` other
+  than 0 or 1, a nucleus `top_p` strictly between 0 and 1, and a `top_k` above 1 all contradict
+  greedy selection. Values that request greedy selection themselves (`temperature == 0`,
+  `top_k == 1`) or restrict nothing (`top_k == 0`, `top_p` of 0 or 1, `temperature` of 1) are
+  accepted in any combination, so `do_sample = false` together with `top_k = 1` is valid while
+  `do_sample = false` together with `temperature = 0.7` is not.
+- Admission also rejects an explicit `do_sample = true` that a model search default silently
+  overrides, because the model supplies `top_k == 1` or `temperature == 0`. The caller cannot see
+  those defaults through the options object, so the error names the model-supplied cause and the
+  Turn must override that exact field -- a `top_k` above 1, or a nonzero `temperature` -- to sample.
+  A Turn that spells greedy out itself (`top_k = 1` or `temperature = 0` set on the Turn) has chosen
+  it and is accepted alongside `do_sample = true`.
+- A sampled Turn requires a positive `top_k` or a positive `top_p`. Both zero is rejected: it
+  selects from nothing, and it is not the same request as greedy selection.
+- `no_repeat_ngram_size` is rejected at admission on a scoring device whose search cannot apply it,
+  rather than failing after the model has already run.
+- Static batching completes generation on a non-transactional path, so it rejects stop strings and a
+  per-turn seed at admission, before the Request is mutated.
+- Dynamic batching also rejects a per-turn seed when the active batched sampler cannot checkpoint
+  and restore its device RNG state.
+- The complete resolved policy is validated before any Request or Engine mutation, so a rejected
+  turn leaves the previous completed turn entirely reusable.
+
+Unsupported requested behavior must never be accepted and ignored. `OgaTurnOptions` may be reused
+and reapplies its configured fields to every turn it is passed to; `OgaTurnOptionsReset` restores
+every option to unset. `OgaRequestBeginTurn` snapshots all values before returning. An options object
+is bound to the Request that created it; passing it to another Request is rejected. The options
+object does not keep the Request alive. Using it after the bound Request is closed or destroyed
+returns an error.
+
+### Seeds
+
+A turn seed reseeds both the Request's host random stream and its device sampler state at the start
+of the turn. The seed is full-width `uint64_t`; a value below 2^32 reproduces exactly what the
+classic `search.random_seed` produced for the same value.
+
+Every Request has a durable seed basis that its streams start from and that only a committed reseed
+advances. A Request created from a model that configures `search.random_seed` uses that value; a
+Request created from a model that leaves it unset (the default) draws a generated 64-bit basis once,
+at creation, so an unseeded Request is not reproducible across processes while its own later turns
+still continue one stream.
+
+The reseed is applied inside the step transaction, strictly after every checkpoint and strictly
+before the first random consumer, and it becomes durable only when that sampling step commits.
+A rolled-back step restores both streams and leaves the reseed pending, so the retry reseeds
+identically. A turn that is canceled, fails, or otherwise ends before a sampling step commits
+discards its pending reseed without changing the durable basis, leaving the Request on exactly the
+stream position it had before the turn.
+
+Determinism is scoped to the same model, package, provider, platform toolchain, effective turn
+policy, scheduling path, and speculative draft path.
+
+### Guidance
+
+Guidance is strictly turn-scoped. `OgaTurnOptionsSetGuidance` supplies one grammar
+(`json_schema`, `regex`, or `lark_grammar`) for the next admitted turn; `OgaTurnOptionsClearGuidance`
+and an omitted grammar both mean an unguided turn. Guidance is never inherited from a previous turn
+or implicitly enabled from model or Request state.
+
+Both strings are copied immediately. The setter validates the request shape and guidance type.
+Build support and the grammar itself are validated at turn admission, before the Request is mutated,
+so an unsupported or invalid grammar leaves the previous completed turn reusable. Every terminal path --
+completion, stop match, cancellation, failure, and close -- releases the turn's grammar cursor, and a
+rolled-back step restores it.
+
+A guided turn does not accept speculative drafts; the next unguided turn is draft-eligible again.
+Guidance and stop strings can be enabled together.
 
 ### Stop strings
 
@@ -335,7 +445,6 @@ void OgaDestroyEngine(OgaEngine* engine);
 
 OgaResult* OgaEngineCreateRequest(
     OgaEngine* engine,
-    const OgaGeneratorParams* generation_params,
     const OgaRequestOptions* request_options,
     OgaRequest** out);
 
@@ -422,11 +531,30 @@ after Engine destruction, the Buffer remains owned by the caller and must still 
 being passed to Run. Buffer creation and Run honor the Engine owner thread. Buffer access, Run, and
 destruction are serialized; getters may read immutable views but must not race a Run or destruction.
 
-Request creation snapshots the supplied generation parameters. Engine Requests require
-`search.batch_size == 1` and `search.num_beams == 1`; `top_p` must be in `[0, 1]`, and `top_k`
-must be nonnegative. Guidance fast-forward tokens are unsupported, and guidance type and data
-must either both be present or both be absent. The parameters must belong to the same `OgaModel`
-instance used to create the Engine. Creation itself does not queue work.
+Request creation takes no generation parameters. The Engine derives each Request's private search
+configuration from its own model and forces the single-sequence invariants the Engine depends on:
+`batch_size` and `num_beams` are one, the search length limit is the Request's `max_session_tokens`,
+and guidance is off (guidance is per Turn, and fast-forward tokens are never enabled). Nothing about
+sampling, guidance, or stop strings is fixed at creation.
+
+Creation validates the model configuration it is about to derive from, before minting a Request:
+
+- `search.max_length` must be greater than zero. It is the ceiling for `max_session_tokens`, which
+  defaults to it and may be lower but never higher.
+- `search.num_beams` must be one. Beam search is rejected rather than silently forced, because the
+  Request would otherwise decode something the caller never asked for. `search.batch_size` is not
+  rejected: the Engine batches Requests rather than rows, so it simply derives its own single-row
+  search.
+- `search.min_length` must be zero. It is a session-absolute floor, while the Engine's minimum is
+  per Turn (`OgaTurnOptionsSetMinGeneratedTokens`).
+
+The rejections name a route the caller can take without editing the model directory: overlay the
+value on the `Config` before creating the Model, for example
+`OgaConfigOverlay(config, "{\"search\":{\"num_beams\":1}}")`. Raising the session ceiling of a model
+whose `search.max_length` is lower than its context length uses the same overlay route.
+
+Per-Turn generation policy is validated separately, at each `OgaRequestBeginTurn`, before the Turn
+mutates the Request. Creation itself does not queue work.
 
 Input IDs are copied before `BeginTurn` returns. The public count is fixed-width and is converted to
 `size_t` only after range validation. A pointer/count pair is canonical because an Engine Request is
@@ -690,18 +818,12 @@ than parsing diagnostic strings.
 Initial events use borrowed pointer identity. Pointer comparison is a constant-time machine-word
 comparison. No separate Request ID or lookup API is planned.
 
-### Engine-bound Request parameters
-
-A future `OgaRequestParams` may be created from an Engine and replace `OgaGeneratorParams` in
-Request creation. It should preserve search setters while hiding internal `GeneratorParams`.
-This is deferred until Search, RNG, sampling, guidance, and execution ownership are separated from
-the classic Generator parameter type.
-
 ## Language surfaces
 
 ### C++
 
-- RAII `OgaRequestOptions` and `OgaTurnOptions`.
+- RAII `OgaRequestOptions` and `OgaTurnOptions`, the latter created from its Request.
+- `OgaEngine::CreateRequest(const OgaRequestOptions* = nullptr)`.
 - RAII `OgaEngineEventBuffer`, created once with `OgaEngine::CreateEventBuffer(capacity)`.
 - `OgaRequest::BeginTurn` returns `uint64_t`.
 - `OgaRequest::CancelTurn(uint64_t) -> bool`.
@@ -715,9 +837,15 @@ the classic Generator parameter type.
 ### Python
 
 - `RequestOptions.set_max_session_tokens(value)` configures the cumulative Request limit.
-- `Engine.create_request(params, options=None) -> Request`.
+- `Engine.create_request(*, options=None) -> Request`. `options` is keyword-only, so an older
+  positional `create_request(params)` call fails loudly instead of binding generation parameters the
+  Engine no longer accepts.
 - `Request.begin_turn(tokens, turn_options=None) -> int`.
 - `Request.cancel_turn(turn_id) -> bool`.
+- `TurnOptions` mirrors the C setters: `set_max_generated_tokens`, `set_min_generated_tokens`,
+  `set_do_sample`, `set_temperature`, `set_top_p`, `set_top_k`, `set_repetition_penalty`,
+  `set_no_repeat_ngram_size`, `set_seed`, `clear_seed`, `set_stop_strings`, `set_guidance`,
+  `clear_guidance`, and `reset`.
 - `TurnOptions.set_stop_strings(strings)` converts a Python list of `str` to a temporary
   `OgaStringArray` and rejects (raises `ValueError`) any entry containing an embedded NUL byte
   before conversion, since the C string-array surface cannot represent bytes after one. An empty
@@ -744,7 +872,8 @@ is part of the current source surface.
 
 ### Benchmarks and examples
 
-- Keep existing `OgaGeneratorParams` setup for Request creation.
+- Configure the session limit through `OgaRequestOptions` and generation policy through
+  `OgaTurnOptions`; Request creation takes no generation parameters.
 - Replace ready-Request lookup and FIFO draining with event handling.
 - Preserve application-owned maps when additional metadata is needed.
 
@@ -752,8 +881,8 @@ is part of the current source surface.
 
 1. Added opaque Engine option, event, usage, and reusable Buffer handles; kept finish reasons,
    event flags, and error codes fixed-width.
-2. Implemented Turn option creation, supported limit snapshotting, explicit unsupported setters,
-   nonzero Turn IDs, and named cancellation.
+2. Implemented Turn option creation, per-turn policy snapshotting, nonzero Turn IDs, and named
+   cancellation.
 3. Replaced internal ready-Request retention with pre-reserved pending event storage.
 4. Captured token and terminal payload atomically at transaction commit on dynamic and static paths.
 5. Replaced `OgaEngineRun` and removed unseen-token delivery.
@@ -775,11 +904,15 @@ commit buildable; the completed change exposes events only.
 - A Buffer remains safely destructible after its Engine is destroyed and is not passed to Run.
 - Capacity zero validates the owner thread and otherwise does no work.
 - `uint64_t` counts that do not fit internal types are rejected.
-- Unsupported Turn setters return explicit not-implemented errors.
+- Every declared Turn setter is wired end to end; none returns success before the Engine honors it.
 
 ### Request and Turn lifecycle
 
-- Request settings are snapshotted at creation.
+- Request settings are snapshotted at creation, and a model configuration the Engine cannot honor --
+  a nonzero `search.min_length`, a `search.num_beams` other than one, or a nonpositive
+  `search.max_length` -- is rejected there rather than forced.
+- Turn policy is resolved anew for every Turn from model defaults plus that Turn's explicit
+  overrides, and is validated before any Request mutation.
 - Turn IDs begin at one, zero means no Turn, and failed admission does not consume an ID.
 - IDs increase across continuation Turns and exhaustion is rejected before mutation.
 - Named stale cancellation cannot cancel a successor Turn.

--- a/docs/engine_c_api_spec.md
+++ b/docs/engine_c_api_spec.md
@@ -184,6 +184,9 @@ Rules:
   it and is accepted alongside `do_sample = true`.
 - A sampled Turn requires a positive `top_k` or a positive `top_p`. Both zero is rejected: it
   selects from nothing, and it is not the same request as greedy selection.
+- A sampled Turn rejects a resolved `top_k` greater than the model vocabulary size. If that value
+  came from the model's `search.top_k`, the error names the model default so the Turn can override
+  it explicitly.
 - `no_repeat_ngram_size` is rejected at admission on a scoring device whose search cannot apply it,
   rather than failing after the model has already run.
 - Static batching completes generation on a non-transactional path, so it rejects stop strings and a
@@ -211,6 +214,10 @@ advances. A Request created from a model that configures `search.random_seed` us
 Request created from a model that leaves it unset (the default) draws a generated 64-bit basis once,
 at creation, so an unseeded Request is not reproducible across processes while its own later turns
 still continue one stream.
+
+A greedy step consumes neither the Request's host random stream nor its persistent device sampler
+state. Adding or lengthening a greedy Turn therefore does not shift the random draws used by a later
+unseeded sampled Turn.
 
 The reseed is applied inside the step transaction, strictly after every checkpoint and strictly
 before the first random consumer, and it becomes durable only when that sampling step commits.

--- a/docs/paged_attention_batching.md
+++ b/docs/paged_attention_batching.md
@@ -74,15 +74,20 @@ It is a poor fit for a server.
 The path used by `PagedAttention` models. Requests arrive and depart independently; each step the
 scheduler picks whichever requests are runnable and forms a batch out of them.
 
-Each `Request` owns its own `GeneratorParams` and its own single-sequence `Search`:
+Each `Request` derives its own private, Model-derived search parameters and owns its own
+single-sequence `Search`:
 
 ```cpp
 // src/engine/request.cpp
-Request::Request(std::shared_ptr<GeneratorParams> params)
-    : params_{params}, search_{CreateSearch(*params.get())} {
+Request::Request(const Model& model, size_t max_session_tokens, ...)
+    : params_{CreateRequestParams(model, max_session_tokens)},
+      search_{CreateSearch(*params_)} {
   search_->DeferCompletion(true);
 }
 ```
+
+Generation policy does not live there. It is resolved per turn into an `EffectiveTurnPolicy` from
+the model defaults plus that turn's explicit overrides.
 
 The decoder IO is chosen from the cache manager, which is chosen from config:
 
@@ -244,28 +249,28 @@ existing two-phase per-request loop runs unchanged.
   per-request loops, which would otherwise leave holes in the logits rows that a single batched
   sampler call cannot express.
 - Every scheduled request resolves to the same `(k, p, temperature)` triple. `Request` funnels every
-  sampling branch into `SampleTopKTopP`, so comparing the resolved triple rather than the raw
-  options also treats equivalent spellings (`top_k == 1`, `temperature == 0`, `do_sample == false`)
-  as the same.
-- If the resolved triple is not argmax, no request pinned `random_seed`. Argmax ignores the random
-  state, so batching cannot change it; a batch-wide generator would otherwise break the
-  reproducibility a pinned seed promises.
+  sampling branch into `SampleTopKTopP`, so comparing the triple resolved from the turn policy
+  rather than the raw options also treats equivalent spellings (`top_k == 1`, `temperature == 0`,
+  `do_sample == false`) as the same.
 - The logits rows are `vocab_size` long, back to back in request order, and inside a single
   allocation. `DeviceSpan::SameBufferAs` establishes the last part, which is what makes it safe to
   widen row 0 into the `[batch, vocab]` view the sampler reads.
 - Every request's `Search` accepts a shared next-token slot. Only `GreedySearch_Cuda` does, so this
-  doubles as the device and single-row check. `num_beams == 1` and `batch_size == 1` are already
-  enforced by `Request`'s constructor.
+  doubles as the device and single-row check. `num_beams == 1` and `batch_size == 1` hold for every
+  Engine Request by construction: the Request derives its own private search parameters and forces
+  both to one (`Request::CreateRequestParams`), and `Engine::CreateRequest` rejects a model that
+  configures beam search rather than silently forcing it.
 
 Note the layout check naturally excludes mixed prefill/decode steps, which is correct: those pick
 their rows out of a larger tensor and are not the steady-state case worth optimizing.
 
 Logits processors do **not** have to be no-ops. Each request still runs `ApplyMinLength`,
 `ApplyRepetitionPenalty` and `ApplyNoRepeatNgram` over its own row of the shared tensor before the
-batched sampler runs, so `min_length` and `repetition_penalty` stay per-request.
+batched sampler runs, so the turn's minimum generated tokens and repetition penalty stay
+per-request.
 
-Per-request `max_length` and per-request EOS token sets likewise do not need to match, because those
-are handled after sampling, in the per-request tail (see 5.4).
+Per-Request session limits and EOS token sets likewise do not need to match, because those are
+handled after sampling, in the per-request tail (see 5.4).
 
 ### 5.3 Layering
 
@@ -322,7 +327,7 @@ slot and copies the shared buffer back itself, which is why a partial bind can s
 | `src/ep/cuda/search_cuda.h` / `.cpp` | `GreedySearch_Cuda` overrides both. `BindNextTokensSlot` rejects unless the search is single-row and the slot is one element, then repoints `next_tokens_buffer_` and `next_tokens_`. The post-sampling tail moves into `LaunchNextTokensTail()`, shared by `SampleTopKTopP` and `OnNextTokensSampled`. `CompleteGeneration` skips its own `CopyDeviceToCpu()` when the caller owns the copy. |
 | `src/engine/engine.h` / `.cpp` | Own the shared next-token `DeviceSpan<int32_t>`, grown as batches get larger, and hand it to `ScheduledRequests` each step. |
 | `src/engine/scheduled_requests.h` / `.cpp` | Implement the gate and the fast path in `GenerateNextTokens()`; keep the existing two-loop path as the fallback. |
-| `src/engine/request.h` / `.cpp` | Split the pre-sampling half of `GenerateNextTokens()` into `PrepareGeneration()`, and forward `SearchOptions()`, `BindNextTokensSlot()` and `OnNextTokensSampled()`. |
+| `src/engine/request.h` / `.cpp` | Split the pre-sampling half of `GenerateNextTokens()` into `PrepareGeneration()`, and forward `TurnPolicy()`, `BindNextTokensSlot()` and `OnNextTokensSampled()`. |
 | `src/engine/decoders/*_decoder_io.cpp` | Wrap the fp32 logits tensor once instead of per row. `Tensor::GetDeviceSpan()` wraps the tensor memory afresh on each call, so calling it inside the loop produced rows that were adjacent in device memory but belonged to unrelated `DeviceBuffer` objects, which the gate has to reject. This also removes N redundant wraps per step. |
 
 Nothing outside `src/engine/` and `src/ep/cuda/` changes behaviour: the new `Search` virtuals default
@@ -393,7 +398,7 @@ because of heterogeneous parameters, pinned seeds, batch size one, or ragged log
 Generator design" option in its strongest form. It was rejected because it requires reworking
 `Sequences` to carry a per-row length cursor (today: one `current_length_`, and `GetSequence(i)`
 depends on it), reworking every kernel that writes at a shared `past_length` offset, moving
-per-request `GeneratorParams` into per-row arrays, and adding row allocation/eviction to `Search`.
+per-request search parameters into per-row arrays, and adding row allocation/eviction to `Search`.
 It also collides with the Engine-owned Request lifecycle and its externally serialized
 `BeginTurn`/`Run`/`Close` contract. It is a plausible long-term direction, but it is a rewrite of the
 search layer, and Phase 2 gets most of the benefit without touching any of it.

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -1546,7 +1546,8 @@ cache blocks at its join point is skipped for the rest of its life and decodes w
 the drafter keeps serving requests that already hold blocks. This makes `max_batch_size` the
 drafter's service-capacity limit across both active and idle long-lived requests, not merely the
 per-step scheduler limit. `dflash2_admission_misses` reports requests denied cache blocks because
-that capacity was occupied.
+that capacity was occupied. A tracked request remains part of this capacity while a sampled turn is
+ingest-only, because retaining its cache is what lets a later greedy turn resume drafting.
 
 ## Backpressure and fairness
 

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -130,11 +130,15 @@ Fixed state currently requires `engine.dynamic_batching`; static batching is rej
 
 ## Request lifecycle
 
-A `Request` is one sequence. Engine requests currently require:
+A `Request` is one sequence. It derives its own private search parameters from the model, so the
+single-sequence invariants are properties of the Engine rather than of a caller-supplied
+configuration:
 
-- `search.batch_size == 1`
-- `search.num_beams == 1`
-- At least one input token in every `BeginTurn()`
+- `search.batch_size` is forced to 1, because the Engine batches Requests, not rows within one.
+- `search.num_beams` is forced to 1, and a model that configures anything else is rejected at
+  Request creation instead of silently decoding one beam (see "Model configuration the Engine
+  rejects" below).
+- Every `BeginTurn()` needs at least one input token.
 
 The engine creates throughput by batching several independent requests, not by placing several sequence rows inside one request.
 
@@ -161,8 +165,10 @@ between `Run()` calls, not a cross-thread interrupt. Stale, unknown, and complet
 
 The request is already bound to its creating Engine but has no scheduler or cache membership.
 `BeginTurn()` copies the initial input, snapshots the turn options, and establishes submission
-order. Request-level generation parameters were snapshotted at creation and cannot change between
-turns. The caller does not need to keep either the input or options storage alive after the call.
+order. Resident-session policy -- the session token limit -- is fixed at creation; generation policy
+is not fixed at all, and is resolved anew for every turn from the model's search defaults plus that
+turn's explicit overrides. The caller does not need to keep either the input or options storage
+alive after the call.
 
 First-turn admission is transactional. Device input allocation, Search append, scheduler storage,
 and per-request sampler acquisition must all succeed before the new Turn is committed. The
@@ -174,13 +180,15 @@ duplicating the prompt.
 ### `Assigned`
 
 This is the queued state. A successful first or later `BeginTurn()` moves a Request here while its
-copied input waits for execution. `BeginTurn()` is rejected while already queued or active. Input must leave room for at least one generated token below the request's internal
-`max_total_tokens`.
+copied input waits for execution. `BeginTurn()` is rejected while already queued or active. Input must leave room for at least one
+generated token below the Request's `max_session_tokens`.
 
-Public `max_session_tokens` (stored internally as `max_total_tokens`) is the cumulative total
+`max_session_tokens` is the cumulative total
 sequence limit for the entire Request: the initial
 prompt, generated output, and every continuation input all count against the same limit. It defaults
-to `max_length`, cannot exceed `max_length`, and is not reset by `BeginTurn()`.
+to the model-configured `search.max_length`, cannot exceed it, and is not reset by `BeginTurn()`.
+It is the Request's one session limit: Search completion, static cache sizing, speculative bounds,
+and the `MaxSessionTokens` finish reason all read the same value.
 
 Opaque nullable `TurnOptions` are separate. Null, or setting `max_generated_tokens` to zero, means
 that no per-Turn limit applies beyond the cumulative Request limit. The current Turn counts only
@@ -189,10 +197,43 @@ input, continuation input, and the previously generated token replayed during co
 do not count. A later turn may begin whenever its input still leaves room for at least one generated
 token under the cumulative limit, and it may choose a different per-Turn limit.
 
-`OgaRequestOptions` is an opaque, reusable handle. Null options and zero
-`max_session_tokens` use the Request's snapshotted `OgaGeneratorParams.search.max_length`. That
-search value normally defaults from the model context length, but a caller may set it lower before
-Request creation. `OgaTurnOptions` is opaque and reusable; `BeginTurn()` snapshots supported values.
+`OgaRequestOptions` is an opaque, reusable handle carrying resident-session policy only. Null
+options and zero `max_session_tokens` use the model-configured `search.max_length`, which normally
+defaults from the model context length. Request creation takes no generation parameters at all: the
+Engine builds each Request's private, Model-derived search configuration itself, forcing one
+sequence and one beam.
+
+`OgaTurnOptions` is opaque and reusable and carries the whole generation policy of one turn;
+`BeginTurn()` snapshots it. See "Per-turn generation policy" below.
+
+#### Model configuration the Engine rejects
+
+Request creation validates the model configuration it is about to derive from, and rejects what it
+would otherwise have to reinterpret or silently override. Each rejection names a route the caller
+can take without editing the model directory -- overlaying the value on the `Config` before creating
+the Model:
+
+- A nonzero `search.min_length`, because it is a session-absolute floor while the Engine's minimum
+  is per turn: `OgaConfigOverlay(config, "{\"search\":{\"min_length\":0}}")`, or
+  `config.overlay('{"search": {"min_length": 0}}')` in Python, and then `min_generated_tokens` per
+  turn.
+- A `search.num_beams` other than 1, because beam search never overrides the deferred-completion
+  contract and its next tokens would never be copied back. Forcing it to one would decode something
+  the caller never asked for, so it is rejected instead:
+  `config.overlay('{"search": {"num_beams": 1}}')`, and batch across Requests.
+- A `search.max_length` of zero or less, since it is the Request's session ceiling.
+- A nonzero `search.chunk_size` when static batching is selected. Chunking is an Engine/model
+  scheduler policy, so this is rejected at Engine creation; disable it with
+  `config.overlay('{"search": {"chunk_size": 0}}')`.
+
+`search.batch_size` is deliberately not rejected. The Engine batches Requests rather than rows, so a
+wider configured batch simply means "configured for the classic Generator"; the Request derives its
+own single-row search and decodes exactly one sequence either way.
+
+The same overlay route raises the session ceiling where that is what the caller wants: because
+`max_session_tokens` cannot exceed the model-configured `search.max_length`, a model whose
+`search.max_length` is lower than the context length its cache can serve is raised with
+`config.overlay('{"search": {"max_length": <tokens>}}')` before the Model is created.
 
 ### `Active`
 
@@ -419,13 +460,16 @@ return one logits row per packed token or that its cache/state cannot commit an 
 The reported value is a capability limit, not a guarantee that every proposed token fits the next
 step's global token budget or current cache capacity. Automatic drafters also leave room for the
 target's correction token and cap each proposal by the Request's session limit and remaining Turn
-token budget.
+token budget. The proposal width an automatic drafter aims for is model/Engine configuration
+(`model.speculative.max_draft_tokens`); it is not a public Request or Turn option.
 
 The request must already belong to the Engine, have completed prefill, and be ready to decode.
 Verification supports greedy target selection and random target sampling with a positive `top_k`;
-proposals remain deterministic. Guidance,
-repetition penalty, no-repeat-ngram processing, and active minimum-length processing are not
-supported. Passing an empty sequence clears a pending proposal.
+proposals remain deterministic. A turn that enables guidance, a `repetition_penalty` other than 1,
+no-repeat-ngram processing, or a not-yet-met minimum generated token count is not draft-eligible,
+because the verification rows do not reproduce those logits processors. Eligibility is per turn: the
+next turn that drops those options can draft again. Passing an empty sequence clears a pending
+proposal.
 
 For a decode with K scheduled drafts, the packed input is the request's one unprocessed token
 followed by the K drafts. The decoder must return K+1 logits rows for that request. Row `i` predicts
@@ -447,6 +491,12 @@ A committed decode consumes the complete proposal, including drafts omitted by b
 retryable rollback restores the request and leaves the proposal pending for retry. During commit,
 the cache reservation is narrowed from the scheduled K+1 slots to the accepted prefix plus the
 request's mandatory token; paged KV and fixed recurrent state publish at that same boundary.
+
+A proposal never outlives the turn it was made under. `Request::ReleaseTurnResources()` discards it
+at every terminal boundary -- normal completion, stop match, cancellation, and a failed turn --
+alongside that turn's stop controller, guidance cursor, and pending reseed. Eligibility is per turn,
+so a proposal produced under one turn's guidance, minimum, repetition penalty, and n-gram blocking
+can never be verified under a later turn that resolved a different policy.
 
 ### Engine-hosted MTP head: operational contract
 
@@ -478,7 +528,7 @@ request releases it as well.
 the step. A request that was prefilling, finished its turn, or has a proposal the Engine cannot
 verify is skipped for that step and picks drafting back up on its next decode step.
 
-**Seeded sampling.** `search.random_seed` reproduces output for a given decode path, not across
+**Seeded sampling.** A turn seed reproduces output for a given decode path, not across
 decode paths. A verified drafted step draws its target tokens from the Request's own host random
 stream because acceptance is sequential, while an ordinary batched step draws from the device
 sampler state. Whether drafts are admitted depends on batch composition and cache pressure, so a
@@ -566,7 +616,7 @@ If at least one request fits, the step is executable even when other requests we
 After cache planning selects the batch, each decode keeps its one-token
 contribution. Every selected prefill also keeps its provisional token, then
 prefills expand in stable order while tokens remain. A prefill contribution is
-bounded by its remaining prompt, `search.chunk_size` when configured, and
+bounded by its remaining prompt, the model-configured `search.chunk_size` when present, and
 `max_scheduled_tokens`.
 
 The scheduler recomputes cache targets and assigns each request:
@@ -761,16 +811,22 @@ Finally, the engine swaps `staged_events_` into `pending_events_`. The first eve
 
 ## Constrained decoding and tool calling
 
-Engine requests use the guidance configuration carried by their `GeneratorParams`. This allows
-concurrent requests to use different JSON schemas, regular expressions, or Lark grammars. Tool
-definitions and chat-template rendering remain application concerns; the Engine constrains the
-generated token stream but does not parse tool calls from the decoded output.
+Guidance is turn-scoped. `OgaTurnOptionsSetGuidance` supplies one grammar for the next admitted
+turn; `OgaTurnOptionsClearGuidance` and an omitted grammar both mean an unguided turn, and guidance
+is never inherited from a previous turn or from model state. Concurrent requests, and successive
+turns of one request, can therefore use different JSON schemas, regular expressions, or Lark
+grammars. Tool definitions and chat-template rendering remain application concerns; the Engine
+constrains the generated token stream but does not parse tool calls from the decoded output.
 
-Each guided request owns an independent constrained-logits processor. Its mask is applied before
+`Engine::BeginTurn` validates the grammar, acquires the cached compiled assets, and constructs the
+turn's processor before it mutates anything, so a malformed or unusable grammar leaves the previous
+completed turn entirely reusable. The processor is installed only at the turn-admission commit
+boundary, and every terminal path -- completion, stop match, cancellation, failure, and close --
+releases it again.
+
+Each guided turn owns an independent constrained-logits processor. Its mask is applied before
 minimum-length, repetition-penalty, and no-repeat-ngram processing, matching Generator ordering.
-The processor snapshots its guidance and search configuration when the request is created, so later
-mutation of the caller-owned `GeneratorParams` cannot change an active grammar. After sampling, the
-selected token advances that request's grammar cursor.
+After sampling, the selected token advances that turn's grammar cursor.
 
 The grammar cursor participates in the same transaction as search and paged-cache state. A step
 checkpoints it before sampling, retains the advanced cursor on commit, and restores the checkpoint
@@ -785,9 +841,106 @@ dirty cursor retries mask construction when the next step needs it. Transient su
 future-delivery failures can recover this way; an error reported by llguidance permanently poisons
 that cursor and continues to fail rather than allowing generation with a stale mask.
 
-Guidance fast-forward tokens are not currently supported by the Engine. Requests that enable them
-are rejected because each forced token would also need a corresponding model execution and paged
-KV-cache advancement inside the transaction.
+A guided turn does not accept speculative drafts, because a draft's proposals are not produced under
+the grammar; the next unguided turn is draft-eligible again. Guidance and stop strings can be
+enabled together.
+
+Guidance fast-forward tokens are not supported by the Engine: each forced token would also need a
+corresponding model execution and paged KV-cache advancement inside the transaction. The Engine
+never enables them for a Request.
+
+## Per-turn generation policy
+
+Every generation-policy value is resolved anew for each `BeginTurn()`. Nothing carries over
+implicitly: a turn that overrides nothing decodes with the model's configured defaults again, even
+directly after a turn that overrode everything.
+
+`Engine::BeginTurn` resolves the turn's `EffectiveTurnPolicy` from the model `search` defaults plus
+the fields the caller explicitly set on `TurnOptions`, forces the Engine's single-sequence
+invariants, validates the complete result, and builds the turn's fallible resources -- its stop
+controller and guidance processor -- all before it mutates the Request. Only the turn-admission
+commit boundary installs them.
+
+The per-field unset behavior is normative in "Turn options" in `docs/engine_c_api_spec.md`; it is
+not repeated here.
+
+`EffectiveTurnPolicy::IsGreedy()` is the one classification every execution path shares, so a policy
+can never be greedy for ordinary sampling and sampled for batched sampling, draft verification, or
+drafting eligibility.
+
+Under any greedy resolution, admission rejects an explicitly set scalar that contradicts it instead
+of silently selecting the top logit: a `temperature` other than 0 or 1, a nucleus `top_p` strictly
+between 0 and 1, or a `top_k` above 1. A scalar that itself requests greedy selection
+(`temperature == 0`, `top_k == 1`) or that restricts nothing (`top_k == 0`, `top_p` of 0 or 1,
+`temperature` of 1) is honored exactly as written, in any combination: `do_sample = false` with
+`top_k = 1` is accepted, while `do_sample = false` with `temperature = 0.7`, or `top_k = 1` with
+`top_p = 0.9`, is not. The error names every condition that made the policy greedy and every scalar
+that contradicted it.
+
+An explicit `do_sample = true` that a model default silently overrides is rejected separately,
+because it is the one greedy resolution the caller cannot have meant. A model whose
+`search.top_k` is 1 or whose `search.temperature` is 0 keeps every turn greedy, and the caller
+cannot see those defaults through `TurnOptions`, so the error names the model-supplied cause and the
+turn must override that exact field -- a `top_k` above 1, or a nonzero `temperature` -- to sample.
+A turn that spells greedy out itself is unaffected: `do_sample = true` with the turn's own
+`top_k = 1` or `temperature = 0` is the caller's own choice and is accepted.
+
+A sampled resolution requires a positive `top_k` or a positive `top_p`; both zero is rejected,
+because it selects from nothing and is not the same request as greedy selection.
+
+`no_repeat_ngram_size` is only implemented by the CPU search, so a nonzero value is rejected at
+admission by a core-owned capability predicate keyed by the scoring device type, rather than
+throwing after the model has already run. A `repetition_penalty` other than 1, a nonzero
+`no_repeat_ngram_size`, or an unmet minimum also disables speculative drafting for that turn,
+because verification rows do not reproduce those logits processors.
+
+`min_generated_tokens` masks the end-of-sequence token until the turn has generated that many
+tokens. Admission rejects a minimum that exceeds the turn maximum or does not fit between the
+turn's prompt length and the Request's session limit. The absolute sequence floor `ApplyMinLength`
+uses is derived from the committed turn's prompt length plus its minimum rather than stored, so it
+cannot disagree with the policy the turn actually resolved to.
+
+### Per-turn seeds
+
+The Request carries a durable seed basis, initialized once at construction, plus an optional pending
+reseed for the admitted turn. A model that configures `search.random_seed` supplies the basis
+directly; the default unset (negative) configuration draws a generated 64-bit basis from
+`std::random_device` instead, so an unseeded Request is not reproducible across processes but its
+own later turns still continue one stream rather than redrawing.
+
+- An omitted turn seed continues the current streams.
+- An explicit turn seed records a new pending basis. Zero is a valid deterministic seed, so
+  `ClearSeed` -- not a sentinel value -- removes a pending reseed.
+- Seeds are full-width `uint64_t`. A value below 2^32 seeds the host generator exactly as the
+  classic `search.random_seed` did; a nonzero high half mixes both halves through a seed sequence.
+  CUDA receives the complete 64-bit value.
+
+A sampler state is always created from the durable basis, never from the pending reseed, because
+only a reseed applied inside the step transaction can be rolled back with it.
+
+`ScheduledRequests::GenerateNextTokensForTransaction` applies the pending reseed strictly after
+every Request and sampler checkpoint and strictly before the first host or device random consumer.
+The host generator is checkpointed by every `SaveState*ForTransaction` variant, so it is always safe
+to reseed. A device sampler state is reseeded in place -- keeping its pooled index -- and
+`BeginTransaction` therefore extends its sampler checkpoint beyond the batched sampling plan to
+cover every state a pending reseed targets, including requests that sample their draft verification
+on the host or whose plan was abandoned. That is an invariant, not a preference:
+`Request::ApplyPendingSeedForTransaction` fails the step if it is ever handed an existing device
+state the step did not checkpoint, because reseeding it could not be rolled back and skipping it
+would promote the seed to the durable basis while that stream still ran the old one.
+
+The pending marker is promoted to the durable basis only when the sampling step commits. Rollback
+restores both random streams and leaves the marker pending, so the retry reseeds identically.
+A turn that is canceled, fails, or otherwise reaches a terminal boundary before a sampling step
+commits discards the marker in `Request::ReleaseTurnResources()` without promoting it; because the
+rolled back step also restored both streams, the Request continues from exactly the position it held
+before the turn. Determinism is still scoped to the same scheduling path, because which drafts are
+admitted -- and therefore how many draws a turn makes -- depends on batch composition.
+
+Because `BatchedSampler` and `BatchedSamplerState` objects are constructed by the dynamically loaded
+CUDA add-on and called through by core, widening their seed interface required a
+`kDeviceInterfaceVersion` bump. That constant must be incremented whenever the virtual layout of
+`DeviceInterface`, or the virtual or data layout of any type crossing the add-on boundary, changes.
 
 ## Decoded stop strings
 
@@ -1153,9 +1306,9 @@ the request. The window block table repeats those $R$ block IDs: column $j$ uses
 $j \bmod R$, so position $p$ resolves to slot $p \bmod (R B)$. Positions outside the live window
 are overwritten in place.
 
-The dynamic scheduler treats $C$ as a physical per-request query limit. A request-level
-`chunk_size` that is absent, zero, or larger than $C$ is capped to $C$; a smaller positive override
-is preserved. This prevents a transactional step from wrapping the ring while older positions are
+The dynamic scheduler treats $C$ as a physical per-request query limit. A configured
+`search.chunk_size` that is absent, zero, or larger than $C$ is capped to $C$; a smaller positive
+value is preserved. This prevents a transactional step from wrapping the ring while older positions are
 still live.
 
 Window blocks participate in the same reservation, rollback, commit, removal, and invariant checks
@@ -1286,8 +1439,13 @@ The engine uses the same transaction flow for prefill and decoding.
 ### Prefill
 
 A prefill contributes as many pending prompt tokens as the remaining global
-budget allows, bounded by `search.chunk_size` when configured. A prompt can
-therefore span several committed steps even when `search.chunk_size` is absent.
+budget allows, bounded by the model-configured `search.chunk_size` when present. A prompt can
+therefore span several committed steps even when `search.chunk_size` is absent. Chunking is
+model/Engine configuration, not per-Request policy: a static-batching Engine cannot resume a
+half-written prompt, so `Engine::CreateDependencies` rejects a chunking model when it builds the
+static dependencies, and `StaticBatchScheduler::AddRequest` independently rejects a chunking Request
+at admission. The second check is what protects an Engine assembled from injected dependencies,
+which never runs the first.
 
 Admitting a new prefill still reserves blocks for its whole prompt. Only the
 executed contribution advances committed slots. This prevents another request
@@ -1316,7 +1474,7 @@ failure constructing the owning state wrapper releases the acquired index withou
 
 `ScheduledRequests` resolves each request's sampling configuration, groups compatible work inside the sampler, and submits the logits rows together. The implementation can handle heterogeneous request parameters without turning the requests into one shared `Search`.
 
-If batched sampling or transactional sampler checkpoints are unsupported on the active device or search implementation, the code falls back to per-request sampling while preserving the same engine transaction boundary.
+If batched sampling or transactional sampler checkpoints are unsupported on the active device or search implementation, the code falls back to per-request sampling while preserving the same engine transaction boundary. A per-turn seed is rejected at admission when a device batched sampler exists but cannot checkpoint and restore its RNG state; a host-only path with no batched sampler remains supported.
 
 Logits processing remains per request. Minimum length, repetition penalty, no-repeat n-gram processing, EOS handling, maximum length, and sequence ownership continue to use each request's own state.
 
@@ -1359,9 +1517,12 @@ still get them, and the retry budget is therefore spent on real drafter failures
 failures disable the drafter for the Engine, and a proposal contract violation disables it at once.
 `dflash2_failures` and `dflash2_disables` report those events.
 
-Automatic block drafting is greedy-only. A request that uses random sampling (`do_sample` with
-`top_k != 1` and a non-zero temperature) can never take a block draft, so it is never fed to the
-drafter and never claims cache blocks.
+Automatic block drafting is greedy-only. A request joins on its position-zero step only when the
+current turn is greedy. If a sampled first turn executes that step, eligibility is not reconsidered
+and the request decodes without block drafts for the rest of its life. Once a request has joined,
+later sampled turns continue feeding their committed context into its cache without requesting
+drafts, so a subsequent greedy turn can resume drafting without a cache hole. These ingest-only
+steps still execute the drafter session to preserve that continuity.
 
 A windowed block drafter (DFlash 2) owns a fixed ring of cache blocks per maximum batch row, so its
 pool is sized for `max_batch_size` rings and is allocated before the target pool measures free
@@ -1372,13 +1533,12 @@ reported by the graph. That trade is explicit -- a DSpark drafter with the same 
 the target roughly halves the target's paged-cache capacity for the same GPU memory budget, and it
 attends the whole resident sequence on every step rather than a window.
 
-A request joins the drafter on its first decode step and holds its blocks until it is closed, so
-both pools are only sufficient while at most `max_batch_size` requests are tracked. A request that
-first decodes while the drafter is already carrying that many is skipped for the rest of its life
-and decodes without block drafts; the drafter keeps serving the requests that already hold blocks.
-This makes `max_batch_size` the drafter's service-capacity limit across both active and idle
-long-lived requests, not merely the per-step scheduler limit. `dflash2_admission_misses` reports
-requests denied cache blocks because that capacity was occupied.
+Both pools are only sufficient while at most `max_batch_size` requests are tracked. A request denied
+cache blocks at its join point is skipped for the rest of its life and decodes without block drafts;
+the drafter keeps serving requests that already hold blocks. This makes `max_batch_size` the
+drafter's service-capacity limit across both active and idle long-lived requests, not merely the
+per-step scheduler limit. `dflash2_admission_misses` reports requests denied cache blocks because
+that capacity was occupied.
 
 ## Backpressure and fairness
 
@@ -1413,8 +1573,10 @@ The static engine path is intentionally separate.
 A resident static request queued by `BeginTurn()` returns to `Active` without reallocating the
 batch. Static cache rows still cannot be released independently, and an all-turn-complete batch may
 be recycled for new work. Static continuation is therefore valid only while the original
-single-request batch remains resident. The per-turn generated-token budget applies on this path
-too, although static execution does not use the dynamic reservation/checkpoint transaction.
+single-request batch remains resident. The per-turn generated-token budget and the resolved scalar
+turn policy both apply on this path, although static execution does not use the dynamic
+reservation/checkpoint transaction. Because it cannot stage, roll back, or replay, static admission
+rejects stop strings and a per-turn seed before mutating the Request.
 
 Close or abandonment logically removes a Request from scheduling and purges its undelivered events.
 A closed Request that is already resident in a static batch nevertheless remains part of that
@@ -1434,9 +1596,12 @@ The language bindings currently expose the same basic low-level loop. Production
 ```python
 request_options = og.RequestOptions()
 request_options.set_max_session_tokens(4096)
-request = engine.create_request(generation_params, request_options)
+request = engine.create_request(options=request_options)
 turn_options = og.TurnOptions(request)
 turn_options.set_max_generated_tokens(128)
+turn_options.set_do_sample(True)
+turn_options.set_top_k(40)
+turn_options.set_seed(1234)
 turn_id = request.begin_turn(initial_tokens, turn_options)
 
 event_buffer = engine.create_event_buffer(8)

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -887,6 +887,9 @@ A turn that spells greedy out itself is unaffected: `do_sample = true` with the 
 
 A sampled resolution requires a positive `top_k` or a positive `top_p`; both zero is rejected,
 because it selects from nothing and is not the same request as greedy selection.
+A sampled resolution also rejects a `top_k` greater than the model vocabulary size. If the resolved
+value came from the model's `search.top_k`, the error names that model default so the turn can
+override it explicitly.
 
 `no_repeat_ngram_size` is only implemented by the CPU search, so a nonzero value is rejected at
 admission by a core-owned capability predicate keyed by the scoring device type, rather than
@@ -911,6 +914,8 @@ own later turns still continue one stream rather than redrawing.
 - An omitted turn seed continues the current streams.
 - An explicit turn seed records a new pending basis. Zero is a valid deterministic seed, so
   `ClearSeed` -- not a sentinel value -- removes a pending reseed.
+- A greedy step consumes neither the host stream nor the persistent device sampler state, so a
+  greedy turn does not shift the random draws used by a later unseeded sampled turn.
 - Seeds are full-width `uint64_t`. A value below 2^32 seeds the host generator exactly as the
   classic `search.random_seed` did; a nonzero high half mixes both halves through a seed sequence.
   CUDA receives the complete 64-bit value.

--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -825,8 +825,9 @@ boundary, and every terminal path -- completion, stop match, cancellation, failu
 releases it again.
 
 Each guided turn owns an independent constrained-logits processor. Its mask is applied before
-minimum-length, repetition-penalty, and no-repeat-ngram processing, matching Generator ordering.
-After sampling, the selected token advances that turn's grammar cursor.
+minimum-length, repetition-penalty, and no-repeat-ngram processing. If applying the minimum would
+mask every guidance-permitted token because only configured EOS tokens remain, guidance termination
+takes precedence. After sampling, the selected token advances that turn's grammar cursor.
 
 The grammar cursor participates in the same transaction as search and paged-cache state. A step
 checkpoints it before sampling, retains the advanced cursor on commit, and restores the checkpoint
@@ -901,7 +902,9 @@ because verification rows do not reproduce those logits processors.
 tokens. Admission rejects a minimum that exceeds the turn maximum or does not fit between the
 turn's prompt length and the Request's session limit. The absolute sequence floor `ApplyMinLength`
 uses is derived from the committed turn's prompt length plus its minimum rather than stored, so it
-cannot disagree with the policy the turn actually resolved to.
+cannot disagree with the policy the turn actually resolved to. An extendable accepting grammar
+continues under the minimum, but once guidance permits EOS and no continuation token, guidance
+termination takes precedence rather than leaving the turn with no legal token.
 
 ### Per-turn seeds
 

--- a/examples/python/engine/continuous-batching.py
+++ b/examples/python/engine/continuous-batching.py
@@ -65,11 +65,8 @@ class RequestPool:
 
     def admit(self, prompt: str):
         client_request = ClientRequest(prompt, self.tokenizer)
-        params = og.GeneratorParams(self.model)
-        params.set_search_options(
-            do_sample=False,
-            max_length=256,
-        )
+        request_options = og.RequestOptions()
+        request_options.set_max_session_tokens(256)
         messages = json.dumps(
             [
                 {"role": "system", "content": ""},
@@ -79,9 +76,11 @@ class RequestPool:
         tokens = self.tokenizer.encode(
             self.tokenizer.apply_chat_template(messages=messages, add_generation_prompt=True)
         )
-        request = self.engine.create_request(params)
+        request = self.engine.create_request(options=request_options)
         self.requests[request] = client_request
         turn_options = og.TurnOptions(request)
+        # Per-turn policy never carries over, so a turn that wants the top logit says so every time.
+        turn_options.set_do_sample(False)
         turn_options.set_max_generated_tokens(128)
         request.begin_turn(
             np.asarray(tokens, dtype=np.int32),

--- a/examples/python/engine/model-qa.py
+++ b/examples/python/engine/model-qa.py
@@ -36,11 +36,8 @@ def run(args: argparse.Namespace):
     tokenizer = og.Tokenizer(model)
     engine = og.Engine(model)
 
-    params = og.GeneratorParams(model)
-    params.set_search_options(
-        do_sample=False,
-        max_length=MAX_LENGTH,
-    )
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(MAX_LENGTH)
 
     system_message = json.dumps([{"role": "system", "content": ""}])
     system_tokens = tokenizer.encode(
@@ -48,7 +45,11 @@ def run(args: argparse.Namespace):
     )
     session_token_count = len(system_tokens)
     streaming_tokenizer = tokenizer.create_stream()
-    request = engine.create_request(params)
+    request = engine.create_request(options=request_options)
+    # Per-turn policy is resolved anew for every turn and never carries over, so the same options
+    # object is reused to ask for top-logit selection on each one.
+    turn_options = og.TurnOptions(request)
+    turn_options.set_do_sample(False)
     first_turn = True
 
     try:
@@ -76,7 +77,7 @@ def run(args: argparse.Namespace):
                 first_turn = False
             else:
                 input_tokens = np.asarray(turn_tokens, dtype=np.int32)
-            request.begin_turn(input_tokens)
+            request.begin_turn(input_tokens, turn_options)
 
             print("🤖 :", end="", flush=True)
 

--- a/examples/python/engine/tool-calling.py
+++ b/examples/python/engine/tool-calling.py
@@ -114,21 +114,26 @@ def run(args):
         add_generation_prompt=True,
     )
 
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=args.max_length)
-    if args.guidance:
-        grammar = get_lark_grammar(
-            tools=to_tool(tools),
-            text_output=False,
-            tool_output=True,
-            tool_call_start=TOOL_CALL_START,
-            tool_call_end=TOOL_CALL_END,
-        )
-        params.set_guidance("lark_grammar", grammar)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(args.max_length)
     prompt_tokens = list(tokenizer.encode(prompt))
-    request = engine.create_request(params)
+    request = engine.create_request(options=request_options)
     try:
-        request.begin_turn(np.asarray(prompt_tokens, dtype=np.int32))
+        # Guidance is per turn: the tool-call turn is constrained to the grammar, and the
+        # tool-result continuation below simply clears it. Both turns select the top logit, which
+        # every turn must ask for explicitly because policy never carries over.
+        tool_call_turn = og.TurnOptions(request)
+        tool_call_turn.set_do_sample(False)
+        if args.guidance:
+            grammar = get_lark_grammar(
+                tools=to_tool(tools),
+                text_output=False,
+                tool_output=True,
+                tool_call_start=TOOL_CALL_START,
+                tool_call_end=TOOL_CALL_END,
+            )
+            tool_call_turn.set_guidance("lark_grammar", grammar)
+        request.begin_turn(np.asarray(prompt_tokens, dtype=np.int32), tool_call_turn)
 
         tool_call_output, tool_call_tokens = generate(engine, request, tokenizer)
         tool_call_start_tokens = list(tokenizer.encode(TOOL_CALL_START))
@@ -143,15 +148,10 @@ def run(args):
         print(f"Tool result: {json.dumps(tool_result)}")
 
         continuation_tokens = list(tokenizer.encode(tool_result_fragment(tool_result)))
-        if args.guidance:
-            request.close()
-            final_params = og.GeneratorParams(model)
-            final_params.set_search_options(do_sample=False, max_length=args.max_length)
-            request = engine.create_request(final_params)
-            final_context = prompt_tokens + tool_call_tokens + continuation_tokens
-            request.begin_turn(np.asarray(final_context, dtype=np.int32))
-        else:
-            request.begin_turn(np.asarray(continuation_tokens, dtype=np.int32))
+        # The same options object drives the continuation turn: clearing the grammar is all it takes
+        # to make this turn unguided, and do_sample stays false for it.
+        tool_call_turn.clear_guidance()
+        request.begin_turn(np.asarray(continuation_tokens, dtype=np.int32), tool_call_turn)
 
         final_output, _ = generate(engine, request, tokenizer)
         final_output = final_output.strip()

--- a/src/constrained_logits_processor.cpp
+++ b/src/constrained_logits_processor.cpp
@@ -632,6 +632,58 @@ std::span<const uint32_t> GuidanceLogitsProcessor::GetReadyMask() {
   return masks_;
 }
 
+bool GuidanceLogitsProcessor::AllowsOnlyTokens(
+    size_t index, std::span<const int> tokens) {
+  EnsureMaskScheduled();
+  EnsureMaskReady();
+  if (index >= llg_constraints_.size()) {
+    throw std::out_of_range("Guidance row index is out of range.");
+  }
+  if (mask_words_per_row_ == 0 ||
+      masks_.size() / mask_words_per_row_ != llg_constraints_.size() ||
+      masks_.size() % mask_words_per_row_ != 0) {
+    throw std::runtime_error("Guidance mask dimensions do not match its constraint rows.");
+  }
+
+  const auto row = std::span<const uint32_t>{masks_}.subspan(
+      index * mask_words_per_row_, mask_words_per_row_);
+  return MaskAllowsOnlyTokens(
+      row, static_cast<size_t>(params_->config.model.vocab_size), tokens);
+}
+
+bool GuidanceLogitsProcessor::MaskAllowsOnlyTokens(
+    std::span<const uint32_t> mask, size_t vocab_size,
+    std::span<const int> tokens) {
+  if (mask.size() != (vocab_size + 31) / 32) {
+    throw std::runtime_error("Guidance mask size does not match the model vocabulary.");
+  }
+
+  bool permits_supplied_token = false;
+  for (size_t word = 0; word < mask.size(); ++word) {
+    uint32_t supplied_bits = 0;
+    for (int token : tokens) {
+      if (token >= 0 && static_cast<size_t>(token) < vocab_size &&
+          static_cast<size_t>(token) / 32 == word) {
+        supplied_bits |= uint32_t{1} << (static_cast<size_t>(token) % 32);
+      }
+    }
+
+    uint32_t valid_bits = std::numeric_limits<uint32_t>::max();
+    if (word + 1 == mask.size() && vocab_size % 32 != 0) {
+      valid_bits = (uint32_t{1} << (vocab_size % 32)) - 1;
+    }
+    const uint32_t allowed = mask[word] & valid_bits;
+    permits_supplied_token |= (allowed & supplied_bits) != 0;
+    if ((allowed & ~supplied_bits) != 0) {
+      return false;
+    }
+  }
+  if (!permits_supplied_token) {
+    return false;
+  }
+  return true;
+}
+
 // Reset the LLGuidance constraints and then recompute the mask
 void GuidanceLogitsProcessor::Reset() {
   pending_masks_ = {};

--- a/src/constrained_logits_processor.cpp
+++ b/src/constrained_logits_processor.cpp
@@ -658,16 +658,6 @@ std::unique_ptr<ConstrainedLogitsProcessor> GuidanceLogitsProcessor::Clone() con
   return clone;
 }
 
-std::unique_ptr<ConstrainedLogitsProcessor> GuidanceLogitsProcessor::CloneForNewTurn() const {
-  auto clone = std::unique_ptr<GuidanceLogitsProcessor>(new GuidanceLogitsProcessor());
-  clone->params_ = params_;
-  clone->eos_token_ = eos_token_;
-  clone->grammar_asset_ = grammar_asset_;
-  clone->InitializeLlgConstraints();
-  clone->ComputeMask();
-  return clone;
-}
-
 void ScheduleGuidanceMaskComputation(
     std::span<ConstrainedLogitsProcessor* const> processors) {
   std::vector<GuidanceLogitsProcessor*> candidates;
@@ -804,9 +794,8 @@ std::unique_ptr<ConstrainedLogitsProcessor> CreateGuidanceLogitsProcessor(
 #endif
 }
 
-// Engine-facing overload: a Request exists (and must validate its guidance request) before it is
-// necessarily associated with a model, so this checks the request's shape and this build's
-// support for it first - neither of which needs a model - and only then requires one.
+// Engine-facing overload: a turn's guidance request is checked for shape and for this build's
+// support first - neither of which needs a model - and only then requires one.
 std::unique_ptr<ConstrainedLogitsProcessor> CreateGuidanceLogitsProcessor(
     std::shared_ptr<const GeneratorParams> params) {
   if (!ValidateGuidanceRequest(params->guidance_type, params->guidance_data)) {

--- a/src/constrained_logits_processor.h
+++ b/src/constrained_logits_processor.h
@@ -52,14 +52,6 @@ struct ConstrainedLogitsProcessor {
   // Clone as an independent grammar cursor at the current state. Speculative decoding uses this to
   // mask a draft's proposals without disturbing the verify cursor.
   virtual std::unique_ptr<ConstrainedLogitsProcessor> Clone() const = 0;
-
-  // Create an independent cursor reset to the start of the same grammar. The default preserves compatibility for
-  // lightweight processors; implementations may avoid cloning mutable state that Reset would immediately discard.
-  virtual std::unique_ptr<ConstrainedLogitsProcessor> CloneForNewTurn() const {
-    auto clone = Clone();
-    clone->Reset();
-    return clone;
-  }
 };
 
 #if USE_GUIDANCE
@@ -79,7 +71,6 @@ struct GuidanceLogitsProcessor : public ConstrainedLogitsProcessor {
   void Reset() override;
   std::vector<int32_t> GetFFTokens(size_t index) override;
   std::unique_ptr<ConstrainedLogitsProcessor> Clone() const override;
-  std::unique_ptr<ConstrainedLogitsProcessor> CloneForNewTurn() const override;
 
   // tokenize_partial is used to tokenize the input tokens with special prefix, this will get stable
   // token ids.
@@ -163,8 +154,8 @@ std::unique_ptr<ConstrainedLogitsProcessor> CreateGuidanceLogitsProcessor(const 
 std::unique_ptr<ConstrainedLogitsProcessor> CreateGuidanceLogitsProcessor(
     const Model& model, std::shared_ptr<const GeneratorParams> params);
 
-// Engine-facing overload. Request objects can exist before they are associated with a model, so
-// this validates the guidance request first (which needs no model) and only then requires one.
+// Engine-facing overload. A turn's guidance request is validated for shape and build support
+// first -- neither of which needs a model -- and only then requires the model the params carry.
 std::unique_ptr<ConstrainedLogitsProcessor> CreateGuidanceLogitsProcessor(
     std::shared_ptr<const GeneratorParams> params);
 

--- a/src/constrained_logits_processor.h
+++ b/src/constrained_logits_processor.h
@@ -43,6 +43,11 @@ struct ConstrainedLogitsProcessor {
   // span is invalidated by any subsequent call on the same processor.
   virtual std::span<const uint32_t> GetReadyMask() { return {}; }
 
+  // True when this row's ready mask permits at least one of the supplied tokens and no other
+  // in-vocabulary token. Used to avoid composing constraints into an empty legal-token set.
+  virtual bool AllowsOnlyTokens(
+      size_t index, std::span<const int> tokens) = 0;
+
   // Reset is used to reset the constraints of the logits processor and then recompute the mask, used after rewinding
   virtual void Reset() = 0;
 
@@ -67,6 +72,8 @@ struct GuidanceLogitsProcessor : public ConstrainedLogitsProcessor {
 
   void ProcessLogits(DeviceSpan<float> logits) override;
   std::span<const uint32_t> GetReadyMask() override;
+  bool AllowsOnlyTokens(
+      size_t index, std::span<const int> tokens) override;
   void CommitTokens(std::span<int32_t> tokens) override;
   void Reset() override;
   std::vector<int32_t> GetFFTokens(size_t index) override;
@@ -104,6 +111,9 @@ struct GuidanceLogitsProcessor : public ConstrainedLogitsProcessor {
   static std::vector<uint32_t> ComputeMasks(
       const GeneratorParams& params, uint32_t eos_token,
       const std::vector<std::shared_ptr<LlgConstraint>>& constraints);
+  static bool MaskAllowsOnlyTokens(
+      std::span<const uint32_t> mask, size_t vocab_size,
+      std::span<const int> tokens);
 
   std::shared_ptr<const GeneratorParams> params_;
   uint32_t eos_token_;

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -461,8 +461,8 @@ Tensor& Dflash2StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device
   return *slot;
 }
 
-bool Dflash2CanDraft(const Config::Search& search) {
-  return !search.do_sample || search.top_k == 1 || search.temperature == 0;
+bool Dflash2CanJoin(bool draft_eligible, size_t first_position) noexcept {
+  return draft_eligible && first_position == 0;
 }
 
 void Dflash2Drafter::AllocateCache() {
@@ -490,12 +490,11 @@ bool Dflash2Drafter::Admit(const Feed& feed) {
   if (requests_.find(feed.request) != requests_.end()) {
     return true;
   }
-  // The drafter cannot backfill K/V for context whose auxiliary hidden states have already been
-  // consumed, so a request can only join from the start of its sequence. Requests that arrive when
-  // the ring pool is full decode without DFlash 2 drafts instead of taking the whole drafter down.
-  if (feed.first_position != 0) {
+  if (!Dflash2CanJoin(feed.draft_eligible, feed.first_position)) {
     return false;
   }
+  // Requests that arrive when the ring pool is full decode without DFlash 2 drafts instead of
+  // taking the whole drafter down.
   if (ring_blocks_ != 0) {
     if (free_blocks_.size() < ring_blocks_) {
       ++admission_misses_;
@@ -545,11 +544,11 @@ void Dflash2Drafter::ReleaseAll() {
   requests_.clear();
 }
 
-void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> feeds,
+bool Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> feeds,
                              std::vector<std::vector<int32_t>>& drafts) {
   drafts.assign(feeds.size(), {});
   if (feeds.empty()) {
-    return;
+    return false;
   }
 
   const size_t block_size = static_cast<size_t>(config_.block_size);
@@ -565,7 +564,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
     }
   }
   if (served.empty()) {
-    return;
+    return false;
   }
 
   // Batch layout. Every served feed contributes its context rows so the drafter cache never
@@ -821,7 +820,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
   }
 
   if (!drafts_wanted) {
-    return;
+    return true;
   }
 
   // The spans own the host mirrors these point into, so they must outlive the reads below.
@@ -842,6 +841,7 @@ void Dflash2Drafter::Propose(Tensor& aux_hidden_states, std::span<const Feed> fe
       previous = best;
     }
   }
+  return true;
 }
 
 }  // namespace Generators

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -24,9 +24,10 @@ size_t Dflash2DraftWidth(size_t capability_limit, size_t configured_limit,
 Tensor& Dflash2StepTensor(std::unique_ptr<Tensor>& slot, DeviceInterface* device,
                           ONNXTensorElementDataType type, const std::vector<int64_t>& shape);
 
-// Whether a request's search options can ever take a DFlash 2 block. Drafting is greedy-only, and
-// this is fixed when the request is created, so a request this rejects is never fed to the drafter.
-bool Dflash2CanDraft(const Config::Search& search);
+// The drafter cannot backfill K/V for context whose auxiliary hidden states were already consumed,
+// so an untracked request can join only at position zero while its current turn is eligible to
+// draft. Tracked requests bypass this rule so every later turn keeps their cached context contiguous.
+bool Dflash2CanJoin(bool draft_eligible, size_t first_position) noexcept;
 
 /**
  * @brief Hosts a DFlash 2 or DSpark block-drafter session.
@@ -80,6 +81,7 @@ struct Dflash2Drafter {
     size_t aux_row_count{};
     size_t first_position{};
     int32_t anchor_token{};
+    bool draft_eligible{};
     bool wants_drafts{};
   };
 
@@ -116,11 +118,13 @@ struct Dflash2Drafter {
    * @param aux_hidden_states The target's packed [token_count, aux_hidden_size] output.
    * @param drafts Resized to feeds.size(); entry i is empty unless feeds[i] was served and asked.
    *
-   * A request joins the drafter on its first feed, which must start at position zero, and keeps its
-   * cache blocks until Release. Requests that arrive once the pool is fully subscribed are skipped
-   * for good rather than failing the step, so they decode without block drafts.
+   * A request joins the drafter on its first draft-eligible feed, which must start at position zero,
+   * and keeps its cache blocks until Release. Requests that arrive once the pool is fully subscribed
+   * are skipped for good rather than failing the step, so they decode without block drafts. A tracked
+   * request continues feeding context during sampled turns so a later greedy turn can resume drafting.
    */
-  void Propose(Tensor& aux_hidden_states, std::span<const Feed> feeds,
+  // Returns true only when the drafter session executed.
+  bool Propose(Tensor& aux_hidden_states, std::span<const Feed> feeds,
                std::vector<std::vector<int32_t>>& drafts);
 
   // Returns a request's blocks to the pool. Safe for requests the drafter never saw.

--- a/src/engine/cache_manager.cpp
+++ b/src/engine/cache_manager.cpp
@@ -258,12 +258,12 @@ void StaticCacheManager::Allocate(const std::vector<std::shared_ptr<Request>>& r
         std::max_element(
             requests.begin(), requests.end(),
             [](const std::shared_ptr<Request>& a, const std::shared_ptr<Request>& b) {
-              return a->SearchOptions().max_length < b->SearchOptions().max_length;
+              return a->MaxSessionTokens() < b->MaxSessionTokens();
             });
 
     params_ = std::make_shared<GeneratorParams>(*model_);
-    params_->search.max_length =
-        (*request_with_max_max_sequence_length)->SearchOptions().max_length;
+    params_->search.max_length = static_cast<int>(
+        (*request_with_max_max_sequence_length)->MaxSessionTokens());
     params_->search.batch_size = static_cast<int>(cache_allocated_requests_.size());
 
     key_value_cache_state_ = std::make_unique<KeyValueCacheState>(*params_, *model_);

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -4,6 +4,7 @@
 #include "engine.h"
 #include "../logging.h"
 #include "../search.h"
+#include "../constrained_logits_processor.h"
 #include "../models/preprocessing/genai_tokenizer.h"
 #include "../stop_string_controller.h"
 
@@ -22,23 +23,6 @@ constexpr size_t kDflash2FailureDisableThreshold = 3;
 struct MtpRollbackError : std::runtime_error {
   using std::runtime_error::runtime_error;
 };
-
-std::shared_ptr<GeneratorParams> CloneRequestParams(
-    const GeneratorParams& source,
-    const Model& model) {
-  auto copy = std::make_shared<GeneratorParams>(model);
-  copy->search = source.search;
-  copy->speculative = source.speculative;
-  copy->max_batch_size = source.max_batch_size;
-  copy->use_graph_capture = source.use_graph_capture;
-  copy->max_graph_capture_length = source.max_graph_capture_length;
-  copy->use_multi_profile = source.use_multi_profile;
-  copy->p_device = source.p_device;
-  copy->guidance_type = source.guidance_type;
-  copy->guidance_data = source.guidance_data;
-  copy->guidance_ff_tokens_enabled = source.guidance_ff_tokens_enabled;
-  return copy;
-}
 
 std::string AddExceptionCause(std::string message, std::exception_ptr error) {
   if (!error) {
@@ -252,6 +236,15 @@ void ValidateMtpModelCompatibility(const Config& config,
 }
 
 EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
+  // The static batch decoder rebuilds its contiguous cache from the whole sequence every step, so
+  // it cannot resume a half-written prompt. Reject a model that configures chunking here rather
+  // than surfacing it once a Request is already being admitted.
+  if (!model->config_->engine.dynamic_batching &&
+      model->config_->search.chunk_size.value_or(0) != 0) {
+    throw std::runtime_error(
+        "search.chunk_size requires dynamic batching; the static batch scheduler cannot chunk a "
+        "prefill.");
+  }
   std::shared_ptr<DecoderOnly_Model> mtp_model;
   size_t mtp_bytes_per_block = 0;
   if (!model->config_->model.mtp.filename.empty()) {
@@ -367,13 +360,7 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
   dflash2_draft_widths_.reserve(plan.requests.size());
   for (size_t i = 0; i < plan.requests.size(); ++i) {
     const auto& entry = plan.requests[i];
-    const auto& search = entry.request->SearchOptions();
-    // Feeding a request that can never take a block would only burn a ring an eligible request
-    // could use, and a request skipped here is skipped for its whole life, so it never joins the
-    // drafter's contiguity contract.
-    if (!Dflash2CanDraft(search)) {
-      continue;
-    }
+    const bool greedy = entry.request->TurnPolicy().IsGreedy();
     const size_t accepted = entry.request->AcceptedDraftTokenCount();
     if (accepted > entry.draft_token_count) {
       throw std::logic_error("DFlash 2 observed more accepted drafts than the target planned.");
@@ -391,12 +378,12 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
     feed.aux_row_begin = entry.packed_token_offset;
     feed.aux_row_count = valid_rows;
     feed.first_position = first_position;
+    feed.draft_eligible = greedy;
 
     // The committed length this step ends at: the accepted prefix plus the token just sampled.
     const int64_t length_after_step = static_cast<int64_t>(first_position + valid_rows) +
                                       (results[i].token_appended ? 1 : 0);
-    const size_t sequence_limit =
-        std::min(static_cast<size_t>(search.max_length), entry.request->MaxTotalTokens());
+    const size_t sequence_limit = entry.request->MaxSessionTokens();
     const size_t remaining_turn_tokens = entry.request->RemainingTurnTokenBudget();
     const size_t remaining_turn_tokens_after_step =
         results[i].visible_token_count < remaining_turn_tokens
@@ -406,7 +393,7 @@ void Engine::PrepareDflash2Feeds(const StepPlan& plan,
         max_drafts, static_cast<size_t>(entry.request->SpeculativeOptions().max_draft_tokens),
         static_cast<size_t>(length_after_step), sequence_limit,
         remaining_turn_tokens_after_step);
-    feed.wants_drafts = width > 0 && results[i].token_appended && !results[i].done &&
+    feed.wants_drafts = greedy && width > 0 && results[i].token_appended && !results[i].done &&
                         !entry.request->DraftTokenValidationError();
     feed.anchor_token = results[i].token;
     dflash2_feeds_.push_back(feed);
@@ -423,8 +410,9 @@ void Engine::PublishDflash2Drafts(ScheduledRequests& scheduled_requests) {
     throw std::logic_error("The main decoder did not expose auxiliary hidden states for DFlash 2.");
   }
 
-  dflash2_drafter_->Propose(*aux_hidden_states, dflash2_feeds_, dflash2_drafts_);
-  ++speculative_stats_.draft_forward_passes;
+  if (dflash2_drafter_->Propose(*aux_hidden_states, dflash2_feeds_, dflash2_drafts_)) {
+    ++speculative_stats_.draft_forward_passes;
+  }
   for (size_t i = 0; i < dflash2_feeds_.size(); ++i) {
     auto& drafts = dflash2_drafts_[i];
     if (drafts.empty()) {
@@ -553,12 +541,9 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
     for (size_t i = 0; i < target_plan.requests.size(); ++i) {
       const auto& entry = target_plan.requests[i];
       const auto& result = target_results[i];
-      const auto& search = entry.request->SearchOptions();
       const int64_t committed_length_after_step =
           entry.request->CurrentSequenceLength();
-      const size_t sequence_limit =
-          std::min(static_cast<size_t>(search.max_length),
-                   entry.request->MaxTotalTokens());
+      const size_t sequence_limit = entry.request->MaxSessionTokens();
       const size_t remaining_turn_tokens =
           entry.request->RemainingTurnTokenBudget();
       const size_t remaining_turn_tokens_after_step =
@@ -610,10 +595,8 @@ std::unique_ptr<Engine::MtpStep> Engine::PrepareMtpStep(
         checkpointed_shadows.push_back(feed.shadow);
         feed.shadow->AppendTokensForAuxiliaryDecoder(feed.tokens);
       } else {
-        auto params = CreateGeneratorParams(*mtp_model_);
-        params->search = search;
         feed.shadow = Request::CreateAuxiliaryDecoderRequest(
-            std::move(params), entry.request->MaxTotalTokens(),
+            *mtp_model_, entry.request->MaxSessionTokens(),
             abandonment_pending_, shared_from_this(), feed.tokens);
         feed.newly_created = true;
       }
@@ -1041,35 +1024,59 @@ void Engine::ValidateOwnerThread() const {
   }
 }
 
-std::shared_ptr<Request> Engine::CreateRequest(const GeneratorParams& params,
-                                               size_t max_total_tokens) {
+std::shared_ptr<Request> Engine::CreateRequest(const RequestOptions& options) {
   ValidateOwnerThread();
   CompleteNonresidentClosedRequests();
   ReclaimAbandonedRequests();
   if (health_ == EngineHealth::Unhealthy) {
     std::rethrow_exception(fatal_error_);
   }
-  if (params.model_.get() != model_.get()) {
+  const auto& model_search = model_->config_->search;
+  if (model_search.max_length <= 0) {
     throw std::runtime_error(
-        "Engine request parameters must belong to the Engine's model.");
+        "The model's search.max_length must be greater than zero; actual value is " +
+        std::to_string(model_search.max_length) + ".");
   }
-  if (params.search.max_length <= 0) {
+  // The Engine expresses a per-turn floor through TurnOptions::min_generated_tokens. A model that
+  // still carries the legacy session-absolute floor would silently mean something else here, so it
+  // is rejected rather than reinterpreted -- but the caller can clear it without editing the model
+  // directory, through the config overlay that OgaCreateConfig/OgaConfigOverlay already support.
+  if (model_search.min_length != 0) {
     throw std::runtime_error(
-        "max_length must be greater than zero; actual value is " +
-        std::to_string(params.search.max_length) + ".");
+        "The model configures a nonzero search.min_length (" +
+        std::to_string(model_search.min_length) +
+        "), which is a session-absolute floor the Engine does not support; its minimum is per "
+        "turn. Clear it on the Config before creating the model -- "
+        R"(OgaConfigOverlay(config, "{\"search\":{\"min_length\":0}}"), or in Python )"
+        R"(config.overlay('{"search": {"min_length": 0}}') -- and use )"
+        "OgaTurnOptionsSetMinGeneratedTokens for a per-turn minimum instead.");
   }
-  if (max_total_tokens == 0 ||
-      max_total_tokens > static_cast<size_t>(params.search.max_length)) {
+  // Beam search does not implement the Engine's deferred completion contract -- its next tokens are
+  // never copied back -- and a Request is one sequence, so the Engine forces num_beams to 1 in the
+  // private search parameters it derives. Silently forcing a model that asked for beams would
+  // decode something the caller never requested, so a model-configured value other than 1 is
+  // rejected here instead. The overlay clears it without editing the model directory.
+  if (model_search.num_beams != 1) {
     throw std::runtime_error(
-        "max_total_tokens (" + std::to_string(max_total_tokens) +
-        ") must be greater than zero and no greater than max_length (" +
-        std::to_string(params.search.max_length) + ").");
+        "The model configures search.num_beams = " +
+        std::to_string(model_search.num_beams) +
+        ", and beam search is not supported by the Engine; every Engine Request decodes one "
+        "sequence with one beam. Clear it on the Config before creating the model -- "
+        R"(OgaConfigOverlay(config, "{\"search\":{\"num_beams\":1}}"), or in Python )"
+        R"(config.overlay('{"search": {"num_beams": 1}}') -- )"
+        "and batch across Requests instead.");
   }
-
+  const size_t model_ceiling = static_cast<size_t>(model_search.max_length);
+  const size_t max_session_tokens =
+      options.max_session_tokens.value_or(model_ceiling);
+  if (max_session_tokens == 0 || max_session_tokens > model_ceiling) {
+    throw std::runtime_error(
+        "max_session_tokens (" + std::to_string(max_session_tokens) +
+        ") must be greater than zero and no greater than the model-configured search.max_length (" +
+        std::to_string(model_ceiling) + ").");
+  }
   auto request = std::make_shared<Request>(
-      CloneRequestParams(params, *model_), max_total_tokens,
-      abandonment_pending_);
-  request->ValidateEngineCompatibility();
+      *model_, max_session_tokens, abandonment_pending_);
   auto engine = shared_from_this();
 
   // Fatal handling preserves every token event from the current step, then needs one terminal
@@ -1105,20 +1112,39 @@ uint64_t Engine::BeginTurn(const std::shared_ptr<Request>& request,
         "Cannot begin a turn for a request that does not belong to this engine.");
   }
   request->ValidateTurnAdmission(tokens, options);
+
+  // Resolve and validate this turn's complete policy before any Request mutation, so an
+  // unsatisfiable combination leaves the previous completed turn entirely reusable.
+  const bool dynamic_batching = cache_manager_->SupportsDynamicBatching();
+  const auto policy = ResolveTurnPolicy(model_->config_->search, options);
+  const size_t turn_prompt_length =
+      static_cast<size_t>(request->IsAwaitingFirstTurn()
+                              ? 0
+                              : request->CurrentSequenceLength()) +
+      tokens.size();
+  ValidateTurnPolicy(policy, options, model_->p_device_scoring_->GetType(),
+                     turn_prompt_length, request->MaxSessionTokens());
   // Static batching completes generation through a non-transactional path (RunStatic) that cannot
-  // stage, roll back, or replay a stop match. Reject before any Request mutation rather than
-  // letting a stop-enabled turn run without the guarantee its finish reason promises.
-  if (!options.stop_strings.empty() && !cache_manager_->SupportsDynamicBatching()) {
+  // stage, roll back, or replay a stop match, and its sampler RNG state is created once when the
+  // Request joins the batch rather than inside a rollback-capable step. Reject both before any
+  // Request mutation rather than letting a turn run without the guarantee its options promise.
+  if (!dynamic_batching) {
+    if (!options.stop_strings.empty()) {
+      throw std::runtime_error(
+          "Stop strings require an Engine configured for dynamic batching.");
+    }
+    if (options.seed) {
+      throw std::runtime_error(
+          "A per-turn seed requires an Engine configured for dynamic batching.");
+    }
+  }
+  if (options.seed && !scheduler_->SupportsTransactionalSamplerState()) {
     throw std::runtime_error(
-        "Stop strings require an Engine configured for dynamic batching.");
+        "A per-turn seed requires a batched sampler that supports transaction rollback.");
   }
 
   const bool first_turn = request->IsAwaitingFirstTurn();
-  if (first_turn) {
-    if (cache_manager_->SupportsDynamicBatching()) {
-      request->ValidateEngineCompatibility();
-    }
-  } else {
+  if (!first_turn) {
     const bool restartable_canceled_turn =
         request->IsRestartableCanceledTurn() &&
         !cache_manager_->IsResident(request);
@@ -1129,19 +1155,21 @@ uint64_t Engine::BeginTurn(const std::shared_ptr<Request>& request,
   }
 
   RequestTurnAdmission admission;
+  admission.policy = policy;
   bool added_to_scheduler = false;
 
-  // Build this turn's complete stop controller (or leave admission.pending_stop_controller null
-  // for a no-stop turn) before any Request or Engine mutation: tokenizer/stream construction can
-  // throw, and at this point nothing has been touched yet, so a failure here leaves the Request,
-  // its MTP shadow, and Engine health entirely unchanged for a caller to retry. Ownership passes
-  // into admission; Request::CommitTurnAdmission() installs it as the live stop_controller_, and
-  // Request::RollbackTurnAdmission() (or simply this function returning through the catch below)
-  // discards it without ever having touched the Request's actual stop_controller_.
+  // Build this turn's complete stop controller and guidance processor (or leave either null for a
+  // turn that does not use them) before any Request or Engine mutation: tokenizer/stream
+  // construction and grammar compilation can throw, and at this point nothing has been touched yet,
+  // so a failure here leaves the Request, its MTP shadow, and Engine health entirely unchanged for
+  // a caller to retry. Ownership passes into admission; Request::CommitTurnAdmission() installs
+  // them, and Request::RollbackTurnAdmission() (or simply this function returning through the catch
+  // below) discards them without ever having touched the Request's live state.
   if (!options.stop_strings.empty()) {
     admission.pending_stop_controller = std::make_unique<StopStringController>(
         GetOrCreateStopTokenizer(), options.stop_strings);
   }
+  admission.pending_guidance = CreateTurnGuidance(options);
 
   // A continuation appends a prompt the MTP shadow never sees, so keeping the shadow would leave it
   // a concatenation of generated tokens across turns with the intervening prompt missing. Drop it
@@ -1716,25 +1744,6 @@ void Engine::RunDynamic() {
     };
 
     try {
-      for (const auto& entry : step_plan_.requests) {
-        entry.request->ValidateEngineCompatibility();
-      }
-    } catch (...) {
-      const auto validation_error = std::current_exception();
-      rollback_transaction();
-      ++transaction_metrics_.post_processing_aborts;
-      ++transaction_metrics_.retryable_aborts;
-      throw EngineStepError{
-          {StepOutcomeKind::RetryableBatchAbort,
-           step_plan_.transaction_id,
-           nullptr},
-          AddExceptionCause(
-              "Request validation failed; the batch was rolled back.",
-              validation_error),
-      };
-    }
-
-    try {
       // Sampling mutates each request's Search state. Checkpoint it before the model run so failures
       // in execution or post-processing can discard the whole batch rather than partially advancing
       // whichever requests happened to finish first.
@@ -2256,6 +2265,19 @@ const std::shared_ptr<Tokenizer>& Engine::GetOrCreateStopTokenizer() {
     stop_tokenizer_ = model_->CreateTokenizer();
   }
   return stop_tokenizer_;
+}
+
+std::unique_ptr<ConstrainedLogitsProcessor> Engine::CreateTurnGuidance(
+    const TurnOptions& options) const {
+  if (options.guidance_type.empty() && options.guidance_data.empty()) {
+    return nullptr;
+  }
+  // Guidance is turn-scoped, so its parameters are built here rather than read from the Request:
+  // nothing about a previous turn's grammar can leak into this one.
+  auto params = std::make_shared<GeneratorParams>(*model_);
+  params->search.batch_size = 1;
+  params->SetGuidance(options.guidance_type, options.guidance_data, false);
+  return CreateGuidanceLogitsProcessor(std::move(params));
 }
 
 SpeculativeStats Engine::GetSpeculativeStats() const {

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1032,6 +1032,8 @@ std::shared_ptr<Request> Engine::CreateRequest(const RequestOptions& options) {
     std::rethrow_exception(fatal_error_);
   }
   const auto& model_search = model_->config_->search;
+  // These model-fixed checks stay at Request creation because tests and embedders can construct an
+  // Engine with injected dependencies, bypassing CreateDependencies() and its model validation.
   if (model_search.max_length <= 0) {
     throw std::runtime_error(
         "The model's search.max_length must be greater than zero; actual value is " +

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1123,7 +1123,8 @@ uint64_t Engine::BeginTurn(const std::shared_ptr<Request>& request,
                               : request->CurrentSequenceLength()) +
       tokens.size();
   ValidateTurnPolicy(policy, options, model_->p_device_scoring_->GetType(),
-                     turn_prompt_length, request->MaxSessionTokens());
+                     model_->config_->model.vocab_size, turn_prompt_length,
+                     request->MaxSessionTokens());
   // Static batching completes generation through a non-transactional path (RunStatic) that cannot
   // stage, roll back, or replay a stop match, and its sampler RNG state is created once when the
   // Request joins the batch rather than inside a rollback-capable step. Reject both before any

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -145,11 +145,9 @@ struct Engine : std::enable_shared_from_this<Engine>,
    */
   static EngineDependencies CreateDependencies(std::shared_ptr<Model> model);
 
-  std::shared_ptr<Request> CreateRequest(const GeneratorParams& params,
-                                         size_t max_total_tokens);
-  std::shared_ptr<Request> CreateRequest(const GeneratorParams& params) {
-    return CreateRequest(
-        params, static_cast<size_t>(params.search.max_length));
+  std::shared_ptr<Request> CreateRequest(const RequestOptions& options);
+  std::shared_ptr<Request> CreateRequest() {
+    return CreateRequest(RequestOptions{});
   }
 
   /**
@@ -212,6 +210,11 @@ struct Engine : std::enable_shared_from_this<Engine>,
       const EngineStepError& error,
       std::exception_ptr caught_error) noexcept;
   std::shared_ptr<Request> FindTrackedRequest(const void* request_id) const;
+  // Builds the guidance processor a turn asked for, or null when it asked for none. Fallible by
+  // design and called before any Request mutation: grammar validation, cache acquisition, and
+  // processor construction all happen here.
+  std::unique_ptr<ConstrainedLogitsProcessor> CreateTurnGuidance(
+      const TurnOptions& options) const;
   EngineEvent FailUnserviceableRequest(const void* request_id);
   void ValidateRequestCanContinue(
       const std::shared_ptr<Request>& request,

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -354,6 +354,7 @@ void Request::CompleteFailedTurnFromEngine(const Engine& engine) noexcept {
 void Request::ReleaseTurnResources() noexcept {
   stop_controller_.reset();
   stop_controller_transaction_checkpoint_ = 0;
+  guidance_transaction_checkpoint_.reset();
   guidance_logits_processor_.reset();
   // A draft proposal is verified under the admitted turn's policy: the drafter produced it knowing
   // that turn's guidance, minimum, repetition penalty, and n-gram blocking. Carrying it across a
@@ -826,14 +827,17 @@ void Request::SaveStateForTransaction() {
 }
 
 void Request::SaveStateForNewTurnTransaction() {
-  search_->SaveStateForTransaction();
   // Every terminal path releases the previous turn's guidance cursor and stop controller, and this
   // turn's replacements are installed only by CommitTurnAdmission(), so a rolled back admission has
   // neither to restore. The same paths discard any reseed the previous turn left pending, so this
   // admission cannot promote a stale seed when it commits.
-  assert(!guidance_logits_processor_);
-  assert(!stop_controller_);
-  assert(!pending_reseed_ && !pending_reseed_applied_);
+  if (guidance_logits_processor_ || stop_controller_ ||
+      pending_reseed_ || pending_reseed_applied_) {
+    assert(false && "A new turn cannot inherit resources from the previous turn.");
+    throw std::logic_error(
+        "Cannot begin a new turn while resources from the previous turn remain active.");
+  }
+  search_->SaveStateForTransaction();
   guidance_transaction_checkpoint_.reset();
   transaction_rng_ = rng_;
   transaction_processed_sequence_length_ = processed_sequence_length_;

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -1043,7 +1043,16 @@ void Request::ApplyLogitsProcessors(DeviceSpan<float> logits,
   if (guidance_logits_processor_ && !guidance_applied) {
     guidance_logits_processor_->ProcessLogits(logits);
   }
-  search_->ApplyMinLength(TurnEosFloor());
+  const int eos_floor = TurnEosFloor();
+  // An extendable accepting grammar still honors the minimum by suppressing its optional EOS.
+  // Once EOS is the grammar's only legal token, guidance termination takes precedence over the
+  // floor; masking it as well would leave no valid token to select.
+  if (eos_floor > CurrentSequenceLength() &&
+      !(guidance_logits_processor_ &&
+        guidance_logits_processor_->AllowsOnlyTokens(
+            0, params_->config.model.eos_token_id))) {
+    search_->ApplyMinLength(eos_floor);
+  }
   search_->ApplyRepetitionPenalty(turn_policy_.repetition_penalty);
   search_->ApplyNoRepeatNgram(turn_policy_.no_repeat_ngram_size);
 }

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -3,8 +3,6 @@
 
 #include "request.h"
 
-#include <cmath>
-
 #include "engine.h"
 #include "sequence_positions.h"
 #include "../constrained_logits_processor.h"
@@ -12,6 +10,57 @@
 #include "../stop_string_controller.h"
 
 namespace Generators {
+
+namespace {
+
+// Preserves the existing host output for every seed that fits in 32 bits, so an Engine turn seeded
+// with a value the classic Generator could also express reproduces exactly the same token stream.
+// A seed with a nonzero high half -- which the classic int seed could never express -- mixes both
+// halves through a seed sequence.
+std::mt19937 MakeHostRandomGenerator(uint64_t seed) {
+  if (seed <= std::numeric_limits<uint32_t>::max()) {
+    return std::mt19937{static_cast<uint32_t>(seed)};
+  }
+  std::seed_seq seed_sequence{static_cast<uint32_t>(seed & 0xffffffffu),
+                              static_cast<uint32_t>(seed >> 32)};
+  return std::mt19937{seed_sequence};
+}
+
+// The model-configured seed initializes the Request's durable basis exactly once. A negative
+// configured seed means "pick one", and the drawn value becomes the basis so later turns that omit
+// a seed continue that same stream instead of redrawing.
+uint64_t InitialSeedBasis(int configured_seed) {
+  if (configured_seed >= 0) {
+    return static_cast<uint64_t>(configured_seed);
+  }
+  static thread_local std::random_device random_device;
+  const uint64_t high = random_device();
+  const uint64_t low = random_device();
+  return (high << 32) | low;
+}
+
+}  // namespace
+
+std::shared_ptr<GeneratorParams> Request::CreateRequestParams(
+    const Model& model,
+    size_t max_session_tokens) {
+  auto params = std::make_shared<GeneratorParams>(model);
+  // A Request is one sequence and the Engine batches Requests, not rows within a Request. These are
+  // internal invariants every Request holds, including the scheduler-private MTP shadows built from
+  // a second model: several places here read row 0 only, and beam search never overrides the
+  // deferred-completion contract. Engine::CreateRequest() separately rejects a public Request whose
+  // model configures num_beams != 1, so forcing it here never silently changes what a caller asked
+  // for.
+  params->search.batch_size = 1;
+  params->search.num_beams = 1;
+  // The Request's session limit is the only length limit the Search may complete on.
+  params->search.max_length = static_cast<int>(max_session_tokens);
+  // Generation policy fields such as sampling, penalties, minimum length, and seed are inert
+  // constructor storage. Engine generation reads Request::TurnPolicy(); search.chunk_size remains
+  // live model-owned scheduler policy and is exposed through Request::PrefillChunkSize().
+  // Guidance is turn-scoped and installed at turn admission; the Request itself is never guided.
+  return params;
+}
 
 DeviceSpan<int32_t> Request::AllocateOnDevice(
     GeneratorParams& params,
@@ -24,18 +73,18 @@ DeviceSpan<int32_t> Request::AllocateOnDevice(
 }
 
 void Request::ValidateAppendLength(
-    size_t max_total_tokens,
+    size_t max_session_tokens,
     size_t current_sequence_length,
     size_t token_count) {
-  if (current_sequence_length >= max_total_tokens ||
-      token_count >= max_total_tokens - current_sequence_length) {
+  if (current_sequence_length >= max_session_tokens ||
+      token_count >= max_session_tokens - current_sequence_length) {
     throw std::runtime_error(
         "Appending input_tokens_count (" + std::to_string(token_count) +
         ") to current_sequence_length (" +
         std::to_string(current_sequence_length) +
         ") must leave room for at least one generated token before "
-        "max_total_tokens (" +
-        std::to_string(max_total_tokens) + ").");
+        "max_session_tokens (" +
+        std::to_string(max_session_tokens) + ").");
   }
 }
 
@@ -46,6 +95,12 @@ void TurnOptions::ValidateOwnerThread() const {
         "Cannot use Turn options after their Request has been destroyed.");
   }
   bound_request->ValidateOwnerThread();
+}
+
+void TurnOptions::Reset() {
+  auto bound_request = std::move(request);
+  *this = TurnOptions{};
+  request = std::move(bound_request);
 }
 
 void Request::ValidateOwnerThread() const {
@@ -61,42 +116,24 @@ void Request::ValidateOwnerThread() const {
 }
 
 Request::Request(
-    std::shared_ptr<GeneratorParams> params,
-    size_t max_total_tokens,
+    const Model& model,
+    size_t max_session_tokens,
     std::shared_ptr<std::atomic<bool>> abandonment_pending)
     : ExternalRefCounted<Request>{std::move(abandonment_pending)},
-      max_total_tokens_{max_total_tokens},
-      params_{params},
-      rng_{CreateRandomGenerator(params->search.random_seed)},
-      search_{CreateSearch(*params)} {
+      // Until a turn is admitted the Request decodes under the model's own defaults. Every
+      // BeginTurn resolves this again from those defaults plus that turn's explicit overrides.
+      turn_policy_{ResolveTurnPolicy(model.config_->search, TurnOptions{})},
+      max_session_tokens_{max_session_tokens},
+      params_{CreateRequestParams(model, max_session_tokens)},
+      current_seed_basis_{InitialSeedBasis(model.config_->search.random_seed)},
+      rng_{MakeHostRandomGenerator(current_seed_basis_)},
+      search_{CreateSearch(*params_)} {
   draft_tokens_.reserve(kMaxDraftTokensPerStep);
-  // A request is one sequence: the engine batches requests, not rows within a request. Several
-  // places here read row 0 only (UnprocessedTokens, CurrentSequenceLength) or take the tail of the
-  // next-token span, so a wider search would silently mirror the wrong row's tokens.
-  if (params->search.batch_size != 1) {
-    throw std::runtime_error(
-        "Engine requests require search.batch_size == 1; actual value is " +
-        std::to_string(params->search.batch_size) +
-        ". Batch across requests instead.");
-  }
-  // Beam search does not implement the deferred completion contract below, so its next tokens would
-  // never be copied back from the device.
-  if (params->search.num_beams != 1) {
-    throw std::runtime_error(
-        "Engine requests require search.num_beams == 1; actual value is " +
-        std::to_string(params->search.num_beams) +
-        ". Beam search is not supported by the Engine.");
-  }
-  if (params->guidance_ff_tokens_enabled) {
-    throw std::runtime_error("Guidance fast-forward tokens are not supported by the engine.");
-  }
-
-  guidance_logits_processor_ = CreateGuidanceLogitsProcessor(params);
 
   // The engine drives one independent search per request, so completion is batched: see
   // ScheduledRequests::GenerateNextTokens().
   search_->DeferCompletion(true);
-  tokens_host_.reserve(max_total_tokens_);
+  tokens_host_.reserve(max_session_tokens_);
 }
 
 Request::~Request() = default;
@@ -128,6 +165,9 @@ RequestTurnAdmission::~RequestTurnAdmission() = default;
 void Request::ValidateTurnAdmission(
     std::span<const int32_t> tokens,
     const TurnOptions& options) const {
+  // The single place a zero turn maximum is rejected. The C API's setter treats zero as "unset",
+  // so this only fires for a direct in-process TurnOptions that asked for a turn generating
+  // nothing; ValidateTurnPolicy() deliberately does not repeat the check.
   if (options.max_generated_tokens && *options.max_generated_tokens == 0) {
     throw std::runtime_error(
         "max_generated_tokens (0) must be greater than zero.");
@@ -152,7 +192,7 @@ void Request::ValidateTurnAdmission(
 
   const size_t sequence_length =
       first_turn ? 0 : static_cast<size_t>(CurrentSequenceLength());
-  ValidateAppendLength(max_total_tokens_, sequence_length, tokens.size());
+  ValidateAppendLength(max_session_tokens_, sequence_length, tokens.size());
   if (tokens_host_.capacity() < tokens_host_.size() + tokens.size()) {
     throw std::logic_error(
         "The request host token mirror does not have reserved turn capacity.");
@@ -195,13 +235,20 @@ uint64_t Request::CommitTurnAdmission(
     RequestTurnAdmission& admission) {
   assert(admission.transaction_started);
   CommitStateForTransaction();
-  // The caller built this turn's complete stop controller (or null, for a no-stop turn) before
-  // the admission attempt began and it has been untouched ever since, so installing it here is a
-  // plain, infallible move: whatever the Request's stop_controller_ was before this call (a prior
-  // turn's controller, or null) is simply discarded now that the new turn is durable.
+  // The caller built this turn's complete stop controller (or null, for a no-stop turn) and its
+  // guidance processor (or null, for an unguided turn) before the admission attempt began and both
+  // have been untouched ever since, so installing them here is a plain, infallible move: whatever
+  // the Request held before this call is simply discarded now that the new turn is durable.
   stop_controller_ = std::move(admission.pending_stop_controller);
   stop_controller_transaction_checkpoint_ = 0;
-  turn_max_generated_tokens_ = options.max_generated_tokens;
+  guidance_logits_processor_ = std::move(admission.pending_guidance);
+  guidance_transaction_checkpoint_.reset();
+  turn_policy_ = admission.policy;
+  // Every terminal path already discarded the previous turn's pending reseed, so this simply
+  // records what this turn asked for: nothing when the seed is omitted, or a new basis that becomes
+  // durable only once a sampling step commits.
+  pending_reseed_ = options.seed;
+  pending_reseed_applied_ = false;
   turn_prompt_tokens_ = tokens_host_.size() - admission.host_token_count;
   turn_generated_tokens_ = 0;
   current_turn_id_ = next_turn_id_;
@@ -255,14 +302,12 @@ RequestTurnCounters Request::CompleteCancelFromEngine(
   assert(turn_id == current_turn_id_);
   assert(!Generators::IsTurnComplete(status_));
   assert(IsExecutable(status_));
-  draft_tokens_.clear();
   status_ = RequestStatus::TurnComplete;
   finish_reason_ = GenerationFinishReason::Canceled;
   // A cancellation replaces any undelivered result and becomes the sole terminal outcome, so any
   // previously staged/committed stop match no longer applies.
   matched_stop_string_index_ = -1;
-  stop_controller_.reset();
-  stop_controller_transaction_checkpoint_ = 0;
+  ReleaseTurnResources();
   return {turn_prompt_tokens_, turn_generated_tokens_};
 }
 
@@ -300,8 +345,36 @@ void Request::CompleteFailedTurnFromEngine(const Engine& engine) noexcept {
   status_ = RequestStatus::TurnComplete;
   finish_reason_ = GenerationFinishReason::Failed;
   matched_stop_string_index_ = -1;
+  ReleaseTurnResources();
+}
+
+// Everything scoped to one turn goes away together at every terminal boundary, so the next turn
+// starts from the documented defaults: no stop strings, no guidance, and no draft proposal unless
+// it asks for them.
+void Request::ReleaseTurnResources() noexcept {
   stop_controller_.reset();
   stop_controller_transaction_checkpoint_ = 0;
+  guidance_logits_processor_.reset();
+  // A draft proposal is verified under the admitted turn's policy: the drafter produced it knowing
+  // that turn's guidance, minimum, repetition penalty, and n-gram blocking. Carrying it across a
+  // terminal boundary would let a completed, canceled, or failed turn's proposal be verified under
+  // the next turn's different policy, which never validated it. Resetting the staged counters here
+  // cannot orphan tokens the sequence still owns: CommitStep() has already folded its accepted
+  // prefix into tokens_host_ and repeats these same resets immediately afterwards, cancellation and
+  // unserviceable failure happen between steps with nothing staged, and a fatal failure leaves the
+  // Request unable to execute again at all.
+  draft_tokens_.clear();
+  staged_draft_count_ = 0;
+  accepted_draft_count_ = 0;
+  evaluated_draft_count_ = 0;
+  draft_verification_completed_generation_ = false;
+  draft_verification_stop_match_index_ = -1;
+  // The turn's reseed dies with the turn. A reseed that a sampling step already committed was
+  // promoted to current_seed_basis_ by CommitStateForTransaction(), which runs before any terminal
+  // boundary; anything still pending here belongs to a turn that ended before it sampled (or whose
+  // reseeded step was rolled back), so it is discarded without touching the durable basis.
+  pending_reseed_.reset();
+  pending_reseed_applied_ = false;
 }
 
 void Request::Schedule() {
@@ -388,6 +461,14 @@ int64_t Request::CommittedSequenceLength() const {
   return CurrentSequenceLength() - static_cast<int64_t>(staged_draft_count_);
 }
 
+int Request::TurnEosFloor() const noexcept {
+  if (turn_policy_.min_generated_tokens == 0) {
+    return 0;
+  }
+  return static_cast<int>(static_cast<size_t>(prompt_sequence_length_) +
+                          turn_policy_.min_generated_tokens);
+}
+
 const char* Request::DraftTokenValidationError() const noexcept {
   // A stop-enabled turn is not excluded here: draft verification observes target-accepted tokens
   // through stop_controller_ in exactly the same committed order the ordinary one-token path uses
@@ -396,14 +477,13 @@ const char* Request::DraftTokenValidationError() const noexcept {
   if (guidance_logits_processor_) {
     return "Speculative draft tokens are not supported with guidance.";
   }
-  const auto& search = params_->search;
-  if (search.do_sample && search.top_k != 1 && search.temperature != 0 && search.top_k <= 0) {
+  if (!turn_policy_.IsGreedy() && turn_policy_.top_k <= 0) {
     return "Sampled speculative draft tokens require a positive top_k.";
   }
-  if (search.repetition_penalty != 1.0f || search.no_repeat_ngram_size > 0 ||
-      search.min_length > CurrentSequenceLength()) {
+  if (turn_policy_.repetition_penalty != 1.0f || turn_policy_.no_repeat_ngram_size > 0 ||
+      TurnEosFloor() > CurrentSequenceLength()) {
     return "Speculative draft tokens require repetition_penalty 1, no_repeat_ngram_size 0, and a "
-           "sequence already past min_length.";
+           "turn already past its minimum generated token count.";
   }
   return nullptr;
 }
@@ -439,7 +519,7 @@ void Request::SetDraftTokens(std::span<const int32_t> tokens) {
         "A step accepts at most " + std::to_string(max_drafts) + " draft tokens.");
   }
   ValidateAppendLength(
-      max_total_tokens_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+      max_session_tokens_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
   if (tokens_host_.capacity() < tokens_host_.size() + tokens.size()) {
     throw std::logic_error("The request host token mirror does not have reserved draft capacity.");
   }
@@ -520,9 +600,9 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
           "Committing an accepted draft produced an invalid sequence transition.");
     }
     const bool turn_limit_reached =
-        turn_max_generated_tokens_ &&
+        turn_policy_.max_generated_tokens &&
         turn_generated_tokens_ + accepted_draft_count_ >=
-            *turn_max_generated_tokens_;
+            *turn_policy_.max_generated_tokens;
     if (search_->IsDone() || turn_limit_reached) {
       draft_verification_completed_generation_ = true;
       break;
@@ -621,7 +701,7 @@ size_t Request::ScheduledTokenCount() const {
 
 void Request::ScheduleTokens() {
   const size_t unprocessed = static_cast<size_t>(CurrentSequenceLength() - processed_sequence_length_);
-  scheduled_token_count_ = Generators::ScheduledTokenCount(unprocessed, params_->search.chunk_size);
+  scheduled_token_count_ = Generators::ScheduledTokenCount(unprocessed, PrefillChunkSize());
 }
 
 void Request::BindScheduledTokenCount(size_t token_count) {
@@ -647,13 +727,13 @@ void Request::AdvanceChunk() {
 }
 
 std::shared_ptr<Request> Request::CreateAuxiliaryDecoderRequest(
-    std::shared_ptr<GeneratorParams> params,
-    size_t max_total_tokens,
+    const Model& model,
+    size_t max_session_tokens,
     std::shared_ptr<std::atomic<bool>> abandonment_pending,
     const std::shared_ptr<Engine>& engine,
     std::span<const int32_t> tokens) {
   auto request = std::make_shared<Request>(
-      std::move(params), max_total_tokens, std::move(abandonment_pending));
+      model, max_session_tokens, std::move(abandonment_pending));
   request->AttachToEngine(engine);
   // The shadow is never admitted through BeginTurn, so it starts decoding directly and treats the
   // tokens it mirrors from the target as its prompt.
@@ -669,7 +749,7 @@ void Request::AppendTokensForAuxiliaryDecoder(std::span<const int32_t> tokens) {
     throw std::logic_error(
         "Auxiliary decoder tokens require an active request with no pending rows.");
   }
-  ValidateAppendLength(max_total_tokens_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+  ValidateAppendLength(max_session_tokens_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
   auto device_tokens = AllocateOnDevice(*params_, tokens);
   search_->AppendTokens(device_tokens);
   tokens_host_.insert(tokens_host_.end(), tokens.begin(), tokens.end());
@@ -681,7 +761,7 @@ void Request::AppendTokensForAuxiliaryDecoder(DeviceSpan<int32_t> tokens) {
     throw std::logic_error(
         "Auxiliary decoder tokens require an active request with no pending rows.");
   }
-  ValidateAppendLength(max_total_tokens_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
+  ValidateAppendLength(max_session_tokens_, static_cast<size_t>(CurrentSequenceLength()), tokens.size());
   search_->AppendTokens(tokens);
   const int32_t non_pad = params_->config.model.pad_token_id == 0 ? 1 : 0;
   tokens_host_.insert(tokens_host_.end(), tokens.size(), non_pad);
@@ -729,54 +809,7 @@ bool Request::IsPrefill() const {
 
 void Request::GenerateNextTokens(DeviceSpan<float> logits, bool guidance_applied) {
   PrepareGeneration(logits, guidance_applied);
-
-  auto& search_params = search_->params_->search;
-  if (!search_params.do_sample || search_params.top_k == 1 || search_params.temperature == 0) {
-    search_->SelectTop();
-  } else {
-    // The user explicitly called TopKTopP on a beam search
-    if (search_params.num_beams != 1)
-      throw std::runtime_error("TopK and TopP cannot be used with a beam search");
-
-    // Sanity checks
-    if (!std::isfinite(search_params.top_p) ||
-        search_params.top_p < 0.0f || search_params.top_p > 1.0f)
-      throw std::runtime_error(
-          "top_p (" + std::to_string(search_params.top_p) +
-          ") must be finite and between 0.0 and 1.0.");
-    if (search_params.top_k < 0)
-      throw std::runtime_error(
-          "top_k (" + std::to_string(search_params.top_k) +
-          ") must be 0 or greater.");
-
-    if (search_params.top_p > 0.0f && search_params.top_p < 1.0f && search_params.top_k > 1) {
-      search_->SampleTopKTopP(search_params.top_k, search_params.top_p, search_params.temperature,
-                              rng_);
-    } else if (search_params.top_k > 1) {
-      search_->SampleTopK(search_params.top_k, search_params.temperature, rng_);
-    } else {
-      assert(search_params.top_k == 0);
-      search_->SampleTopP(search_params.top_p, search_params.temperature, rng_);
-    }
-  }
-}
-
-void Request::ValidateEngineCompatibility() const {
-  const auto& search = params_->search;
-  if (search.batch_size != 1 || search.num_beams != 1) {
-    throw std::runtime_error("Engine requests require batch_size and num_beams to both be 1.");
-  }
-  if (!std::isfinite(search.top_p) ||
-      search.top_p < 0.0f || search.top_p > 1.0f) {
-    throw std::runtime_error(
-        "top_p (" + std::to_string(search.top_p) +
-        ") must be finite and between 0.0 and 1.0.");
-  }
-  if (search.top_k < 0) {
-    throw std::runtime_error(
-        "top_k (" + std::to_string(search.top_k) +
-        ") must be 0 or greater.");
-  }
+  SelectNextToken();
 }
 
 void Request::SaveStateForTransaction() {
@@ -793,19 +826,18 @@ void Request::SaveStateForTransaction() {
 }
 
 void Request::SaveStateForNewTurnTransaction() {
-  auto new_turn_guidance = guidance_logits_processor_
-                               ? guidance_logits_processor_->CloneForNewTurn()
-                               : nullptr;
   search_->SaveStateForTransaction();
-  guidance_transaction_checkpoint_ =
-      std::exchange(guidance_logits_processor_, std::move(new_turn_guidance));
+  // Every terminal path releases the previous turn's guidance cursor and stop controller, and this
+  // turn's replacements are installed only by CommitTurnAdmission(), so a rolled back admission has
+  // neither to restore. The same paths discard any reseed the previous turn left pending, so this
+  // admission cannot promote a stale seed when it commits.
+  assert(!guidance_logits_processor_);
+  assert(!stop_controller_);
+  assert(!pending_reseed_ && !pending_reseed_applied_);
+  guidance_transaction_checkpoint_.reset();
   transaction_rng_ = rng_;
   transaction_processed_sequence_length_ = processed_sequence_length_;
   transaction_tokens_host_size_ = tokens_host_.size();
-  // Every terminal path releases the previous turn's controller. Engine::BeginTurn builds the
-  // replacement separately and installs it only after successful admission, so rollback has no
-  // stop-controller state to restore during this transaction.
-  assert(!stop_controller_);
   stop_controller_transaction_checkpoint_ = 0;
 }
 
@@ -860,9 +892,9 @@ RequestStepResult Request::StageDraftCompletionForTransaction() {
     matched_stop_string_index = draft_verification_stop_match_index_;
   } else {
     const bool turn_limit_reached =
-        turn_max_generated_tokens_ &&
+        turn_policy_.max_generated_tokens &&
         turn_generated_tokens_ + accepted_draft_count_ >=
-            *turn_max_generated_tokens_;
+            *turn_policy_.max_generated_tokens;
     if (turn_limit_reached) {
       finish_reason = GenerationFinishReason::TurnLimit;
     } else {
@@ -895,6 +927,9 @@ void Request::RestoreStateForTransaction() {
   scheduled_token_count_ = 0;
   draft_verification_completed_generation_ = false;
   draft_verification_stop_match_index_ = -1;
+  // The pending reseed itself is deliberately kept so the retry reseeds identically; only its
+  // "already applied to the live streams" marker is undone, because rng_ was just rolled back.
+  pending_reseed_applied_ = false;
   if (guidance_transaction_checkpoint_) {
     guidance_logits_processor_ = std::move(guidance_transaction_checkpoint_);
   }
@@ -917,6 +952,7 @@ void Request::QueueStateRestoreForTransaction() {
   scheduled_token_count_ = 0;
   draft_verification_completed_generation_ = false;
   draft_verification_stop_match_index_ = -1;
+  pending_reseed_applied_ = false;
   // Deliberately does not replay the stop controller yet: like the guidance checkpoint swap below,
   // that work is deferred to CompleteStateRestoreForTransaction() so this stays lightweight
   // bookkeeping that cannot itself allocate, decode, or throw.
@@ -939,6 +975,13 @@ void Request::CompleteStateRestoreForTransaction() {
 void Request::CommitStateForTransaction() {
   search_->CommitStateForTransaction();
   guidance_transaction_checkpoint_.reset();
+  // A reseed becomes durable only once the step that consumed it commits, so a rolled back or
+  // never-sampled step leaves both the pending marker and the durable basis exactly as they were.
+  if (pending_reseed_applied_) {
+    current_seed_basis_ = *pending_reseed_;
+    pending_reseed_.reset();
+    pending_reseed_applied_ = false;
+  }
 }
 
 void Request::CommitStep(const RequestStepPlan& plan,
@@ -959,8 +1002,7 @@ void Request::CommitStep(const RequestStepPlan& plan,
   if (result.done) {
     finish_reason_ = result.finish_reason;
     matched_stop_string_index_ = result.matched_stop_string_index;
-    stop_controller_.reset();
-    stop_controller_transaction_checkpoint_ = 0;
+    ReleaseTurnResources();
   }
   draft_tokens_.clear();
   staged_draft_count_ = 0;
@@ -997,24 +1039,22 @@ void Request::ApplyLogitsProcessors(DeviceSpan<float> logits,
   if (guidance_logits_processor_ && !guidance_applied) {
     guidance_logits_processor_->ProcessLogits(logits);
   }
-  auto& search_params = search_->params_->search;
-  search_->ApplyMinLength(search_params.min_length);
-  search_->ApplyRepetitionPenalty(search_params.repetition_penalty);
-  search_->ApplyNoRepeatNgram(search_params.no_repeat_ngram_size);
+  search_->ApplyMinLength(TurnEosFloor());
+  search_->ApplyRepetitionPenalty(turn_policy_.repetition_penalty);
+  search_->ApplyNoRepeatNgram(turn_policy_.no_repeat_ngram_size);
 }
 
 void Request::SelectNextToken() {
-  auto& search_params = search_->params_->search;
-  if (!search_params.do_sample || search_params.top_k == 1 || search_params.temperature == 0) {
+  if (turn_policy_.IsGreedy()) {
     search_->SelectTop();
-  } else if (search_params.top_p > 0.0f && search_params.top_p < 1.0f &&
-             search_params.top_k > 1) {
-    search_->SampleTopKTopP(search_params.top_k, search_params.top_p,
-                            search_params.temperature, rng_);
-  } else if (search_params.top_k > 1) {
-    search_->SampleTopK(search_params.top_k, search_params.temperature, rng_);
+  } else if (turn_policy_.top_p > 0.0f && turn_policy_.top_p < 1.0f &&
+             turn_policy_.top_k > 1) {
+    search_->SampleTopKTopP(turn_policy_.top_k, turn_policy_.top_p,
+                            turn_policy_.temperature, rng_);
+  } else if (turn_policy_.top_k > 1) {
+    search_->SampleTopK(turn_policy_.top_k, turn_policy_.temperature, rng_);
   } else {
-    search_->SampleTopP(search_params.top_p, search_params.temperature, rng_);
+    search_->SampleTopP(turn_policy_.top_p, turn_policy_.temperature, rng_);
   }
 }
 
@@ -1028,10 +1068,10 @@ RequestStepResult Request::StageGeneration(int64_t sequence_length_before) {
       turn_generated_tokens_ + accepted_draft_count_ +
       static_cast<size_t>(token_appended);
   const bool turn_limit_reached =
-      turn_max_generated_tokens_ &&
-      generated_tokens_after_step >= *turn_max_generated_tokens_;
+      turn_policy_.max_generated_tokens &&
+      generated_tokens_after_step >= *turn_policy_.max_generated_tokens;
   const bool context_limit_reached =
-      static_cast<size_t>(CurrentSequenceLength()) >= max_total_tokens_;
+      static_cast<size_t>(CurrentSequenceLength()) >= max_session_tokens_;
   GenerationFinishReason finish_reason = GenerationFinishReason::None;
   int32_t matched_stop_string_index = -1;
   // Stop strings take precedence over the turn/context limit for the same generated token: a token
@@ -1070,9 +1110,6 @@ RequestStepResult Request::StageGeneration(int64_t sequence_length_before) {
       result, accepted_draft_count_,
       token_appended ? std::optional<int32_t>{token} : std::nullopt);
   CommitGuidanceToken(result);
-  if (done && guidance_logits_processor_) {
-    guidance_logits_processor_->Reset();
-  }
   return result;
 }
 
@@ -1094,8 +1131,8 @@ std::span<const uint32_t> Request::GetReadyGuidanceMask() {
                                     : std::span<const uint32_t>{};
 }
 
-const Config::Search& Request::SearchOptions() const {
-  return search_->params_->search;
+const std::optional<size_t>& Request::PrefillChunkSize() const noexcept {
+  return params_->search.chunk_size;
 }
 
 const Config::Speculative& Request::SpeculativeOptions() const {
@@ -1116,8 +1153,46 @@ void Request::OnNextTokensSampled() {
 
 BatchedSamplerState& Request::SamplingState(BatchedSampler& sampler) {
   if (!batched_sampler_state_ || !sampler.OwnsState(*batched_sampler_state_))
-    batched_sampler_state_ = sampler.CreateState(search_->params_->search.random_seed);
+    batched_sampler_state_ = sampler.CreateState(current_seed_basis_);
   return *batched_sampler_state_;
+}
+
+BatchedSamplerState* Request::ExistingSamplingState(
+    BatchedSampler& sampler) const noexcept {
+  if (batched_sampler_state_ && sampler.OwnsState(*batched_sampler_state_)) {
+    return batched_sampler_state_.get();
+  }
+  return nullptr;
+}
+
+void Request::ApplyPendingSeedForTransaction(BatchedSampler* sampler,
+                                             bool device_state_checkpointed) {
+  if (!pending_reseed_) {
+    return;
+  }
+  auto* device_state = sampler ? ExistingSamplingState(*sampler) : nullptr;
+  // A device stream this step did not checkpoint can neither be reseeded (rollback could not undo
+  // it) nor be left behind (CommitStateForTransaction() would promote the seed to the durable basis
+  // while that stream still runs the old one, so a later turn that omits a seed would silently
+  // continue the wrong stream). ScheduledRequests::BeginTransaction() checkpoints every state a
+  // pending reseed targets, and Engine admission rejects samplers that cannot checkpoint, so
+  // reaching this is an internal contract violation: fail the step instead of promoting a seed
+  // only half of the Request honors.
+  if (device_state && !device_state_checkpointed) {
+    assert(false &&
+           "A pending turn seed targeted a device sampler state this step did not checkpoint.");
+    throw std::logic_error(
+        "A pending turn seed targeted a device sampler state this step did not checkpoint.");
+  }
+  // rng_ is checkpointed by every SaveState*ForTransaction() variant, so the host stream can always
+  // be reseeded here and rewound by the same rollback that rewinds the tokens it produced.
+  rng_ = MakeHostRandomGenerator(*pending_reseed_);
+  if (device_state) {
+    // Reseeding in place keeps the pooled index, so a reseeded turn neither leaks nor churns
+    // sampler-pool slots.
+    sampler->ReseedState(*device_state, *pending_reseed_);
+  }
+  pending_reseed_applied_ = true;
 }
 
 void Request::CommitSamplingState(std::unique_ptr<BatchedSamplerState> state) noexcept {
@@ -1148,10 +1223,10 @@ RequestStepResult Request::CompleteGeneration() {
   }
 
   const bool turn_limit_reached =
-      turn_max_generated_tokens_ &&
-      turn_generated_tokens_ >= *turn_max_generated_tokens_;
+      turn_policy_.max_generated_tokens &&
+      turn_generated_tokens_ >= *turn_policy_.max_generated_tokens;
   const bool context_limit_reached =
-      static_cast<size_t>(CurrentSequenceLength()) >= max_total_tokens_;
+      static_cast<size_t>(CurrentSequenceLength()) >= max_session_tokens_;
   if (search_->IsDone() || turn_limit_reached || context_limit_reached) {
     status_ = RequestStatus::TurnComplete;
     if (search_->IsDone() && !next_tokens.empty() &&
@@ -1162,9 +1237,7 @@ RequestStepResult Request::CompleteGeneration() {
     } else {
       finish_reason_ = GenerationFinishReason::ContextLimit;
     }
-    if (guidance_logits_processor_) {
-      guidance_logits_processor_->Reset();
-    }
+    ReleaseTurnResources();
   }
   RequestStepResult result{
       token,

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -12,6 +12,7 @@
 #include "request_status.h"
 #include "engine_invariants.h"
 #include "step_plan.h"
+#include "turn_policy.h"
 
 /**
  * @file request.h
@@ -30,19 +31,43 @@ struct ScheduledRequests;
 struct Tokenizer;
 class StopStringController;
 
+// Resident-session policy. Everything here outlives a single turn.
 struct RequestOptions {
+  // Total tokens (prompt plus generated, across every turn) the Request may ever reach. Defaults to
+  // the model-configured search.max_length, which is also its ceiling.
   std::optional<size_t> max_session_tokens;
 };
 
+// Per-turn generation policy. Every field is unset by default, and an unset field means "use the
+// model-configured default for this turn" -- never "keep whatever the previous turn used". A
+// caller may reuse one options object across turns; the Request itself never makes these sticky.
 struct TurnOptions {
   std::weak_ptr<Request> request;
   std::optional<size_t> max_generated_tokens;
+  std::optional<size_t> min_generated_tokens;
+  std::optional<bool> do_sample;
+  std::optional<float> temperature;
+  std::optional<float> top_p;
+  std::optional<int> top_k;
+  std::optional<float> repetition_penalty;
+  std::optional<int> no_repeat_ngram_size;
+  // Seed is the one deliberate exception to non-sticky resolution. Unset means "continue the
+  // Request's existing host and device RNG streams"; set means "reseed both streams for this turn".
+  // Zero is a valid deterministic seed, which is why clearing is a distinct operation rather than a
+  // sentinel value.
+  std::optional<uint64_t> seed;
   // Copied UTF-8 stop strings for this turn. Empty means stop strings are disabled (or, when set on
   // an already-configured turn, cleared). Bounds and UTF-8 validity are enforced by
   // OgaTurnOptionsSetStopStrings (via StopStringMatcher) before this is populated.
   std::vector<std::string> stop_strings;
+  // Copied grammar for this turn. Both empty means the turn is unguided; guidance is never
+  // inherited from a previous turn or from model/Request state.
+  std::string guidance_type;
+  std::string guidance_data;
 
   void ValidateOwnerThread() const;
+  // Restores every option to its unset state, leaving the bound Request alone.
+  void Reset();
 };
 
 struct RequestStepResult {
@@ -68,6 +93,10 @@ struct RequestTurnAdmission {
   int64_t prompt_sequence_length{};
   int64_t processed_sequence_length{};
   bool transaction_started{};
+  // This turn's fully resolved generation policy. Built and validated before the attempt starts and
+  // installed by Request::CommitTurnAdmission(). Value-initialized (an inert greedy policy) so it
+  // is never indeterminate between constructing the admission and assigning the resolved policy.
+  EffectiveTurnPolicy policy{};
   // The complete stop controller this turn will have once committed (null when the turn has no
   // stop strings). The caller builds this -- including any tokenizer/stream construction, which
   // can throw -- before starting this admission attempt, so it is never itself a source of
@@ -76,6 +105,11 @@ struct RequestTurnAdmission {
   // destructor otherwise simply discard it, leaving whatever stop_controller_ the Request had
   // before this attempt (from a prior committed turn, or null) completely untouched.
   std::unique_ptr<StopStringController> pending_stop_controller;
+  // This turn's guidance processor, or null for an unguided turn. Built by the caller under exactly
+  // the same pre-mutation rules as pending_stop_controller: grammar validation, cache acquisition,
+  // and processor construction all happen before the attempt begins, so an invalid grammar leaves
+  // the previous completed turn's Request entirely reusable.
+  std::unique_ptr<ConstrainedLogitsProcessor> pending_guidance;
 };
 
 struct RequestTurnCounters {
@@ -97,12 +131,19 @@ struct Request : std::enable_shared_from_this<Request>,
                  LeakChecked<Request>,
                  ExternalRefCounted<Request> {
   /**
-   * @brief Constructs a Request object with the given generator parameters.
-   * @param params Shared pointer to GeneratorParams containing generation configuration.
+   * @brief Constructs a Request bound to a model and a session token limit.
+   * @param model The model this Request decodes with. Its configuration supplies the generation
+   *              defaults every turn resolves from.
+   * @param max_session_tokens Total tokens (prompt plus generated, across every turn) this Request
+   *              may ever reach.
+   *
+   * The Request derives its own private search parameters from the model: batch size and beam count
+   * are forced to one, the search length limit is the session limit, and no caller-supplied
+   * generation policy is retained. Per-turn policy arrives through TurnOptions instead.
    */
   Request(
-      std::shared_ptr<GeneratorParams> params,
-      size_t max_total_tokens,
+      const Model& model,
+      size_t max_session_tokens,
       std::shared_ptr<std::atomic<bool>> abandonment_pending =
           std::make_shared<std::atomic<bool>>(false));
   ~Request();
@@ -151,8 +192,8 @@ struct Request : std::enable_shared_from_this<Request>,
   // scheduler-private shadow the Engine owns outright. They never sample and never enter the
   // public turn API, so they are admitted through this factory instead of BeginTurn.
   static std::shared_ptr<Request> CreateAuxiliaryDecoderRequest(
-      std::shared_ptr<GeneratorParams> params,
-      size_t max_total_tokens,
+      const Model& model,
+      size_t max_session_tokens,
       std::shared_ptr<std::atomic<bool>> abandonment_pending,
       const std::shared_ptr<Engine>& engine,
       std::span<const int32_t> tokens);
@@ -163,8 +204,23 @@ struct Request : std::enable_shared_from_this<Request>,
 
   /**
    * @brief Total tokens (prompt plus generated) this request may ever reach.
+   *
+   * This is the Request's one session limit: Search completion, static cache sizing, speculative
+   * bounds, and the MaxSessionTokens finish reason all use it.
    */
-  size_t MaxTotalTokens() const noexcept { return max_total_tokens_; }
+  size_t MaxSessionTokens() const noexcept { return max_session_tokens_; }
+
+  /**
+   * @brief The generation policy the currently admitted turn resolved to.
+   */
+  const EffectiveTurnPolicy& TurnPolicy() const noexcept { return turn_policy_; }
+
+  /**
+   * @brief Model/Engine-configured prefill chunk size, or nothing when chunking is disabled.
+   *
+   * Scheduler policy, deliberately kept out of the per-turn generation policy.
+   */
+  const std::optional<size_t>& PrefillChunkSize() const noexcept;
 
   /**
    * @brief The speculative-decoding options this request was created with.
@@ -293,7 +349,6 @@ struct Request : std::enable_shared_from_this<Request>,
   // any appended replacement is committed normally through the ordinary token_appended path.
   void MarkFinalStageAsEvaluatedNonAcceptedDraft() noexcept { ++evaluated_draft_count_; }
 
-  void ValidateEngineCompatibility() const;
   void SaveStateForTransaction();
   void SaveStateForNewTurnTransaction();
   void SaveStateForExternalSamplingTransaction();
@@ -333,12 +388,11 @@ struct Request : std::enable_shared_from_this<Request>,
   size_t TurnPromptTokens() const noexcept { return turn_prompt_tokens_; }
   size_t TurnGeneratedTokens() const noexcept { return turn_generated_tokens_; }
   size_t RemainingTurnTokenBudget() const noexcept {
-    if (!turn_max_generated_tokens_) {
+    const auto& limit = turn_policy_.max_generated_tokens;
+    if (!limit) {
       return std::numeric_limits<size_t>::max();
     }
-    return turn_generated_tokens_ < *turn_max_generated_tokens_
-               ? *turn_max_generated_tokens_ - turn_generated_tokens_
-               : 0;
+    return turn_generated_tokens_ < *limit ? *limit - turn_generated_tokens_ : 0;
   }
 
   RequestStatus Status() const noexcept { return status_; }
@@ -415,11 +469,6 @@ struct Request : std::enable_shared_from_this<Request>,
   RequestStatus status_{RequestStatus::Unassigned};
 
   /**
-   * @brief The search options this request was created with.
-   */
-  const Config::Search& SearchOptions() const;
-
-  /**
    * @brief Binds this request's search to a one-element slot of a caller-owned next-token buffer.
    * @return True if the search accepted the slot, false if it must be sampled on its own.
    *
@@ -445,9 +494,49 @@ struct Request : std::enable_shared_from_this<Request>,
 
   /**
    * @brief Returns this request's persistent random state for the given batched sampler.
+   *
+   * Always created from the durable seed basis. A turn's reseed is never folded into creation,
+   * because only a reseed applied inside the step transaction can be rolled back with it.
    */
   BatchedSamplerState& SamplingState(BatchedSampler& sampler);
   void CommitSamplingState(std::unique_ptr<BatchedSamplerState> state) noexcept;
+
+  /**
+   * @brief The durable seed basis a newly created sampler state starts from.
+   */
+  uint64_t SamplerSeedBasis() const noexcept { return current_seed_basis_; }
+
+  /**
+   * @brief True while an admitted turn's reseed is still waiting to be applied or committed.
+   */
+  bool HasPendingTurnSeed() const noexcept { return pending_reseed_.has_value(); }
+
+  /**
+   * @brief This request's existing sampler-owned device RNG state, or null when it has none.
+   *
+   * Never creates one. The step transaction uses it to checkpoint exactly the states a pending
+   * reseed is about to overwrite.
+   */
+  BatchedSamplerState* ExistingSamplingState(BatchedSampler& sampler) const noexcept;
+
+  /**
+   * @brief Applies this turn's pending reseed to the host and device RNG streams.
+   *
+   * Called inside the step transaction, strictly after every Request and sampler checkpoint and
+   * strictly before the first RNG consumer, so a rolled back step restores both streams and leaves
+   * the reseed pending for the retry. The pending marker is promoted to the durable basis only by
+   * CommitStateForTransaction().
+   *
+   * @param sampler The batched sampler owning this request's device state, or null when the step
+   *                has none.
+   * @param device_state_checkpointed Whether this step checkpointed that device state. The caller
+   *                guarantees this is true whenever the Request has one, because a reseed the step
+   *                could not roll back must not be applied and must not be promoted either; a
+   *                violation throws instead of leaving the host and device streams on different
+   *                seeds.
+   */
+  void ApplyPendingSeedForTransaction(BatchedSampler* sampler,
+                                      bool device_state_checkpointed);
 
  private:
   // The search sequence is partitioned at processed_sequence_length_: tokens before it already
@@ -459,13 +548,27 @@ struct Request : std::enable_shared_from_this<Request>,
   friend struct test::RequestGuidanceTestAccess;
 
   void CompleteClose() noexcept;
+  // Builds the Request's private, Model-derived search parameters. Not caller-created and not
+  // publicly visible: it exists only because Search and sequence storage are still constructed from
+  // a GeneratorParams.
+  static std::shared_ptr<GeneratorParams> CreateRequestParams(
+      const Model& model,
+      size_t max_session_tokens);
   static DeviceSpan<int32_t> AllocateOnDevice(
       GeneratorParams& params,
       std::span<const int32_t> input_ids);
   static void ValidateAppendLength(
-      size_t max_total_tokens,
+      size_t max_session_tokens,
       size_t current_sequence_length,
       size_t token_count);
+  // Releases everything scoped to the turn that just ended: its stop matcher and its guidance
+  // cursor. Finish metadata is stored separately, so a completed turn stays fully queryable.
+  void ReleaseTurnResources() noexcept;
+  // Absolute sequence position below which EOS stays masked, or 0 when the turn set no minimum.
+  // Derived rather than stored so it can never disagree with the committed turn's policy or prompt
+  // length. The sum fits an int because admission proved the turn's prompt length plus its minimum
+  // does not exceed the session limit, which is itself within the internal search length type.
+  int TurnEosFloor() const noexcept;
   // Drops whatever the step in flight staged past the committed sequence, leaving the host mirror
   // exactly as long as the search after its own transaction rewind.
   void DiscardStagedDrafts() noexcept;
@@ -475,10 +578,12 @@ struct Request : std::enable_shared_from_this<Request>,
   // request is still prefilling while processed_sequence_length_ has not caught up with it.
   int64_t prompt_sequence_length_{};
   size_t scheduled_token_count_{};
-  std::optional<size_t> turn_max_generated_tokens_;
+  // The committed turn's resolved policy. The constructor resolves it from the model's own search
+  // defaults so an unadmitted Request already has a complete one.
+  EffectiveTurnPolicy turn_policy_;
   size_t turn_prompt_tokens_{};
   size_t turn_generated_tokens_{};
-  const size_t max_total_tokens_;
+  const size_t max_session_tokens_;
   uint64_t current_turn_id_{};
   uint64_t next_turn_id_{1};
   bool has_current_turn_{};
@@ -522,6 +627,15 @@ struct Request : std::enable_shared_from_this<Request>,
   // result.
   int32_t draft_verification_stop_match_index_{-1};
   std::shared_ptr<GeneratorParams> params_;
+  // Durable seed basis every RNG stream of this Request starts from. Initialized once from the
+  // model-configured seed (a generated 64-bit value when the model leaves it unset) and advanced
+  // only when a turn's explicit reseed actually commits.
+  uint64_t current_seed_basis_{};
+  // The reseed the admitted turn asked for, still waiting to be applied (or, once applied, waiting
+  // for its step to commit). Survives rollback so the retry reseeds identically, and is discarded
+  // by ReleaseTurnResources() if the turn ends before a sampling step commits it.
+  std::optional<uint64_t> pending_reseed_;
+  bool pending_reseed_applied_{};
   std::mt19937 rng_;
   std::mt19937 transaction_rng_;
   int64_t transaction_processed_sequence_length_{};

--- a/src/engine/scheduled_requests.cpp
+++ b/src/engine/scheduled_requests.cpp
@@ -17,22 +17,18 @@ namespace Generators {
 
 namespace {
 
-// Collapses Request::GenerateNextTokens' dispatch into the single (k, p, temperature) triple that
+// Collapses Request::SelectNextToken's dispatch into the single (k, p, temperature) triple that
 // each branch ends up handing to the sampler on CUDA, where SelectTop() is SampleTopKTopP(1, 0, 1),
 // SampleTopK(k, t) is SampleTopKTopP(k, 1, t) and SampleTopP(p, t) is SampleTopKTopP(-1, p, t).
-// Returns nothing for options the per-request path rejects, so that it keeps raising the error.
-std::optional<BatchedSamplingParams> ResolveSampleArgs(const Config::Search& search) {
-  if (!search.do_sample || search.top_k == 1 || search.temperature == 0)
+BatchedSamplingParams ResolveSampleArgs(const EffectiveTurnPolicy& policy) {
+  if (policy.IsGreedy())
     return BatchedSamplingParams{1, 0.0f, 1.0f};
 
-  if (search.num_beams != 1 || search.top_p < 0.0f || search.top_p > 1.0f || search.top_k < 0)
-    return std::nullopt;
-
-  if (search.top_p > 0.0f && search.top_p < 1.0f && search.top_k > 1)
-    return BatchedSamplingParams{search.top_k, search.top_p, search.temperature};
-  if (search.top_k > 1)
-    return BatchedSamplingParams{search.top_k, 1.0f, search.temperature};
-  return BatchedSamplingParams{-1, search.top_p, search.temperature};
+  if (policy.top_p > 0.0f && policy.top_p < 1.0f && policy.top_k > 1)
+    return BatchedSamplingParams{policy.top_k, policy.top_p, policy.temperature};
+  if (policy.top_k > 1)
+    return BatchedSamplingParams{policy.top_k, 1.0f, policy.temperature};
+  return BatchedSamplingParams{-1, policy.top_p, policy.temperature};
 }
 
 // Greedy token for every row, computed on the device so that the full vocabulary never crosses the
@@ -56,10 +52,6 @@ std::vector<int32_t> TryDeviceArgmaxPerRow(DeviceInterface& device,
                      static_cast<int>(vocab_size), tokens.data()))
     return {};
   return tokens;
-}
-
-bool UsesRandomSampling(const Config::Search& search) {
-  return search.do_sample && search.top_k != 1 && search.temperature != 0;
 }
 
 struct TopKScores {
@@ -95,22 +87,22 @@ TopKScores TryDeviceTopKScoresPerRow(DeviceInterface& device,
 }
 
 TargetTokenSelection BuildTargetSelection(
-    size_t row, DeviceSpan<float> logits, const Config::Search& search,
+    size_t row, DeviceSpan<float> logits, const EffectiveTurnPolicy& policy,
     const TopKScores& topk, SampledCategorical& scratch) {
   TargetTokenSelection selection;
   if (topk.k == 0) {
     const auto cpu_logits = logits.CopyDeviceToCpu();
-    ComputeSampledCategorical(cpu_logits, search.top_k, search.top_p,
-                              search.temperature, scratch);
+    ComputeSampledCategorical(cpu_logits, policy.top_k, policy.top_p,
+                              policy.temperature, scratch);
     selection.indices = scratch.indices;
     selection.probs = scratch.probs;
     return selection;
   }
 
-  const int k = std::min(search.top_k, topk.k);
+  const int k = std::min(policy.top_k, topk.k);
   const size_t offset = row * static_cast<size_t>(topk.k);
   const float max_score = topk.scores[offset];
-  const float inverse_temperature = 1.0f / search.temperature;
+  const float inverse_temperature = 1.0f / policy.temperature;
   std::vector<float> probabilities(static_cast<size_t>(k));
   float sum = 0.0f;
   for (int i = 0; i < k; ++i) {
@@ -123,11 +115,11 @@ TargetTokenSelection BuildTargetSelection(
     probability /= sum;
 
   int keep = k;
-  if (search.top_p > 0.0f && search.top_p < 1.0f) {
+  if (policy.top_p > 0.0f && policy.top_p < 1.0f) {
     float cumulative = 0.0f;
     for (int i = 0; i < k; ++i) {
       cumulative += probabilities[static_cast<size_t>(i)];
-      if (cumulative >= search.top_p) {
+      if (cumulative >= policy.top_p) {
         keep = i + 1;
         break;
       }
@@ -338,8 +330,8 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
   int max_sampling_top_k = 0;
   bool any_checkpoint_needed = false;
   for (size_t i = 0; i < requests_.size(); ++i) {
-    if (draft_token_counts_[i] != 0 && UsesRandomSampling(requests_[i]->SearchOptions())) {
-      max_sampling_top_k = std::max(max_sampling_top_k, requests_[i]->SearchOptions().top_k);
+    if (draft_token_counts_[i] != 0 && !requests_[i]->TurnPolicy().IsGreedy()) {
+      max_sampling_top_k = std::max(max_sampling_top_k, requests_[i]->TurnPolicy().top_k);
       any_checkpoint_needed = any_checkpoint_needed || requests_[i]->stop_controller_ != nullptr;
     }
   }
@@ -358,11 +350,11 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
       continue;
     }
 
-    if (UsesRandomSampling(requests_[i]->SearchOptions())) {
+    if (!requests_[i]->TurnPolicy().IsGreedy()) {
       // Draft acceptance is sequential: each row is drawn only if the previous draw matched its
       // draft, which the batched device sampler cannot express. These draws therefore come from
       // the Request's own host stream (checkpointed with the transaction) rather than its device
-      // BatchedSamplerState. search.random_seed consequently reproduces a given decode path, not
+      // BatchedSamplerState. The turn seed consequently reproduces a given decode path, not
       // output across decode paths, because whether drafts are admitted depends on batch
       // composition. See "Seeded sampling" in docs/paged_attention_engine.md.
       //
@@ -391,7 +383,7 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
              selected_tokens[i].size() < token_budget) {
         const auto selection = BuildTargetSelection(
             row + accepted_count, verify_rows[row + accepted_count],
-            requests_[i]->SearchOptions(), topk, sampling_scratch);
+            requests_[i]->TurnPolicy(), topk, sampling_scratch);
         const int32_t token = SampleTargetToken(selection, requests_[i]->rng_);
         selected_tokens[i].push_back(token);
         if (checkpoint_rng) {
@@ -405,7 +397,7 @@ std::vector<DeviceSpan<float>> ScheduledRequests::SelectSampledRows(
           selected_tokens[i].size() < token_budget) {
         const auto selection = BuildTargetSelection(
             row + draft_count, verify_rows[row + draft_count],
-            requests_[i]->SearchOptions(), topk, sampling_scratch);
+            requests_[i]->TurnPolicy(), topk, sampling_scratch);
         selected_tokens[i].push_back(
             SampleTargetToken(selection, requests_[i]->rng_));
         if (checkpoint_rng) {
@@ -630,18 +622,17 @@ bool ScheduledRequests::PrepareBatchedSamplingPlan(
         !request->IsChunkComplete())
       continue;
     if (require_transaction_support && draft_token_counts_[request_index] != 0 &&
-        UsesRandomSampling(request->SearchOptions())) {
+        !request->TurnPolicy().IsGreedy()) {
       continue;
     }
 
-    const auto args = ResolveSampleArgs(request->SearchOptions());
-    if (!args || !request->SupportsBatchedSampling()) {
+    if (!request->SupportsBatchedSampling()) {
       sampling_plan_->Clear();
       return false;
     }
     sampling_plan_->requests.push_back(request.get());
     sampling_plan_->result_indices.push_back(request_index);
-    sampling_plan_->params.push_back(*args);
+    sampling_plan_->params.push_back(ResolveSampleArgs(request->TurnPolicy()));
     sampling_plan_->states.push_back(&request->SamplingState(*batched_sampler_));
   }
   return !sampling_plan_->requests.empty();
@@ -652,6 +643,7 @@ void ScheduledRequests::BeginTransaction() {
     throw std::logic_error("Scheduled request transaction is already active.");
 
   transaction_uses_batched_sampler_ = PrepareBatchedSamplingPlan(true);
+  checkpointed_sampler_states_.clear();
   try {
     for (const auto& request : requests_) {
       const bool uses_batched_sampler =
@@ -669,9 +661,30 @@ void ScheduledRequests::BeginTransaction() {
     for (size_t i = 0; i < draft_token_counts_.size(); ++i) {
       requests_[i]->AppendDraftsForTransaction(draft_token_counts_[i]);
     }
-    if (transaction_uses_batched_sampler_) {
-      batched_sampler_->SaveStateForTransaction(sampling_plan_->states);
-      sampler_checkpoint_active_ = true;
+    if (batched_sampler_ && batched_sampler_->SupportsTransactions()) {
+      if (transaction_uses_batched_sampler_) {
+        checkpointed_sampler_states_ = sampling_plan_->states;
+      }
+      // A pending turn reseed overwrites a device stream in place, so its state has to be
+      // checkpointed even when this step does not sample that request through the batched sampler
+      // (a sampled draft verification draws on the host, and a plan can be abandoned entirely).
+      // Without this the reseed would be an unrecoverable mutation inside the transaction.
+      for (const auto& request : requests_) {
+        if (!request->HasPendingTurnSeed() || !request->IsChunkComplete())
+          continue;
+        auto* state = request->ExistingSamplingState(*batched_sampler_);
+        if (!state)
+          continue;
+        if (std::find(checkpointed_sampler_states_.begin(),
+                      checkpointed_sampler_states_.end(),
+                      state) == checkpointed_sampler_states_.end()) {
+          checkpointed_sampler_states_.push_back(state);
+        }
+      }
+      if (!checkpointed_sampler_states_.empty()) {
+        batched_sampler_->SaveStateForTransaction(checkpointed_sampler_states_);
+        sampler_checkpoint_active_ = true;
+      }
     }
   } catch (...) {
     const auto error = std::current_exception();
@@ -689,6 +702,24 @@ void ScheduledRequests::GenerateNextTokensForTransaction(
   if (plan.requests.size() != requests_.size() ||
       transaction_checkpoint_count_ != requests_.size()) {
     throw std::logic_error("Scheduled request transaction does not match the step plan.");
+  }
+
+  // Strictly after every Request and sampler checkpoint taken in BeginTransaction() and strictly
+  // before the first host or device RNG consumer below, so a rolled back step restores both streams
+  // and leaves the reseed pending for the retry. A device state is reseeded only when this step
+  // checkpointed it; BeginTransaction() checkpoints every state a pending reseed targets.
+  for (const auto& request : requests_) {
+    if (!request->HasPendingTurnSeed() || !request->IsChunkComplete()) {
+      continue;
+    }
+    const bool device_state_checkpointed =
+        sampler_checkpoint_active_ && batched_sampler_ &&
+        std::find(checkpointed_sampler_states_.begin(),
+                  checkpointed_sampler_states_.end(),
+                  request->ExistingSamplingState(*batched_sampler_)) !=
+            checkpointed_sampler_states_.end();
+    request->ApplyPendingSeedForTransaction(batched_sampler_,
+                                            device_state_checkpointed);
   }
 
   auto verify_rows = ProcessLogits();
@@ -883,6 +914,7 @@ void ScheduledRequests::RestoreStateForTransaction() {
     }
     sampler_checkpoint_active_ = false;
   }
+  checkpointed_sampler_states_.clear();
 
   std::vector<Request*> pending_restore_completion;
   pending_restore_completion.reserve(transaction_checkpoint_count_);
@@ -928,6 +960,7 @@ void ScheduledRequests::CommitStateForTransaction() {
     batched_sampler_->CommitStateForTransaction();
     sampler_checkpoint_active_ = false;
   }
+  checkpointed_sampler_states_.clear();
   transaction_uses_batched_sampler_ = false;
 }
 

--- a/src/engine/scheduled_requests.h
+++ b/src/engine/scheduled_requests.h
@@ -138,6 +138,10 @@ struct ScheduledRequests {
   std::shared_ptr<GeneratorParams> params_;
   BatchedSampler* batched_sampler_{};
   BatchedSamplingPlan* sampling_plan_{};
+  // Every device RNG state this transaction checkpointed: the batched sampling plan's states plus
+  // the states of any request whose pending turn reseed is about to overwrite one. Only a state in
+  // here may be reseeded inside the transaction, because only these can be rolled back.
+  std::vector<BatchedSamplerState*> checkpointed_sampler_states_;
   size_t transaction_checkpoint_count_{};
   bool transaction_uses_batched_sampler_{};
   bool sampler_checkpoint_active_{};

--- a/src/engine/scheduler.cpp
+++ b/src/engine/scheduler.cpp
@@ -38,7 +38,7 @@ ScheduledRequests Scheduler::CreateScheduledRequests(const StepPlan& plan) {
 std::unique_ptr<BatchedSamplerState> Scheduler::CreateSamplingState(
     const Request& request) const {
   if (auto* sampler = GetBatchedSampler()) {
-    return sampler->CreateState(request.SearchOptions().random_seed);
+    return sampler->CreateState(request.SamplerSeedBasis());
   }
   return nullptr;
 }
@@ -47,11 +47,14 @@ StaticBatchScheduler::StaticBatchScheduler(std::shared_ptr<Model> model, std::sh
     : Scheduler{model}, model_{model}, cache_manager_{cache_manager} {}
 
 void StaticBatchScheduler::AddRequest(std::shared_ptr<Request> request) {
-  // The static batch decoder rebuilds its contiguous cache from the whole sequence every step, so it
-  // cannot resume a half written prompt. Only the paged cache can hold one.
-  if (request->SearchOptions().chunk_size.value_or(0) != 0) {
+  // Engine::CreateDependencies already rejects a chunking model for static batching, but an Engine
+  // built with injected dependencies never runs that check. Keep this guard: the static batch
+  // decoder rebuilds its contiguous cache from the whole sequence every step, so it cannot resume a
+  // half-written prompt, and admitting one here would corrupt the batch instead of failing.
+  if (request->PrefillChunkSize().value_or(0) != 0) {
     throw std::runtime_error(
-        "search.chunk_size requires dynamic batching; the static batch scheduler cannot chunk a prefill.");
+        "search.chunk_size requires dynamic batching; the static batch scheduler cannot chunk a "
+        "prefill.");
   }
   requests_pool_.reserve(requests_pool_.size() + 1);
   auto sampling_state = CreateSamplingState(*request);
@@ -219,7 +222,7 @@ StepPlanningResult DynamicBatchScheduler::PlanStep(StepPlan& plan) {
         SlotsForWholeSequence(snapshot.current_sequence_length);
     candidate.entry.is_prefill = snapshot.is_prefill;
     candidate.entry.newly_admitted = newly_admitted;
-    auto prefill_token_cap = request->SearchOptions().chunk_size;
+    auto prefill_token_cap = request->PrefillChunkSize();
     if (cache_query_token_cap != 0 &&
         (prefill_token_cap.value_or(0) == 0 || *prefill_token_cap > cache_query_token_cap)) {
       prefill_token_cap = cache_query_token_cap;

--- a/src/engine/scheduler.h
+++ b/src/engine/scheduler.h
@@ -72,6 +72,10 @@ struct Scheduler {
 
   ScheduledRequests CreateScheduledRequests(const StepPlan& plan);
 
+  bool SupportsTransactionalSamplerState() const {
+    return !batched_sampler_ || batched_sampler_->SupportsTransactions();
+  }
+
   /**
    * @brief Checks if the Scheduler has any pending requests.
    * @return True if there are pending requests, false otherwise.

--- a/src/engine/turn_policy.cpp
+++ b/src/engine/turn_policy.cpp
@@ -51,7 +51,8 @@ void RejectModelSuppliedGreedy(const std::vector<const char*>& model_causes) {
 
 bool SupportsNoRepeatNgram(DeviceType scoring_device_type) noexcept {
   // Only Search_Cpu implements ApplyNoRepeatNgram; the Search base class throws for every other
-  // scoring device. Keyed by device type because the scoring device is what builds the Search.
+  // scoring device. Model maps every EP except CUDA and NvTensorRtRtx to CPU scoring, so this is
+  // keyed by the device that actually builds the Search rather than the model execution device.
   return scoring_device_type == DeviceType::CPU;
 }
 

--- a/src/engine/turn_policy.cpp
+++ b/src/engine/turn_policy.cpp
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "turn_policy.h"
+
+#include <cassert>
+#include <cmath>
+#include <stdexcept>
+
+#include "request.h"
+
+namespace Generators {
+
+namespace {
+
+// Names the explicitly-set scalars that contradict a greedy resolution, so the error tells the
+// caller exactly which of their values asked for a distribution the turn will never draw from.
+void RejectContradictoryScalars(const std::string& greedy_cause,
+                                const std::vector<const char*>& contradictory_fields) {
+  std::string message =
+      "The resolved turn policy selects the top logit (" + greedy_cause +
+      "), so these explicitly set sampling options contradict it:";
+  for (const char* field : contradictory_fields) {
+    message += ' ';
+    message += field;
+  }
+  message +=
+      ". Either remove them or request sampling with do_sample=true, top_k != 1, and a nonzero "
+      "temperature.";
+  throw std::runtime_error(std::move(message));
+}
+
+// Names the model-supplied condition that keeps a turn greedy even though the caller explicitly
+// asked to sample. The caller cannot see the model's search defaults from the options object, so
+// the error names the field to override rather than a value to remove.
+void RejectModelSuppliedGreedy(const std::vector<const char*>& model_causes) {
+  std::string message =
+      "do_sample=true was explicitly set, but this turn still selects the top logit because the "
+      "model's own search defaults supply";
+  for (size_t i = 0; i < model_causes.size(); ++i) {
+    message += i == 0 ? " " : " and ";
+    message += model_causes[i];
+  }
+  message +=
+      ". Set that field explicitly on the turn -- top_k above 1, or a nonzero temperature -- to "
+      "request sampling, or drop do_sample to accept top-logit selection.";
+  throw std::runtime_error(std::move(message));
+}
+
+}  // namespace
+
+bool SupportsNoRepeatNgram(DeviceType scoring_device_type) noexcept {
+  // Only Search_Cpu implements ApplyNoRepeatNgram; the Search base class throws for every other
+  // scoring device. Keyed by device type because the scoring device is what builds the Search.
+  return scoring_device_type == DeviceType::CPU;
+}
+
+EffectiveTurnPolicy ResolveTurnPolicy(const Config::Search& model_defaults,
+                                      const TurnOptions& options) {
+  // Value-initialized so nothing is ever indeterminate; every field is then written below.
+  EffectiveTurnPolicy policy{};
+  policy.do_sample = options.do_sample.value_or(model_defaults.do_sample);
+  policy.temperature = options.temperature.value_or(model_defaults.temperature);
+  policy.top_p = options.top_p.value_or(model_defaults.top_p);
+  policy.top_k = options.top_k.value_or(model_defaults.top_k);
+  policy.repetition_penalty =
+      options.repetition_penalty.value_or(model_defaults.repetition_penalty);
+  policy.no_repeat_ngram_size =
+      options.no_repeat_ngram_size.value_or(model_defaults.no_repeat_ngram_size);
+  // Deliberately not defaulted from the model's session-absolute search.min_length: a per-turn
+  // floor and a whole-session floor are different quantities, and Engine Request creation rejects
+  // a model that still carries a nonzero legacy value.
+  policy.min_generated_tokens = options.min_generated_tokens.value_or(0);
+  policy.max_generated_tokens = options.max_generated_tokens;
+  return policy;
+}
+
+void ValidateTurnPolicy(const EffectiveTurnPolicy& policy,
+                        const TurnOptions& options,
+                        DeviceType scoring_device_type,
+                        size_t turn_prompt_length,
+                        size_t max_session_tokens) {
+  if (!std::isfinite(policy.temperature) || policy.temperature < 0.0f) {
+    throw std::runtime_error(
+        "temperature (" + std::to_string(policy.temperature) +
+        ") must be finite and 0 or greater.");
+  }
+  if (!std::isfinite(policy.top_p) || policy.top_p < 0.0f || policy.top_p > 1.0f) {
+    throw std::runtime_error(
+        "top_p (" + std::to_string(policy.top_p) +
+        ") must be finite and between 0.0 and 1.0.");
+  }
+  if (policy.top_k < 0) {
+    throw std::runtime_error(
+        "top_k (" + std::to_string(policy.top_k) + ") must be 0 or greater.");
+  }
+  if (!std::isfinite(policy.repetition_penalty) || policy.repetition_penalty <= 0.0f) {
+    throw std::runtime_error(
+        "repetition_penalty (" + std::to_string(policy.repetition_penalty) +
+        ") must be finite and greater than zero.");
+  }
+  if (policy.no_repeat_ngram_size < 0) {
+    throw std::runtime_error(
+        "no_repeat_ngram_size (" + std::to_string(policy.no_repeat_ngram_size) +
+        ") must be 0 or greater.");
+  }
+  if (policy.no_repeat_ngram_size > 0 && !SupportsNoRepeatNgram(scoring_device_type)) {
+    throw std::runtime_error(
+        "no_repeat_ngram_size is not supported on the selected scoring device type (" +
+        to_string(scoring_device_type) + ").");
+  }
+
+  // A greedy resolution draws from no distribution at all. An explicitly set scalar that only
+  // makes sense for a distribution is a caller mistake, not a preference: reject it instead of
+  // silently selecting the top logit. Values that are consistent with greedy selection
+  // (temperature 0, top_k 1) or that request no restriction at all (top_k 0, top_p 0 or 1,
+  // temperature 1) are accepted, because honoring them exactly is what the turn already does.
+  if (policy.IsGreedy()) {
+    // A caller who spells greedy out themselves has chosen it; the model's defaults did not choose
+    // it for them. Only these two spellings resolve to greedy on their own.
+    const bool caller_requested_greedy =
+        (options.top_k.has_value() && policy.top_k == 1) ||
+        (options.temperature.has_value() && policy.temperature == 0.0f);
+    // An explicit do_sample=true that a model default silently overrides is the one greedy
+    // resolution the caller cannot have meant, so it is rejected before anything is mutated.
+    // Requesting sampling means overriding the field the model set, not just setting do_sample.
+    if (options.do_sample.value_or(false) && !caller_requested_greedy) {
+      std::vector<const char*> model_causes;
+      if (policy.top_k == 1) {
+        model_causes.push_back("search.top_k = 1");
+      }
+      if (policy.temperature == 0.0f) {
+        model_causes.push_back("search.temperature = 0");
+      }
+      // do_sample is true here, so top_k == 1 or temperature == 0 is the only way to be greedy,
+      // and neither of them came from this turn's options.
+      assert(!model_causes.empty());
+      RejectModelSuppliedGreedy(model_causes);
+    }
+
+    std::vector<const char*> contradictory;
+    // Every condition that made this policy greedy, so the error names the resolution the caller
+    // actually got rather than one arbitrarily chosen reason.
+    std::string cause;
+    const auto add_cause = [&cause](const char* reason) {
+      if (!cause.empty()) cause += " and ";
+      cause += reason;
+    };
+    if (!policy.do_sample) add_cause("do_sample is false");
+    if (policy.top_k == 1) add_cause("top_k is 1");
+    if (policy.temperature == 0.0f) add_cause("temperature is 0");
+
+    // Temperature 1 rescales nothing, exactly like top_p 1 and top_k 0, so it is neutral under a
+    // greedy resolution rather than a request for a distribution.
+    if (options.temperature.has_value() && policy.temperature != 0.0f &&
+        policy.temperature != 1.0f) {
+      contradictory.push_back("temperature");
+    }
+    if (options.top_p.has_value() && policy.top_p > 0.0f && policy.top_p < 1.0f) {
+      contradictory.push_back("top_p");
+    }
+    if (options.top_k.has_value() && policy.top_k > 1) {
+      contradictory.push_back("top_k");
+    }
+    if (!contradictory.empty()) {
+      RejectContradictoryScalars(cause, contradictory);
+    }
+  } else if (policy.top_k == 0 && policy.top_p == 0.0f) {
+    throw std::runtime_error(
+        "A sampled turn requires a positive top_k or a positive top_p; both are 0.");
+  }
+
+  if (policy.min_generated_tokens != 0) {
+    if (policy.max_generated_tokens &&
+        policy.min_generated_tokens > *policy.max_generated_tokens) {
+      throw std::runtime_error(
+          "min_generated_tokens (" + std::to_string(policy.min_generated_tokens) +
+          ") must not exceed max_generated_tokens (" +
+          std::to_string(*policy.max_generated_tokens) + ").");
+    }
+    // The floor is an absolute sequence position, so it has to fit inside the session limit, which
+    // Engine Request creation has already proven fits the internal Search length type.
+    const size_t remaining_session_tokens =
+        turn_prompt_length < max_session_tokens ? max_session_tokens - turn_prompt_length : 0;
+    if (policy.min_generated_tokens > remaining_session_tokens) {
+      throw std::runtime_error(
+          "min_generated_tokens (" + std::to_string(policy.min_generated_tokens) +
+          ") does not fit between the turn's prompt length (" +
+          std::to_string(turn_prompt_length) + ") and max_session_tokens (" +
+          std::to_string(max_session_tokens) + ").");
+    }
+  }
+}
+
+}  // namespace Generators

--- a/src/engine/turn_policy.cpp
+++ b/src/engine/turn_policy.cpp
@@ -78,6 +78,7 @@ EffectiveTurnPolicy ResolveTurnPolicy(const Config::Search& model_defaults,
 void ValidateTurnPolicy(const EffectiveTurnPolicy& policy,
                         const TurnOptions& options,
                         DeviceType scoring_device_type,
+                        int vocab_size,
                         size_t turn_prompt_length,
                         size_t max_session_tokens) {
   if (!std::isfinite(policy.temperature) || policy.temperature < 0.0f) {
@@ -165,9 +166,23 @@ void ValidateTurnPolicy(const EffectiveTurnPolicy& policy,
     if (!contradictory.empty()) {
       RejectContradictoryScalars(cause, contradictory);
     }
-  } else if (policy.top_k == 0 && policy.top_p == 0.0f) {
-    throw std::runtime_error(
-        "A sampled turn requires a positive top_k or a positive top_p; both are 0.");
+  } else {
+    if (policy.top_k > vocab_size) {
+      if (!options.top_k) {
+        throw std::runtime_error(
+            "The model's search.top_k (" + std::to_string(policy.top_k) +
+            ") exceeds vocab_size (" + std::to_string(vocab_size) +
+            "). Set top_k explicitly to a value no greater than vocab_size.");
+      }
+      throw std::runtime_error(
+          "top_k (" + std::to_string(policy.top_k) +
+          ") must be less than or equal to vocab_size (" +
+          std::to_string(vocab_size) + ").");
+    }
+    if (policy.top_k == 0 && policy.top_p == 0.0f) {
+      throw std::runtime_error(
+          "A sampled turn requires a positive top_k or a positive top_p; both are 0.");
+    }
   }
 
   if (policy.min_generated_tokens != 0) {

--- a/src/engine/turn_policy.h
+++ b/src/engine/turn_policy.h
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "../config.h"
+#include "../smartptrs.h"
+
+/**
+ * @file turn_policy.h
+ * @brief The generation policy one Engine turn runs under.
+ *
+ * Every value here is resolved anew for each turn from the model-authored search defaults plus the
+ * fields the caller explicitly set on that turn's options. Nothing carries over implicitly from the
+ * preceding turn: a turn that overrides nothing decodes with model defaults again.
+ */
+
+namespace Generators {
+
+struct TurnOptions;
+
+/**
+ * @brief The complete, already-resolved generation policy of one turn.
+ *
+ * Deliberately has no member initializers for the scalars: `ResolveTurnPolicy()` writes every one
+ * of them from the model defaults plus that turn's overrides, so a default here would be a second,
+ * silent source of policy that never applies. Anything that builds a policy outside
+ * `ResolveTurnPolicy()` has to state every field.
+ */
+struct EffectiveTurnPolicy {
+  bool do_sample;
+  float temperature;
+  float top_p;
+  int top_k;
+  float repetition_penalty;
+  int no_repeat_ngram_size;
+  size_t min_generated_tokens;
+  std::optional<size_t> max_generated_tokens;
+
+  /**
+   * @brief The single classification every Engine execution path shares.
+   *
+   * Ordinary sampling, batched sampling, sampled draft verification, and draft eligibility all
+   * decide "greedy or sampled" here, so a policy can never be greedy on one path and sampled on
+   * another.
+   */
+  bool IsGreedy() const noexcept {
+    return !do_sample || top_k == 1 || temperature == 0;
+  }
+};
+
+/**
+ * @brief True when a Search built on this scoring device implements no_repeat_ngram_size.
+ *
+ * Core-owned and keyed by the device type rather than asked of Search or DeviceInterface, so an
+ * unsupported request is rejected at admission instead of throwing after the model has already run.
+ */
+bool SupportsNoRepeatNgram(DeviceType scoring_device_type) noexcept;
+
+/**
+ * @brief Resolves one turn's policy from model defaults plus that turn's explicit overrides.
+ *
+ * Performs no validation and touches no Request state.
+ */
+EffectiveTurnPolicy ResolveTurnPolicy(const Config::Search& model_defaults,
+                                      const TurnOptions& options);
+
+/**
+ * @brief Rejects a resolved policy the Engine cannot honor exactly as written.
+ *
+ * Called before any Request or Engine mutation. Besides ordinary range checks it rejects two
+ * inconsistencies between what the caller asked for and how the turn actually selects tokens:
+ *
+ * - An explicit `do_sample = true` that a model search default silently overrides, because the
+ *   model supplies `top_k == 1` or `temperature == 0`. The caller cannot see those defaults through
+ *   the options object, so the error names the model-supplied cause and the turn must override that
+ *   exact field to sample. A caller who spelled greedy out themselves (`top_k == 1` or
+ *   `temperature == 0` set on this turn) chose it and is accepted.
+ * - An explicitly set distribution scalar that contradicts a greedy resolution -- a `temperature`
+ *   other than 0 or 1, a nucleus `top_p` strictly between 0 and 1, or a `top_k` above 1 -- so a
+ *   caller never believes a turn sampled when it actually selected the top logit. Values that are
+ *   themselves consistent with greedy selection (`temperature == 0`, `top_k == 1`) or that restrict
+ *   nothing (`top_k == 0`, `top_p` of 0 or 1, `temperature` of 1) are accepted.
+ *
+ * A zero `max_generated_tokens` is rejected earlier by Request::ValidateTurnAdmission(), which
+ * every admission passes through first.
+ *
+ * @param policy The resolved policy.
+ * @param options The turn options, read only to tell an explicit override from a model default.
+ * @param scoring_device_type Device that will build this Request's Search.
+ * @param turn_prompt_length Sequence length the turn's generated output starts at.
+ * @param max_session_tokens The Request's one session limit.
+ */
+void ValidateTurnPolicy(const EffectiveTurnPolicy& policy,
+                        const TurnOptions& options,
+                        DeviceType scoring_device_type,
+                        size_t turn_prompt_length,
+                        size_t max_session_tokens);
+
+}  // namespace Generators

--- a/src/engine/turn_policy.h
+++ b/src/engine/turn_policy.h
@@ -94,12 +94,14 @@ EffectiveTurnPolicy ResolveTurnPolicy(const Config::Search& model_defaults,
  * @param policy The resolved policy.
  * @param options The turn options, read only to tell an explicit override from a model default.
  * @param scoring_device_type Device that will build this Request's Search.
+ * @param vocab_size Number of tokens in the model vocabulary.
  * @param turn_prompt_length Sequence length the turn's generated output starts at.
  * @param max_session_tokens The Request's one session limit.
  */
 void ValidateTurnPolicy(const EffectiveTurnPolicy& policy,
                         const TurnOptions& options,
                         DeviceType scoring_device_type,
+                        int vocab_size,
                         size_t turn_prompt_length,
                         size_t max_session_tokens);
 

--- a/src/ep/cuda/cuda_sampling.cu
+++ b/src/ep/cuda/cuda_sampling.cu
@@ -95,6 +95,9 @@ __global__ void FusedSamplingKernel(int32_t* next_token_out, const float* scores
   const float* batch_scores = scores + batch_idx * stride;
   const int* batch_indices = indices + batch_idx * stride;
 
+  // Greedy rows resolve to k=1. Candidates are sorted by descending score, so indices[0] is the
+  // top token; returning before a curand draw also prevents a greedy turn from shifting the
+  // persistent device RNG stream used by a later sampled turn.
   if (k == 1) {
     if (threadIdx.x == 0) {
       next_token_out[batch_idx] = batch_indices[0];

--- a/src/ep/cuda/cuda_sampling.cu
+++ b/src/ep/cuda/cuda_sampling.cu
@@ -95,6 +95,13 @@ __global__ void FusedSamplingKernel(int32_t* next_token_out, const float* scores
   const float* batch_scores = scores + batch_idx * stride;
   const int* batch_indices = indices + batch_idx * stride;
 
+  if (k == 1) {
+    if (threadIdx.x == 0) {
+      next_token_out[batch_idx] = batch_indices[0];
+    }
+    return;
+  }
+
   // Allocate shared memory for all intermediate data. This is the key to performance.
   extern __shared__ float smem[];
   float* temp_scaled_logits = smem;

--- a/src/ep/cuda/interface.cpp
+++ b/src/ep/cuda/interface.cpp
@@ -151,18 +151,22 @@ struct CudaSamplerStatePool {
   }
 
   template <typename Create>
-  auto AcquireOwned(int random_seed, Create&& create) {
+  auto AcquireOwned(uint64_t random_seed, Create&& create) {
     return indices_.AcquireOwned(
         [this, random_seed](int index, int required_size) {
           EnsureCapacity(required_size);
-          const unsigned long long seed =
-              random_seed == -1
-                  ? static_cast<unsigned long long>(std::random_device{}())
-                  : static_cast<unsigned long long>(random_seed);
           cuda::LaunchInitCurandState(
-              seed, states_.Span().data() + index, GetStream());
+              static_cast<unsigned long long>(random_seed),
+              states_.Span().data() + index, GetStream());
         },
         std::forward<Create>(create));
+  }
+
+  // Restarts one already-acquired slot's stream in place, keeping its pooled index.
+  void Reseed(int index, uint64_t random_seed) {
+    cuda::LaunchInitCurandState(
+        static_cast<unsigned long long>(random_seed),
+        states_.Span().data() + index, GetStream());
   }
 
   void Release(int index) noexcept { indices_.Release(index); }
@@ -216,13 +220,20 @@ struct CudaBatchedSampler final : BatchedSampler {
     transaction_state_indices_.CpuSpan();
   }
 
-  std::unique_ptr<BatchedSamplerState> CreateState(int random_seed) override {
+  std::unique_ptr<BatchedSamplerState> CreateState(uint64_t random_seed) override {
     auto pool = state_pool_;
     return state_pool_->AcquireOwned(
         random_seed,
         [pool = std::move(pool)](int index) {
           return std::make_unique<CudaBatchedSamplerState>(pool, index);
         });
+  }
+
+  void ReseedState(BatchedSamplerState& state, uint64_t random_seed) override {
+    auto* cuda_state = dynamic_cast<CudaBatchedSamplerState*>(&state);
+    if (!cuda_state || cuda_state->pool_.get() != state_pool_.get())
+      throw std::runtime_error("BatchedSampler received an RNG state from a different sampler.");
+    state_pool_->Reseed(cuda_state->index_, random_seed);
   }
 
   bool OwnsState(const BatchedSamplerState& state) const override {

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -1038,6 +1038,8 @@ struct OgaRequestOptions : OgaAbstract {
     return std::unique_ptr<OgaRequestOptions>(options);
   }
 
+  /** Total tokens (prompt plus generated, across every Turn) the Request may reach. Zero restores
+   *  the model-configured search.max_length, which is also the ceiling for any explicit value. */
   void SetMaxSessionTokens(uint64_t value) {
     OgaCheckResult(OgaRequestOptionsSetMaxSessionTokens(this, value));
   }
@@ -1054,24 +1056,45 @@ struct OgaTurnOptions : OgaAbstract {
     return std::unique_ptr<OgaTurnOptions>(options);
   }
 
+  /** Caps the tokens this Turn generates. Zero unsets the cap. */
   void SetMaxGeneratedTokens(uint64_t value) {
     OgaCheckResult(OgaTurnOptionsSetMaxGeneratedTokens(this, value));
   }
-  /** Reserved for future use; currently throws a not-implemented error. */
+  /** Masks end-of-sequence until this Turn has generated `value` tokens. Zero unsets it. */
+  void SetMinGeneratedTokens(uint64_t value) {
+    OgaCheckResult(OgaTurnOptionsSetMinGeneratedTokens(this, value));
+  }
+  /** Selects random sampling (true) or the top logit (false) for this Turn. */
+  void SetDoSample(bool value) {
+    OgaCheckResult(OgaTurnOptionsSetDoSample(this, value));
+  }
+  /** Sampling temperature; zero requests top-logit selection. */
   void SetTemperature(float value) {
     OgaCheckResult(OgaTurnOptionsSetTemperature(this, value));
   }
-  /** Reserved for future use; currently throws a not-implemented error. */
+  /** Nucleus bound between 0.0 and 1.0. */
   void SetTopP(float value) {
     OgaCheckResult(OgaTurnOptionsSetTopP(this, value));
   }
-  /** Reserved for future use; currently throws a not-implemented error. */
+  /** Top-k bound; one requests top-logit selection and zero disables top-k. */
   void SetTopK(int32_t value) {
     OgaCheckResult(OgaTurnOptionsSetTopK(this, value));
   }
-  /** Reserved for future use; currently throws a not-implemented error. */
+  /** Repetition penalty; must be finite and greater than zero. */
+  void SetRepetitionPenalty(float value) {
+    OgaCheckResult(OgaTurnOptionsSetRepetitionPenalty(this, value));
+  }
+  /** Forbids repeating any n-gram of this size. Zero disables it. */
+  void SetNoRepeatNgramSize(int32_t value) {
+    OgaCheckResult(OgaTurnOptionsSetNoRepeatNgramSize(this, value));
+  }
+  /** Reseeds the Request's random streams at the start of this Turn. Zero is a valid seed. */
   void SetSeed(uint64_t value) {
     OgaCheckResult(OgaTurnOptionsSetSeed(this, value));
+  }
+  /** Removes a pending reseed, continuing the Request's existing random streams. */
+  void ClearSeed() {
+    OgaCheckResult(OgaTurnOptionsClearSeed(this));
   }
   /** Copies stop_strings for this turn immediately; reusing or destroying it afterward cannot
    *  affect these options. An empty array (zero entries) clears/disables stop strings; this is
@@ -1083,9 +1106,18 @@ struct OgaTurnOptions : OgaAbstract {
   void SetStopStrings(const OgaStringArray& values) {
     OgaCheckResult(OgaTurnOptionsSetStopStrings(this, &values));
   }
-  /** Reserved for future use; currently throws a not-implemented error. */
+  /** Constrains this Turn's output to a grammar ("json_schema", "regex", or "lark_grammar"),
+   *  copying both strings immediately. Guidance is strictly Turn-scoped. */
   void SetGuidance(const char* type, const char* data) {
     OgaCheckResult(OgaTurnOptionsSetGuidance(this, type, data));
+  }
+  /** Removes the configured grammar, so the Turn is unguided. */
+  void ClearGuidance() {
+    OgaCheckResult(OgaTurnOptionsClearGuidance(this));
+  }
+  /** Restores every Turn option to its unset state. */
+  void Reset() {
+    OgaCheckResult(OgaTurnOptionsReset(this));
   }
 
   static void operator delete(void* p) {
@@ -1168,10 +1200,9 @@ struct OgaEngine : OgaAbstract {
   }
 
   std::unique_ptr<OgaRequest> CreateRequest(
-      const OgaGeneratorParams& params,
       const OgaRequestOptions* options = nullptr) {
     OgaRequest* request{};
-    OgaCheckResult(OgaEngineCreateRequest(this, &params, options, &request));
+    OgaCheckResult(OgaEngineCreateRequest(this, options, &request));
     return std::unique_ptr<OgaRequest>(request);
   }
 

--- a/src/ort_genai_c.cpp
+++ b/src/ort_genai_c.cpp
@@ -1772,7 +1772,6 @@ OgaResult* OgaEngineGetSpeculativeStats(
 
 OgaResult* OgaEngineCreateRequest(
     OgaEngine* engine,
-    const OgaGeneratorParams* params,
     const OgaRequestOptions* options,
     OgaRequest** out) {
   OGA_TRY
@@ -1783,14 +1782,9 @@ OgaResult* OgaEngineCreateRequest(
   if (!engine) {
     throw std::runtime_error("engine must not be null.");
   }
-  if (!params) {
-    throw std::runtime_error("params must not be null.");
-  }
-  const size_t max_total_tokens =
-      options && options->max_session_tokens
-          ? *options->max_session_tokens
-          : static_cast<size_t>(params->search.max_length);
-  auto request = engine->CreateRequest(*params, max_total_tokens);
+  auto request = engine->CreateRequest(
+      options ? static_cast<const Generators::RequestOptions&>(*options)
+              : Generators::RequestOptions{});
   *out = ReturnShared<OgaRequest>(request);
   return nullptr;
   OGA_CATCH
@@ -1891,30 +1885,115 @@ OgaResult* OgaTurnOptionsSetMaxGeneratedTokens(
   OGA_CATCH
 }
 
-#define OGA_UNIMPLEMENTED_TURN_SETTER(name, signature)       \
-  OgaResult* name signature {                                \
+OgaResult* OgaTurnOptionsSetMinGeneratedTokens(
+    OgaTurnOptions* options, uint64_t min_generated_tokens) {
+  OGA_TRY
+  if (!options) {
+    throw std::runtime_error("options must not be null.");
+  }
+  options->ValidateOwnerThread();
+  if (min_generated_tokens > std::numeric_limits<size_t>::max()) {
+    throw std::overflow_error(
+        "min_generated_tokens (" +
+        std::to_string(min_generated_tokens) +
+        ") exceeds the maximum internal size (" +
+        std::to_string(std::numeric_limits<size_t>::max()) + ").");
+  }
+  if (min_generated_tokens == 0) {
+    options->min_generated_tokens.reset();
+  } else {
+    options->min_generated_tokens =
+        static_cast<size_t>(min_generated_tokens);
+  }
+  return nullptr;
+  OGA_CATCH
+}
+
+// Every scalar setter below only records the caller's value. The complete resolved policy is
+// validated at turn admission, before any Request mutation, so an inconsistent combination is
+// rejected as a whole rather than one setter at a time.
+#define OGA_TURN_SCALAR_SETTER(name, type, field)            \
+  OgaResult* name(OgaTurnOptions* options, type value) {     \
     OGA_TRY                                                  \
     if (!options) {                                          \
       throw std::runtime_error("options must not be null."); \
     }                                                        \
     options->ValidateOwnerThread();                          \
-    throw std::runtime_error(#name " is not implemented.");  \
+    options->field = value;                                  \
+    return nullptr;                                          \
     OGA_CATCH                                                \
   }
 
-OGA_UNIMPLEMENTED_TURN_SETTER(
-    OgaTurnOptionsSetTemperature, (OgaTurnOptions * options, float))
-OGA_UNIMPLEMENTED_TURN_SETTER(
-    OgaTurnOptionsSetTopP, (OgaTurnOptions * options, float))
-OGA_UNIMPLEMENTED_TURN_SETTER(
-    OgaTurnOptionsSetTopK, (OgaTurnOptions * options, int32_t))
-OGA_UNIMPLEMENTED_TURN_SETTER(
-    OgaTurnOptionsSetSeed, (OgaTurnOptions * options, uint64_t))
-OGA_UNIMPLEMENTED_TURN_SETTER(
-    OgaTurnOptionsSetGuidance,
-    (OgaTurnOptions * options, const char*, const char*))
+OGA_TURN_SCALAR_SETTER(OgaTurnOptionsSetDoSample, bool, do_sample)
+OGA_TURN_SCALAR_SETTER(OgaTurnOptionsSetTemperature, float, temperature)
+OGA_TURN_SCALAR_SETTER(OgaTurnOptionsSetTopP, float, top_p)
+OGA_TURN_SCALAR_SETTER(OgaTurnOptionsSetTopK, int32_t, top_k)
+OGA_TURN_SCALAR_SETTER(
+    OgaTurnOptionsSetRepetitionPenalty, float, repetition_penalty)
+OGA_TURN_SCALAR_SETTER(
+    OgaTurnOptionsSetNoRepeatNgramSize, int32_t, no_repeat_ngram_size)
+OGA_TURN_SCALAR_SETTER(OgaTurnOptionsSetSeed, uint64_t, seed)
 
-#undef OGA_UNIMPLEMENTED_TURN_SETTER
+#undef OGA_TURN_SCALAR_SETTER
+
+OgaResult* OgaTurnOptionsClearSeed(OgaTurnOptions* options) {
+  OGA_TRY
+  if (!options) {
+    throw std::runtime_error("options must not be null.");
+  }
+  options->ValidateOwnerThread();
+  options->seed.reset();
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OgaTurnOptionsSetGuidance(
+    OgaTurnOptions* options, const char* guidance_type,
+    const char* guidance_data) {
+  OGA_TRY
+  if (!options) {
+    throw std::runtime_error("options must not be null.");
+  }
+  if (!guidance_type || !guidance_data) {
+    throw std::runtime_error(
+        "guidance_type and guidance_data must not be null.");
+  }
+  options->ValidateOwnerThread();
+  // Validate before assignment so a malformed or unsupported request leaves the prior
+  // configuration intact. The grammar itself is compiled at turn admission.
+  if (!Generators::ValidateGuidanceRequest(guidance_type, guidance_data)) {
+    throw std::runtime_error(
+        "guidance_type and guidance_data must both be non-empty. Use "
+        "OgaTurnOptionsClearGuidance for an unguided turn.");
+  }
+  options->guidance_type = guidance_type;
+  options->guidance_data = guidance_data;
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OgaTurnOptionsClearGuidance(OgaTurnOptions* options) {
+  OGA_TRY
+  if (!options) {
+    throw std::runtime_error("options must not be null.");
+  }
+  options->ValidateOwnerThread();
+  options->guidance_type.clear();
+  options->guidance_data.clear();
+  return nullptr;
+  OGA_CATCH
+}
+
+OgaResult* OgaTurnOptionsReset(OgaTurnOptions* options) {
+  OGA_TRY
+  if (!options) {
+    throw std::runtime_error("options must not be null.");
+  }
+  options->ValidateOwnerThread();
+  options->Reset();
+  return nullptr;
+  OGA_CATCH
+}
 
 OgaResult* OgaTurnOptionsSetStopStrings(
     OgaTurnOptions* options, const OgaStringArray* stop_strings) {

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -1354,21 +1354,18 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaEngineHasPendingRequests(OgaEngine* engine
 /**
  * \brief Creates a Request permanently bound to an Engine.
  *
- * Generation parameters are snapshotted and remain fixed for every turn. The parameters must have
- * been created from the same OgaModel instance used to create the Engine. Creation does not queue
- * work; call OgaRequestBeginTurn.
+ * A Request owns resident-session policy only. Generation policy belongs to each Turn, so nothing
+ * about sampling, guidance, or stop strings is fixed here. Creation does not queue work; call
+ * OgaRequestBeginTurn.
  *
  * \param[in] engine The owning Engine.
- * \param[in] params The fixed request-level generation parameters.
- * \param[in] options Nullable request-scoped options. Null options or zero max_session_tokens use
- * the Request's snapshotted params.search.max_length. search.max_length normally defaults from the
- * model context length but may have been set lower by the caller.
+ * \param[in] options Nullable request-scoped options. Null options, or zero max_session_tokens, use
+ * the model-configured search.max_length, which is also the ceiling for an explicit value.
  * \param[out] out The caller-owned Request handle.
  * \return OgaResult containing the error message if the operation failed, or nullptr on success.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaEngineCreateRequest(
-    OgaEngine* engine, const OgaGeneratorParams* params,
-    const OgaRequestOptions* options, OgaRequest** out);
+    OgaEngine* engine, const OgaRequestOptions* options, OgaRequest** out);
 
 /**
  * \brief Creates reusable Request options.
@@ -1377,29 +1374,93 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaCreateRequestOptions(
     OgaRequestOptions** out);
 OGA_EXPORT void OGA_API_CALL OgaDestroyRequestOptions(
     OgaRequestOptions* options);
+/**
+ * \brief Sets the total tokens (prompt plus generated, across every Turn) the Request may reach.
+ *
+ * Zero restores the default, which is the model-configured search.max_length. A nonzero value may
+ * be lower than that ceiling but never higher. This is the Request's one session limit: Search
+ * completion, cache sizing, speculative bounds, and the MaxSessionTokens finish reason all use it.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaRequestOptionsSetMaxSessionTokens(
     OgaRequestOptions* options, uint64_t max_session_tokens);
 
 /**
  * \brief Creates reusable Turn options bound to one Request.
+ *
+ * Every option below is unset by default, and an unset option means "use the model-configured
+ * default for this Turn" -- never "keep what the previous Turn used". Seed is the one exception:
+ * an unset seed continues the Request's existing random streams. A reused options object reapplies
+ * its configured fields to every Turn it is passed to; OgaTurnOptionsReset removes them all.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaRequestCreateTurnOptions(
     OgaRequest* request, OgaTurnOptions** out);
 OGA_EXPORT void OGA_API_CALL OgaDestroyTurnOptions(OgaTurnOptions* options);
+/** \brief Caps the tokens this Turn generates. Zero unsets the cap. */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetMaxGeneratedTokens(
     OgaTurnOptions* options, uint64_t max_generated_tokens);
-/** \brief Reserved for future use; currently returns a not-implemented result. */
+/**
+ * \brief Masks the end-of-sequence token until this Turn has generated this many tokens.
+ *
+ * Zero unsets the minimum. It does not prevent stop strings, Turn or session limits, cancellation,
+ * failure, or guidance termination. Admission rejects a minimum that exceeds the Turn's maximum or
+ * does not fit inside the Request's session limit.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetMinGeneratedTokens(
+    OgaTurnOptions* options, uint64_t min_generated_tokens);
+/** \brief Selects random sampling (true) or the top logit (false) for this Turn. */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetDoSample(
+    OgaTurnOptions* options, bool do_sample);
+/**
+ * \brief Sets this Turn's sampling temperature.
+ *
+ * Zero requests top-logit selection. Admission rejects an explicitly set temperature that the
+ * resolved policy would ignore because the Turn selects the top logit for another reason.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetTemperature(
     OgaTurnOptions* options, float temperature);
-/** \brief Reserved for future use; currently returns a not-implemented result. */
+/**
+ * \brief Sets this Turn's nucleus (top-p) bound, between 0.0 and 1.0.
+ *
+ * Admission rejects an explicitly set top_p that the resolved policy would ignore.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetTopP(
     OgaTurnOptions* options, float top_p);
-/** \brief Reserved for future use; currently returns a not-implemented result. */
+/**
+ * \brief Sets this Turn's top-k bound. One requests top-logit selection; zero disables top-k.
+ *
+ * Admission rejects an explicitly set top_k that the resolved policy would ignore.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetTopK(
     OgaTurnOptions* options, int32_t top_k);
-/** \brief Reserved for future use; currently returns a not-implemented result. */
+/** \brief Sets this Turn's repetition penalty. Must be finite and greater than zero. */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetRepetitionPenalty(
+    OgaTurnOptions* options, float repetition_penalty);
+/**
+ * \brief Forbids repeating any n-gram of this size in the generated sequence. Zero disables it.
+ *
+ * Admission rejects a nonzero size on a scoring device whose search cannot apply it, rather than
+ * failing after the model has already run.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetNoRepeatNgramSize(
+    OgaTurnOptions* options, int32_t no_repeat_ngram_size);
+/**
+ * \brief Reseeds the Request's random streams at the start of this Turn.
+ *
+ * Zero is a valid deterministic seed, so use OgaTurnOptionsClearSeed to remove a pending reseed.
+ * Reusing a seeded options object deliberately reseeds identically at the start of every Turn it is
+ * passed to. The seed takes effect only when the Turn's first sampling step commits, so a rolled
+ * back step reseeds the retry identically. Requires an Engine configured for dynamic batching and,
+ * when a device batched sampler is present, support for checkpointing its RNG state.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetSeed(
     OgaTurnOptions* options, uint64_t seed);
+/**
+ * \brief Removes a pending reseed, continuing the Request's existing random streams.
+ *
+ * This is not "randomize again": the streams simply carry on from where the previous Turn left off.
+ */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsClearSeed(
+    OgaTurnOptions* options);
 /**
  * \brief Sets decoded UTF-8 stop strings for a Turn, copying them immediately.
  *
@@ -1417,10 +1478,23 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetSeed(
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetStopStrings(
     OgaTurnOptions* options, const OgaStringArray* stop_strings);
-/** \brief Reserved for future use; currently returns a not-implemented result. */
+/**
+ * \brief Constrains this Turn's output to a grammar, copying both strings immediately.
+ *
+ * guidance_type is one of "json_schema", "regex", or "lark_grammar". The grammar is compiled and
+ * validated before the Turn mutates the Request, so an invalid grammar leaves the Request exactly
+ * as it was. Guidance is strictly Turn-scoped: a following Turn that sets none is unguided. A
+ * guided Turn does not accept speculative drafts; the next unguided Turn does again.
+ */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetGuidance(
     OgaTurnOptions* options, const char* guidance_type,
     const char* guidance_data);
+/** \brief Removes the configured grammar, so the Turn is unguided. */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsClearGuidance(
+    OgaTurnOptions* options);
+/** \brief Restores every Turn option to its unset state. */
+OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsReset(
+    OgaTurnOptions* options);
 
 /** \brief Begins a Turn, copying input and supported options before return. */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaRequestBeginTurn(

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -1428,7 +1428,8 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetTopP(
 /**
  * \brief Sets this Turn's top-k bound. One requests top-logit selection; zero disables top-k.
  *
- * Admission rejects an explicitly set top_k that the resolved policy would ignore.
+ * Admission rejects an explicitly set top_k that the resolved policy would ignore, and a sampled
+ * Turn rejects a top_k greater than the model vocabulary size.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetTopK(
     OgaTurnOptions* options, int32_t top_k);

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -1402,8 +1402,9 @@ OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetMaxGeneratedTokens(
  * \brief Masks the end-of-sequence token until this Turn has generated this many tokens.
  *
  * Zero unsets the minimum. It does not prevent stop strings, Turn or session limits, cancellation,
- * failure, or guidance termination. Admission rejects a minimum that exceeds the Turn's maximum or
- * does not fit inside the Request's session limit.
+ * failure, or guidance termination. If guidance permits EOS and no continuation token, its
+ * termination takes precedence rather than leaving the Turn with no legal token. Admission rejects
+ * a minimum that exceeds the Turn's maximum or does not fit inside the Request's session limit.
  */
 OGA_EXPORT OgaResult* OGA_API_CALL OgaTurnOptionsSetMinGeneratedTokens(
     OgaTurnOptions* options, uint64_t min_generated_tokens);

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -830,21 +830,37 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def(pybind11::init([] {
         return OgaRequestOptions::Create();
       }))
-      .def("set_max_session_tokens", &OgaRequestOptions::SetMaxSessionTokens);
+      .def("set_max_session_tokens", &OgaRequestOptions::SetMaxSessionTokens,
+           "Total tokens (prompt plus generated, across every turn) the request may reach. Zero "
+           "restores the model-configured search.max_length, which is also the ceiling for an "
+           "explicit value.");
 
   pybind11::class_<OgaTurnOptions>(m, "TurnOptions")
       .def(pybind11::init([](OgaRequest& request) {
         return OgaTurnOptions::Create(request);
       }))
-      .def("set_max_generated_tokens", &OgaTurnOptions::SetMaxGeneratedTokens)
+      .def("set_max_generated_tokens", &OgaTurnOptions::SetMaxGeneratedTokens,
+           "Caps the tokens this turn generates. Zero unsets the cap.")
+      .def("set_min_generated_tokens", &OgaTurnOptions::SetMinGeneratedTokens,
+           "Masks the end-of-sequence token until this turn has generated this many tokens. Zero "
+           "unsets the minimum.")
+      .def("set_do_sample", &OgaTurnOptions::SetDoSample,
+           "Selects random sampling (True) or the top logit (False) for this turn.")
       .def("set_temperature", &OgaTurnOptions::SetTemperature,
-           "Reserved for future use; currently raises a not-implemented error.")
+           "Sampling temperature for this turn; zero requests top-logit selection.")
       .def("set_top_p", &OgaTurnOptions::SetTopP,
-           "Reserved for future use; currently raises a not-implemented error.")
+           "Nucleus bound for this turn, between 0.0 and 1.0.")
       .def("set_top_k", &OgaTurnOptions::SetTopK,
-           "Reserved for future use; currently raises a not-implemented error.")
+           "Top-k bound for this turn; one requests top-logit selection and zero disables top-k.")
+      .def("set_repetition_penalty", &OgaTurnOptions::SetRepetitionPenalty,
+           "Repetition penalty for this turn; must be finite and greater than zero.")
+      .def("set_no_repeat_ngram_size", &OgaTurnOptions::SetNoRepeatNgramSize,
+           "Forbids repeating any n-gram of this size in the generated sequence. Zero disables it.")
       .def("set_seed", &OgaTurnOptions::SetSeed,
-           "Reserved for future use; currently raises a not-implemented error.")
+           "Reseeds the request's random streams at the start of this turn. Zero is a valid "
+           "deterministic seed; use clear_seed to remove a pending reseed.")
+      .def("clear_seed", &OgaTurnOptions::ClearSeed,
+           "Removes a pending reseed, continuing the request's existing random streams.")
       .def("set_stop_strings", [](OgaTurnOptions& options, const std::vector<std::string>& values) {
         auto strings = OgaStringArray::Create();
         for (const auto& value : values) {
@@ -863,7 +879,12 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
            "list containing an empty string entry, which is invalid. Every entry in a nonempty "
            "list must itself be a nonempty, valid UTF-8 string with no embedded NUL byte; the "
            "list may contain at most 16 entries totaling at most 16 KiB.")
-      .def("set_guidance", &OgaTurnOptions::SetGuidance, "Reserved for future use; currently raises a not-implemented error.");
+      .def("set_guidance", &OgaTurnOptions::SetGuidance,
+           "Constrains this turn's output to a grammar ('json_schema', 'regex', or "
+           "'lark_grammar'), copying both strings immediately. Guidance is strictly turn-scoped: a "
+           "following turn that sets none is unguided.")
+      .def("clear_guidance", &OgaTurnOptions::ClearGuidance, "Removes the configured grammar, so the turn is unguided.")
+      .def("reset", &OgaTurnOptions::Reset, "Restores every turn option to its unset state.");
 
   pybind11::class_<OgaRequest>(m, "Request")
       .def(
@@ -958,11 +979,12 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .def(pybind11::init([](OgaModel& model) { return OgaEngine::Create(model); }))
       .def(
           "create_request",
-          [](OgaEngine& engine, PyGeneratorParams& params,
-             OgaRequestOptions* options) {
-            return engine.CreateRequest(*params.params_, options);
+          [](OgaEngine& engine, OgaRequestOptions* options) {
+            return engine.CreateRequest(options);
           },
-          pybind11::arg("params"),
+          // Keyword-only so an older positional create_request(params) call fails loudly instead of
+          // silently binding generation parameters the Engine no longer accepts.
+          pybind11::kw_only(),
           pybind11::arg("options") = pybind11::none())
       .def(
           "create_event_buffer",

--- a/src/smartptrs.h
+++ b/src/smartptrs.h
@@ -135,7 +135,10 @@ struct BatchedSamplingParams {
 struct BatchedSampler {
   virtual ~BatchedSampler() = default;
 
-  virtual std::unique_ptr<BatchedSamplerState> CreateState(int random_seed) = 0;
+  virtual std::unique_ptr<BatchedSamplerState> CreateState(uint64_t random_seed) = 0;
+  // Restarts an existing state's stream from `random_seed` without releasing or reacquiring any
+  // pooled resource the state holds, so a per-turn reseed neither leaks nor churns sampler slots.
+  virtual void ReseedState(BatchedSamplerState& state, uint64_t random_seed) = 0;
   virtual bool OwnsState(const BatchedSamplerState& state) const = 0;
   virtual bool SupportsTransactions() const { return false; }
   virtual void SaveStateForTransaction(std::span<BatchedSamplerState* const> /*states*/) {
@@ -209,9 +212,12 @@ struct StateUpdateReplayDesc {
 
 static_assert(std::is_trivially_copyable_v<StateUpdateReplayDesc>);
 
-// Increment whenever DeviceInterface's virtual layout changes. Dynamically loaded add-ons must
-// report this exact version before the host can safely call through the C++ interface.
-inline constexpr uint32_t kDeviceInterfaceVersion = 4;
+// Increment whenever a layout the add-on boundary depends on changes: DeviceInterface's virtual
+// layout, or the virtual or data layout of any type constructed by, passed to, or returned across
+// that boundary (Search, BatchedSampler, BatchedSamplerState, GeneratorParams, or Config).
+// Dynamically loaded add-ons must report this exact version before the host can safely call through
+// the C++ interface.
+inline constexpr uint32_t kDeviceInterfaceVersion = 5;
 
 struct DeviceInterface {
   virtual ~DeviceInterface() {}

--- a/test/cpp/c_api_tests.cpp
+++ b/test/cpp/c_api_tests.cpp
@@ -7,6 +7,7 @@
 #include <cstring>  // for memcmp
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <numeric>
 #include <iostream>
 #include <optional>
@@ -1618,8 +1619,10 @@ struct Phi2Test {
     }
   }
 
-  void RunEngine() {
+  void RunEngine(const std::function<void(OgaTurnOptions&)>& configure_turn) {
     auto engine = OgaEngine::Create(*model_);
+    auto request_options = OgaRequestOptions::Create();
+    request_options->SetMaxSessionTokens(40);
 
     struct OwnedRequest {
       std::unique_ptr<OgaRequest> request;
@@ -1640,11 +1643,13 @@ struct Phi2Test {
       tokenizer_->Encode(input_strings[i], *input_sequence);
       auto input_tokens = std::span<const int32_t>{
           input_sequence->SequenceData(0), input_sequence->SequenceCount(0)};
-      requests.push_back({engine->CreateRequest(),
+      requests.push_back({engine->CreateRequest(request_options.get()),
                           std::vector<int32_t>(input_tokens.begin(), input_tokens.end())});
       auto& owned_request = requests.back();
       requests_by_handle.emplace(owned_request.request.get(), &owned_request);
-      owned_request.request->BeginTurn(input_tokens);
+      auto turn_options = owned_request.request->CreateTurnOptions();
+      configure_turn(*turn_options);
+      owned_request.request->BeginTurn(input_tokens, turn_options.get());
     }
 
     EXPECT_TRUE(engine->HasPendingRequests());
@@ -1727,7 +1732,11 @@ TEST_P(ParametrizedTopKCAPITestsTests, TopKCAPI) {
   test.params_->SetSearchOption("temperature", 0.6f);
 
   if (GetParam()) {
-    test.RunEngine();
+    test.RunEngine([](OgaTurnOptions& options) {
+      options.SetDoSample(true);
+      options.SetTopK(50);
+      options.SetTemperature(0.6f);
+    });
   } else {
     test.Run();
   }
@@ -1752,7 +1761,11 @@ TEST_P(ParametrizedTopPCAPITestsTests, TopPCAPI) {
   test.params_->SetSearchOption("temperature", 0.6f);
 
   if (GetParam()) {
-    test.RunEngine();
+    test.RunEngine([](OgaTurnOptions& options) {
+      options.SetDoSample(true);
+      options.SetTopP(0.6f);
+      options.SetTemperature(0.6f);
+    });
   } else {
     test.Run();
   }
@@ -1778,7 +1791,12 @@ TEST_P(ParametrizedTopKTopPCAPITestsTests, TopKCAPITest) {
   test.params_->SetSearchOption("temperature", 0.6f);
 
   if (GetParam()) {
-    test.RunEngine();
+    test.RunEngine([](OgaTurnOptions& options) {
+      options.SetDoSample(true);
+      options.SetTopK(50);
+      options.SetTopP(0.6f);
+      options.SetTemperature(0.6f);
+    });
   } else {
     test.Run();
   }

--- a/test/cpp/c_api_tests.cpp
+++ b/test/cpp/c_api_tests.cpp
@@ -947,10 +947,10 @@ TEST(CAPITests, SetTerminate) {
 
 TEST(CAPITests, EngineRequestTurnAndEventContracts) {
   auto model = OgaModel::Create(MODEL_PATH "engine/synthetic-paged");
-  auto params = OgaGeneratorParams::Create(*model);
-  params->SetSearchOption("max_length", 16);
   auto engine = OgaEngine::Create(*model);
-  auto request = engine->CreateRequest(*params);
+  auto session_options = OgaRequestOptions::Create();
+  session_options->SetMaxSessionTokens(16);
+  auto request = engine->CreateRequest(session_options.get());
   const std::array<int32_t, 3> input_tokens{2, 3, 4};
 
   auto turn_options = request->CreateTurnOptions();
@@ -979,25 +979,30 @@ TEST(CAPITests, EngineRequestTurnAndEventContracts) {
 
   auto request_options = OgaRequestOptions::Create();
   request_options->SetMaxSessionTokens(8);
-  auto options_request = engine->CreateRequest(*params, request_options.get());
+  auto options_request = engine->CreateRequest(request_options.get());
   options_request->Close();
 
+  // Omitting the option (or clearing it with zero) uses the model-configured ceiling.
+  request_options->SetMaxSessionTokens(0);
+  auto default_limit_request = engine->CreateRequest(request_options.get());
+  default_limit_request->Close();
+
   auto excessive_request_options = OgaRequestOptions::Create();
-  excessive_request_options->SetMaxSessionTokens(17);
+  excessive_request_options->SetMaxSessionTokens(129);
   try {
     static_cast<void>(
-        engine->CreateRequest(*params, excessive_request_options.get()));
-    FAIL() << "Expected max_session_tokens above max_length to fail.";
+        engine->CreateRequest(excessive_request_options.get()));
+    FAIL() << "Expected max_session_tokens above the model ceiling to fail.";
   } catch (const std::runtime_error& error) {
     EXPECT_NE(
-        std::string(error.what()).find("max_total_tokens (17)"),
+        std::string(error.what()).find("max_session_tokens (129)"),
         std::string::npos);
     EXPECT_NE(
-        std::string(error.what()).find("max_length (16)"),
+        std::string(error.what()).find("search.max_length (128)"),
         std::string::npos);
   }
 
-  auto owner_thread_request = engine->CreateRequest(*params);
+  auto owner_thread_request = engine->CreateRequest();
   auto owner_thread_options = owner_thread_request->CreateTurnOptions();
   OgaResult* create_options_result{};
   OgaResult* set_options_result{};
@@ -1019,7 +1024,7 @@ TEST(CAPITests, EngineRequestTurnAndEventContracts) {
             std::string::npos);
   owner_thread_request->Close();
 
-  auto validation_request = engine->CreateRequest(*params);
+  auto validation_request = engine->CreateRequest();
   auto validation_options = validation_request->CreateTurnOptions();
 
   std::unique_ptr<OgaResult> null_stop_strings_result{
@@ -1032,14 +1037,14 @@ TEST(CAPITests, EngineRequestTurnAndEventContracts) {
 
   OgaRequest* abandoned_created{};
   OgaCheckResult(OgaEngineCreateRequest(
-      engine.get(), params.get(), nullptr, &abandoned_created));
+      engine.get(), nullptr, &abandoned_created));
   ASSERT_NE(abandoned_created, nullptr);
   OgaDestroyRequest(abandoned_created);
   EXPECT_FALSE(engine->HasPendingRequests());
 
   OgaRequest* abandoned_queued{};
   OgaCheckResult(OgaEngineCreateRequest(
-      engine.get(), params.get(), nullptr, &abandoned_queued));
+      engine.get(), nullptr, &abandoned_queued));
   ASSERT_NE(abandoned_queued, nullptr);
   uint64_t abandoned_turn_id{};
   OgaCheckResult(OgaRequestBeginTurn(
@@ -1055,16 +1060,193 @@ TEST(CAPITests, EngineRequestTurnAndEventContracts) {
   EXPECT_EQ(idle_buffer->Get(0), nullptr);
 }
 
+TEST(CAPITests, EngineTurnOptionsGenerationPolicy) {
+  auto model = OgaModel::Create(MODEL_PATH "engine/synthetic-paged");
+  auto engine = OgaEngine::Create(*model);
+  const std::array<int32_t, 3> input_tokens{2, 3, 4};
+
+  const auto run_turn = [&](OgaRequest& request, const OgaTurnOptions* options,
+                            std::span<const int32_t> tokens) {
+    request.BeginTurn(tokens, options);
+    std::vector<int32_t> generated;
+    auto buffer = engine->CreateEventBuffer(8);
+    for (int step = 0; step < 64; ++step) {
+      const size_t count = engine->Run(*buffer);
+      bool finished = false;
+      for (size_t i = 0; i < count; ++i) {
+        const auto* event = buffer->Get(i);
+        if (event->Flags() & OgaEngineEventFlag_Token) {
+          generated.push_back(event->Token());
+        }
+        finished = finished || (event->Flags() & OgaEngineEventFlag_TurnFinished) != 0;
+      }
+      if (finished) {
+        break;
+      }
+    }
+    return generated;
+  };
+
+  // Every scalar is accepted, and the same seed on the same prompt reproduces exactly.
+  struct SampledRequest {
+    std::unique_ptr<OgaRequest> request;
+    std::unique_ptr<OgaTurnOptions> options;
+  };
+  const auto sampled_request = [&](uint64_t seed) {
+    SampledRequest sampled{engine->CreateRequest(), nullptr};
+    sampled.options = sampled.request->CreateTurnOptions();
+    sampled.options->SetDoSample(true);
+    sampled.options->SetTemperature(0.8f);
+    sampled.options->SetTopP(0.9f);
+    sampled.options->SetTopK(4);
+    sampled.options->SetRepetitionPenalty(1.1f);
+    sampled.options->SetNoRepeatNgramSize(0);
+    sampled.options->SetMinGeneratedTokens(2);
+    sampled.options->SetMaxGeneratedTokens(4);
+    sampled.options->SetSeed(seed);
+    return sampled;
+  };
+
+  {
+    // Zero is an ordinary deterministic seed.
+    auto first = sampled_request(0);
+    const auto reference =
+        run_turn(*first.request, first.options.get(), input_tokens);
+    EXPECT_GE(reference.size(), 2u);
+    EXPECT_LE(reference.size(), 4u);
+
+    auto second = sampled_request(0);
+    EXPECT_EQ(run_turn(*second.request, second.options.get(), input_tokens),
+              reference);
+
+    // Reset removes every option, so the next turn is plain model-default generation.
+    auto third = sampled_request(0);
+    third.options->Reset();
+    third.options->SetMaxGeneratedTokens(4);
+    const auto defaults =
+        run_turn(*third.request, third.options.get(), input_tokens);
+    EXPECT_EQ(defaults.size(), 4u);
+
+    // ClearSeed is always valid and simply removes the pending reseed.
+    EXPECT_NO_THROW(first.options->ClearSeed());
+
+    first.request->Close();
+    second.request->Close();
+    third.request->Close();
+  }
+
+  // An explicitly set scalar that contradicts the resolved greedy policy is rejected at admission,
+  // before the Request is mutated, rather than silently taking the top logit.
+  {
+    auto request = engine->CreateRequest();
+    auto turn_options = request->CreateTurnOptions();
+    turn_options->SetDoSample(false);
+    turn_options->SetTopK(40);
+    try {
+      request->BeginTurn(input_tokens, turn_options.get());
+      FAIL() << "Expected a contradictory sampling scalar to be rejected.";
+    } catch (const std::runtime_error& error) {
+      EXPECT_NE(std::string(error.what()).find("contradict it: top_k"), std::string::npos);
+    }
+
+    // top_k == 1 alongside do_sample == false says the same thing twice, so it is accepted and the
+    // turn selects the top logit.
+    turn_options->SetTopK(1);
+    turn_options->SetMaxGeneratedTokens(1);
+    EXPECT_EQ(request->BeginTurn(input_tokens, turn_options.get()), 1u);
+    request->Close();
+  }
+
+  // Guidance setters validate the request shape immediately and leave the prior configuration
+  // untouched when they reject it.
+  {
+    auto request = engine->CreateRequest();
+    auto turn_options = request->CreateTurnOptions();
+    std::unique_ptr<OgaResult> incomplete{
+        OgaTurnOptionsSetGuidance(turn_options.get(), "regex", "")};
+    ASSERT_NE(incomplete, nullptr);
+    std::unique_ptr<OgaResult> unsupported{
+        OgaTurnOptionsSetGuidance(turn_options.get(), "xml_schema", "<x/>")};
+    ASSERT_NE(unsupported, nullptr);
+    EXPECT_NE(std::string(unsupported->GetError()).find("Unsupported guidance type"),
+              std::string::npos);
+    // Clearing guidance is always valid and makes the turn unguided.
+    EXPECT_NO_THROW(turn_options->ClearGuidance());
+    turn_options->SetMaxGeneratedTokens(1);
+    EXPECT_EQ(request->BeginTurn(input_tokens, turn_options.get()), 1u);
+    request->Close();
+  }
+}
+
+// A model whose own search defaults keep every turn greedy silently overrides an explicit
+// do_sample. The caller cannot see those defaults through the options handle, so admission rejects
+// the turn and names the model-supplied cause instead of quietly selecting the top logit. One
+// representative model default is enough here; the full matrix of greedy-keeping defaults is
+// covered by the core turn-policy tests and by the Python surface.
+TEST(CAPITests, EngineTurnOptionsRejectDoSampleUnderModelGreedyDefaults) {
+  const std::array<int32_t, 3> input_tokens{2, 3, 4};
+
+  auto config = OgaConfig::Create(MODEL_PATH "engine/synthetic-paged");
+  config->Overlay(R"({"search": {"top_k": 1}})");
+  auto model = OgaModel::Create(*config);
+  auto engine = OgaEngine::Create(*model);
+  auto request = engine->CreateRequest();
+  auto turn_options = request->CreateTurnOptions();
+  turn_options->SetDoSample(true);
+  turn_options->SetMaxGeneratedTokens(2);
+  try {
+    request->BeginTurn(input_tokens, turn_options.get());
+    FAIL() << "Expected an explicit do_sample to be rejected.";
+  } catch (const std::runtime_error& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("do_sample=true"), std::string::npos) << message;
+    EXPECT_NE(message.find("search.top_k = 1"), std::string::npos) << message;
+  }
+
+  // Nothing was mutated, so overriding the field the message names admits the same Request.
+  turn_options->SetTopK(4);
+  turn_options->SetTemperature(0.8f);
+  EXPECT_EQ(request->BeginTurn(input_tokens, turn_options.get()), 1u);
+  request->Close();
+}
+
+// A model configured for beam search is rejected when the Request is created, rather than silently
+// decoding a single beam. The message names the overlay route, so this test takes it.
+TEST(CAPITests, EngineCreateRequestRejectsModelBeamSearch) {
+  auto config = OgaConfig::Create(MODEL_PATH "engine/synthetic-paged");
+  config->Overlay(R"({"search": {"num_beams": 4}})");
+  auto model = OgaModel::Create(*config);
+  auto engine = OgaEngine::Create(*model);
+
+  try {
+    static_cast<void>(engine->CreateRequest());
+    FAIL() << "Expected a model-configured num_beams != 1 to be rejected.";
+  } catch (const std::runtime_error& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("search.num_beams"), std::string::npos) << message;
+    EXPECT_NE(message.find("overlay"), std::string::npos) << message;
+  }
+
+  auto cleared_config = OgaConfig::Create(MODEL_PATH "engine/synthetic-paged");
+  cleared_config->Overlay(R"({"search": {"num_beams": 4}})");
+  cleared_config->Overlay(R"({"search": {"num_beams": 1}})");
+  auto cleared_model = OgaModel::Create(*cleared_config);
+  auto cleared_engine = OgaEngine::Create(*cleared_model);
+  auto request = cleared_engine->CreateRequest();
+  auto turn_options = request->CreateTurnOptions();
+  turn_options->SetMaxGeneratedTokens(1);
+  EXPECT_EQ(request->BeginTurn(std::array<int32_t, 3>{2, 3, 4}, turn_options.get()), 1u);
+  request->Close();
+}
+
 TEST(CAPITests, EngineTurnOptionsStopStrings) {
   auto model = OgaModel::Create(MODEL_PATH "engine/synthetic-paged");
-  auto params = OgaGeneratorParams::Create(*model);
-  params->SetSearchOption("max_length", 16);
   auto engine = OgaEngine::Create(*model);
   const std::array<int32_t, 3> input_tokens{2, 3, 4};
 
   // An empty array is a valid configuration: it clears/disables stop strings rather than throwing.
   {
-    auto request = engine->CreateRequest(*params);
+    auto request = engine->CreateRequest();
     auto turn_options = request->CreateTurnOptions();
     auto empty = OgaStringArray::Create();
     EXPECT_NO_THROW(turn_options->SetStopStrings(*empty));
@@ -1074,7 +1256,7 @@ TEST(CAPITests, EngineTurnOptionsStopStrings) {
   // Bounds and UTF-8 validation happen immediately, at set time, using the same contract
   // StopStringMatcher enforces -- not deferred to the next BeginTurn.
   {
-    auto request = engine->CreateRequest(*params);
+    auto request = engine->CreateRequest();
     auto turn_options = request->CreateTurnOptions();
     auto invalid_entry = OgaStringArray::Create();
     invalid_entry->Add("");
@@ -1120,7 +1302,7 @@ TEST(CAPITests, EngineTurnOptionsStopStrings) {
   // Reusing and destroying the array after SetStopStrings returns cannot affect the options: the
   // strings are copied immediately.
   {
-    auto request = engine->CreateRequest(*params);
+    auto request = engine->CreateRequest();
     auto turn_options = request->CreateTurnOptions();
     {
       auto transient = OgaStringArray::Create();
@@ -1142,7 +1324,7 @@ TEST(CAPITests, EngineTurnOptionsStopStrings) {
   // A stop-enabled turn is not rejected just because this dynamic-batching Engine could support
   // speculative draft verification: only static batching and an active draft proposal reject it.
   {
-    auto request = engine->CreateRequest(*params);
+    auto request = engine->CreateRequest();
     auto turn_options = request->CreateTurnOptions();
     auto stop_strings = OgaStringArray::Create();
     stop_strings->Add("STOP");
@@ -1154,13 +1336,11 @@ TEST(CAPITests, EngineTurnOptionsStopStrings) {
 
 TEST(CAPITests, EngineBulkRunAndReusableStorage) {
   auto model = OgaModel::Create(MODEL_PATH "engine/synthetic-paged");
-  auto params = OgaGeneratorParams::Create(*model);
-  params->SetSearchOption("max_length", 16);
   auto engine = OgaEngine::Create(*model);
   const std::array<int32_t, 3> input_tokens{2, 3, 4};
 
   const auto create_one_token_request = [&] {
-    auto request = engine->CreateRequest(*params);
+    auto request = engine->CreateRequest();
     auto turn_options = request->CreateTurnOptions();
     turn_options->SetMaxGeneratedTokens(1);
     request->BeginTurn(input_tokens, turn_options.get());
@@ -1316,7 +1496,7 @@ TEST(CAPITests, EngineBulkRunAndReusableStorage) {
   first->Close();
   second->Close();
 
-  auto reusable_request = engine->CreateRequest(*params);
+  auto reusable_request = engine->CreateRequest();
   auto reusable_turn_options = reusable_request->CreateTurnOptions();
   reusable_turn_options->SetMaxGeneratedTokens(2);
   reusable_request->BeginTurn(input_tokens, reusable_turn_options.get());
@@ -1337,13 +1517,11 @@ TEST(CAPITests, EngineBulkRunAndReusableStorage) {
 
 TEST(CAPITests, EngineCppRunReturnsBorrowedBufferViews) {
   auto model = OgaModel::Create(MODEL_PATH "engine/synthetic-paged");
-  auto params = OgaGeneratorParams::Create(*model);
-  params->SetSearchOption("max_length", 16);
   auto engine = OgaEngine::Create(*model);
   const std::array<int32_t, 3> input_tokens{2, 3, 4};
 
   const auto create_request = [&] {
-    auto request = engine->CreateRequest(*params);
+    auto request = engine->CreateRequest();
     auto turn_options = request->CreateTurnOptions();
     turn_options->SetMaxGeneratedTokens(1);
     request->BeginTurn(input_tokens, turn_options.get());
@@ -1442,8 +1620,6 @@ struct Phi2Test {
 
   void RunEngine() {
     auto engine = OgaEngine::Create(*model_);
-    constexpr size_t per_request_batch_size = 1;
-    params_->SetSearchOption("batch_size", static_cast<int>(per_request_batch_size));
 
     struct OwnedRequest {
       std::unique_ptr<OgaRequest> request;
@@ -1464,7 +1640,7 @@ struct Phi2Test {
       tokenizer_->Encode(input_strings[i], *input_sequence);
       auto input_tokens = std::span<const int32_t>{
           input_sequence->SequenceData(0), input_sequence->SequenceCount(0)};
-      requests.push_back({engine->CreateRequest(*params_),
+      requests.push_back({engine->CreateRequest(),
                           std::vector<int32_t>(input_tokens.begin(), input_tokens.end())});
       auto& owned_request = requests.back();
       requests_by_handle.emplace(owned_request.request.get(), &owned_request);
@@ -1509,16 +1685,15 @@ TEST(CAPITests, EngineRequestCAbiAndRaiiContracts) {
 
   auto model = OgaModel::Create(PHI2_PATH);
   auto tokenizer = OgaTokenizer::Create(*model);
-  auto params = OgaGeneratorParams::Create(*model);
   auto engine = OgaEngine::Create(*model);
   auto input_sequences = OgaSequences::Create();
   tokenizer->Encode("This is a test.", *input_sequences);
   auto input_tokens = std::span<const int32_t>{
       input_sequences->SequenceData(0), input_sequences->SequenceCount(0)};
-  params->SetSearchOption(
-      "max_length", static_cast<int>(input_tokens.size() + 4));
+  auto session_options = OgaRequestOptions::Create();
+  session_options->SetMaxSessionTokens(input_tokens.size() + 4);
 
-  auto owned_request = engine->CreateRequest(*params);
+  auto owned_request = engine->CreateRequest(session_options.get());
   auto one_token_turn = owned_request->CreateTurnOptions();
   one_token_turn->SetMaxGeneratedTokens(1);
   EXPECT_EQ(owned_request->BeginTurn(input_tokens, one_token_turn.get()), 1u);
@@ -2568,8 +2743,6 @@ TEST(CAPITests, RequestSetDraftTokensRejectsNullArguments) {
 TEST(CAPITests, RequestSetDraftTokensRunsProposal) {
   auto model = OgaModel::Create(
       MODEL_PATH "engine/synthetic-paged-per-token");
-  auto params = OgaGeneratorParams::Create(*model);
-  params->SetSearchOption("max_length", 16);
   auto engine = OgaEngine::Create(*model);
 
   size_t max_drafts{};
@@ -2590,7 +2763,7 @@ TEST(CAPITests, RequestSetDraftTokensRunsProposal) {
       std::string(owned_off_thread_result->GetError()).find("owner thread"),
       std::string::npos);
 
-  auto request = engine->CreateRequest(*params);
+  auto request = engine->CreateRequest();
   auto turn_options = request->CreateTurnOptions();
   turn_options->SetMaxGeneratedTokens(4);
   const std::array<int32_t, 3> prompt{2, 3, 4};

--- a/test/cpp/cuda_batched_sampler_tests/cuda_batched_sampler_tests.cpp
+++ b/test/cpp/cuda_batched_sampler_tests/cuda_batched_sampler_tests.cpp
@@ -114,6 +114,59 @@ TEST(SamplingTests, SchedulerOwnedSamplerHandlesHeterogeneousRowsCuda) {
   EXPECT_EQ(tokens[2], 3);
 }
 
+TEST(SamplingTests, SchedulerOwnedSamplerGreedyRowsDoNotAdvanceRngCuda) {
+  constexpr int vocab_size = 8;
+  [[maybe_unused]] auto model = CreateCudaModel();
+  auto* device = Generators::GetDeviceInterface(Generators::DeviceType::CUDA);
+  auto sampler = device->CreateBatchedSampler(2, vocab_size);
+  ASSERT_NE(sampler, nullptr);
+
+  auto logits = device->Allocate<float>(2 * vocab_size);
+  const std::array<float, vocab_size> row_logits{
+      {0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f}};
+  std::copy(row_logits.begin(), row_logits.end(), logits.CpuSpan().begin());
+  std::copy(row_logits.begin(), row_logits.end(),
+            logits.CpuSpan().begin() + vocab_size);
+  logits.CopyCpuToDevice();
+  std::array<Generators::DeviceSpan<float>, 2> rows{
+      {logits.subspan(0, vocab_size),
+       logits.subspan(vocab_size, vocab_size)}};
+
+  constexpr uint64_t seed = 31337;
+  auto after_greedy = sampler->CreateState(seed);
+  auto untouched = sampler->CreateState(seed);
+  std::array<Generators::BatchedSamplerState*, 2> states{
+      {after_greedy.get(), untouched.get()}};
+
+  std::array<Generators::DeviceSpan<float>, 1> greedy_row{{rows[0]}};
+  const std::array<Generators::BatchedSamplingParams, 1> greedy_params{
+      {{1, 0.0f, 1.0f}}};
+  const std::array<Generators::BatchedSamplerState*, 1> greedy_state{
+      {after_greedy.get()}};
+  for (int step = 0; step < 5; ++step) {
+    const auto token =
+        sampler->Sample(greedy_row, greedy_params, greedy_state, vocab_size)
+            .CopyDeviceToCpu();
+    EXPECT_EQ(token[0], vocab_size - 1);
+  }
+
+  const std::array<Generators::BatchedSamplingParams, 2> sampled_params{
+      {{vocab_size, 1.0f, 1.0f}, {vocab_size, 1.0f, 1.0f}}};
+  std::vector<int32_t> sampled_tokens;
+  for (int step = 0; step < 16; ++step) {
+    const auto tokens =
+        sampler->Sample(rows, sampled_params, states, vocab_size)
+            .CopyDeviceToCpu();
+    EXPECT_EQ(tokens[0], tokens[1]) << "RNG diverged at sampled step " << step;
+    sampled_tokens.push_back(tokens[0]);
+  }
+  EXPECT_TRUE(std::any_of(sampled_tokens.begin() + 1, sampled_tokens.end(),
+                          [&](int32_t token) {
+                            return token != sampled_tokens.front();
+                          }))
+      << "Sampled output was constant, so RNG-stream equivalence was not exercised.";
+}
+
 TEST(LogitsMaskTests, UsesPaddedRowStrideForNonAlignedVocabularyCuda) {
   constexpr int batch_size = 2;
   constexpr int vocab_size = 33;

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -456,8 +456,8 @@ TEST(Dflash2ConfigTest, RunsFullAttentionDsparkAcrossRequestLifecycles) {
   const std::array<int64_t, 2> first_aux_shape{18, 1};
   first_aux.CreateTensor(first_aux_shape);
   const std::array first_feeds{
-      Dflash2Drafter::Feed{request_a, 0, 9, 0, 11, true},
-      Dflash2Drafter::Feed{request_b, 9, 9, 0, 12, true},
+      Dflash2Drafter::Feed{.request = request_a, .aux_row_begin = 0, .aux_row_count = 9, .first_position = 0, .anchor_token = 11, .draft_eligible = true, .wants_drafts = true},
+      Dflash2Drafter::Feed{.request = request_b, .aux_row_begin = 9, .aux_row_count = 9, .first_position = 0, .anchor_token = 12, .draft_eligible = true, .wants_drafts = true},
   };
   std::vector<std::vector<int32_t>> drafts;
   drafter.Propose(first_aux, first_feeds, drafts);
@@ -469,8 +469,8 @@ TEST(Dflash2ConfigTest, RunsFullAttentionDsparkAcrossRequestLifecycles) {
   const std::array<int64_t, 2> growth_aux_shape{8, 1};
   growth_aux.CreateTensor(growth_aux_shape);
   const std::array growth_feeds{
-      Dflash2Drafter::Feed{request_a, 0, 4, 9, 13, true},
-      Dflash2Drafter::Feed{request_b, 4, 4, 9, 14, true},
+      Dflash2Drafter::Feed{.request = request_a, .aux_row_begin = 0, .aux_row_count = 4, .first_position = 9, .anchor_token = 13, .draft_eligible = true, .wants_drafts = true},
+      Dflash2Drafter::Feed{.request = request_b, .aux_row_begin = 4, .aux_row_count = 4, .first_position = 9, .anchor_token = 14, .draft_eligible = true, .wants_drafts = true},
   };
   drafter.Propose(growth_aux, growth_feeds, drafts);
   ASSERT_EQ(drafts.size(), 2u);
@@ -482,7 +482,7 @@ TEST(Dflash2ConfigTest, RunsFullAttentionDsparkAcrossRequestLifecycles) {
   const std::array<int64_t, 2> reused_aux_shape{9, 1};
   reused_aux.CreateTensor(reused_aux_shape);
   const std::array reused_feed{
-      Dflash2Drafter::Feed{request_c, 0, 9, 0, 15, true},
+      Dflash2Drafter::Feed{.request = request_c, .aux_row_begin = 0, .aux_row_count = 9, .first_position = 0, .anchor_token = 15, .draft_eligible = true, .wants_drafts = true},
   };
   drafter.Propose(reused_aux, reused_feed, drafts);
   ASSERT_EQ(drafts.size(), 1u);
@@ -492,14 +492,14 @@ TEST(Dflash2ConfigTest, RunsFullAttentionDsparkAcrossRequestLifecycles) {
   const std::array<int64_t, 2> failed_aux_shape{1, 1};
   failed_aux.CreateTensor(failed_aux_shape);
   const std::array failed_feed{
-      Dflash2Drafter::Feed{request_c, 0, 1, 10, 16, true},
+      Dflash2Drafter::Feed{.request = request_c, .aux_row_begin = 0, .aux_row_count = 1, .first_position = 10, .anchor_token = 16, .draft_eligible = true, .wants_drafts = true},
   };
   EXPECT_THROW(drafter.Propose(failed_aux, failed_feed, drafts), std::logic_error);
   drafter.ReleaseAll();
 
   const std::array recovered_feeds{
-      Dflash2Drafter::Feed{request_d, 0, 9, 0, 17, true},
-      Dflash2Drafter::Feed{request_e, 9, 9, 0, 18, true},
+      Dflash2Drafter::Feed{.request = request_d, .aux_row_begin = 0, .aux_row_count = 9, .first_position = 0, .anchor_token = 17, .draft_eligible = true, .wants_drafts = true},
+      Dflash2Drafter::Feed{.request = request_e, .aux_row_begin = 9, .aux_row_count = 9, .first_position = 0, .anchor_token = 18, .draft_eligible = true, .wants_drafts = true},
   };
   drafter.Propose(first_aux, recovered_feeds, drafts);
   ASSERT_EQ(drafts.size(), 2u);
@@ -510,6 +510,63 @@ TEST(Dflash2ConfigTest, RunsFullAttentionDsparkAcrossRequestLifecycles) {
   EXPECT_EQ(drafts[1][2], 13);
   EXPECT_EQ(drafts[1][3], 64);
   EXPECT_EQ(drafter.AdmissionMisses(), 0u);
+}
+
+TEST(Dflash2ConfigTest, TrackedDsparkIngestsSampledTurnsAndResumesDrafting) {
+  auto config = MakeDflash2Config();
+  config.config_path = fs::path{MODEL_PATH "engine/synthetic-dspark"};
+  auto& dspark = config.model.dflash2;
+  dspark.filename = "dspark.onnx";
+  dspark.is_dspark = true;
+  dspark.num_hidden_layers = 1;
+  dspark.num_key_value_heads = 1;
+  dspark.head_size = 1;
+  dspark.block_size = 4;
+  dspark.num_draft_tokens = 4;
+  dspark.sliding_window = 0;
+
+  auto model = std::make_shared<Dflash2Model>(CreateDflash2Config(config), GetOrtEnv());
+  Dflash2Drafter drafter{model, /*paged_block_size=*/4, /*num_blocks=*/6,
+                         /*max_requests=*/1};
+
+  int tracked_id = 0;
+  int untracked_id = 0;
+  auto* tracked = reinterpret_cast<Request*>(&tracked_id);
+  auto* untracked = reinterpret_cast<Request*>(&untracked_id);
+  auto* device = GetDeviceInterface(DeviceType::CPU);
+  Tensor aux{device, Ort::TypeToTensorType<float>};
+  const std::array<int64_t, 2> aux_shape{1, 1};
+  aux.CreateTensor(aux_shape);
+  std::vector<std::vector<int32_t>> drafts;
+
+  const std::array initial{
+      Dflash2Drafter::Feed{.request = tracked, .aux_row_count = 1, .anchor_token = 11, .draft_eligible = true, .wants_drafts = true},
+  };
+  EXPECT_TRUE(drafter.Propose(aux, initial, drafts));
+  ASSERT_EQ(drafts.size(), 1u);
+  EXPECT_FALSE(drafts[0].empty());
+
+  const std::array sampled{
+      Dflash2Drafter::Feed{.request = tracked, .aux_row_count = 1, .first_position = 1, .anchor_token = 12, .draft_eligible = false, .wants_drafts = false},
+  };
+  EXPECT_TRUE(drafter.Propose(aux, sampled, drafts));
+  ASSERT_EQ(drafts.size(), 1u);
+  EXPECT_TRUE(drafts[0].empty());
+
+  const std::array resumed{
+      Dflash2Drafter::Feed{.request = tracked, .aux_row_count = 1, .first_position = 2, .anchor_token = 13, .draft_eligible = true, .wants_drafts = true},
+  };
+  EXPECT_TRUE(drafter.Propose(aux, resumed, drafts));
+  ASSERT_EQ(drafts.size(), 1u);
+  EXPECT_FALSE(drafts[0].empty());
+
+  drafter.Release(tracked);
+  const std::array ineligible{
+      Dflash2Drafter::Feed{.request = untracked, .aux_row_count = 1, .anchor_token = 14, .draft_eligible = false, .wants_drafts = false},
+  };
+  EXPECT_FALSE(drafter.Propose(aux, ineligible, drafts));
+  EXPECT_EQ(drafter.AdmissionMisses(), 0u);
+  EXPECT_FALSE(drafter.Propose(aux, {}, drafts));
 }
 
 TEST(Dflash2ConfigTest, RequiresMatchingCacheTypes) {

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -691,23 +691,10 @@ TEST(Dflash2ConfigTest, ReplacesProposalBufferWhenTheElementTypeChanges) {
   EXPECT_EQ(slot->GetElementCount(), 4u);
 }
 
-TEST(Dflash2ConfigTest, DraftsOnlyForGreedyRequests) {
-  Config::Search search;
-  search.do_sample = false;
-  EXPECT_TRUE(Dflash2CanDraft(search));
-
-  search.do_sample = true;
-  search.top_k = 50;
-  search.temperature = 1.0f;
-  EXPECT_FALSE(Dflash2CanDraft(search));
-
-  // Sampling that can only ever pick the top logit is still greedy.
-  search.top_k = 1;
-  EXPECT_TRUE(Dflash2CanDraft(search));
-
-  search.top_k = 50;
-  search.temperature = 0.0f;
-  EXPECT_TRUE(Dflash2CanDraft(search));
+TEST(Dflash2ConfigTest, JoinsOnlyFromAnEligibleTurnAtSequenceStart) {
+  EXPECT_TRUE(Dflash2CanJoin(/*draft_eligible=*/true, /*first_position=*/0));
+  EXPECT_FALSE(Dflash2CanJoin(/*draft_eligible=*/false, /*first_position=*/0));
+  EXPECT_FALSE(Dflash2CanJoin(/*draft_eligible=*/true, /*first_position=*/1));
 }
 
 }  // namespace Generators::test

--- a/test/cpp/engine/engine_run_tests.cpp
+++ b/test/cpp/engine/engine_run_tests.cpp
@@ -69,6 +69,18 @@ std::vector<int32_t> Prompt(int32_t seed) {
   return {base, base + 1, base + 2};
 }
 
+// A nearly deterministic sampled turn policy: top-k 3 at a very low temperature with a fixed seed,
+// so the sampled and speculative-sampled paths take their random branches while still selecting a
+// predictable token.
+TurnOptions SampledTurnOptions(uint64_t seed = 1234) {
+  TurnOptions options;
+  options.do_sample = true;
+  options.top_k = 3;
+  options.temperature = 0.01f;
+  options.seed = seed;
+  return options;
+}
+
 // Index of the first occurrence of `entry` in the trace, or -1 if absent.
 int IndexOf(const CallTrace& trace, const std::string& entry) {
   auto it = std::find(trace.entries.begin(), trace.entries.end(), entry);
@@ -143,8 +155,12 @@ static_assert(noexcept(std::declval<Request&>().ExternalRelease()));
 static_assert(
     noexcept(std::declval<ExternalRequestRaceProbe&>().ExternalRelease()));
 
+// Row-selective post-processing failure. The scoring device is shared by every Request in the
+// Engine, so each Search records the ordinal it was created with and only the selected one throws.
 struct RequestPostProcessingControl {
   bool fail{};
+  size_t target_search_index{};
+  size_t next_search_index{};
 };
 
 class FailingPostProcessingSearch final : public GreedySearch_Cpu {
@@ -152,10 +168,12 @@ class FailingPostProcessingSearch final : public GreedySearch_Cpu {
   FailingPostProcessingSearch(
       const GeneratorParams& params,
       std::shared_ptr<RequestPostProcessingControl> control)
-      : GreedySearch_Cpu(params), control_{std::move(control)} {}
+      : GreedySearch_Cpu(params),
+        control_{std::move(control)},
+        search_index_{control_->next_search_index++} {}
 
   void ApplyRepetitionPenalty(float penalty) override {
-    if (control_->fail) {
+    if (control_->fail && search_index_ == control_->target_search_index) {
       throw std::runtime_error("Injected request post-processing failure.");
     }
     GreedySearch_Cpu::ApplyRepetitionPenalty(penalty);
@@ -163,6 +181,7 @@ class FailingPostProcessingSearch final : public GreedySearch_Cpu {
 
  private:
   std::shared_ptr<RequestPostProcessingControl> control_;
+  size_t search_index_;
 };
 
 class FailingPostProcessingDevice final : public DeviceInterface {
@@ -316,8 +335,8 @@ TEST(EngineLifetimeTest, DestroyingEngineReleasesCompositeCacheStorage) {
   EngineDependencies dependencies{
       cache, std::move(scheduler), std::move(executor)};
   auto engine = std::make_shared<Engine>(model, std::move(dependencies));
-  auto first = CreateRequestWithPrompt(engine, *model, Prompt(10));
-  auto second = CreateRequestWithPrompt(engine, *model, Prompt(20));
+  auto first = CreateRequestWithPrompt(engine, Prompt(10));
+  auto second = CreateRequestWithPrompt(engine, Prompt(20));
 
   EXPECT_EQ(RunOne(*engine).request, first);
   EXPECT_EQ(RunOne(*engine).request, second);
@@ -338,7 +357,7 @@ TEST_F(EngineRunTest, SingleRequestSchedulesThenDecodesThenReturns) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
 
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
   ASSERT_TRUE(engine.engine->HasPendingRequests());
 
   auto ready = RunOne(*engine.engine);
@@ -369,7 +388,7 @@ TEST_F(EngineRunTest, FittingRequestsShareOneDecodeAndReturnAllEvents) {
   std::vector<std::shared_ptr<Request>> requests;
   for (int32_t seed : {10, 20, 30}) {
     auto prompt = Prompt(seed);
-    auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+    auto request = CreateRequestWithPrompt(engine.engine, prompt);
     requests.push_back(request);
   }
 
@@ -400,7 +419,7 @@ TEST_F(EngineRunTest, CapacityOneExecutesOnceThenDrainsOverflow) {
   for (int32_t seed : {10, 20, 30}) {
     auto prompt = Prompt(seed);
     requests.push_back(
-        CreateRequestWithPrompt(engine.engine, *model_, prompt));
+        CreateRequestWithPrompt(engine.engine, prompt));
   }
 
   std::array<EngineEvent, 1> storage;
@@ -423,7 +442,7 @@ TEST_F(EngineRunTest, RetainedEventsDrainWithoutExecutingIntoSpareCapacity) {
   for (int32_t seed : {10, 20, 30}) {
     auto prompt = Prompt(seed);
     requests.push_back(
-        CreateRequestWithPrompt(engine.engine, *model_, prompt));
+        CreateRequestWithPrompt(engine.engine, prompt));
   }
 
   std::array<EngineEvent, 1> first_storage;
@@ -449,7 +468,7 @@ TEST_F(EngineRunTest, RetainedEventsDrainWithoutExecutingIntoSpareCapacity) {
 TEST_F(EngineRunTest, CreateRequestReclaimsAbandonedTurnCompleteAtCapacity) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, EosToken(*model_));
   auto first_prompt = Prompt(10);
-  auto first = CreateEngineRequest(engine.engine, *model_);
+  auto first = CreateEngineRequest(engine.engine);
   ExternalRequestReference first_external{*first};
   first->BeginTurn(first_prompt);
 
@@ -460,7 +479,7 @@ TEST_F(EngineRunTest, CreateRequestReclaimsAbandonedTurnCompleteAtCapacity) {
   first_external.Release();
 
   auto second_prompt = Prompt(20);
-  auto second = CreateEngineRequest(engine.engine, *model_);
+  auto second = CreateEngineRequest(engine.engine);
   ExternalRequestReference second_external{*second};
   second->BeginTurn(second_prompt);
 
@@ -480,8 +499,8 @@ TEST_F(EngineRunTest, RunReclaimsAbandonedTurnCompleteBeforePlanningAtCapacity) 
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, EosToken(*model_));
   auto first_prompt = Prompt(10);
   auto second_prompt = Prompt(20);
-  auto first = CreateEngineRequest(engine.engine, *model_);
-  auto second = CreateEngineRequest(engine.engine, *model_);
+  auto first = CreateEngineRequest(engine.engine);
+  auto second = CreateEngineRequest(engine.engine);
   ExternalRequestReference first_external{*first};
   ExternalRequestReference second_external{*second};
   first->BeginTurn(first_prompt);
@@ -509,9 +528,9 @@ TEST_F(EngineRunTest, RunPurgesAbandonedReadyAndQueuedRequestsExactlyOnce) {
   auto survivor_prompt = Prompt(10);
   auto ready_orphan_prompt = Prompt(20);
   auto queued_orphan_prompt = Prompt(30);
-  auto survivor = CreateEngineRequest(engine.engine, *model_);
-  auto ready_orphan = CreateEngineRequest(engine.engine, *model_);
-  auto queued_orphan = CreateEngineRequest(engine.engine, *model_);
+  auto survivor = CreateEngineRequest(engine.engine);
+  auto ready_orphan = CreateEngineRequest(engine.engine);
+  auto queued_orphan = CreateEngineRequest(engine.engine);
   ExternalRequestReference survivor_external{*survivor};
   ExternalRequestReference ready_orphan_external{*ready_orphan};
   ExternalRequestReference queued_orphan_external{*queued_orphan};
@@ -549,7 +568,7 @@ TEST_F(EngineRunTest, RunPurgesAbandonedReadyAndQueuedRequestsExactlyOnce) {
 TEST_F(EngineRunTest, ReacquiringExternalReferenceCancelsDeferredAbandonment) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, EosToken(*model_));
   auto prompt = Prompt(10);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   ExternalRequestReference initial_external{*request};
   request->BeginTurn(prompt);
   ASSERT_EQ(RunOne(*engine.engine).request, request);
@@ -569,7 +588,7 @@ TEST_F(EngineRunTest, ReacquiringExternalReferenceCancelsDeferredAbandonment) {
 
 TEST_F(EngineRunTest, AbandonmentCleanupRetriesAfterDeallocationFailure) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, EosToken(*model_));
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   ExternalRequestReference external{*request};
   request->BeginTurn(Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
@@ -593,8 +612,8 @@ TEST_F(EngineRunTest, AbandonmentCleanupRetriesAfterDeallocationFailure) {
 
 TEST_F(EngineRunTest, AbandonmentInvariantFailureTerminalizesExecutableTurns) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/2, /*forced_token=*/5);
-  auto abandoned = CreateEngineRequest(engine.engine, *model_);
-  auto survivor = CreateEngineRequest(engine.engine, *model_);
+  auto abandoned = CreateEngineRequest(engine.engine);
+  auto survivor = CreateEngineRequest(engine.engine);
   ExternalRequestReference abandoned_external{*abandoned};
   abandoned->BeginTurn(Prompt(10), std::optional<size_t>{2});
   survivor->BeginTurn(Prompt(20), std::optional<size_t>{2});
@@ -624,8 +643,8 @@ TEST_F(EngineRunTest, AbandonmentInvariantFailureTerminalizesExecutableTurns) {
 
 TEST_F(EngineRunTest, FatalScratchReleasesDrainedRequestEvents) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, /*forced_token=*/5);
-  auto abandoned = CreateEngineRequest(engine.engine, *model_);
-  auto retained_event_request = CreateEngineRequest(engine.engine, *model_);
+  auto abandoned = CreateEngineRequest(engine.engine);
+  auto retained_event_request = CreateEngineRequest(engine.engine);
   ExternalRequestReference abandoned_external{*abandoned};
   abandoned->BeginTurn(Prompt(10), std::optional<size_t>{2});
   const auto retained_turn =
@@ -659,9 +678,9 @@ TEST_F(EngineRunTest, FatalScratchReleasesDrainedRequestEvents) {
 TEST_F(EngineRunTest,
        AbandonmentInvariantFailureFromBeginTurnRetainsFatalEvents) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/2, /*forced_token=*/5);
-  auto abandoned = CreateEngineRequest(engine.engine, *model_);
-  auto survivor = CreateEngineRequest(engine.engine, *model_);
-  auto boundary_request = CreateEngineRequest(engine.engine, *model_);
+  auto abandoned = CreateEngineRequest(engine.engine);
+  auto survivor = CreateEngineRequest(engine.engine);
+  auto boundary_request = CreateEngineRequest(engine.engine);
   ExternalRequestReference abandoned_external{*abandoned};
   abandoned->BeginTurn(Prompt(10), std::optional<size_t>{2});
   survivor->BeginTurn(Prompt(20), std::optional<size_t>{2});
@@ -696,7 +715,7 @@ TEST_F(EngineRunTest,
 TEST_F(EngineRunTest,
        ConcurrentFinalReleaseAndReacquireCancelsRequestAbandonment) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, EosToken(*model_));
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->ExternalAddRef();
   request->BeginTurn(Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
@@ -728,8 +747,8 @@ TEST_F(EngineRunTest, BeginTurnRejectsUndrainedReadyNotificationWithoutMutation)
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto first_prompt = Prompt(10);
   auto second_prompt = Prompt(20);
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, first_prompt);
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, second_prompt);
+  auto first = CreateRequestWithPrompt(engine.engine, first_prompt);
+  auto second = CreateRequestWithPrompt(engine.engine, second_prompt);
 
   ASSERT_EQ(RunOne(*engine.engine).request, first);
   ASSERT_EQ(engine.executor->decode_calls, 1);
@@ -763,7 +782,7 @@ TEST_F(EngineRunTest, BeginTurnRejectsUndrainedReadyNotificationWithoutMutation)
 TEST_F(EngineRunTest, ContinuedUnreadOutputPreservesOrder) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
 
   auto event = RunOne(*engine.engine);
   ASSERT_EQ(event.request, request);
@@ -798,10 +817,8 @@ TEST_F(EngineRunTest, ContinuedUnreadOutputPreservesOrder) {
 TEST_F(EngineRunTest, PerTurnBudgetsPublishOneTerminalNotificationAcrossContinuations) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, /*forced_token=*/5);
   const auto prompt = Prompt(10);
-  auto params = MakeGreedyParams(*model_);
-  params->search.max_length =
-      static_cast<int>(prompt.size() + 9);
-  auto request = CreateEngineRequest(engine.engine, *params);
+  auto request = CreateEngineRequest(
+      engine.engine, /*max_session_tokens=*/prompt.size() + 9);
 
   const auto run_turn = [&](std::span<const int32_t> input,
                             size_t max_generated_tokens) {
@@ -846,7 +863,7 @@ TEST_F(EngineRunTest, BackpressureFormsAFreshBatchAcrossRuns) {
   std::vector<std::shared_ptr<Request>> requests;
   for (int32_t seed : {10, 20, 30}) {
     auto prompt = Prompt(seed);
-    auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+    auto request = CreateRequestWithPrompt(engine.engine, prompt);
     requests.push_back(request);
   }
 
@@ -893,7 +910,7 @@ TEST_F(EngineRunTest, RunWithNoRequestsReturnsNull) {
 TEST_F(EngineRunTest, ZeroCapacityValidatesOwnerThreadWithoutReclaimingOrProgressing) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
   ExternalRequestReference public_handle{*request};
   public_handle.Release();
 
@@ -923,7 +940,7 @@ TEST_F(EngineRunTest, ZeroCapacityValidatesOwnerThreadWithoutReclaimingOrProgres
 
 TEST_F(EngineRunTest, HasPendingRequestsReclaimsPubliclyDestroyedUnassignedRequest) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   ExternalRequestReference public_handle{*request};
 
   public_handle.Release();
@@ -936,7 +953,7 @@ TEST_F(EngineRunTest, HasPendingRequestsReclaimsPubliclyDestroyedUnassignedReque
 
 TEST_F(EngineRunTest, OffThreadFinalReleaseBeforeBeginTurnDefersDestructionToOwnerThread) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   ExternalRequestReference public_handle{*request};
   std::weak_ptr<Request> request_lifetime = request;
   request.reset();
@@ -956,7 +973,7 @@ TEST_F(EngineRunTest, OffThreadFinalReleaseBeforeBeginTurnDefersDestructionToOwn
 
 TEST_F(EngineRunTest, OffThreadFinalReleaseDoesNotKeepDestroyedEngineAlive) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   ExternalRequestReference public_handle{*request};
   std::weak_ptr<Engine> engine_lifetime = engine.engine;
 
@@ -972,7 +989,7 @@ TEST_F(EngineRunTest, OffThreadFinalReleaseDoesNotKeepDestroyedEngineAlive) {
 TEST_F(EngineRunTest, HasPendingRequestsReclaimsPubliclyDestroyedQueuedRequest) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
   ExternalRequestReference public_handle{*request};
 
   public_handle.Release();
@@ -986,7 +1003,7 @@ TEST_F(EngineRunTest, HasPendingRequestsReclaimsPubliclyDestroyedQueuedRequest) 
 TEST_F(EngineRunTest, HasPendingRequestsValidatesOwnerThreadBeforeReclamation) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
   ExternalRequestReference public_handle{*request};
   public_handle.Release();
 
@@ -1012,7 +1029,7 @@ TEST_F(EngineRunTest, HasPendingRequestsValidatesOwnerThreadBeforeReclamation) {
 TEST_F(EngineRunTest, HasPendingRequestsReclaimsPubliclyDestroyedActiveResidentRequest) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
   ExternalRequestReference public_handle{*request};
   engine.cache->Allocate({request});
   request->Schedule();
@@ -1031,9 +1048,9 @@ TEST_F(EngineRunTest, HasPendingRequestsReclaimsPubliclyDestroyedActiveResidentR
 TEST_F(EngineRunTest, HasPendingRequestsPurgesDestroyedTurnCompleteEventWithoutAffectingPeer) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/2, EosToken(*model_));
   auto survivor = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
   auto abandoned = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(20));
+      engine.engine, Prompt(20));
   ExternalRequestReference survivor_handle{*survivor};
   ExternalRequestReference abandoned_handle{*abandoned};
 
@@ -1072,7 +1089,7 @@ TEST_F(EngineRunTest, DestroyingEngineClosesRequestWhosePublicHandleSurvives) {
   auto engine = std::make_shared<Engine>(
       model_, std::move(dependencies));
   auto request = CreateRequestWithPrompt(
-      engine, *model_, Prompt(10));
+      engine, Prompt(10));
   ExternalRequestReference public_request{*request};
   ASSERT_EQ(RunOne(*engine).request, request);
   ASSERT_EQ(cache->AllocatedCount(), 1u);
@@ -1100,7 +1117,7 @@ TEST_F(EngineRunTest, StaticBatchingPreservesOrderingAndReusesResidentContinuati
                                   std::move(executor)};
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
   auto prompt = Prompt(10);
-  auto request = CreateEngineRequest(engine, *model_);
+  auto request = CreateEngineRequest(engine);
   request->BeginTurn(prompt, std::optional<size_t>{1});
 
   EXPECT_EQ(RunOne(*engine).request, request);
@@ -1129,8 +1146,8 @@ TEST_F(EngineRunTest, StaticBatchReturnsAllRowEventsWhenCapacitySuffices) {
   EngineDependencies dependencies{cache, std::move(scheduler),
                                   std::move(executor)};
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
-  auto first = CreateEngineRequest(engine, *model_);
-  auto second = CreateEngineRequest(engine, *model_);
+  auto first = CreateEngineRequest(engine);
+  auto second = CreateEngineRequest(engine);
   first->BeginTurn(Prompt(10), std::optional<size_t>{1});
   second->BeginTurn(Prompt(20), std::optional<size_t>{1});
 
@@ -1157,8 +1174,8 @@ TEST_F(EngineRunTest, StaticCloseLogicallyRemovesActiveRowWhilePeerContinues) {
   EngineDependencies dependencies{cache, std::move(scheduler),
                                   std::move(executor)};
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
-  auto first = CreateEngineRequest(engine, *model_);
-  auto second = CreateEngineRequest(engine, *model_);
+  auto first = CreateEngineRequest(engine);
+  auto second = CreateEngineRequest(engine);
   first->BeginTurn(Prompt(10), std::optional<size_t>{2});
   second->BeginTurn(Prompt(20), std::optional<size_t>{2});
 
@@ -1195,7 +1212,7 @@ TEST_F(EngineRunTest, StaticCloseLogicallyRemovesActiveRowWhilePeerContinues) {
 
   // New work recycles the all-terminal static batch. The Engine completes the retained close on
   // its owner thread before executing the replacement row, leaving only a lightweight tombstone.
-  auto replacement = CreateEngineRequest(engine, *model_);
+  auto replacement = CreateEngineRequest(engine);
   replacement->BeginTurn(Prompt(30), std::optional<size_t>{1});
   const int searches_before_recycle = LeakChecked<Search>::Count();
   EXPECT_EQ(RunOne(*engine).request, replacement);
@@ -1217,8 +1234,8 @@ TEST_F(EngineRunTest, StaticAbandonmentLogicallyRemovesActiveRowAtNextBoundary) 
   EngineDependencies dependencies{cache, std::move(scheduler),
                                   std::move(executor)};
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
-  auto first = CreateEngineRequest(engine, *model_);
-  auto second = CreateEngineRequest(engine, *model_);
+  auto first = CreateEngineRequest(engine);
+  auto second = CreateEngineRequest(engine);
   ExternalRequestReference second_handle{*second};
   first->BeginTurn(Prompt(10), std::optional<size_t>{2});
   second->BeginTurn(Prompt(20), std::optional<size_t>{2});
@@ -1253,7 +1270,7 @@ TEST_F(EngineRunTest, StaticAbandonmentLogicallyRemovesActiveRowAtNextBoundary) 
   EXPECT_EQ(second->TurnGeneratedTokens(), closed_generated);
   EXPECT_EQ(LeakChecked<Search>::Count(), searches_while_resident);
 
-  auto replacement = CreateEngineRequest(engine, *model_);
+  auto replacement = CreateEngineRequest(engine);
   replacement->BeginTurn(Prompt(30), std::optional<size_t>{1});
   const int searches_before_recycle = LeakChecked<Search>::Count();
   EXPECT_EQ(RunOne(*engine).request, replacement);
@@ -1274,7 +1291,7 @@ TEST_F(EngineRunTest, StaticExecutionFailureTerminatesRequestsAndMarksEngineUnhe
   EngineDependencies dependencies{cache, std::move(scheduler),
                                   std::move(executor)};
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
-  auto request = CreateRequestWithPrompt(engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine, Prompt(10));
   executor_observer->SetNextFailure(ScriptedExecutionFailure::Fatal);
 
   const auto failure = RunOne(*engine);
@@ -1304,7 +1321,7 @@ TEST_F(EngineRunTest, StaticHasPendingClosesAbandonedResidentWithoutIndividualDe
                                   std::move(executor)};
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
   auto prompt = Prompt(10);
-  auto request = CreateEngineRequest(engine, *model_);
+  auto request = CreateEngineRequest(engine);
   ExternalRequestReference external{*request};
   request->BeginTurn(prompt);
 
@@ -1335,12 +1352,12 @@ TEST_F(EngineRunTest, StaticContinuationFailsAfterBatchRecycling) {
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
 
   auto first_prompt = Prompt(10);
-  auto first = CreateRequestWithPrompt(engine, *model_, first_prompt);
+  auto first = CreateRequestWithPrompt(engine, first_prompt);
   ASSERT_EQ(RunOne(*engine).request, first);
   ASSERT_EQ(first->status_, RequestStatus::TurnComplete);
 
   auto second_prompt = Prompt(20);
-  auto second = CreateRequestWithPrompt(engine, *model_, second_prompt);
+  auto second = CreateRequestWithPrompt(engine, second_prompt);
   for (int run = 0; run < 2 && cache->IsResident(first); ++run) {
     ASSERT_NE(RunOne(*engine).flags, EngineEventFlagNone);
   }
@@ -1364,8 +1381,8 @@ TEST_F(EngineRunTest, StaticContinuationRejectsMultiRowBatchAfterPeerCloses) {
 
   auto first_prompt = Prompt(10);
   auto second_prompt = Prompt(20);
-  auto first = CreateRequestWithPrompt(engine, *model_, first_prompt);
-  auto second = CreateRequestWithPrompt(engine, *model_, second_prompt);
+  auto first = CreateRequestWithPrompt(engine, first_prompt);
+  auto second = CreateRequestWithPrompt(engine, second_prompt);
   ASSERT_EQ(RunOne(*engine).request, first);
   ASSERT_EQ(first->status_, RequestStatus::TurnComplete);
   ASSERT_EQ(second->status_, RequestStatus::TurnComplete);
@@ -1381,7 +1398,7 @@ TEST_F(EngineRunTest, RunDoesNotReturnNullWhenCapacityDefersPendingWork) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
   engine.cache->SetCanAllocate(false);
   auto prompt = Prompt(10);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(prompt, std::optional<size_t>{1});
 
   const auto deferred = RunOne(*engine.engine);
@@ -1398,7 +1415,7 @@ TEST_F(EngineRunTest, RunDoesNotReturnNullWhenCapacityDefersPendingWork) {
 TEST_F(EngineRunTest, RetryableExecutionFailureRollsBackAndCanRetry) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
   auto prompt = Prompt(10);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(prompt, std::optional<size_t>{1});
   const auto before = request->Snapshot();
   engine.executor->SetNextFailure(
@@ -1424,7 +1441,7 @@ TEST_F(EngineRunTest, RetryableExecutionFailureRollsBackAndCanRetry) {
 TEST_F(EngineRunTest, ContinuedResidentRollsBackToQueuedAndCanRetry) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   ASSERT_EQ(request->status_, RequestStatus::TurnComplete);
   ASSERT_EQ(engine.cache->AllocatedCount(), 1u);
@@ -1451,11 +1468,10 @@ TEST_F(EngineRunTest, ContinuedResidentRollsBackToQueuedAndCanRetry) {
 }
 
 TEST_F(EngineRunTest, PartialPrefillCommitsOneTransactionAndReturnsNoEvents) {
+  model_ = LoadDummyDecoderModelWithChunking(/*chunk_size=*/2);
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto prompt = Prompt(10);
-  auto params = MakeGreedyParams(*model_);
-  params->search.chunk_size = 2;
-  auto request = CreateRequestWithPrompt(engine.engine, *params, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
 
   std::array<EngineEvent, 1> storage;
   EXPECT_EQ(engine.engine->Run(storage), 0u);
@@ -1491,7 +1507,7 @@ TEST_F(EngineRunTest, PartialPrefillCommitsOneTransactionAndReturnsNoEvents) {
 TEST_F(EngineRunTest, UnserviceableContinuationPublishesTerminalFailure) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   ASSERT_EQ(request->status_, RequestStatus::TurnComplete);
 
@@ -1513,7 +1529,7 @@ TEST_F(EngineRunTest, UnserviceableContinuationPublishesTerminalFailure) {
 TEST_F(EngineRunTest, ExecutionCapacityFailureRollsBackWithoutPoisoningEngine) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
   const auto before = request->Snapshot();
   engine.executor->SetNextFailure(ScriptedExecutionFailure::CapacityExceeded);
 
@@ -1539,7 +1555,7 @@ TEST_F(EngineRunTest, ExecutionCapacityFailureRollsBackWithoutPoisoningEngine) {
 TEST_F(EngineRunTest, PostProcessingFailureRestoresSearchAndCanRetry) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
   const auto before = request->Snapshot();
   engine.executor->SetNextFailure(ScriptedExecutionFailure::PostProcessing);
 
@@ -1561,13 +1577,14 @@ TEST_F(EngineRunTest, LaterRequestFailureRestoresEarlierSample) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
   auto first_prompt = Prompt(10);
   auto second_prompt = Prompt(20);
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, first_prompt);
   auto control = std::make_shared<RequestPostProcessingControl>();
-  auto second_params = MakeGreedyParams(*model_);
-  FailingPostProcessingDevice device{*second_params->p_device, control};
-  second_params->p_device = &device;
-  auto second =
-      CreateRequestWithPrompt(engine.engine, *second_params, second_prompt);
+  // Only the second Request's own post-processing fails: the shared scoring device hands every
+  // Request the same failing Search, and the control selects which one actually throws.
+  FailingPostProcessingDevice device{*model_->p_device_scoring_, control};
+  ScopedScoringDevice scoped_device{*model_, device};
+  auto first = CreateRequestWithPrompt(engine.engine, first_prompt);
+  control->target_search_index = 1;
+  auto second = CreateRequestWithPrompt(engine.engine, second_prompt);
   const auto first_before = first->Snapshot();
   const auto second_before = second->Snapshot();
 
@@ -1596,8 +1613,8 @@ TEST_F(EngineRunTest, ClosingUndrainedReadyRequestPurgesItFromQueue) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
   auto first_prompt = Prompt(10);
   auto second_prompt = Prompt(20);
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, first_prompt);
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, second_prompt);
+  auto first = CreateRequestWithPrompt(engine.engine, first_prompt);
+  auto second = CreateRequestWithPrompt(engine.engine, second_prompt);
 
   ASSERT_EQ(RunOne(*engine.engine).request, first);
   second->Close();
@@ -1609,7 +1626,7 @@ TEST_F(EngineRunTest, ClosingUndrainedReadyRequestPurgesItFromQueue) {
 TEST_F(EngineRunTest, ClosingOnlyDrainedReadyRequestClearsQueue) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
 
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   request->Close();
@@ -1632,14 +1649,14 @@ TEST_F(EngineRunTest, StaticTurnCompleteRowIsNotRepublishedWhilePeerRuns) {
 
   auto first_prompt = Prompt(10);
   auto second_prompt = Prompt(20);
-  auto first_params = MakeGreedyParams(*model_);
-  first_params->search.max_length =
-      static_cast<int>(first_prompt.size() + 1);
-  auto second_params = MakeGreedyParams(*model_);
-  second_params->search.max_length =
-      static_cast<int>(second_prompt.size() + 3);
-  auto first = CreateRequestWithPrompt(engine, *first_params, first_prompt);
-  auto second = CreateRequestWithPrompt(engine, *second_params, second_prompt);
+  RequestOptions first_options;
+  first_options.max_session_tokens = first_prompt.size() + 1;
+  RequestOptions second_options;
+  second_options.max_session_tokens = second_prompt.size() + 3;
+  auto first = engine->CreateRequest(first_options);
+  first->BeginTurn(first_prompt);
+  auto second = engine->CreateRequest(second_options);
+  second->BeginTurn(second_prompt);
 
   ASSERT_EQ(RunOne(*engine).request, first);
   ASSERT_EQ(first->status_, RequestStatus::TurnComplete);
@@ -1653,7 +1670,7 @@ TEST_F(EngineRunTest, StaticTurnCompleteRowIsNotRepublishedWhilePeerRuns) {
 TEST_F(EngineRunTest, FatalExecutionFailureMarksEngineUnhealthy) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
   engine.executor->SetNextFailure(ScriptedExecutionFailure::Fatal);
 
   const auto failure = RunOne(*engine.engine);
@@ -1688,7 +1705,7 @@ TEST_F(EngineRunTest, FatalDiagnosticCaptureFailureDrainsExecutionFallback) {
   auto engine = std::make_shared<Engine>(
       model_, std::move(dependencies));
   auto request = CreateRequestWithPrompt(
-      engine, *model_, Prompt(10));
+      engine, Prompt(10));
   executor_observer->SetNextFailure(ScriptedExecutionFailure::Fatal);
 
   const auto failure = RunOne(*engine);
@@ -1716,9 +1733,9 @@ TEST_F(EngineRunTest, FatalDiagnosticCaptureFailureDrainsExecutionFallback) {
 TEST_F(EngineRunTest, FatalExecutionFailurePublishesEveryAffectedTurn) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto first = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
   auto second = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(20));
+      engine.engine, Prompt(20));
   engine.executor->SetNextFailure(ScriptedExecutionFailure::Fatal);
 
   std::array<EngineEvent, 2> events;
@@ -1746,7 +1763,7 @@ TEST_F(EngineRunTest, FatalFailurePublishesQueuedTurnsAfterEventCapacitySwap) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, /*forced_token=*/5);
   std::vector<std::shared_ptr<Request>> requests;
   for (int32_t seed : {10, 20, 30}) {
-    auto request = CreateEngineRequest(engine.engine, *model_);
+    auto request = CreateEngineRequest(engine.engine);
     request->BeginTurn(Prompt(seed), std::optional<size_t>{2});
     requests.push_back(std::move(request));
   }
@@ -1779,8 +1796,8 @@ TEST_F(EngineRunTest, FatalFailureFinishesLastPendingSpeculativeToken) {
   const int32_t filler = eos == 5 ? 6 : 5;
   auto engine = MakeDoublesEngine(model_, /*capacity=*/2, filler);
   engine.cache->SetMaxDraftTokensPerStep(kMaxDraftTokensPerStep);
-  auto abandoned = CreateEngineRequest(engine.engine, *model_);
-  auto survivor = CreateEngineRequest(engine.engine, *model_);
+  auto abandoned = CreateEngineRequest(engine.engine);
+  auto survivor = CreateEngineRequest(engine.engine);
   ExternalRequestReference abandoned_external{*abandoned};
   abandoned->BeginTurn(Prompt(10), std::optional<size_t>{1});
   survivor->BeginTurn(Prompt(20), std::optional<size_t>{16});
@@ -1798,9 +1815,9 @@ TEST_F(EngineRunTest, FatalFailureFinishesLastPendingSpeculativeToken) {
   ASSERT_EQ(first_speculative_token.request, survivor);
   ASSERT_EQ(first_speculative_token.token, 11);
   auto queued_first = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(30));
+      engine.engine, Prompt(30));
   auto queued_second = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(40));
+      engine.engine, Prompt(40));
   abandoned_external.Release();
   engine.cache->ThrowDeallocateInvariantFailureOnce();
   EXPECT_TRUE(engine.engine->HasPendingRequests());
@@ -1851,7 +1868,7 @@ TEST_F(EngineRunTest, StaticSchedulerFailureMarksEngineUnhealthy) {
   auto engine = std::make_shared<Engine>(
       model_, std::move(dependencies));
 
-  auto request = CreateRequestWithPrompt(engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine, Prompt(10));
 
   const auto failure = RunOne(*engine);
   EXPECT_EQ(failure.request, request);
@@ -1871,7 +1888,7 @@ TEST_F(EngineRunTest, StaticSchedulerFailureMarksEngineUnhealthy) {
 
 TEST_F(EngineRunTest, FatalWithoutExecutableTurnAppendsRequestlessFailure) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, EosToken(*model_));
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   ExternalRequestReference external{*request};
   request->BeginTurn(Prompt(10));
 
@@ -1898,12 +1915,12 @@ TEST_F(EngineRunTest, FatalWithoutExecutableTurnAppendsRequestlessFailure) {
 TEST_F(EngineRunTest, BeginTurnIsRejectedAfterEngineBecomesUnhealthy) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto first_prompt = Prompt(10);
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, first_prompt);
+  auto first = CreateRequestWithPrompt(engine.engine, first_prompt);
   ASSERT_EQ(RunOne(*engine.engine).request, first);
   ASSERT_EQ(first->status_, RequestStatus::TurnComplete);
 
   auto second_prompt = Prompt(20);
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, second_prompt);
+  auto second = CreateRequestWithPrompt(engine.engine, second_prompt);
   engine.executor->SetNextFailure(ScriptedExecutionFailure::Fatal);
   EXPECT_EQ(
       RunOne(*engine.engine).flags,
@@ -1922,9 +1939,9 @@ TEST_F(EngineRunTest, UnserviceableRequestDoesNotBlockFittingRequest) {
   auto large_prompt = Prompt(10);
   auto fitting_prompt = Prompt(20);
   auto too_large =
-      CreateRequestWithPrompt(engine.engine, *model_, large_prompt);
+      CreateRequestWithPrompt(engine.engine, large_prompt);
   auto fitting =
-      CreateRequestWithPrompt(engine.engine, *model_, fitting_prompt);
+      CreateRequestWithPrompt(engine.engine, fitting_prompt);
   engine.cache->SetUnserviceableRequest(too_large);
 
   const auto failed = RunOne(*engine.engine);
@@ -1937,8 +1954,8 @@ TEST_F(EngineRunTest, LaterFailurePreservesEarlierCommittedCycle) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/1, /*forced_token=*/5);
   auto first_prompt = Prompt(10);
   auto second_prompt = Prompt(20);
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, first_prompt);
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, second_prompt);
+  auto first = CreateRequestWithPrompt(engine.engine, first_prompt);
+  auto second = CreateRequestWithPrompt(engine.engine, second_prompt);
 
   EXPECT_EQ(RunOne(*engine.engine).request, first);
   const auto committed = first->Snapshot();
@@ -1961,13 +1978,13 @@ TEST_F(EngineRunTest, MixedDecodeAndPrefillCommitPlanOwnedTokenCounts) {
   model_->config_->engine.dynamic_batching->max_scheduled_tokens = 3;
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
   auto first_prompt = Prompt(10);
-  auto decode = CreateRequestWithPrompt(engine.engine, *model_, first_prompt);
+  auto decode = CreateRequestWithPrompt(engine.engine, first_prompt);
   ASSERT_EQ(RunOne(*engine.engine).request, decode);
   const auto decode_before_mixed = decode->Snapshot();
 
   const std::vector<int32_t> long_prompt{2, 3, 4, 5, 6};
   auto prefill =
-      CreateRequestWithPrompt(engine.engine, *model_, long_prompt);
+      CreateRequestWithPrompt(engine.engine, long_prompt);
 
   EXPECT_EQ(RunOne(*engine.engine).request, decode);
 
@@ -1988,12 +2005,12 @@ TEST_F(EngineRunTest, MixedRunRollbackPreservesProgressAndCacheResidents) {
   model_->config_->engine.dynamic_batching->max_scheduled_tokens = 3;
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
   auto first_prompt = Prompt(10);
-  auto decode = CreateRequestWithPrompt(engine.engine, *model_, first_prompt);
+  auto decode = CreateRequestWithPrompt(engine.engine, first_prompt);
   ASSERT_EQ(RunOne(*engine.engine).request, decode);
 
   const std::vector<int32_t> long_prompt{2, 3, 4, 5, 6};
   auto prefill =
-      CreateRequestWithPrompt(engine.engine, *model_, long_prompt);
+      CreateRequestWithPrompt(engine.engine, long_prompt);
   const auto decode_before = decode->Snapshot();
   const auto prefill_before = prefill->Snapshot();
   ASSERT_EQ(engine.cache->AllocatedCount(), 1u);
@@ -2027,7 +2044,7 @@ TEST_F(EngineRunTest, SpeculativeRunKeepsAcceptedPrefixAndEmitsAllTokens) {
   engine.cache->SetMaxDraftTokensPerStep(3);
 
   auto request =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   ASSERT_EQ(request->status_, RequestStatus::Active);
   const int64_t length_after_prefill = request->CurrentSequenceLength();
@@ -2061,18 +2078,100 @@ TEST_F(EngineRunTest, SpeculativeRunKeepsAcceptedPrefixAndEmitsAllTokens) {
   EXPECT_EQ(request->PendingDraftTokenCount(), 0u);
 }
 
+// A draft proposal belongs to the turn it was proposed under: the drafter produced it knowing that
+// turn's guidance, minimum, repetition penalty, and n-gram blocking. Every terminal boundary must
+// take the proposal with it, or a later turn -- whose different policy never validated those
+// drafts, and which may forbid drafting entirely -- would verify them anyway.
+TEST_F(EngineRunTest, FailedTurnDiscardsPendingDraftsAndTheNextTurnPolicyGoverns) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto failing = CreateRequestWithPrompt(engine.engine, Prompt(10));
+  ASSERT_EQ(RunOne(*engine.engine).request, failing);
+  ASSERT_EQ(failing->status_, RequestStatus::Active);
+  failing->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  ASSERT_EQ(failing->PendingDraftTokenCount(), 3u);
+
+  // A recoverable per-request failure: the scheduler reports this Request unserviceable, its turn
+  // is failed, and the Engine itself stays healthy.
+  engine.cache->SetUnserviceableRequest(failing);
+  const auto failure = RunOne(*engine.engine);
+  ASSERT_EQ(failure.request, failing);
+  ASSERT_EQ(failure.error_code, EngineErrorCode::RequestUnserviceable);
+  ASSERT_EQ(failing->FinishReason(), GenerationFinishReason::Failed);
+  ASSERT_EQ(failing->status_, RequestStatus::TurnComplete);
+
+  // The proposal died with the turn instead of waiting for whatever runs next.
+  EXPECT_EQ(failing->PendingDraftTokenCount(), 0u);
+  // The failed turn also released this Request's model state, so it cannot continue at all, and it
+  // no longer accepts a proposal either.
+  EXPECT_THROW(failing->SetDraftTokens(std::vector<int32_t>{11, 12, 13}),
+               std::runtime_error);
+  EXPECT_THROW(failing->BeginTurn(std::vector<int32_t>{7}), std::runtime_error);
+  engine.cache->SetUnserviceableRequest({});
+
+  // The other half of the boundary, on the same healthy Engine: a Request that ends a drafted turn
+  // starts its next turn with no proposal and under that turn's own policy.
+  auto reused = CreateEngineRequest(engine.engine);
+  TurnOptions drafted_turn;
+  drafted_turn.request = reused;
+  drafted_turn.max_generated_tokens = 2;
+  reused->BeginTurn(Prompt(20), drafted_turn);
+  ASSERT_EQ(RunOne(*engine.engine).request, reused);
+  ASSERT_EQ(reused->status_, RequestStatus::Active);
+  reused->SetDraftTokens(std::vector<int32_t>{21, 22, 23});
+  engine.executor->SetVerifyRowTokens({21, 22, 23, 24});
+  while (!reused->IsTurnComplete()) {
+    static_cast<void>(RunOne(*engine.engine));
+  }
+  EXPECT_EQ(reused->PendingDraftTokenCount(), 0u);
+
+  // The next turn masks end-of-stream until it has generated three tokens, one of the policies that
+  // makes a turn ineligible for drafting at all.
+  engine.executor->SetVerifyRowTokens({});
+  engine.executor->SetForcedToken(eos);
+  const size_t prefix_commits_before = engine.cache->prefix_commits.size();
+  TurnOptions floored_turn;
+  floored_turn.request = reused;
+  floored_turn.min_generated_tokens = 3;
+  floored_turn.max_generated_tokens = 3;
+  reused->BeginTurn(std::vector<int32_t>{7}, floored_turn);
+  EXPECT_EQ(reused->PendingDraftTokenCount(), 0u);
+  EXPECT_NE(reused->DraftTokenValidationError(), nullptr);
+  EXPECT_THROW(reused->SetDraftTokens(std::vector<int32_t>{21, 22, 23}),
+               std::runtime_error);
+
+  std::vector<int32_t> generated;
+  std::array<EngineEvent, 8> storage;
+  for (int step = 0; step < 32 && !reused->IsTurnComplete(); ++step) {
+    const size_t count = engine.engine->Run(storage);
+    for (size_t i = 0; i < count; ++i) {
+      if (storage[i].flags & EngineEventFlagToken) {
+        generated.push_back(storage[i].token);
+      }
+    }
+  }
+
+  // The floor held for every one of this turn's tokens, and no step verified a draft: a proposal
+  // carried across the boundary would have produced verification rows and a partial prefix commit.
+  ASSERT_TRUE(reused->IsTurnComplete());
+  EXPECT_EQ(generated.size(), 3u);
+  for (const int32_t token : generated) {
+    EXPECT_NE(token, eos);
+  }
+  EXPECT_EQ(reused->FinishReason(), GenerationFinishReason::TurnLimit);
+  EXPECT_EQ(engine.cache->prefix_commits.size(), prefix_commits_before);
+}
+
 TEST_F(EngineRunTest, SampledSpeculativeRunKeepsAcceptedPrefixAndCorrection) {
   const int32_t eos = EosToken(*model_);
   const int32_t filler = eos == 5 ? 6 : 5;
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-
-  auto request = CreateRequestWithPrompt(engine.engine, *params, Prompt(10));
+  auto request =
+      CreateRequestWithPrompt(engine.engine, Prompt(10), SampledTurnOptions());
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   const int64_t length_after_prefill = request->CurrentSequenceLength();
   const size_t generated_after_prefill = request->TurnGeneratedTokens();
@@ -2107,13 +2206,9 @@ TEST_F(EngineRunTest, SampledSpeculativeBatchHandlesMixedDraftLengths) {
   engine.cache->SetMaxDraftTokensPerStep(3);
   std::vector<std::shared_ptr<Request>> requests;
   for (int32_t prompt_seed : {20, 30}) {
-    auto params = MakeGreedyParams(*model_);
-    params->search.do_sample = true;
-    params->search.top_k = 3;
-    params->search.temperature = 0.01f;
-    params->search.random_seed = static_cast<unsigned int>(1234 + prompt_seed);
-    requests.push_back(
-        CreateRequestWithPrompt(engine.engine, *params, Prompt(prompt_seed)));
+    requests.push_back(CreateRequestWithPrompt(
+        engine.engine, Prompt(prompt_seed),
+        SampledTurnOptions(static_cast<uint64_t>(1234 + prompt_seed))));
   }
 
   std::array<EngineEvent, 2> prefill_events;
@@ -2147,13 +2242,10 @@ TEST_F(EngineRunTest, SampledSpeculativeRunRespectsTurnTokenLimit) {
   const int32_t filler = eos == 5 ? 6 : 5;
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(10), std::optional<size_t>{3});
+  auto request = CreateEngineRequest(engine.engine);
+  auto turn_options = SampledTurnOptions();
+  turn_options.max_generated_tokens = 3;
+  request->BeginTurn(Prompt(10), turn_options);
 
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   ASSERT_EQ(request->TurnGeneratedTokens(), 1u);
@@ -2184,7 +2276,7 @@ TEST_F(EngineRunTest, SpeculativeRunWithEosBonusTokenEmitsOnlyAcceptedDrafts) {
   engine.cache->SetMaxDraftTokensPerStep(3);
 
   auto request =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   const int64_t length_after_prefill = request->CurrentSequenceLength();
   const size_t generated_after_prefill = request->TurnGeneratedTokens();
@@ -2216,7 +2308,7 @@ TEST_F(EngineRunTest, SpeculativeRunAcceptingEveryDraftEmitsBonusToken) {
   engine.cache->SetMaxDraftTokensPerStep(3);
 
   auto request =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   const int64_t length_after_prefill = request->CurrentSequenceLength();
   const size_t generated_after_prefill = request->TurnGeneratedTokens();
@@ -2249,7 +2341,7 @@ TEST_F(EngineRunTest, SpeculativeTelemetryAggregatesAcceptanceLengths) {
   engine.cache->SetMaxDraftTokensPerStep(3);
 
   auto request =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
 
   request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
@@ -2289,7 +2381,7 @@ TEST_F(EngineRunTest, SpeculativeOverflowCancellationFinishesLastTokenEvent) {
   engine.cache->SetMaxDraftTokensPerStep(3);
 
   auto request =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
 
   request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
@@ -2323,7 +2415,7 @@ TEST_F(EngineRunTest, CancelClearsPendingDraftsBeforeContinuation) {
   engine.cache->SetMaxDraftTokensPerStep(3);
 
   auto request =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   request->SetDraftTokens(std::vector<int32_t>{11, 12});
   ASSERT_EQ(request->PendingDraftTokenCount(), 2u);
@@ -2360,7 +2452,7 @@ TEST_F(EngineRunTest, SpeculativeRunStopsAtAcceptedEos) {
   engine.cache->SetMaxDraftTokensPerStep(3);
 
   auto request =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   const int64_t length_after_prefill = request->CurrentSequenceLength();
   const size_t generated_after_prefill = request->TurnGeneratedTokens();
@@ -2392,7 +2484,7 @@ TEST_F(EngineRunTest, RolledBackSpeculativeRunLeavesProposalPendingAndRetryable)
   engine.cache->SetMaxDraftTokensPerStep(3);
 
   auto request =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   const auto committed = request->Snapshot();
   const size_t generated_after_prefill = request->TurnGeneratedTokens();
@@ -2430,14 +2522,13 @@ TEST_F(EngineRunTest, RolledBackTerminalDraftCanRetryWithoutProposal) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
   engine.cache->SetMaxDraftTokensPerStep(3);
 
-  auto first_params = MakeGreedyParams(*model_);
-  auto first = CreateEngineRequest(engine.engine, *first_params);
-  first->BeginTurn(Prompt(10), std::optional<size_t>{2});
   auto control = std::make_shared<RequestPostProcessingControl>();
-  auto second_params = MakeGreedyParams(*model_);
-  FailingPostProcessingDevice device{*second_params->p_device, control};
-  second_params->p_device = &device;
-  auto second = CreateEngineRequest(engine.engine, *second_params);
+  FailingPostProcessingDevice device{*model_->p_device_scoring_, control};
+  ScopedScoringDevice scoped_device{*model_, device};
+  auto first = CreateEngineRequest(engine.engine);
+  first->BeginTurn(Prompt(10), std::optional<size_t>{2});
+  control->target_search_index = 1;
+  auto second = CreateEngineRequest(engine.engine);
   second->BeginTurn(Prompt(20));
 
   std::array<EngineEvent, 2> initial;
@@ -2467,7 +2558,7 @@ TEST_F(EngineRunTest, RolledBackTerminalDraftCanRetryWithoutProposal) {
 TEST_F(EngineRunTest, DraftsRequireRollbackAndPerTokenLogitsCapabilities) {
   auto engine =
       MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
 
   EXPECT_EQ(engine.engine->MaxDraftTokensPerStep(), 0u);
   EXPECT_THROW(
@@ -2483,15 +2574,16 @@ TEST_F(EngineRunTest, DraftsRequireRollbackAndPerTokenLogitsCapabilities) {
 }
 
 TEST_F(EngineRunTest, DraftProposalRequiresDecodeReadyRequest) {
+  // A model-configured chunk size leaves the prompt half-prefilled after the first step, which is
+  // exactly the state a draft proposal must be rejected in.
+  model_ = LoadDummyDecoderModelWithChunking(/*chunk_size=*/2);
   const int32_t eos = EosToken(*model_);
   const int32_t filler = eos == 5 ? 6 : 5;
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
   engine.cache->SetMaxDraftTokensPerStep(3);
 
-  auto params = MakeGreedyParams(*model_);
-  params->search.chunk_size = 2;
   auto request =
-      CreateRequestWithPrompt(engine.engine, *params, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   EXPECT_THROW(
       request->SetDraftTokens(std::vector<int32_t>{11, 12}),
       std::runtime_error);
@@ -2516,7 +2608,7 @@ TEST_F(EngineRunTest, InvalidDraftReplacementPreservesPendingProposal) {
   engine.cache->SetMaxDraftTokensPerStep(3);
 
   auto request =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   request->SetDraftTokens(std::vector<int32_t>{11, 12});
 
@@ -2539,7 +2631,7 @@ TEST_F(EngineRunTest, MtpPlanningFailureCommitsTargetStepWithoutDrafts) {
   const int32_t filler = eos == 5 ? 6 : 5;
   auto engine = MakeMtpDoublesEngine(model_, filler);
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
 
   std::array<EngineEvent, 8> storage;
   ASSERT_GT(engine.engine->Run(storage), 0u);
@@ -2574,7 +2666,7 @@ TEST_F(EngineRunTest, PersistentMtpFailureKeepsTheRequestAdvancing) {
   const int32_t eos = EosToken(*model_);
   auto engine = MakeMtpDoublesEngine(model_, eos == 5 ? 6 : 5);
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
 
   // A head failure that never clears must degrade to ordinary decoding instead of livelocking on
   // a rolled back target step that commits no progress.
@@ -2602,7 +2694,7 @@ TEST_F(EngineRunTest, ContinuationDropsTheMtpShadowFromThePreviousTurn) {
   const int32_t eos = EosToken(*model_);
   auto engine = MakeMtpDoublesEngine(model_, eos == 5 ? 6 : 5);
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
 
   std::array<EngineEvent, 8> storage;
   ASSERT_GT(engine.engine->Run(storage), 0u);
@@ -2634,7 +2726,7 @@ TEST_F(EngineRunTest, CancelDropsTheMtpShadow) {
   const int32_t eos = EosToken(*model_);
   auto engine = MakeMtpDoublesEngine(model_, eos == 5 ? 6 : 5);
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
 
   std::array<EngineEvent, 8> storage;
   ASSERT_GT(engine.engine->Run(storage), 0u);
@@ -2649,7 +2741,7 @@ TEST_F(EngineRunTest, MtpCleanupFailureLeavesCancellationRetryable) {
   const int32_t eos = EosToken(*model_);
   auto engine = MakeMtpDoublesEngine(model_, eos == 5 ? 6 : 5);
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
 
   std::array<EngineEvent, 8> storage;
   ASSERT_GT(engine.engine->Run(storage), 0u);
@@ -2688,7 +2780,7 @@ TEST_F(EngineRunTest, MtpRollbackFailureMarksEngineUnhealthy) {
   auto engine = MakeMtpDoublesEngine(
       model_, eos == 5 ? 6 : 5);
   auto request = CreateRequestWithPrompt(
-      engine.engine, *model_, Prompt(10));
+      engine.engine, Prompt(10));
 
   ASSERT_EQ(RunOne(*engine.engine).request, request);
   ASSERT_GT(request->PendingDraftTokenCount(), 0u);
@@ -2715,7 +2807,7 @@ TEST_F(EngineRunTest, MtpRollbackFailureMarksEngineUnhealthy) {
 TEST_F(EngineRunTest, DensePagedModelHasNoFixedStateReservation) {
   model_ = LoadSyntheticPagedModel();
   auto engine = MakeCompositeDoublesEngine(model_, EosToken(*model_));
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   engine.executor->SetExecutionCallback([](ExecutionContext& context) {
     ASSERT_NE(context.plan, nullptr);
     EXPECT_FALSE(context.plan->fixed_state.required);
@@ -2737,14 +2829,14 @@ TEST_F(EngineRunTest, CompositeMixedPrefillDefersResidentDraft) {
   const int32_t eos = EosToken(*model_);
   auto engine = MakeCompositeDoublesEngine(
       model_, eos == 5 ? 6 : 5);
-  auto decode = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto decode = CreateRequestWithPrompt(engine.engine, Prompt(10));
 
   ASSERT_EQ(RunOne(*engine.engine).request, decode);
   const auto decode_before_mixed = decode->Snapshot();
   decode->SetDraftTokens(std::array<int32_t, 1>{11});
   const std::array<int32_t, 5> long_prompt{2, 3, 4, 5, 6};
   auto prefill = CreateRequestWithPrompt(
-      engine.engine, *model_, long_prompt);
+      engine.engine, long_prompt);
 
   engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
     ASSERT_NE(context.plan, nullptr);
@@ -2776,8 +2868,8 @@ TEST_F(EngineRunTest, CompositeMixedPrefillDefersResidentDraft) {
 TEST_F(EngineRunTest, CompositeReservationExposesRowsAndCommitsBothStates) {
   model_ = LoadSyntheticCompositeModel();
   auto engine = MakeCompositeDoublesEngine(model_, /*forced_token=*/5);
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, Prompt(20));
+  auto first = CreateRequestWithPrompt(engine.engine, Prompt(10));
+  auto second = CreateRequestWithPrompt(engine.engine, Prompt(20));
 
   engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
     ASSERT_NE(context.plan, nullptr);
@@ -2825,7 +2917,7 @@ TEST_F(EngineRunTest, CompositeReservationExposesRowsAndCommitsBothStates) {
 TEST_F(EngineRunTest, CompositeExecutionFailureDiscardsBothAndRetryMatches) {
   model_ = LoadSyntheticCompositeModel();
   auto engine = MakeCompositeDoublesEngine(model_, /*forced_token=*/5);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   int callback_calls = 0;
   engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
     ++callback_calls;
@@ -2862,7 +2954,7 @@ TEST_F(EngineRunTest, CompositeExecutionFailureDiscardsBothAndRetryMatches) {
 TEST_F(EngineRunTest, CompositePostProcessingFailurePreservesResidentState) {
   model_ = LoadSyntheticCompositeModel();
   auto engine = MakeCompositeDoublesEngine(model_, /*forced_token=*/5);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   float expected_input = 0.0f;
   float staged_output = 5.0f;
   engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
@@ -2894,12 +2986,10 @@ TEST_F(EngineRunTest, CompositePostProcessingFailurePreservesResidentState) {
 }
 
 TEST_F(EngineRunTest, CompositeChunkFailureRetriesAndContinuesResidentState) {
-  model_ = LoadSyntheticCompositeModel();
+  model_ = LoadSyntheticCompositeModelWithChunking(/*chunk_size=*/2);
   auto engine = MakeCompositeDoublesEngine(model_, EosToken(*model_));
   const std::vector<int32_t> prompt{2, 3, 4, 5, 6};
-  auto params = MakeGreedyParams(*model_);
-  params->search.chunk_size = 2;
-  auto request = CreateRequestWithPrompt(engine.engine, *params, prompt);
+  auto request = CreateRequestWithPrompt(engine.engine, prompt);
 
   size_t execution_count = 0;
   engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
@@ -2960,7 +3050,7 @@ TEST_F(EngineRunTest, CompositeReservationRequiredMismatchIsFatal) {
   engine.cache->ScriptFixedStateMismatch(
       FixedStateResourcePlan{true, 1, 1, 256}, /*slots=*/{},
       /*staging_bytes=*/0);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
 
   const auto failure = RunOne(*engine.engine);
   EXPECT_EQ(failure.request, request);
@@ -2972,7 +3062,7 @@ TEST_F(EngineRunTest, CompositeReservationRequiredMismatchIsFatal) {
 
 TEST_F(EngineRunTest, PlanningAllocationFailureDoesNotPoisonEngine) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/4, EosToken(*model_));
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   engine.cache->ThrowPlanningBadAllocOnce();
 
   EXPECT_THROW(static_cast<void>(RunOne(*engine.engine)), std::bad_alloc);
@@ -2983,7 +3073,7 @@ TEST_F(EngineRunTest, PlanningAllocationFailureDoesNotPoisonEngine) {
 
 TEST_F(EngineRunTest, PlanningConsistencyFailurePoisonsEngine) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/4, EosToken(*model_));
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   engine.cache->ThrowPlanningConsistencyOnce();
 
   const auto failure = RunOne(*engine.engine);
@@ -2997,8 +3087,8 @@ TEST_F(EngineRunTest, PlanningConsistencyFailurePoisonsEngine) {
 TEST_F(EngineRunTest, OverselectedTokenBudgetPoisonsEngine) {
   model_->config_->engine.dynamic_batching->max_scheduled_tokens = 1;
   auto engine = MakeDoublesEngine(model_, /*capacity=*/4, EosToken(*model_));
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, Prompt(11));
+  auto first = CreateRequestWithPrompt(engine.engine, Prompt(10));
+  auto second = CreateRequestWithPrompt(engine.engine, Prompt(11));
   engine.cache->OverselectPlanningOnce();
 
   std::array<EngineEvent, 2> failures;
@@ -3015,7 +3105,7 @@ TEST_F(EngineRunTest, OverselectedTokenBudgetPoisonsEngine) {
 
 TEST_F(EngineRunTest, CommitPreparationFailureRestoresRequestStateBeforeFatal) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/4, /*forced_token=*/7);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   const auto sequence_length = request->CurrentSequenceLength();
   engine.cache->ThrowPrepareFailureOnce();
 
@@ -3032,7 +3122,7 @@ TEST_F(EngineRunTest, CommitPreparationFailureRestoresRequestStateBeforeFatal) {
 
 TEST_F(EngineRunTest, CompositeReservationOverreportedRowsAreFatal) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/4, EosToken(*model_));
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   static const char extra_request_storage{};
   engine.cache->ScriptFixedStateMismatch(
       FixedStateResourcePlan{true, 2, 1, 0},
@@ -3051,7 +3141,7 @@ TEST_F(EngineRunTest, CompositeReservationOverreportedRowsAreFatal) {
 
 TEST_F(EngineRunTest, CompositeReservationRowOrderMismatchIsFatal) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/4, EosToken(*model_));
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   static const char other_storage{};
   engine.cache->ScriptFixedStateMismatch(
       FixedStateResourcePlan{true, 1, 1, 0},
@@ -3067,7 +3157,7 @@ TEST_F(EngineRunTest, CompositeReservationRowOrderMismatchIsFatal) {
 
 TEST_F(EngineRunTest, CompositeReservationNewSlotCountMismatchIsFatal) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/4, EosToken(*model_));
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   engine.cache->ScriptFixedStateMismatch(
       FixedStateResourcePlan{true, 1, 1, 0},
       {FixedStateSlotHandle{nullptr, request.get(), 0, 0}},
@@ -3085,8 +3175,8 @@ TEST_F(EngineRunTest, CompositeCapacityBackpressureDefersNewAdmission) {
   model_ = LoadSyntheticCompositeModel();
   model_->config_->engine.dynamic_batching->max_batch_size = 2;
   auto engine = MakeCompositeDoublesEngine(model_, /*forced_token=*/5);
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, Prompt(20));
+  auto first = CreateRequestWithPrompt(engine.engine, Prompt(10));
+  auto second = CreateRequestWithPrompt(engine.engine, Prompt(20));
   engine.executor->SetExecutionCallback([](ExecutionContext& context) {
     for (size_t row = 0; row < context.fixed_state_slots.size(); ++row) {
       for (const auto& binding : context.fixed_state_bindings) {
@@ -3103,7 +3193,7 @@ TEST_F(EngineRunTest, CompositeCapacityBackpressureDefersNewAdmission) {
   EXPECT_EQ(fixed->committed_slots, 2u);
   EXPECT_EQ(fixed->free_slots, 0u);
 
-  auto third = CreateRequestWithPrompt(engine.engine, *model_, Prompt(30));
+  auto third = CreateRequestWithPrompt(engine.engine, Prompt(30));
   size_t observed_new_slots = 999;
   engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
     observed_new_slots = context.plan->fixed_state.new_slot_count;
@@ -3126,8 +3216,8 @@ TEST_F(EngineRunTest, CompositeCapacityBackpressureDefersNewAdmission) {
 TEST_F(EngineRunTest, CompositeRemovalReleasesBothAndIsolatesSibling) {
   model_ = LoadSyntheticCompositeModel();
   auto engine = MakeCompositeDoublesEngine(model_, /*forced_token=*/5);
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, Prompt(20));
+  auto first = CreateRequestWithPrompt(engine.engine, Prompt(10));
+  auto second = CreateRequestWithPrompt(engine.engine, Prompt(20));
   engine.executor->SetExecutionCallback([](ExecutionContext& context) {
     for (size_t row = 0; row < context.fixed_state_slots.size(); ++row) {
       for (const auto& binding : context.fixed_state_bindings) {
@@ -3162,7 +3252,7 @@ TEST_F(EngineRunTest, CompositeRemovalReleasesBothAndIsolatesSibling) {
 TEST_F(EngineRunTest, CompositeStagedOutputInvisibleUntilPublish) {
   model_ = LoadSyntheticCompositeModel();
   auto engine = MakeCompositeDoublesEngine(model_, /*forced_token=*/5);
-  auto request = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt(10));
   float committed_value = 0.0f;
   engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
     for (const auto& binding : context.fixed_state_bindings) {
@@ -3188,7 +3278,7 @@ TEST_F(EngineRunTest, CompositeAggregateAdmissionCommitsEveryNewTable) {
   std::vector<std::shared_ptr<Request>> requests;
   for (int i = 0; i < 3; ++i) {
     requests.push_back(CreateRequestWithPrompt(
-        engine.engine, *model_, Prompt(10 * (i + 1))));
+        engine.engine, Prompt(10 * (i + 1))));
   }
   size_t observed_rows = 0;
   size_t observed_new = 0;
@@ -3224,7 +3314,7 @@ TEST_F(EngineRunTest, CompositeAggregateAdmissionCommitsEveryNewTable) {
 TEST_F(EngineRunTest, CompositeCompletionRemovalFreesSlotForReadmission) {
   model_ = LoadSyntheticCompositeModel();
   auto engine = MakeCompositeDoublesEngine(model_, EosToken(*model_));
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
+  auto first = CreateRequestWithPrompt(engine.engine, Prompt(10));
   engine.executor->SetExecutionCallback([](ExecutionContext& context) {
     for (const auto& binding : context.fixed_state_bindings) {
       FillFixedOutputRow(binding, 0, 31.0f);
@@ -3244,7 +3334,7 @@ TEST_F(EngineRunTest, CompositeCompletionRemovalFreesSlotForReadmission) {
   ASSERT_TRUE(after_removal.has_value());
   EXPECT_EQ(after_removal->committed_slots, 0u);
 
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, Prompt(20));
+  auto second = CreateRequestWithPrompt(engine.engine, Prompt(20));
   engine.executor->SetExecutionCallback([&](ExecutionContext& context) {
     ASSERT_EQ(context.fixed_state_slots.size(), 1u);
     EXPECT_EQ(context.fixed_state_slots[0].slot, released_slot);
@@ -3267,8 +3357,8 @@ TEST_F(EngineRunTest, CompositeCompletionRemovalFreesSlotForReadmission) {
 TEST_F(EngineRunTest, CompositeOrdersResidentRowsByFixedSlotButEventsBySchedulerRank) {
   model_ = LoadSyntheticCompositeModel();
   auto engine = MakeCompositeDoublesEngine(model_, /*forced_token=*/5);
-  auto first = CreateRequestWithPrompt(engine.engine, *model_, Prompt(10));
-  auto second = CreateRequestWithPrompt(engine.engine, *model_, Prompt(20));
+  auto first = CreateRequestWithPrompt(engine.engine, Prompt(10));
+  auto second = CreateRequestWithPrompt(engine.engine, Prompt(20));
   engine.executor->SetExecutionCallback([](ExecutionContext& context) {
     for (size_t row = 0; row < context.fixed_state_slots.size(); ++row) {
       for (const auto& binding : context.fixed_state_bindings) {
@@ -3286,7 +3376,7 @@ TEST_F(EngineRunTest, CompositeOrdersResidentRowsByFixedSlotButEventsByScheduler
   first->Close();
 
   auto replacement =
-      CreateRequestWithPrompt(engine.engine, *model_, Prompt(30));
+      CreateRequestWithPrompt(engine.engine, Prompt(30));
   engine.executor->SetExecutionCallback([](ExecutionContext& context) {
     for (size_t row = 0; row < context.fixed_state_slots.size(); ++row) {
       for (const auto& binding : context.fixed_state_bindings) {

--- a/test/cpp/engine/engine_test_helpers.h
+++ b/test/cpp/engine/engine_test_helpers.h
@@ -26,6 +26,14 @@ inline std::shared_ptr<Model> LoadDummyDecoderModel() {
   return CreateModel(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
 }
 
+// Prefill chunking is model/Engine configuration rather than per-Request policy, so a test that
+// needs a chunked prefill loads the model with the chunk size already set.
+inline std::shared_ptr<Model> LoadDummyDecoderModelWithChunking(size_t chunk_size) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  config->search.chunk_size = chunk_size;
+  return CreateModel(GetOrtEnv(), std::move(config));
+}
+
 inline std::shared_ptr<Model> LoadSyntheticPagedModel() {
   return CreateModel(GetOrtEnv(), MODEL_PATH "engine/synthetic-paged");
 }
@@ -72,22 +80,17 @@ inline std::shared_ptr<Model> LoadSyntheticCompositeModel() {
   return CreateModel(GetOrtEnv(), MODEL_PATH "engine/synthetic-composite");
 }
 
+inline std::shared_ptr<Model> LoadSyntheticCompositeModelWithChunking(size_t chunk_size) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/synthetic-composite");
+  config->search.chunk_size = chunk_size;
+  return CreateModel(GetOrtEnv(), std::move(config));
+}
+
 inline std::shared_ptr<Model> LoadSyntheticCompositeMtpModel() {
   auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/synthetic-composite");
   config->model.mtp.filename = "unused-mtp-head.onnx";
   config->engine.hidden_states_output_required = true;
   return CreateModel(GetOrtEnv(), std::move(config));
-}
-
-// Builds GeneratorParams for the dummy model with greedy, single-sequence search so a minted Request
-// advances deterministically (SelectTop) when fed scripted logits.
-inline std::shared_ptr<GeneratorParams> MakeGreedyParams(const Model& model) {
-  auto params = CreateGeneratorParams(model);
-  params->search.max_length = model.config_->model.context_length;
-  params->search.num_beams = 1;
-  params->search.batch_size = 1;
-  params->search.do_sample = false;
-  return params;
 }
 
 inline void PrepareRequestStep(const std::shared_ptr<Model>& model,
@@ -102,38 +105,56 @@ inline void PrepareRequestStep(const std::shared_ptr<Model>& model,
   static_cast<void>(ScheduledRequests{plan, model, nullptr, nullptr});
 }
 
-// Creates an Engine-owned Request from a frozen snapshot of `params`. Configuration changes must be
-// made before this call.
+// Swaps in an alternative scoring device for the lifetime of the guard. Requests derive their
+// search from the model, so this is how a test injects a failing or recording Search without any
+// production seam. Every Request minted while the guard is live shares the substitute device.
+class ScopedScoringDevice {
+ public:
+  ScopedScoringDevice(Model& model, DeviceInterface& device)
+      : model_{model}, original_{model.p_device_scoring_} {
+    model_.p_device_scoring_ = &device;
+  }
+  ScopedScoringDevice(const ScopedScoringDevice&) = delete;
+  ScopedScoringDevice& operator=(const ScopedScoringDevice&) = delete;
+  ~ScopedScoringDevice() { model_.p_device_scoring_ = original_; }
+
+ private:
+  Model& model_;
+  DeviceInterface* original_;
+};
+
+// Creates an Engine-owned Request. The Engine derives its search from the model, so the only
+// resident-session knob is the session token limit.
 inline std::shared_ptr<Request> CreateEngineRequest(
-    const std::shared_ptr<Engine>& engine,
-    const GeneratorParams& params) {
-  return engine->CreateRequest(params);
+    const std::shared_ptr<Engine>& engine) {
+  return engine->CreateRequest();
 }
 
 inline std::shared_ptr<Request> CreateEngineRequest(
     const std::shared_ptr<Engine>& engine,
-    const Model& model) {
-  auto params = MakeGreedyParams(model);
-  return CreateEngineRequest(engine, *params);
+    size_t max_session_tokens) {
+  RequestOptions options;
+  options.max_session_tokens = max_session_tokens;
+  return engine->CreateRequest(options);
 }
 
 // Creates an Engine-owned Request and begins its first turn, leaving it Assigned and queued.
 inline std::shared_ptr<Request> CreateRequestWithPrompt(
     const std::shared_ptr<Engine>& engine,
-    const GeneratorParams& params,
     std::span<const int32_t> prompt_tokens) {
-  auto request = CreateEngineRequest(engine, params);
+  auto request = CreateEngineRequest(engine);
   request->BeginTurn(prompt_tokens);
   return request;
 }
 
 inline std::shared_ptr<Request> CreateRequestWithPrompt(
     const std::shared_ptr<Engine>& engine,
-    const Model& model,
-    std::span<const int32_t> prompt_tokens) {
-  auto params = MakeGreedyParams(model);
-  auto request = CreateEngineRequest(engine, *params);
-  request->BeginTurn(prompt_tokens);
+    std::span<const int32_t> prompt_tokens,
+    const TurnOptions& turn_options) {
+  auto request = CreateEngineRequest(engine);
+  TurnOptions options = turn_options;
+  options.request = request;
+  request->BeginTurn(prompt_tokens, options);
   return request;
 }
 

--- a/test/cpp/engine/guidance_cache_tests.cpp
+++ b/test/cpp/engine/guidance_cache_tests.cpp
@@ -49,6 +49,50 @@ DeviceSpan<float> LogitsForToken(Model& model, int32_t token) {
   return logits;
 }
 
+TEST(GuidanceMaskTest, RecognizesAnyConfiguredEosAndRejectsOtherTokens) {
+  const std::array<int, 2> eos_tokens{1, 34};
+  std::array<uint32_t, 2> mask{
+      uint32_t{1} << 1,
+      uint32_t{1} << 2,
+  };
+  EXPECT_TRUE(GuidanceProcessorTestAccess::MaskAllowsOnlyTokens(
+      mask, /*vocab_size=*/64, eos_tokens));
+
+  mask[1] |= uint32_t{1} << 3;
+  EXPECT_FALSE(GuidanceProcessorTestAccess::MaskAllowsOnlyTokens(
+      mask, /*vocab_size=*/64, eos_tokens));
+}
+
+TEST(GuidanceMaskTest, IgnoresPaddingBitsAndRequiresAnAllowedToken) {
+  const std::array<int, 1> eos_tokens{34};
+  const std::array<uint32_t, 2> eos_with_padding{
+      0,
+      (uint32_t{1} << 2) | (uint32_t{1} << 31),
+  };
+  EXPECT_TRUE(GuidanceProcessorTestAccess::MaskAllowsOnlyTokens(
+      eos_with_padding, /*vocab_size=*/35, eos_tokens));
+
+  const std::array<uint32_t, 2> padding_only{
+      0,
+      uint32_t{1} << 31,
+  };
+  EXPECT_FALSE(GuidanceProcessorTestAccess::MaskAllowsOnlyTokens(
+      padding_only, /*vocab_size=*/35, eos_tokens));
+
+  const std::array<uint32_t, 2> empty{};
+  EXPECT_FALSE(GuidanceProcessorTestAccess::MaskAllowsOnlyTokens(
+      empty, /*vocab_size=*/64, eos_tokens));
+}
+
+TEST(GuidanceMaskTest, RejectsDimensionsThatDoNotMatchVocabulary) {
+  const std::array<int, 1> eos_tokens{1};
+  const std::array<uint32_t, 1> mask{uint32_t{1} << 1};
+  EXPECT_THROW(
+      GuidanceProcessorTestAccess::MaskAllowsOnlyTokens(
+          mask, /*vocab_size=*/64, eos_tokens),
+      std::runtime_error);
+}
+
 TEST(GuidanceCacheTest, ReusesTokenizerAndCompiledGrammar) {
   auto model = LoadGuidanceModel();
   auto first_params = MakeGuidanceParams(*model);

--- a/test/cpp/engine/guidance_cache_tests.cpp
+++ b/test/cpp/engine/guidance_cache_tests.cpp
@@ -25,6 +25,15 @@ namespace test {
 #if USE_GUIDANCE
 namespace {
 
+// The single-sequence guidance parameters Engine::BeginTurn builds for one turn. These tests
+// exercise the model-local grammar cache directly, below the Engine's turn plumbing.
+std::shared_ptr<GeneratorParams> MakeGuidanceParams(const Model& model) {
+  auto params = CreateGeneratorParams(model);
+  params->search.batch_size = 1;
+  params->search.num_beams = 1;
+  return params;
+}
+
 std::shared_ptr<Model> LoadGuidanceModel() {
   return CreateModel(
       GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
@@ -42,11 +51,11 @@ DeviceSpan<float> LogitsForToken(Model& model, int32_t token) {
 
 TEST(GuidanceCacheTest, ReusesTokenizerAndCompiledGrammar) {
   auto model = LoadGuidanceModel();
-  auto first_params = MakeGreedyParams(*model);
+  auto first_params = MakeGuidanceParams(*model);
   first_params->SetGuidance("regex", "!", false);
   auto first = CreateGuidanceLogitsProcessor(*model, first_params);
 
-  auto second_params = MakeGreedyParams(*model);
+  auto second_params = MakeGuidanceParams(*model);
   second_params->SetGuidance("regex", "!", false);
   auto second = CreateGuidanceLogitsProcessor(*model, second_params);
 
@@ -70,7 +79,7 @@ TEST(GuidanceCacheTest, SingleFlightsConcurrentIdenticalGrammars) {
     threads.emplace_back([&, i] {
       try {
         gate.arrive_and_wait();
-        auto params = MakeGreedyParams(*model);
+        auto params = MakeGuidanceParams(*model);
         params->SetGuidance("regex", "!", false);
         auto processor = CreateGuidanceLogitsProcessor(*model, params);
         static_cast<void>(processor);
@@ -104,7 +113,7 @@ TEST(GuidanceCacheTest, IsolatesConcurrentUniqueGrammars) {
     threads.emplace_back([&, i] {
       try {
         gate.arrive_and_wait();
-        auto params = MakeGreedyParams(*model);
+        auto params = MakeGuidanceParams(*model);
         const std::string grammar(1, static_cast<char>('a' + i));
         params->SetGuidance("regex", grammar.c_str(), false);
         auto processor = CreateGuidanceLogitsProcessor(*model, params);
@@ -133,7 +142,7 @@ TEST(GuidanceCacheTest, PendingMaskOutlivesRemovedProcessor) {
   const auto expected_tokens = tokenizer->Encode("!");
   ASSERT_EQ(expected_tokens.size(), 1u);
 
-  auto params = MakeGreedyParams(*model);
+  auto params = MakeGuidanceParams(*model);
   params->SetGuidance("regex", "!!", false);
   auto processor = CreateGuidanceLogitsProcessor(*model, params);
   processor->ProcessLogits(
@@ -154,7 +163,7 @@ TEST(GuidanceCacheTest, PendingMaskOutlivesRemovedProcessor) {
 
 TEST(GuidanceCacheTest, FailedFutureReschedulesRealProcessor) {
   auto model = LoadGuidanceModel();
-  auto params = MakeGreedyParams(*model);
+  auto params = MakeGuidanceParams(*model);
   params->SetGuidance("regex", "!", false);
   auto processor = CreateGuidanceLogitsProcessor(*model, params);
   auto& guidance = dynamic_cast<GuidanceLogitsProcessor&>(*processor);
@@ -175,11 +184,12 @@ TEST(GuidanceCacheTest, FailedFutureRollsBackAndReschedulesEngineRequest) {
   const auto expected_tokens = tokenizer->Encode("!");
   ASSERT_EQ(expected_tokens.size(), 1u);
 
-  auto params = MakeGreedyParams(*model);
-  params->SetGuidance("regex", "!", false);
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(std::array<int32_t, 3>{2, 3, 4},
-                     std::optional<size_t>{1});
+  auto request = CreateEngineRequest(engine.engine);
+  TurnOptions options;
+  options.guidance_type = "regex";
+  options.guidance_data = "!";
+  options.max_generated_tokens = 1;
+  request->BeginTurn(std::array<int32_t, 3>{2, 3, 4}, options);
   auto& guidance = dynamic_cast<GuidanceLogitsProcessor&>(
       *RequestGuidanceTestAccess::Get(*request));
   GuidanceProcessorTestAccess::InstallFailedMaskFuture(guidance);
@@ -196,12 +206,12 @@ TEST(GuidanceCacheTest, FailedFutureRollsBackAndReschedulesEngineRequest) {
 
 TEST(GuidanceCacheTest, EvictionKeepsLiveProcessorAssetsValid) {
   auto model = LoadGuidanceModel();
-  auto first_params = MakeGreedyParams(*model);
+  auto first_params = MakeGuidanceParams(*model);
   first_params->SetGuidance("regex", "first", false);
   auto first = CreateGuidanceLogitsProcessor(*model, first_params);
 
   for (size_t i = 0; i < 65; ++i) {
-    auto params = MakeGreedyParams(*model);
+    auto params = MakeGuidanceParams(*model);
     const auto grammar = "value" + std::to_string(i);
     params->SetGuidance("regex", grammar.c_str(), false);
     auto processor = CreateGuidanceLogitsProcessor(*model, params);
@@ -221,7 +231,7 @@ TEST(GuidanceCacheTest, EvictionKeepsLiveProcessorAssetsValid) {
 
 TEST(GuidanceCacheTest, OversizedGrammarDoesNotEvictCachedEntries) {
   auto model = LoadGuidanceModel();
-  auto cached_params = MakeGreedyParams(*model);
+  auto cached_params = MakeGuidanceParams(*model);
   cached_params->SetGuidance("regex", "!", false);
   auto cached = CreateGuidanceLogitsProcessor(*model, cached_params);
   const auto before = GetGuidanceCacheStats(*model);
@@ -229,7 +239,7 @@ TEST(GuidanceCacheTest, OversizedGrammarDoesNotEvictCachedEntries) {
 
   std::string oversized_schema(16u * 1024u * 1024u, ' ');
   oversized_schema.front() = 'x';
-  auto oversized_params = MakeGreedyParams(*model);
+  auto oversized_params = MakeGuidanceParams(*model);
   oversized_params->SetGuidance(
       "json_schema", oversized_schema.c_str(), false);
   EXPECT_THROW(
@@ -245,7 +255,7 @@ TEST(GuidanceCacheTest, OversizedGrammarDoesNotEvictCachedEntries) {
 TEST(GuidanceCacheTest, DoesNotRetainFailedCompilations) {
   auto model = LoadGuidanceModel();
   for (size_t attempt = 1; attempt <= 2; ++attempt) {
-    auto params = MakeGreedyParams(*model);
+    auto params = MakeGuidanceParams(*model);
     params->SetGuidance("regex", "[", false);
     EXPECT_THROW(
         CreateGuidanceLogitsProcessor(*model, params),

--- a/test/cpp/engine/guidance_processor_tests.cpp
+++ b/test/cpp/engine/guidance_processor_tests.cpp
@@ -105,6 +105,20 @@ class FakeGuidanceProcessor final : public ConstrainedLogitsProcessor {
     return clone;
   }
 
+  // Lets a test observe the cursor after the Request releases it, without touching freed memory:
+  // the destructor publishes this cursor's final committed history. Deliberately not carried by
+  // Clone(), so a discarded transaction checkpoint never publishes on the live cursor's behalf.
+  ~FakeGuidanceProcessor() override {
+    if (release_observer_) {
+      *release_observer_ = committed_tokens_;
+    }
+  }
+
+  void ObserveReleaseInto(
+      std::shared_ptr<std::optional<std::vector<int32_t>>> observer) {
+    release_observer_ = std::move(observer);
+  }
+
   void ForceToken(std::optional<int32_t> token) { forced_token_ = token; }
   void SetReadyMask(std::vector<uint32_t> mask) {
     ready_mask_ = std::move(mask);
@@ -134,6 +148,7 @@ class FakeGuidanceProcessor final : public ConstrainedLogitsProcessor {
   bool fail_reset_{false};
   std::vector<uint32_t> ready_mask_;
   std::shared_ptr<PendingFailure> pending_failure_;
+  std::shared_ptr<std::optional<std::vector<int32_t>>> release_observer_;
 };
 
 FakeGuidanceProcessor& InstallFake(Request& request) {
@@ -148,12 +163,10 @@ class GuidanceProcessorTest : public ::testing::Test {
     engine_ = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   }
 
-  std::shared_ptr<Request> NewAssignedRequest(int32_t max_length_beyond_prompt) {
-    auto params = MakeGreedyParams(*model_);
+  std::shared_ptr<Request> NewAssignedRequest(size_t max_length_beyond_prompt) {
     const auto prompt = Prompt();
-    params->search.max_length =
-        static_cast<int32_t>(prompt.size()) + max_length_beyond_prompt;
-    auto request = CreateEngineRequest(engine_.engine, *params);
+    auto request = CreateEngineRequest(
+        engine_.engine, prompt.size() + max_length_beyond_prompt);
     request->BeginTurn(prompt);
     return request;
   }
@@ -324,19 +337,21 @@ TEST_F(GuidanceProcessorTest, AsyncMaskFailureRollsBackAndCanRetry) {
   EXPECT_NE(event.flags & EngineEventFlagTurnFinished, 0u);
 }
 
-// Turn completion resets the installed cursor so a subsequent BeginTurn starts from the grammar's
-// initial state. An EOS stop signal is not appended, so the cursor sees no CommitTokens call.
-TEST_F(GuidanceProcessorTest, TurnCompletionResetsGrammarCursor) {
+// Guidance is turn-scoped, so turn completion releases the installed cursor outright: a subsequent
+// BeginTurn is unguided unless it asks for guidance again. An EOS stop signal is not appended, so
+// the released cursor saw no CommitTokens call.
+TEST_F(GuidanceProcessorTest, TurnCompletionReleasesGrammarCursor) {
   auto request = NewAssignedRequest(/*max_length_beyond_prompt=*/4);
-  auto& fake = InstallFake(*request);
+  auto released = std::make_shared<std::optional<std::vector<int32_t>>>();
+  InstallFake(*request).ObserveReleaseInto(released);
 
   request->GenerateNextTokens(LogitsForToken(*model_, EosToken(*model_)));
   request->CompleteGeneration();
 
   ASSERT_TRUE(request->IsTurnComplete());
-  EXPECT_EQ(RequestGuidanceTestAccess::Get(*request), &fake);
-  EXPECT_EQ(fake.ResetCount(), 1);
-  EXPECT_TRUE(fake.CommittedTokens().empty());
+  EXPECT_EQ(RequestGuidanceTestAccess::Get(*request), nullptr);
+  ASSERT_TRUE(released->has_value());
+  EXPECT_TRUE(released->value().empty());
 }
 
 }  // namespace

--- a/test/cpp/engine/guidance_processor_tests.cpp
+++ b/test/cpp/engine/guidance_processor_tests.cpp
@@ -81,6 +81,15 @@ class FakeGuidanceProcessor final : public ConstrainedLogitsProcessor {
     }
   }
 
+  bool AllowsOnlyTokens(
+      size_t index, std::span<const int> tokens) override {
+    if (index != 0) {
+      throw std::out_of_range("Fake guidance row index is out of range.");
+    }
+    return forced_token_ &&
+           std::find(tokens.begin(), tokens.end(), *forced_token_) != tokens.end();
+  }
+
   void Reset() override {
     if (fail_reset_) {
       throw std::runtime_error("Injected guidance reset failure.");

--- a/test/cpp/engine/guidance_test_access.h
+++ b/test/cpp/engine/guidance_test_access.h
@@ -27,6 +27,13 @@ struct GuidanceProcessorTestAccess {
   static bool MaskDirty(const GuidanceLogitsProcessor& processor) {
     return processor.mask_dirty_;
   }
+
+  static bool MaskAllowsOnlyTokens(
+      std::span<const uint32_t> mask, size_t vocab_size,
+      std::span<const int> tokens) {
+    return GuidanceLogitsProcessor::MaskAllowsOnlyTokens(
+        mask, vocab_size, tokens);
+  }
 };
 #endif
 

--- a/test/cpp/engine/model_executor_tests.cpp
+++ b/test/cpp/engine/model_executor_tests.cpp
@@ -83,8 +83,8 @@ void ExpectPackedHiddenStates(const std::shared_ptr<Model>& model) {
   auto assign_target = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model)).engine;
   const std::vector<int32_t> first_prompt{5, 9, 13};
   const std::vector<int32_t> second_prompt{7, 2, 20, 4};
-  auto first = CreateRequestWithPrompt(assign_target, *model, first_prompt);
-  auto second = CreateRequestWithPrompt(assign_target, *model, second_prompt);
+  auto first = CreateRequestWithPrompt(assign_target, first_prompt);
+  auto second = CreateRequestWithPrompt(assign_target, second_prompt);
   scheduler->AddRequest(first);
   scheduler->AddRequest(second);
 
@@ -131,7 +131,7 @@ TEST(ModelExecutorHiddenStatesTest, DoesNotBindOutputWithoutMtpDemand) {
   auto cache = std::shared_ptr<CacheManager>{CacheManager::Create(model)};
   auto scheduler = Scheduler::Create(model, cache);
   auto assign_target = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model)).engine;
-  auto request = CreateRequestWithPrompt(assign_target, *model, std::array<int32_t, 1>{5});
+  auto request = CreateRequestWithPrompt(assign_target, std::array<int32_t, 1>{5});
   scheduler->AddRequest(request);
   StepPlan plan;
   ASSERT_TRUE(scheduler->PlanStep(plan).executable);

--- a/test/cpp/engine/paged_key_value_cache_tests.cpp
+++ b/test/cpp/engine/paged_key_value_cache_tests.cpp
@@ -38,7 +38,7 @@ class PagedKeyValueCacheTest : public ::testing::Test {
   std::shared_ptr<Request> AddCommittedRequest(
       std::array<int32_t, 4> prompt) {
     auto request =
-        CreateRequestWithPrompt(assign_target_, *model_, prompt);
+        CreateRequestWithPrompt(assign_target_, prompt);
     cache_->Add(request);
     cache_->AppendTokens(request);
     return request;
@@ -134,7 +134,7 @@ TEST_F(PagedKeyValueCacheTest, DeferredActiveRequestsStillConsumeAdmissionCapaci
   auto unserviceable = AddCommittedRequest({2, 3, 4, 5});
   auto fitting = AddCommittedRequest({6, 7, 8, 9});
   auto pending = CreateRequestWithPrompt(
-      assign_target_, *model_, std::array<int32_t, 1>{10});
+      assign_target_, std::array<int32_t, 1>{10});
 
   StepPlan plan;
   plan.requests.push_back(PlanEntry(unserviceable, 13));
@@ -156,7 +156,7 @@ TEST_F(PagedKeyValueCacheTest, DeferredActiveRequestsStillConsumeAdmissionCapaci
 // though its first chunk would.
 TEST_F(PagedKeyValueCacheTest, PromptTooLargeForThePoolIsUnserviceableEvenWhenItsChunkFits) {
   auto pending = CreateRequestWithPrompt(
-      assign_target_, *model_, std::array<int32_t, 1>{10});
+      assign_target_, std::array<int32_t, 1>{10});
 
   StepPlan plan;
   plan.requests.push_back(PlanEntry(pending, /*target_cache_slots=*/1, /*newly_admitted=*/true,
@@ -174,7 +174,7 @@ TEST_F(PagedKeyValueCacheTest, PromptTooLargeForThePoolIsUnserviceableEvenWhenIt
 TEST_F(PagedKeyValueCacheTest, AdmissionWaitsUntilTheWholePromptFits) {
   auto committed = AddCommittedRequest({2, 3, 4, 5});
   auto pending = CreateRequestWithPrompt(
-      assign_target_, *model_, std::array<int32_t, 1>{10});
+      assign_target_, std::array<int32_t, 1>{10});
 
   StepPlan plan;
   plan.requests.push_back(PlanEntry(committed, /*target_cache_slots=*/4));
@@ -224,7 +224,7 @@ TEST_F(PagedKeyValueCacheTest, OmittedResidentsStillLimitNewAdmissions) {
   auto first = AddCommittedRequest({2, 3, 4, 5});
   auto second = AddCommittedRequest({6, 7, 8, 9});
   auto pending = CreateRequestWithPrompt(
-      assign_target_, *model_, std::array<int32_t, 1>{10});
+      assign_target_, std::array<int32_t, 1>{10});
 
   StepPlan plan;
   plan.requests.push_back(PlanEntry(pending, 1, true, 1));
@@ -240,9 +240,9 @@ TEST_F(PagedKeyValueCacheTest, OmittedResidentsStillLimitNewAdmissions) {
 TEST_F(PagedKeyValueCacheTest, BlockedPrefillDoesNotPreventLaterAdmission) {
   auto resident = AddCommittedRequest({2, 3, 4, 5});
   auto blocked = CreateRequestWithPrompt(
-      assign_target_, *model_, std::array<int32_t, 1>{10});
+      assign_target_, std::array<int32_t, 1>{10});
   auto fitting = CreateRequestWithPrompt(
-      assign_target_, *model_, std::array<int32_t, 1>{11});
+      assign_target_, std::array<int32_t, 1>{11});
 
   StepPlan plan;
   plan.requests.push_back(PlanEntry(resident, 4));
@@ -265,7 +265,7 @@ TEST_F(PagedKeyValueCacheTest, InterleavedAdmissionAndResidentSubsetAreSelectedB
   auto omitted = AddCommittedRequest({2, 3, 4, 5});
   auto resident = AddCommittedRequest({6, 7, 8, 9});
   auto pending = CreateRequestWithPrompt(
-      assign_target_, *model_, std::array<int32_t, 1>{10});
+      assign_target_, std::array<int32_t, 1>{10});
 
   StepPlan plan;
   plan.requests.push_back(PlanEntry(pending, 1, true, 1));
@@ -289,8 +289,7 @@ TEST_F(PagedKeyValueCacheTest, InterleavedAdmissionAndResidentSubsetAreSelectedB
 
 TEST_F(PagedKeyValueCacheTest, GlobalOnlyPrefillChunkReservesWholePrompt) {
   auto pending = CreateRequestWithPrompt(
-      assign_target_, *model_,
-      std::array<int32_t, 9>{2, 3, 4, 5, 6, 7, 8, 9, 10});
+      assign_target_, std::array<int32_t, 9>{2, 3, 4, 5, 6, 7, 8, 9, 10});
 
   StepPlan plan;
   plan.requests.push_back(
@@ -634,7 +633,7 @@ TEST(PagedKeyValueCacheManifestTest, LegacyCompositeEntryPointsRejectBeforeDiver
                    model, /*capacity=*/1, EosToken(*model))
                    .engine;
   const std::array<int32_t, 3> prompt{2, 3, 4};
-  auto request = CreateRequestWithPrompt(owner, *model, prompt);
+  auto request = CreateRequestWithPrompt(owner, prompt);
 
   EXPECT_THROW(manager.Allocate({request}), std::logic_error);
   EXPECT_THROW(manager.Step(), std::logic_error);

--- a/test/cpp/engine/request_lifecycle_tests.cpp
+++ b/test/cpp/engine/request_lifecycle_tests.cpp
@@ -1282,6 +1282,64 @@ TurnOptions GuidedOptions(std::string grammar) {
   return options;
 }
 
+TEST_F(RequestLifecycleTest, TerminalGuidanceTakesPrecedenceOverMinimumGeneratedTokens) {
+  auto guidance_model = CreateModel(
+      GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto guidance_engine = MakeDoublesEngine(guidance_model, /*capacity=*/8,
+                                           EosToken(*guidance_model));
+  auto tokenizer = guidance_model->CreateTokenizer();
+  const auto guided_tokens = tokenizer->Encode("!");
+  ASSERT_EQ(guided_tokens.size(), 1u);
+
+  auto request = CreateEngineRequest(guidance_engine.engine);
+  auto options = GuidedOptions("!");
+  options.min_generated_tokens = 4;
+  options.max_generated_tokens = 8;
+  request->BeginTurn(Prompt(), options);
+
+  const auto token = RunOne(*guidance_engine.engine);
+  ASSERT_EQ(token.request, request);
+  ASSERT_NE(token.flags & EngineEventFlagToken, 0u);
+  EXPECT_EQ(token.token, guided_tokens.front());
+  EXPECT_FALSE(request->IsTurnComplete());
+
+  const auto terminal = RunOne(*guidance_engine.engine);
+  ASSERT_EQ(terminal.request, request);
+  EXPECT_EQ(terminal.flags & EngineEventFlagToken, 0u);
+  EXPECT_NE(terminal.flags & EngineEventFlagTurnFinished, 0u);
+  EXPECT_EQ(terminal.finish_reason, GenerationFinishReason::EosToken);
+  EXPECT_EQ(terminal.usage.generated_tokens, 1u);
+  EXPECT_TRUE(request->IsTurnComplete());
+}
+
+TEST_F(RequestLifecycleTest, ExtendableGuidanceHonorsMinimumGeneratedTokens) {
+  auto guidance_model = CreateModel(
+      GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto guidance_engine = MakeDoublesEngine(guidance_model, /*capacity=*/8,
+                                           EosToken(*guidance_model));
+
+  auto request = CreateEngineRequest(guidance_engine.engine);
+  auto options = GuidedOptions("[0-9]*");
+  options.min_generated_tokens = 2;
+  options.max_generated_tokens = 8;
+  request->BeginTurn(Prompt(), options);
+
+  for (size_t generated = 1; generated <= options.min_generated_tokens; ++generated) {
+    const auto token = RunOne(*guidance_engine.engine);
+    ASSERT_EQ(token.request, request);
+    EXPECT_NE(token.flags & EngineEventFlagToken, 0u);
+    EXPECT_EQ(token.flags & EngineEventFlagTurnFinished, 0u);
+    EXPECT_EQ(request->TurnGeneratedTokens(), generated);
+  }
+
+  const auto terminal = RunOne(*guidance_engine.engine);
+  ASSERT_EQ(terminal.request, request);
+  EXPECT_EQ(terminal.flags & EngineEventFlagToken, 0u);
+  EXPECT_NE(terminal.flags & EngineEventFlagTurnFinished, 0u);
+  EXPECT_EQ(terminal.finish_reason, GenerationFinishReason::EosToken);
+  EXPECT_EQ(terminal.usage.generated_tokens, options.min_generated_tokens);
+}
+
 TEST_F(RequestLifecycleTest, RequestRejectsDraftTokensWithGuidance) {
   auto guidance_model = CreateModel(
       GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");

--- a/test/cpp/engine/request_lifecycle_tests.cpp
+++ b/test/cpp/engine/request_lifecycle_tests.cpp
@@ -222,7 +222,7 @@ class RequestLifecycleTest : public ::testing::Test {
   }
 
   std::shared_ptr<Request> NewRequest() {
-    return CreateEngineRequest(engine_.engine, *model_);
+    return CreateEngineRequest(engine_.engine);
   }
 
   std::shared_ptr<Model> model_;
@@ -248,7 +248,7 @@ TEST(ConventionalKvCacheTest, CreationDispatchesThroughSelectedDevice) {
     ~CacheDeviceRestorer() { model.p_device_kvcache_ = original; }
   } restore{*model, original_cache_device};
 
-  auto params = MakeGreedyParams(*model);
+  auto params = CreateGeneratorParams(*model);
   class TestState final : public State {
    public:
     TestState(const GeneratorParams& params, const Model& model)
@@ -269,11 +269,10 @@ TEST_F(RequestLifecycleTest, InvalidEosTokenIsRejected) {
         std::to_string(invalid_eos_token_id) + " } }";
     auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder", nullptr, overlay);
     auto model = CreateModel(GetOrtEnv(), std::move(config));
-    auto params = MakeGreedyParams(*model);
 
     try {
       [[maybe_unused]] auto request = std::make_shared<Request>(
-          params, static_cast<size_t>(params->search.max_length));
+          *model, static_cast<size_t>(model->config_->search.max_length));
       FAIL() << "Expected invalid eos_token_id to be rejected";
     } catch (const std::runtime_error& e) {
       EXPECT_NE(std::string(e.what()).find("eos_token_id"), std::string::npos);
@@ -283,14 +282,14 @@ TEST_F(RequestLifecycleTest, InvalidEosTokenIsRejected) {
 
 TEST_F(RequestLifecycleTest, InvalidVocabSizeIsRejected) {
   for (const int invalid_vocab_size : {-1, 0}) {
-    Config config;
-    config.model.vocab_size = invalid_vocab_size;
-    config.model.eos_token_id.clear();
-    auto params = std::make_shared<GeneratorParams>(config);
+    const std::string overlay =
+        R"({ "model": { "vocab_size": )" + std::to_string(invalid_vocab_size) + " } }";
+    auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder", nullptr, overlay);
+    auto model = CreateModel(GetOrtEnv(), std::move(config));
 
     try {
       [[maybe_unused]] auto request = std::make_shared<Request>(
-          params, static_cast<size_t>(params->search.max_length));
+          *model, static_cast<size_t>(model->config_->search.max_length));
       FAIL() << "Expected invalid vocab_size to be rejected";
     } catch (const std::runtime_error& e) {
       EXPECT_NE(std::string(e.what()).find("vocab_size must be 1 or greater"), std::string::npos);
@@ -308,11 +307,10 @@ TEST_F(RequestLifecycleTest, EmptyBeginTurnIsRejected) {
 TEST_F(RequestLifecycleTest,
        DevicePreparationFailureLeavesFirstTurnUnassignedAndRetryAppendsPromptOnce) {
   const auto prompt = Prompt();
-  auto params = MakeGreedyParams(*model_);
-  FailingAllocationDevice failing_device{*params->p_device};
-  params->p_device = &failing_device;
+  FailingAllocationDevice failing_device{*model_->p_device_scoring_};
+  ScopedScoringDevice scoped_device{*model_, failing_device};
   failing_device.SetFailAllocation(false);
-  auto request = CreateEngineRequest(engine_.engine, *params);
+  auto request = CreateEngineRequest(engine_.engine);
 
   failing_device.SetFailAllocation(true);
   EXPECT_THROW(request->BeginTurn(prompt), std::runtime_error);
@@ -346,7 +344,7 @@ TEST_F(RequestLifecycleTest,
       cache, std::move(scheduler), std::move(executor)};
   auto engine =
       std::make_shared<Engine>(model_, std::move(dependencies));
-  auto request = CreateEngineRequest(engine, *model_);
+  auto request = CreateEngineRequest(engine);
 
   EXPECT_THROW(request->BeginTurn(prompt), std::runtime_error);
   EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
@@ -426,7 +424,7 @@ TEST_F(RequestLifecycleTest, CancelQueuedTurnPublishesTerminalReadyAndCanContinu
 
 TEST_F(RequestLifecycleTest, CancelActiveTurnPreservesResidentState) {
   auto request = CreateRequestWithPrompt(
-      engine_.engine, *model_, Prompt());
+      engine_.engine, Prompt());
   engine_.cache->Allocate({request});
   request->Schedule();
   ASSERT_EQ(request->status_, RequestStatus::Active);
@@ -454,15 +452,61 @@ TEST_F(RequestLifecycleTest, CancelCompletedTurnPreservesOriginalFinishReason) {
   EXPECT_FALSE(engine_.engine->HasPendingRequests());
 }
 
-TEST_F(RequestLifecycleTest, CreateRequestSnapshotsParameters) {
-  auto params = MakeGreedyParams(*model_);
-  params->search.chunk_size = 2;
-  auto request = CreateEngineRequest(engine_.engine, *params);
+// Prefill chunking is model/Engine configuration, not per-Request policy. A Request takes the
+// model's chunk size, and a static-batching Engine -- which rebuilds its contiguous cache from the
+// whole sequence every step and so cannot resume a half-written prompt -- rejects a chunking model
+// when it is constructed, long before any Request is admitted.
+TEST_F(RequestLifecycleTest, ModelConfiguredChunkSizeAppliesToEveryRequest) {
+  auto model = LoadDummyDecoderModelWithChunking(/*chunk_size=*/2);
+  auto engine = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model));
+  auto request = CreateEngineRequest(engine.engine);
 
-  params->search.chunk_size = 7;
+  ASSERT_TRUE(request->PrefillChunkSize().has_value());
+  EXPECT_EQ(*request->PrefillChunkSize(), 2u);
+}
 
-  ASSERT_TRUE(request->SearchOptions().chunk_size.has_value());
-  EXPECT_EQ(*request->SearchOptions().chunk_size, 2);
+TEST_F(RequestLifecycleTest, StaticEngineRejectsModelConfiguredChunking) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  config->engine.dynamic_batching.reset();
+  config->search.chunk_size = 2;
+  auto model = CreateModel(GetOrtEnv(), std::move(config));
+
+  try {
+    static_cast<void>(Engine::CreateDependencies(model));
+    FAIL() << "Expected model-configured chunking to be rejected for static batching.";
+  } catch (const std::runtime_error& error) {
+    EXPECT_NE(std::string(error.what()).find("chunk_size requires dynamic batching"),
+              std::string::npos);
+  }
+}
+
+// An Engine assembled from injected dependencies never runs Engine::CreateDependencies, so the
+// static scheduler keeps its own admission guard. Admission is rejected before the batch is
+// touched, leaving the Request retryable on a dynamic Engine.
+TEST_F(RequestLifecycleTest, StaticSchedulerRejectsChunkedAdmissionWithInjectedDependencies) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  config->engine.dynamic_batching.reset();
+  config->search.chunk_size = 2;
+  auto model = CreateModel(GetOrtEnv(), std::move(config));
+
+  auto cache = std::make_shared<RecordingCacheManager>(
+      model, /*capacity=*/8, /*trace=*/nullptr, /*supports_dynamic_batching=*/false);
+  EngineDependencies dependencies{
+      cache, Scheduler::Create(model, cache),
+      std::make_unique<RecordingModelExecutor>(model, cache, EosToken(*model))};
+  auto engine = std::make_shared<Engine>(model, std::move(dependencies));
+
+  auto request = CreateEngineRequest(engine);
+  try {
+    request->BeginTurn(Prompt());
+    FAIL() << "Expected the static scheduler to reject a chunking Request.";
+  } catch (const std::runtime_error& error) {
+    EXPECT_NE(std::string(error.what()).find("chunk_size requires dynamic batching"),
+              std::string::npos);
+  }
+  EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+  EXPECT_EQ(request->CurrentSequenceLength(), 0);
+  EXPECT_FALSE(engine->HasPendingRequests());
 }
 
 // Input that would exceed the model's max length is rejected before mutation, so a subsequent valid
@@ -483,7 +527,7 @@ TEST_F(RequestLifecycleTest, BeginTurnBeyondContextIsRejectedBeforeMutation) {
 // the request untouched.
 TEST_F(RequestLifecycleTest, BeginTurnIsRejectedWhenAlreadyAssigned) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   ASSERT_EQ(request->status_, RequestStatus::Assigned);
   const int64_t length_before = request->CurrentSequenceLength();
 
@@ -505,7 +549,7 @@ TEST_F(RequestLifecycleTest, ScheduleIsRejectedBeforeBeginTurn) {
 // An assigned, non-empty request schedules cleanly and moves to Active.
 TEST_F(RequestLifecycleTest, ScheduleFromAssignedMovesToActive) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   request->Schedule();
   EXPECT_EQ(request->status_, RequestStatus::Active);
 }
@@ -514,7 +558,7 @@ TEST_F(RequestLifecycleTest, ScheduleFromAssignedMovesToActive) {
 // rejected without mutating the request.
 TEST_F(RequestLifecycleTest, BeginTurnIsRejectedWhileActive) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   request->Schedule();
   ASSERT_EQ(request->status_, RequestStatus::Active);
   const int64_t length_before = request->CurrentSequenceLength();
@@ -528,7 +572,7 @@ TEST_F(RequestLifecycleTest, BeginTurnIsRejectedWhileActive) {
 // After a turn completes, BeginTurn appends another input fragment and queues the resident request.
 TEST_F(RequestLifecycleTest, BeginTurnAfterTurnCompleteQueuesNextTurn) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   const int64_t assigned_length = static_cast<int64_t>(prompt.size());
   EXPECT_EQ(request->CurrentTurnId(), 1u);
 
@@ -548,14 +592,14 @@ TEST_F(RequestLifecycleTest, BeginTurnAfterTurnCompleteQueuesNextTurn) {
 
 TEST_F(RequestLifecycleTest, ContinuationBeyondContextIsRejectedBeforeMutation) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   RunOne(*engine_.engine);
   ASSERT_EQ(request->status_, RequestStatus::TurnComplete);
   const auto before = request->Snapshot();
 
   const size_t remaining =
-      static_cast<size_t>(request->SearchOptions().max_length -
-                          request->CurrentSequenceLength());
+      request->MaxSessionTokens() -
+      static_cast<size_t>(request->CurrentSequenceLength());
   std::vector<int32_t> too_many(remaining, 5);
   EXPECT_THROW(request->BeginTurn(too_many), std::runtime_error);
 
@@ -566,11 +610,10 @@ TEST_F(RequestLifecycleTest, ContinuationBeyondContextIsRejectedBeforeMutation) 
 }
 
 TEST_F(RequestLifecycleTest, FailedContinuationAppendPreservesCompletedTurnState) {
-  auto params = MakeGreedyParams(*model_);
   auto control = std::make_shared<FailingContinuationControl>();
-  FailingContinuationDevice device{*params->p_device, control};
-  params->p_device = &device;
-  auto request = CreateEngineRequest(engine_.engine, *params);
+  FailingContinuationDevice device{*model_->p_device_scoring_, control};
+  ScopedScoringDevice scoped_device{*model_, device};
+  auto request = CreateEngineRequest(engine_.engine);
   engine_.executor->SetForcedToken(/*token=*/5);
   request->BeginTurn(Prompt(), std::optional<size_t>{1});
   ASSERT_EQ(RunOne(*engine_.engine).request, request);
@@ -595,11 +638,10 @@ TEST_F(RequestLifecycleTest, FailedContinuationAppendPreservesCompletedTurnState
 }
 
 TEST_F(RequestLifecycleTest, FailedContinuationRestoreClosesRequestAndPoisonsEngine) {
-  auto params = MakeGreedyParams(*model_);
   auto control = std::make_shared<FailingContinuationControl>();
-  FailingContinuationDevice device{*params->p_device, control};
-  params->p_device = &device;
-  auto request = CreateEngineRequest(engine_.engine, *params);
+  FailingContinuationDevice device{*model_->p_device_scoring_, control};
+  ScopedScoringDevice scoped_device{*model_, device};
+  auto request = CreateEngineRequest(engine_.engine);
   request->BeginTurn(Prompt());
   ASSERT_EQ(RunOne(*engine_.engine).request, request);
   ASSERT_TRUE(request->IsTurnComplete());
@@ -639,18 +681,17 @@ TEST_F(RequestLifecycleTest,
   auto engine = std::make_shared<Engine>(
       model_, std::move(dependencies));
 
-  auto params = MakeGreedyParams(*model_);
   auto control = std::make_shared<FailingContinuationControl>();
-  FailingContinuationDevice device{*params->p_device, control};
-  params->p_device = &device;
-  auto request = CreateEngineRequest(engine, *params);
+  FailingContinuationDevice device{*model_->p_device_scoring_, control};
+  ScopedScoringDevice scoped_device{*model_, device};
+  auto request = CreateEngineRequest(engine);
   request->BeginTurn(Prompt());
   ASSERT_EQ(RunOne(*engine).request, request);
   ASSERT_TRUE(request->IsTurnComplete());
   ASSERT_EQ(cache->AllocatedCount(), 1u);
 
-  auto drained_request = CreateEngineRequest(engine, *model_);
-  auto pending_request = CreateEngineRequest(engine, *model_);
+  auto drained_request = CreateEngineRequest(engine);
+  auto pending_request = CreateEngineRequest(engine);
   const auto drained_turn = drained_request->BeginTurn(Prompt());
   const auto pending_turn = pending_request->BeginTurn(Prompt());
   ASSERT_TRUE(drained_request->Cancel(drained_turn));
@@ -706,10 +747,9 @@ TEST_F(RequestLifecycleTest, FailedBeginTurnRestoresThePriorTurnsStopController)
   auto engine = MakeDoublesEngine(model, /*capacity=*/8, /*forced_token=*/5);
 
   auto control = std::make_shared<FailingContinuationControl>();
-  auto params = MakeGreedyParams(*model);
-  FailingContinuationDevice device{*params->p_device, control};
-  params->p_device = &device;
-  auto request = CreateEngineRequest(engine.engine, *params);
+  FailingContinuationDevice device{*model->p_device_scoring_, control};
+  ScopedScoringDevice scoped_device{*model, device};
+  auto request = CreateEngineRequest(engine.engine);
 
   TurnOptions first_turn_options;
   first_turn_options.stop_strings = {"STOP"};
@@ -767,10 +807,9 @@ TEST_F(RequestLifecycleTest, FailedNoStopBeginTurnRestoresThePriorTurnsStopContr
   auto engine = MakeDoublesEngine(model, /*capacity=*/8, /*forced_token=*/5);
 
   auto control = std::make_shared<FailingContinuationControl>();
-  auto params = MakeGreedyParams(*model);
-  FailingContinuationDevice device{*params->p_device, control};
-  params->p_device = &device;
-  auto request = CreateEngineRequest(engine.engine, *params);
+  FailingContinuationDevice device{*model->p_device_scoring_, control};
+  ScopedScoringDevice scoped_device{*model, device};
+  auto request = CreateEngineRequest(engine.engine);
 
   TurnOptions first_turn_options;
   first_turn_options.stop_strings = {"STOP"};
@@ -803,7 +842,7 @@ TEST_F(RequestLifecycleTest, FailedNoStopBeginTurnRestoresThePriorTurnsStopContr
 
 TEST_F(RequestLifecycleTest, ContinuationPreservesUnreadOutputAndHidesInputTokens) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   engine_.cache->Allocate({request});
   request->Schedule();
 
@@ -847,7 +886,7 @@ TEST_F(RequestLifecycleTest, ContinuationPreservesUnreadOutputAndHidesInputToken
 TEST_F(RequestLifecycleTest, RequestCloseIsIdempotentAfterClose) {
   auto prompt = Prompt();
   const std::vector<int32_t> more{5};
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   ASSERT_EQ(request->status_, RequestStatus::Assigned);
 
   request->Close();
@@ -863,7 +902,7 @@ TEST_F(RequestLifecycleTest, CloseRoutesThroughOwningEngineAndIsIdempotent) {
   auto other_engine =
       MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto request =
-      CreateRequestWithPrompt(engine_.engine, *model_, Prompt());
+      CreateRequestWithPrompt(engine_.engine, Prompt());
   ASSERT_EQ(request->status_, RequestStatus::Assigned);
 
   EXPECT_NO_THROW(request->Close());
@@ -888,7 +927,7 @@ TEST_F(RequestLifecycleTest, CloseRemainsIdempotentAfterEngineDestruction) {
   auto local_engine =
       MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(local_engine.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(local_engine.engine, prompt);
   local_engine.engine.reset();
 
   EXPECT_NO_THROW(request->Close());
@@ -898,7 +937,7 @@ TEST_F(RequestLifecycleTest, CloseRemainsIdempotentAfterEngineDestruction) {
 
 TEST_F(RequestLifecycleTest, TransactionalLogitsStageUntilCommit) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   const auto before = request->Snapshot();
   RequestStepPlan plan;
   plan.request = request;
@@ -959,7 +998,7 @@ TEST_F(RequestLifecycleTest, PerTurnLimitStagesUntilTransactionCommit) {
 
 TEST_F(RequestLifecycleTest, TransactionalLogitsRollbackRestoresSearchState) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   const auto before = request->Snapshot();
   auto logits = LogitsForToken(*model_, 5);
 
@@ -975,18 +1014,22 @@ TEST_F(RequestLifecycleTest, TransactionalLogitsRollbackRestoresSearchState) {
 }
 
 TEST_F(RequestLifecycleTest, TransactionalRollbackRestoresSamplingState) {
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.top_p = 1.0f;
-  params->search.temperature = 1.0f;
-  params->search.random_seed = 1234;
+  TurnOptions sampled;
+  sampled.do_sample = true;
+  sampled.top_k = 3;
+  sampled.top_p = 1.0f;
+  sampled.temperature = 1.0f;
+  sampled.seed = 1234u;
 
-  auto request = CreateRequestWithPrompt(engine_.engine, *params, Prompt());
+  auto request = CreateRequestWithPrompt(engine_.engine, Prompt(), sampled);
   const auto before = request->Snapshot();
   auto logits = SamplingLogits(*model_);
 
   request->SaveStateForTransaction();
+  // The turn's reseed is applied inside the step transaction, after the checkpoint, exactly as
+  // ScheduledRequests does before it reaches any RNG consumer.
+  request->ApplyPendingSeedForTransaction(
+      /*sampler=*/nullptr, /*device_state_checkpointed=*/false);
   const auto first = request->ApplyLogitsForTransaction(logits);
   request->RestoreStateForTransaction();
 
@@ -994,6 +1037,9 @@ TEST_F(RequestLifecycleTest, TransactionalRollbackRestoresSamplingState) {
             before.current_sequence_length);
 
   request->SaveStateForTransaction();
+  // Rollback left the reseed pending, so the retry reseeds identically and reproduces the token.
+  request->ApplyPendingSeedForTransaction(
+      /*sampler=*/nullptr, /*device_state_checkpointed=*/false);
   const auto retried = request->ApplyLogitsForTransaction(logits);
   request->RestoreStateForTransaction();
 
@@ -1004,7 +1050,7 @@ TEST_F(RequestLifecycleTest, TransactionalRollbackRestoresSamplingState) {
 
 TEST_F(RequestLifecycleTest, PartialPrefillAdvancesOnlyAtCommit) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   const auto before = request->Snapshot();
   RequestStepPlan plan;
   plan.request = request;
@@ -1028,7 +1074,7 @@ TEST_F(RequestLifecycleTest, PartialPrefillAdvancesOnlyAtCommit) {
 
 TEST_F(RequestLifecycleTest, EosCompletesWithoutAppendingVisibleToken) {
   auto prompt = Prompt();
-  auto request = CreateRequestWithPrompt(engine_.engine, *model_, prompt);
+  auto request = CreateRequestWithPrompt(engine_.engine, prompt);
   const auto before = request->Snapshot();
   RequestStepPlan plan;
   plan.request = request;
@@ -1048,84 +1094,194 @@ TEST_F(RequestLifecycleTest, EosCompletesWithoutAppendingVisibleToken) {
   EXPECT_EQ(request->status_, RequestStatus::TurnComplete);
 }
 
-TEST_F(RequestLifecycleTest, RequestRejectsMultiSequenceSearch) {
-  auto params = MakeGreedyParams(*model_);
-  params->search.batch_size = 2;
+// A Request is one sequence, whatever the model configuration says: the Engine derives its search
+// from the model and forces batch size and beam count to one rather than trusting a caller.
+TEST_F(RequestLifecycleTest, RequestForcesSingleSequenceSearch) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  config->search.batch_size = 2;
+  auto model = CreateModel(GetOrtEnv(), std::move(config));
+  const int32_t forced_token = EosToken(*model) == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model, /*capacity=*/8, forced_token);
+
+  auto request = CreateRequestWithPrompt(engine.engine, Prompt());
+  EXPECT_EQ(request->CurrentSequenceLength(),
+            static_cast<int64_t>(Prompt().size()));
+
+  // One step of a batch-size-2 model configuration still advances this Request by exactly one token
+  // on row 0, which is the invariant every row-indexing assumption in Request depends on. A wider
+  // batch means "the model was configured for the classic Generator"; the Engine batches Requests
+  // instead, so it derives its own single-row search rather than honoring or rejecting that value.
+  const auto event = RunOne(*engine.engine);
+  ASSERT_EQ(event.request, request);
+  EXPECT_EQ(event.token, forced_token);
+  EXPECT_EQ(request->TurnGeneratedTokens(), 1u);
+  EXPECT_EQ(request->CurrentSequenceLength(),
+            static_cast<int64_t>(Prompt().size()) + 1);
+}
+
+// Beam search is different from a wider batch: silently decoding one beam would produce output the
+// caller never asked for, so the model-configured value is rejected instead of forced. The message
+// has to name a route the caller can actually take, so this also takes it.
+TEST_F(RequestLifecycleTest, RequestRejectsModelConfiguredBeamSearch) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  config->search.num_beams = 4;
+  auto model = CreateModel(GetOrtEnv(), std::move(config));
+  auto engine = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model));
+
   try {
-    static_cast<void>(engine_.engine->CreateRequest(*params));
-    FAIL() << "Expected batch_size != 1 to be rejected.";
+    static_cast<void>(engine.engine->CreateRequest());
+    FAIL() << "Expected a model-configured search.num_beams != 1 to be rejected.";
   } catch (const std::runtime_error& error) {
-    EXPECT_NE(std::string(error.what()).find("batch_size == 1"),
-              std::string::npos);
-    EXPECT_NE(std::string(error.what()).find("actual value is 2"),
-              std::string::npos);
+    const std::string message = error.what();
+    EXPECT_NE(message.find("search.num_beams"), std::string::npos) << message;
+    EXPECT_NE(message.find("overlay"), std::string::npos) << message;
   }
+
+  // Taking the route the message names makes the same model usable, and the Request it mints
+  // decodes the single sequence the Engine promises.
+  auto cleared_config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  cleared_config->search.num_beams = 4;
+  OverlayConfig(*cleared_config, R"({"search": {"num_beams": 1}})");
+  auto cleared_model = CreateModel(GetOrtEnv(), std::move(cleared_config));
+  const int32_t forced_token = EosToken(*cleared_model) == 5 ? 6 : 5;
+  auto cleared_engine =
+      MakeDoublesEngine(cleared_model, /*capacity=*/8, forced_token);
+  auto request = CreateRequestWithPrompt(cleared_engine.engine, Prompt());
+  const auto event = RunOne(*cleared_engine.engine);
+  ASSERT_EQ(event.request, request);
+  EXPECT_EQ(event.token, forced_token);
+  EXPECT_EQ(request->CurrentSequenceLength(),
+            static_cast<int64_t>(Prompt().size()) + 1);
 }
 
-TEST_F(RequestLifecycleTest, RequestRejectsInvalidSamplingLimits) {
-  {
-    auto params = MakeGreedyParams(*model_);
-    params->search.top_p = 1.5f;
+// A model that still carries the legacy session-absolute floor cannot be served by the Engine,
+// whose minimum is per turn. The message has to name a route the caller can actually take, so this
+// also takes it: the config overlay clears the value without editing the model directory.
+TEST_F(RequestLifecycleTest, RequestRejectsLegacyModelMinLength) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  config->search.min_length = 4;
+  auto model = CreateModel(GetOrtEnv(), std::move(config));
+  auto engine = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model));
+
+  try {
+    static_cast<void>(engine.engine->CreateRequest());
+    FAIL() << "Expected a nonzero model search.min_length to be rejected.";
+  } catch (const std::runtime_error& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("search.min_length"), std::string::npos) << message;
+    EXPECT_NE(message.find("OgaTurnOptionsSetMinGeneratedTokens"), std::string::npos)
+        << message;
+    EXPECT_NE(message.find("overlay"), std::string::npos) << message;
+  }
+
+  // The overlay the message points at is a real, supported route: applying it before the model is
+  // created makes the same Engine admit the same Request.
+  auto overlaid_config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  overlaid_config->search.min_length = 4;
+  OverlayConfig(*overlaid_config, R"({"search": {"min_length": 0}})");
+  ASSERT_EQ(overlaid_config->search.min_length, 0);
+  auto overlaid_model = CreateModel(GetOrtEnv(), std::move(overlaid_config));
+  auto overlaid_engine =
+      MakeDoublesEngine(overlaid_model, /*capacity=*/8, EosToken(*overlaid_model));
+  auto request = overlaid_engine.engine->CreateRequest();
+  EXPECT_EQ(request->BeginTurn(Prompt()), 1u);
+}
+
+// Sampling limits are turn policy now, so they are rejected at admission -- before any Request
+// mutation -- rather than at Request creation.
+TEST_F(RequestLifecycleTest, TurnAdmissionRejectsInvalidSamplingLimits) {
+  const auto expect_rejected = [&](const TurnOptions& options,
+                                   std::string_view expected_fragment) {
+    auto request = CreateEngineRequest(engine_.engine);
     try {
-      static_cast<void>(engine_.engine->CreateRequest(*params));
-      FAIL() << "Expected top_p above 1.0 to be rejected.";
+      request->BeginTurn(Prompt(), options);
+      FAIL() << "Expected an invalid sampling policy to be rejected.";
     } catch (const std::runtime_error& error) {
-      EXPECT_NE(std::string(error.what()).find("top_p (1.500000)"),
-                std::string::npos);
-      EXPECT_NE(std::string(error.what()).find("between 0.0 and 1.0"),
-                std::string::npos);
+      const std::string message = error.what();
+      EXPECT_NE(message.find(expected_fragment), std::string::npos) << message;
     }
-  }
+    EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+    EXPECT_EQ(request->CurrentSequenceLength(), 0);
+    request->Close();
+  };
 
   {
-    auto params = MakeGreedyParams(*model_);
-    params->search.top_p = std::numeric_limits<float>::quiet_NaN();
-    EXPECT_THROW(
-        static_cast<void>(engine_.engine->CreateRequest(*params)),
-        std::runtime_error);
+    TurnOptions options;
+    options.do_sample = true;
+    options.top_p = 1.5f;
+    expect_rejected(options, "between 0.0 and 1.0");
   }
-
   {
-    auto params = MakeGreedyParams(*model_);
-    params->search.top_k = -1;
-    try {
-      static_cast<void>(engine_.engine->CreateRequest(*params));
-      FAIL() << "Expected negative top_k to be rejected.";
-    } catch (const std::runtime_error& error) {
-      EXPECT_NE(std::string(error.what()).find("top_k (-1)"),
-                std::string::npos);
-    }
+    TurnOptions options;
+    options.do_sample = true;
+    options.top_p = std::numeric_limits<float>::quiet_NaN();
+    expect_rejected(options, "top_p");
+  }
+  {
+    TurnOptions options;
+    options.do_sample = true;
+    options.top_k = -1;
+    expect_rejected(options, "top_k (-1)");
+  }
+  {
+    // Explicitly greedy, so a top_k asking for a 40-candidate distribution contradicts it.
+    TurnOptions options;
+    options.do_sample = false;
+    options.top_k = 40;
+    expect_rejected(options, "contradict it: top_k");
+  }
+  {
+    // top_k == 1 is itself a valid way to ask for greedy selection, but a nucleus top_p alongside
+    // it is not.
+    TurnOptions options;
+    options.do_sample = true;
+    options.top_k = 1;
+    options.top_p = 0.5f;
+    expect_rejected(options, "contradict it: top_p");
+  }
+  {
+    TurnOptions options;
+    options.repetition_penalty = 0.0f;
+    expect_rejected(options, "repetition_penalty");
+  }
+  {
+    TurnOptions options;
+    options.min_generated_tokens = 5;
+    options.max_generated_tokens = 2;
+    expect_rejected(options, "must not exceed max_generated_tokens");
   }
 }
 
-TEST_F(RequestLifecycleTest, RequestRejectsGuidanceFastForwardTokens) {
-  auto params = MakeGreedyParams(*model_);
-  params->SetGuidance("regex", "[0-9]+", true);
-
-  EXPECT_THROW(
-      {
-        auto request = engine_.engine->CreateRequest(*params);
-        static_cast<void>(request);
-      },
-      std::runtime_error);
-}
-
-TEST_F(RequestLifecycleTest, RequestRejectsIncompleteGuidanceConfiguration) {
+// A guidance request that names only half of the pair is malformed, and admission rejects it
+// before the Request is touched.
+TEST_F(RequestLifecycleTest, TurnAdmissionRejectsIncompleteGuidanceConfiguration) {
   for (bool omit_type : {false, true}) {
-    auto params = MakeGreedyParams(*model_);
-    params->guidance_type = omit_type ? "" : "regex";
-    params->guidance_data = omit_type ? "[0-9]+" : "";
+    auto request = CreateEngineRequest(engine_.engine);
+    TurnOptions options;
+    options.guidance_type = omit_type ? "" : "regex";
+    options.guidance_data = omit_type ? "[0-9]+" : "";
 
     try {
-      auto request = engine_.engine->CreateRequest(*params);
+      request->BeginTurn(Prompt(), options);
       FAIL() << "Expected incomplete guidance configuration to be rejected";
     } catch (const std::runtime_error& error) {
       EXPECT_STREQ(error.what(), "Guidance type and data must be provided together.");
     }
+    EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+    EXPECT_EQ(request->CurrentSequenceLength(), 0);
+    request->Close();
   }
 }
 
 #if USE_GUIDANCE
+// A turn-scoped regex grammar. Guidance never carries over, so every guided turn names its own.
+TurnOptions GuidedOptions(std::string grammar) {
+  TurnOptions options;
+  options.guidance_type = "regex";
+  options.guidance_data = std::move(grammar);
+  return options;
+}
+
 TEST_F(RequestLifecycleTest, RequestRejectsDraftTokensWithGuidance) {
   auto guidance_model = CreateModel(
       GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
@@ -1133,13 +1289,23 @@ TEST_F(RequestLifecycleTest, RequestRejectsDraftTokensWithGuidance) {
                                            EosToken(*guidance_model));
   guidance_engine.cache->SetMaxDraftTokensPerStep(3);
 
-  auto params = MakeGreedyParams(*guidance_model);
-  params->SetGuidance("regex", "!!", false);
-  auto request = CreateEngineRequest(guidance_engine.engine, *params);
-  request->BeginTurn(Prompt());
+  auto request = CreateEngineRequest(guidance_engine.engine);
+  request->BeginTurn(Prompt(), GuidedOptions("!!"));
 
   EXPECT_THROW(request->SetDraftTokens(std::array<int32_t, 1>{11}),
                std::runtime_error);
+
+  // Guidance is turn-scoped, so drafting eligibility comes back on the next unguided turn.
+  guidance_engine.executor->SetForcedToken(EosToken(*guidance_model));
+  // The grammar can mask the forced EOS until it accepts, so drive the turn to completion.
+  constexpr size_t kMaxGuidedSteps = 8;
+  for (size_t step = 0; step < kMaxGuidedSteps && !request->IsTurnComplete(); ++step) {
+    ASSERT_EQ(RunOne(*guidance_engine.engine).request, request);
+  }
+  ASSERT_TRUE(request->IsTurnComplete());
+  request->BeginTurn(std::array<int32_t, 1>{5});
+  ASSERT_EQ(RunOne(*guidance_engine.engine).request, request);
+  EXPECT_EQ(request->DraftTokenValidationError(), nullptr);
 }
 
 TEST_F(RequestLifecycleTest, GuidanceMasksTokensAndRollsBackWithSearchState) {
@@ -1153,12 +1319,12 @@ TEST_F(RequestLifecycleTest, GuidanceMasksTokensAndRollsBackWithSearchState) {
   ASSERT_EQ(expected_tokens.size(), 1u);
   ASSERT_EQ(invalid_tokens.size(), 1u);
 
-  auto params = MakeGreedyParams(*guidance_model);
-  params->SetGuidance("regex", "!!", false);
-  auto request = CreateEngineRequest(guidance_engine.engine, *params);
-  params->guidance_data = "a";
+  auto request = CreateEngineRequest(guidance_engine.engine);
+  auto options = GuidedOptions("!!");
   auto prompt = Prompt();
-  request->BeginTurn(prompt);
+  request->BeginTurn(prompt, options);
+  // The admitted turn snapshotted the grammar, so mutating the options afterwards cannot change it.
+  options.guidance_data = "a";
 
   auto first_logits = LogitsFavoringToken(
       *guidance_model, invalid_tokens.front(), expected_tokens.front());
@@ -1191,10 +1357,8 @@ TEST_F(RequestLifecycleTest, BeginTurnAfterCancellationResetsGuidance) {
   ASSERT_EQ(first_tokens.size(), 1u);
   ASSERT_EQ(second_tokens.size(), 1u);
 
-  auto params = MakeGreedyParams(*guidance_model);
-  params->SetGuidance("regex", "!a", false);
-  auto request = CreateEngineRequest(guidance_engine.engine, *params);
-  const auto turn_id = request->BeginTurn(Prompt());
+  auto request = CreateEngineRequest(guidance_engine.engine);
+  const auto turn_id = request->BeginTurn(Prompt(), GuidedOptions("!a"));
 
   guidance_engine.executor->SetForcedToken(first_tokens.front());
   EXPECT_EQ(RunOne(*guidance_engine.engine).token, first_tokens.front());
@@ -1204,7 +1368,9 @@ TEST_F(RequestLifecycleTest, BeginTurnAfterCancellationResetsGuidance) {
       RunOne(*guidance_engine.engine).finish_reason,
       GenerationFinishReason::Canceled);
 
-  request->BeginTurn(std::array<int32_t, 1>{5});
+  // A new turn asking for the same grammar starts that grammar over rather than resuming the
+  // canceled turn's cursor.
+  request->BeginTurn(std::array<int32_t, 1>{5}, GuidedOptions("!a"));
   auto first_logits = LogitsFavoringToken(
       *guidance_model, second_tokens.front(), first_tokens.front());
   request->SaveStateForTransaction();
@@ -1214,24 +1380,24 @@ TEST_F(RequestLifecycleTest, BeginTurnAfterCancellationResetsGuidance) {
   request->RestoreStateForTransaction();
 }
 
-TEST_F(RequestLifecycleTest, FailedBeginTurnRestoresGuidanceCursor) {
+// A guided turn whose admission fails must leave the Request exactly as the previous turn left it,
+// and a corrected retry must then behave like an ordinary guided turn.
+TEST_F(RequestLifecycleTest, FailedGuidedBeginTurnLeavesTheRequestReusable) {
   auto guidance_model = CreateModel(
       GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
   auto guidance_engine = MakeDoublesEngine(guidance_model, /*capacity=*/8,
                                            EosToken(*guidance_model));
   auto tokenizer = guidance_model->CreateTokenizer();
   const auto first_tokens = tokenizer->Encode("!");
-  const auto second_tokens = tokenizer->Encode("a");
   ASSERT_EQ(first_tokens.size(), 1u);
-  ASSERT_EQ(second_tokens.size(), 1u);
+  const auto invalid_tokens = tokenizer->Encode("a");
+  ASSERT_EQ(invalid_tokens.size(), 1u);
 
   auto control = std::make_shared<FailingContinuationControl>();
-  auto params = MakeGreedyParams(*guidance_model);
-  FailingContinuationDevice device{*params->p_device, control};
-  params->p_device = &device;
-  params->SetGuidance("regex", "!a", false);
-  auto request = CreateEngineRequest(guidance_engine.engine, *params);
-  const auto turn_id = request->BeginTurn(Prompt());
+  FailingContinuationDevice device{*guidance_model->p_device_scoring_, control};
+  ScopedScoringDevice scoped_device{*guidance_model, device};
+  auto request = CreateEngineRequest(guidance_engine.engine);
+  const auto turn_id = request->BeginTurn(Prompt(), GuidedOptions("!a"));
 
   guidance_engine.executor->SetForcedToken(first_tokens.front());
   EXPECT_EQ(RunOne(*guidance_engine.engine).token, first_tokens.front());
@@ -1240,22 +1406,65 @@ TEST_F(RequestLifecycleTest, FailedBeginTurnRestoresGuidanceCursor) {
   EXPECT_EQ(
       RunOne(*guidance_engine.engine).finish_reason,
       GenerationFinishReason::Canceled);
+  const auto before = request->Snapshot();
 
+  // An unusable grammar is rejected while building the turn's processor, before any mutation.
+  EXPECT_THROW(request->BeginTurn(std::array<int32_t, 1>{5}, GuidedOptions("[")),
+               std::runtime_error);
+  EXPECT_EQ(request->Snapshot().current_sequence_length,
+            before.current_sequence_length);
+
+  // A failure after the grammar was built must roll back just as completely.
   control->fail_append = true;
   try {
-    request->BeginTurn(std::array<int32_t, 1>{5});
+    request->BeginTurn(std::array<int32_t, 1>{5}, GuidedOptions("!a"));
     FAIL() << "Expected continuation append failure";
   } catch (const std::runtime_error& error) {
     EXPECT_STREQ(error.what(), "Injected continuation append failure.");
   }
   control->fail_append = false;
+  EXPECT_EQ(request->Snapshot().current_sequence_length,
+            before.current_sequence_length);
 
-  auto second_logits = LogitsFavoringToken(
-      *guidance_model, first_tokens.front(), second_tokens.front());
+  // The corrected retry is guided from the start of the grammar.
+  request->BeginTurn(std::array<int32_t, 1>{5}, GuidedOptions("!a"));
+  auto logits = LogitsFavoringToken(
+      *guidance_model, invalid_tokens.front(), first_tokens.front());
   request->SaveStateForTransaction();
   EXPECT_EQ(
-      request->ApplyLogitsForTransaction(second_logits).token,
-      second_tokens.front());
+      request->ApplyLogitsForTransaction(logits).token, first_tokens.front());
+  request->RestoreStateForTransaction();
+}
+
+// Omitting guidance on a following turn leaves that turn unguided; nothing is inherited.
+TEST_F(RequestLifecycleTest, OmittedTurnGuidanceContinuesUnguided) {
+  auto guidance_model = CreateModel(
+      GetOrtEnv(), MODEL_PATH "hf-internal-testing/tiny-random-gpt2-fp32");
+  auto guidance_engine = MakeDoublesEngine(guidance_model, /*capacity=*/8,
+                                           EosToken(*guidance_model));
+  auto tokenizer = guidance_model->CreateTokenizer();
+  const auto guided_tokens = tokenizer->Encode("!");
+  const auto unguided_tokens = tokenizer->Encode("a");
+  ASSERT_EQ(guided_tokens.size(), 1u);
+  ASSERT_EQ(unguided_tokens.size(), 1u);
+
+  auto request = CreateEngineRequest(guidance_engine.engine);
+  request->BeginTurn(Prompt(), GuidedOptions("!a"));
+  guidance_engine.executor->SetForcedToken(guided_tokens.front());
+  EXPECT_EQ(RunOne(*guidance_engine.engine).token, guided_tokens.front());
+  ASSERT_TRUE(request->Cancel(request->CurrentTurnId()));
+  ASSERT_EQ(
+      RunOne(*guidance_engine.engine).finish_reason,
+      GenerationFinishReason::Canceled);
+
+  // The grammar would still forbid this token; without guidance the argmax wins.
+  request->BeginTurn(std::array<int32_t, 1>{5});
+  EXPECT_FALSE(request->HasGuidance());
+  auto logits = LogitsFavoringToken(
+      *guidance_model, unguided_tokens.front(), guided_tokens.front());
+  request->SaveStateForTransaction();
+  EXPECT_EQ(
+      request->ApplyLogitsForTransaction(logits).token, unguided_tokens.front());
   request->RestoreStateForTransaction();
 }
 
@@ -1270,10 +1479,8 @@ TEST_F(RequestLifecycleTest, StaticCpuGenerationAdvancesGuidanceCursor) {
   ASSERT_EQ(first_tokens.size(), 1u);
   ASSERT_EQ(second_tokens.size(), 1u);
 
-  auto params = MakeGreedyParams(*guidance_model);
-  params->SetGuidance("regex", "!a", false);
   auto request = CreateRequestWithPrompt(
-      guidance_engine.engine, *params, Prompt());
+      guidance_engine.engine, Prompt(), GuidedOptions("!a"));
 
   auto first_logits = LogitsFavoringToken(
       *guidance_model, second_tokens.front(), first_tokens.front());

--- a/test/cpp/engine/scheduler_contract_tests.cpp
+++ b/test/cpp/engine/scheduler_contract_tests.cpp
@@ -49,7 +49,7 @@ class SchedulerContractTest : public ::testing::Test {
 
   std::shared_ptr<Request> Assigned(int32_t seed) {
     auto prompt = Prompt(seed);
-    return CreateRequestWithPrompt(assign_target_, *model_, prompt);
+    return CreateRequestWithPrompt(assign_target_, prompt);
   }
 
   void MakePrefillResident(
@@ -136,14 +136,11 @@ TEST_F(SchedulerContractTest, ExecutionOrderingPreservesAssignedTokenBudgets) {
   model_->config_->engine.dynamic_batching->max_scheduled_tokens = 3;
   DynamicBatchScheduler scheduler(model_, cache);
 
-  auto first_params = MakeGreedyParams(*model_);
-  first_params->search.chunk_size = 1;
-  auto first = CreateRequestWithPrompt(
-      assign_target_, *first_params, Prompt(10));
-  auto second_params = MakeGreedyParams(*model_);
-  second_params->search.chunk_size = 3;
-  auto second = CreateRequestWithPrompt(
-      assign_target_, *second_params, Prompt(20));
+  // Unequal remaining prompt lengths under the one Engine-global token budget: the first request
+  // takes its single token, leaving the second only two of the three budgeted tokens.
+  const std::array<int32_t, 1> short_prompt{5};
+  auto first = CreateRequestWithPrompt(assign_target_, short_prompt);
+  auto second = CreateRequestWithPrompt(assign_target_, Prompt(20));
   scheduler.AddRequest(first);
   scheduler.AddRequest(second);
   StepPlan plan;
@@ -448,11 +445,10 @@ TEST_F(SchedulerContractTest, DecodeDemandCanExhaustTheGlobalBudget) {
 TEST_F(SchedulerContractTest, PrefillRespectsChunkAndGlobalCaps) {
   auto cache = std::make_shared<RecordingCacheManager>(model_, /*capacity=*/8);
   model_->config_->engine.dynamic_batching->max_scheduled_tokens = 2;
+  model_->config_->search.chunk_size = 1;
   DynamicBatchScheduler scheduler(model_, cache);
-  auto params = MakeGreedyParams(*model_);
-  params->search.chunk_size = 1;
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(assign_target_, *params, prompt);
+  auto request = CreateRequestWithPrompt(assign_target_, prompt);
   scheduler.AddRequest(request);
   StepPlan plan;
 
@@ -468,11 +464,10 @@ TEST_F(SchedulerContractTest, PrefillRespectsChunkAndGlobalCaps) {
 TEST_F(SchedulerContractTest, CacheQueryCapBoundsOversizedRequestChunk) {
   auto cache = std::make_shared<RecordingCacheManager>(model_, /*capacity=*/8);
   cache->SetMaxQueryTokensPerRequest(2);
+  model_->config_->search.chunk_size = 7;
   DynamicBatchScheduler scheduler(model_, cache);
-  auto params = MakeGreedyParams(*model_);
-  params->search.chunk_size = 7;
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(assign_target_, *params, prompt);
+  auto request = CreateRequestWithPrompt(assign_target_, prompt);
   scheduler.AddRequest(request);
   StepPlan plan;
 
@@ -487,11 +482,10 @@ TEST_F(SchedulerContractTest, CacheQueryCapBoundsOversizedRequestChunk) {
 TEST_F(SchedulerContractTest, CacheQueryCapBoundsUnchunkedRequest) {
   auto cache = std::make_shared<RecordingCacheManager>(model_, /*capacity=*/8);
   cache->SetMaxQueryTokensPerRequest(2);
+  model_->config_->search.chunk_size = 0;
   DynamicBatchScheduler scheduler(model_, cache);
-  auto params = MakeGreedyParams(*model_);
-  params->search.chunk_size = 0;
   auto prompt = Prompt(10);
-  auto request = CreateRequestWithPrompt(assign_target_, *params, prompt);
+  auto request = CreateRequestWithPrompt(assign_target_, prompt);
   scheduler.AddRequest(request);
   StepPlan plan;
 
@@ -508,7 +502,7 @@ TEST_F(SchedulerContractTest, GlobalCapChunksPromptWithoutSearchChunkSize) {
   model_->config_->engine.dynamic_batching->max_scheduled_tokens = 2;
   DynamicBatchScheduler scheduler(model_, cache);
   auto request = Assigned(10);
-  ASSERT_FALSE(request->SearchOptions().chunk_size.has_value());
+  ASSERT_FALSE(request->PrefillChunkSize().has_value());
   scheduler.AddRequest(request);
   StepPlan plan;
 
@@ -599,8 +593,7 @@ TEST_F(SchedulerContractTest, ProductionCacheReservesGloballyChunkedPrompt) {
   auto cache = std::make_shared<PagedCacheManager>(model_);
   DynamicBatchScheduler scheduler(model_, cache);
   auto request = CreateRequestWithPrompt(
-      assign_target_, *model_,
-      std::array<int32_t, 9>{2, 3, 4, 5, 6, 7, 8, 9, 10});
+      assign_target_, std::array<int32_t, 9>{2, 3, 4, 5, 6, 7, 8, 9, 10});
   scheduler.AddRequest(request);
   StepPlan plan;
 

--- a/test/cpp/engine/stop_string_engine_tests.cpp
+++ b/test/cpp/engine/stop_string_engine_tests.cpp
@@ -62,11 +62,41 @@ TurnOptions StopOptions(std::vector<std::string> stop_strings,
   return options;
 }
 
+// A nearly deterministic sampled turn policy: top-k 3 at a very low temperature with a fixed seed,
+// so the sampled and speculative-sampled paths take their random branches while still selecting a
+// predictable token.
+// An omitted seed continues the request's existing streams, which is what a continuation turn of an
+// already-seeded request needs.
+TurnOptions SampledOptions(std::vector<std::string> stop_strings = {},
+                           std::optional<size_t> max_generated_tokens = std::nullopt,
+                           std::optional<uint64_t> seed = uint64_t{1234}) {
+  auto options = StopOptions(std::move(stop_strings), max_generated_tokens);
+  options.do_sample = true;
+  options.top_k = 3;
+  options.temperature = 0.01f;
+  options.seed = seed;
+  return options;
+}
+
 // A minimal ConstrainedLogitsProcessor stand-in so stop-string tests can verify the two features
 // coexist without depending on USE_GUIDANCE or a real grammar. Records every committed token; does
 // not otherwise constrain anything.
 class NoOpGuidanceProcessor final : public ConstrainedLogitsProcessor {
  public:
+  // Guidance is turn-scoped, so a completed turn releases its cursor rather than resetting it. The
+  // destructor publishes the final committed history through this shared slot so a test can observe
+  // the release without touching freed memory. Deliberately not carried by Clone(): a discarded
+  // transaction checkpoint must not publish on the live cursor's behalf.
+  explicit NoOpGuidanceProcessor(
+      std::shared_ptr<std::optional<std::vector<int32_t>>> release_observer = nullptr)
+      : release_observer_{std::move(release_observer)} {}
+
+  ~NoOpGuidanceProcessor() override {
+    if (release_observer_) {
+      *release_observer_ = committed_tokens;
+    }
+  }
+
   void CommitTokens(std::span<int32_t> tokens) override {
     committed_tokens.insert(committed_tokens.end(), tokens.begin(), tokens.end());
   }
@@ -83,8 +113,16 @@ class NoOpGuidanceProcessor final : public ConstrainedLogitsProcessor {
     return clone;
   }
 
+  void ObserveReleaseInto(
+      std::shared_ptr<std::optional<std::vector<int32_t>>> observer) {
+    release_observer_ = std::move(observer);
+  }
+
   std::vector<int32_t> committed_tokens;
   int reset_count{};
+
+ private:
+  std::shared_ptr<std::optional<std::vector<int32_t>>> release_observer_;
 };
 
 class StopStringEngineTest : public ::testing::Test {
@@ -101,7 +139,7 @@ class StopStringEngineTest : public ::testing::Test {
 TEST_F(StopStringEngineTest, NoStopStringsPreserveOrdinaryGenerationBehavior) {
   // Exercise the no-stop path entirely through the public request and event contract.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/8 /* "AB" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({}, std::optional<size_t>{2}));
 
   std::array<EngineEvent, 4> storage;
@@ -126,7 +164,7 @@ TEST_F(StopStringEngineTest, NoStopStringsPreserveOrdinaryGenerationBehavior) {
 
 TEST_F(StopStringEngineTest, MatchSpanningTwoTokensReportsEarliestCompletionAndIndex) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -155,7 +193,7 @@ TEST_F(StopStringEngineTest, SecondOfThreePatternsReportsItsOwnNonZeroIndex) {
   // one that actually matches ("STOP", configured at index 1) must report its own index, not 0 or
   // the index of an unrelated pattern that never matches.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"UNREACHABLE1", "STOP", "UNREACHABLE2"}));
 
   std::array<EngineEvent, 4> storage;
@@ -175,7 +213,7 @@ TEST_F(StopStringEngineTest, MatchWithinASingleTokenRetainsTrailingBytesInHistor
   // whole token is still retained, emitted, and counted -- the Engine never trims or rewrites a
   // committed token's raw bytes.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/7);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -190,7 +228,7 @@ TEST_F(StopStringEngineTest, StopStringTakesPrecedenceOverTurnLimitForTheSameTok
   // max_generated_tokens=1 and the first generated token both complete a stop match and exhaust
   // the turn's token budget. StopString must win.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/7 /* "STOPX" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}, std::optional<size_t>{1}));
 
   std::array<EngineEvent, 4> storage;
@@ -213,7 +251,7 @@ TEST_F(StopStringEngineTest, RealEosTokensDecodeEmptyAndStopStringsDoNotDisturbE
   // not depend on Search's append decision, which the Engine can and does resolve in the stop
   // string's favor.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -227,11 +265,9 @@ TEST_F(StopStringEngineTest, RealEosTokensDecodeEmptyAndStopStringsDoNotDisturbE
 }
 
 TEST_F(StopStringEngineTest, StopStringTakesPrecedenceOverContextLimitForTheSameToken) {
-  auto params = MakeGreedyParams(*model_);
-  params->search.max_length = static_cast<int32_t>(Prompt().size()) + 1;
-
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/7 /* "STOPX" */);
-  auto request = CreateEngineRequest(engine.engine, *params);
+  auto request = CreateEngineRequest(
+      engine.engine, /*max_session_tokens=*/Prompt().size() + 1);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -242,7 +278,7 @@ TEST_F(StopStringEngineTest, StopStringTakesPrecedenceOverContextLimitForTheSame
 
 TEST_F(StopStringEngineTest, TurnResetClearsMatchAndControllerForTheNextTurn) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/7 /* "STOPX" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -281,7 +317,7 @@ TEST_F(StopStringEngineTest, PromptTokensAreNeverSeededIntoTheStopStringMatcher)
   // used to admit the turn. A single nonmatching generated token ("A") must end the turn on the
   // turn limit, not StopString.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/2 /* "A" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(std::vector<int32_t>{5, 6} /* "ST" + "OP" = "STOP" */,
                      StopOptions({"STOP"}, std::optional<size_t>{1}));
 
@@ -301,7 +337,7 @@ TEST_F(StopStringEngineTest, ContinuationInputTokensAreNeverSeededIntoTheNextTur
   // "STOP"; since continuation input is never seeded, only "OP" reaches the fresh controller, which
   // does not complete "STOP" by itself.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}, std::optional<size_t>{1}));
 
   std::array<EngineEvent, 4> storage;
@@ -331,7 +367,7 @@ TEST_F(StopStringEngineTest, PreviousTurnsStopControllerStateNeverLeaksIntoTheNe
   // wrongly complete "STOP" using the stale prefix state; since a fresh controller is built for
   // every turn, it does not.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}, std::optional<size_t>{1}));
 
   std::array<EngineEvent, 4> storage;
@@ -356,8 +392,8 @@ TEST_F(StopStringEngineTest, MultiRequestIsolationKeepsIndependentControllersAnd
   // Two concurrent requests with different stop-string configurations and different per-row
   // scripted tokens must not observe each other's decoded text.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/2);
-  auto first = CreateEngineRequest(engine.engine, *model_);
-  auto second = CreateEngineRequest(engine.engine, *model_);
+  auto first = CreateEngineRequest(engine.engine);
+  auto second = CreateEngineRequest(engine.engine);
   first->BeginTurn(Prompt(), StopOptions({"STOP"}));
   second->BeginTurn(Prompt(), StopOptions({"AB"}));  // completes within one token (token 8)
 
@@ -387,9 +423,10 @@ TEST_F(StopStringEngineTest, MultiRequestIsolationKeepsIndependentControllersAnd
 
 TEST_F(StopStringEngineTest, GuidanceAndStopStringsCoexistOnTheSameRequest) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
-  auto* guidance = new NoOpGuidanceProcessor();
+  auto released = std::make_shared<std::optional<std::vector<int32_t>>>();
+  auto* guidance = new NoOpGuidanceProcessor(released);
   RequestGuidanceTestAccess::Install(
       *request, std::unique_ptr<ConstrainedLogitsProcessor>(guidance));
 
@@ -401,23 +438,23 @@ TEST_F(StopStringEngineTest, GuidanceAndStopStringsCoexistOnTheSameRequest) {
   engine.executor->SetForcedToken(6);
   ASSERT_EQ(engine.engine->Run(storage), 1u);
   EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::StopString);
-  // Guidance still saw both committed tokens before the turn's own completion reset its cursor --
-  // exactly the same turn-completion behavior guidance already has with EOS/turn/context-limit
-  // completions, now also exercised by a StopString completion.
-  EXPECT_EQ(guidance->reset_count, 1);
-  EXPECT_TRUE(guidance->committed_tokens.empty());
+  // Guidance saw both committed tokens, and the completing step released its cursor -- exactly the
+  // same turn-completion behavior guidance has for EOS/turn/context-limit completions, now also
+  // exercised by a StopString completion.
+  EXPECT_EQ(RequestGuidanceTestAccess::Get(*request), nullptr);
+  ASSERT_TRUE(released->has_value());
+  EXPECT_EQ(released->value(), (std::vector<int32_t>{5, 6}));
 }
 
 TEST_F(StopStringEngineTest, GuidanceAndStopRollbackCoexistOnTheSameRequest) {
   // Both guidance and the stop controller are mutated during staging (Request::StageGeneration
-  // calls CommitGuidanceToken() -- and, since a StopString match finishes the turn, immediately
-  // Resets() the *active* guidance processor in the same call -- and observes the stop controller
-  // unconditionally once a token is appended, before the step commits), so a rollback must restore
-  // both together, not just one. RequestGuidanceTestAccess::Get() is used throughout (rather than
-  // holding onto the originally-installed raw pointer) because a rollback swaps the active
-  // processor back to a different object: the pre-staging Clone() checkpoint.
+  // calls CommitGuidanceToken() and observes the stop controller unconditionally once a token is
+  // appended, before the step commits), so a rollback must restore both together, not just one.
+  // RequestGuidanceTestAccess::Get() is used after the rollback (rather than holding onto the
+  // originally-installed raw pointer) because a rollback swaps the active processor back to a
+  // different object: the pre-staging Clone() checkpoint.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   auto* guidance = new NoOpGuidanceProcessor();
   RequestGuidanceTestAccess::Install(
@@ -435,15 +472,13 @@ TEST_F(StopStringEngineTest, GuidanceAndStopRollbackCoexistOnTheSameRequest) {
   plan.target_cache_slots = static_cast<size_t>(before.current_sequence_length);
   PrepareRequestStep(model_, plan);
 
-  // Stage a second step with "OP" (token 6), which completes "STOP". Staging both commits the
-  // token to guidance and, because the step is now done, immediately Resets() it -- exactly the
-  // same turn-completion behavior GuidanceAndStopStringsCoexistOnTheSameRequest exercises on the
-  // committed path, but here it happens speculatively, before any Search/cache commit.
+  // Stage a second step with "OP" (token 6), which completes "STOP". Staging commits the token to
+  // the live guidance cursor; releasing that cursor is deferred to the commit boundary, so nothing
+  // irreversible happens here.
   request->SaveStateForTransaction();
   const auto staged = request->ApplyLogitsForTransaction(LogitsForToken(*model_, 6));
   ASSERT_EQ(staged.finish_reason, GenerationFinishReason::StopString);
-  EXPECT_EQ(guidance->reset_count, 1);
-  EXPECT_TRUE(guidance->committed_tokens.empty());
+  EXPECT_EQ(guidance->committed_tokens, (std::vector<int32_t>{5, 6}));
 
   // Roll back without committing: both guidance and the stop controller must be restored together
   // to their pre-staging state. Guidance's checkpoint is a distinct Clone() taken before staging,
@@ -456,6 +491,8 @@ TEST_F(StopStringEngineTest, GuidanceAndStopRollbackCoexistOnTheSameRequest) {
   EXPECT_EQ(restored_guidance->committed_tokens, (std::vector<int32_t>{5}));
   EXPECT_EQ(restored_guidance->reset_count, 0);
   EXPECT_EQ(request->FinishReason(), GenerationFinishReason::None);
+  auto released = std::make_shared<std::optional<std::vector<int32_t>>>();
+  restored_guidance->ObserveReleaseInto(released);
 
   // Mutation-resistant: re-stage and commit the *same* completing token ("OP", token 6) again,
   // rather than a different, non-matching token. A rollback that only truncated turn_tokens_ and
@@ -472,16 +509,17 @@ TEST_F(StopStringEngineTest, GuidanceAndStopRollbackCoexistOnTheSameRequest) {
   EXPECT_EQ(request->TurnGeneratedTokens(), 2u);
   EXPECT_EQ(request->FinishReason(), GenerationFinishReason::StopString);
   EXPECT_EQ(request->MatchedStopStringIndex(), 0);
-  // Guidance reaches the same terminal/reset state on the replayed-and-recompleted match as it did
-  // on the original (now-discarded) completion: one more Reset() (turn completion resets guidance's
-  // cursor), and no leftover committed tokens.
-  EXPECT_EQ(restored_guidance->reset_count, 1);
-  EXPECT_TRUE(restored_guidance->committed_tokens.empty());
+  // Guidance reaches the same terminal state on the replayed-and-recompleted match as it did on
+  // the original (now-discarded) completion: it saw both tokens and was then released with the
+  // rest of the turn's scoped state.
+  EXPECT_EQ(RequestGuidanceTestAccess::Get(*request), nullptr);
+  ASSERT_TRUE(released->has_value());
+  EXPECT_EQ(released->value(), (std::vector<int32_t>{5, 6}));
 }
 
 TEST_F(StopStringEngineTest, DirectRollbackDiscardsTheStagedObservationCompletely) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -529,7 +567,7 @@ TEST_F(StopStringEngineTest, DirectRollbackDiscardsTheStagedObservationCompletel
 
 TEST_F(StopStringEngineTest, QueuedRollbackReplaysTheControllerInTheCompletionPhase) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -571,7 +609,7 @@ TEST_F(StopStringEngineTest, QueuedRollbackReplaysTheControllerInTheCompletionPh
 
 TEST_F(StopStringEngineTest, QueuedRollbackReplaysControllerBeforeRetry) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -605,7 +643,7 @@ TEST_F(StopStringEngineTest, DirectRollbackReplaysMultipleCommittedTokensInOrder
   // that to two committed tokens ("A" then "ST") so RollbackTo() actually has to replay more than
   // one token, in order, to reconstruct the correct matcher/stream state.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/2 /* "A" */);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -699,7 +737,7 @@ TEST_F(StopStringEngineTest, StaticBatchingEngineRejectsStopEnabledTurnBeforeMut
   EngineDependencies dependencies{cache, std::move(scheduler), std::move(executor)};
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
 
-  auto request = CreateEngineRequest(engine, *model_);
+  auto request = CreateEngineRequest(engine);
   EXPECT_THROW(
       request->BeginTurn(Prompt(), StopOptions({"STOP"})), std::runtime_error);
   // Rejected before any mutation: the request never left its pre-turn state.
@@ -726,7 +764,7 @@ TEST_F(StopStringEngineTest, ManualDraftTokensAreAcceptedAndVerifiedForAStopEnab
   auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
   ASSERT_GT(engine->MaxDraftTokensPerStep(), 0u);
 
-  auto request = CreateEngineRequest(engine, *model_);
+  auto request = CreateEngineRequest(engine);
   request->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
 
   std::array<EngineEvent, 4> storage;
@@ -753,7 +791,7 @@ TEST_F(StopStringEngineTest, GreedyDraftMatchAtTheFirstPositionDiscardsLaterDraf
   // very first committed draft, so verification must never even look at the later two.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -778,7 +816,7 @@ TEST_F(StopStringEngineTest, GreedyDraftMatchAtTheFirstPositionDiscardsLaterDraf
 TEST_F(StopStringEngineTest, GreedyDraftMatchAtAMiddlePositionEmitsThePriorAcceptedTokenFirst) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -801,7 +839,7 @@ TEST_F(StopStringEngineTest, GreedyDraftMatchAtTheLastDraftPositionDiscardsTheBo
   // (the bonus/replacement row the target would otherwise have contributed) is never reached.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -826,7 +864,7 @@ TEST_F(StopStringEngineTest, GreedyBonusTokenCanCompleteAMatchAfterAllDraftsAcce
   // own observation, confirming the bonus token needs no special handling.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -847,7 +885,7 @@ TEST_F(StopStringEngineTest, GreedyRejectedDraftNeverReachesTheMatcherButItsRepl
   // sees the rejected draft at all; it observes only the target's own replacement, which matches.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -869,7 +907,7 @@ TEST_F(StopStringEngineTest, GreedyMatchCanBeginInPriorCommittedOutputAndFinishI
   // partial state, not anything reseeded from the draft proposal itself.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -894,7 +932,7 @@ TEST_F(StopStringEngineTest, GreedyDraftVerificationNeverObservesAnAcceptedEosDr
   // never reached.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11 /* filler */);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);  // commits "t11" (token 11)
@@ -923,13 +961,8 @@ TEST_F(StopStringEngineTest, GreedyDraftVerificationNeverObservesAnAcceptedEosDr
 TEST_F(StopStringEngineTest, SampledDraftMatchAtTheFirstAcceptedPositionTruncates) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
 
@@ -949,13 +982,8 @@ TEST_F(StopStringEngineTest, SampledDraftMatchAtTheFirstAcceptedPositionTruncate
 TEST_F(StopStringEngineTest, SampledDraftMatchAtAMiddleAcceptedPositionEmitsThePriorTokenFirst) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
 
@@ -978,13 +1006,8 @@ TEST_F(StopStringEngineTest, SampledDraftMatchAtTheLastAcceptedPositionDiscardsT
   // last *draft* position -- the trailing bonus token must never be committed or emitted.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
 
@@ -1005,13 +1028,8 @@ TEST_F(StopStringEngineTest, SampledDraftMatchAtTheLastAcceptedPositionDiscardsT
 TEST_F(StopStringEngineTest, SampledFullyAcceptedBonusTokenCanCompleteAMatch) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
 
@@ -1029,13 +1047,8 @@ TEST_F(StopStringEngineTest, SampledFullyAcceptedBonusTokenCanCompleteAMatch) {
 TEST_F(StopStringEngineTest, SampledRejectedDraftReplacementCanCompleteAMatch) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
 
@@ -1057,13 +1070,8 @@ TEST_F(StopStringEngineTest, SampledDraftVerificationNeverObservesAnAcceptedEosD
   // already excludes it -- both stage-loop branches reuse that same function unmodified for this.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);  // commits "t11"
 
@@ -1088,7 +1096,7 @@ TEST_F(StopStringEngineTest, PromoteFinalStageAsAcceptedDraftRejectsAResultThatN
   // counts and token_appended already agree -- so this exercises the guard directly rather than
   // trying to contrive a real end-to-end scenario that violates the invariant.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt());
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -1108,13 +1116,8 @@ TEST_F(StopStringEngineTest, PromoteFinalStageAsAcceptedDraftRejectsAResultThatN
 TEST_F(StopStringEngineTest, SampledAcceptedTelemetryCountsAMatchAtTheFirstPosition) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
 
@@ -1137,13 +1140,8 @@ TEST_F(StopStringEngineTest, SampledAcceptedTelemetryCountsAMatchAtTheFirstPosit
 TEST_F(StopStringEngineTest, SampledAcceptedTelemetryCountsAMatchAtAMiddlePosition) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
 
@@ -1165,13 +1163,8 @@ TEST_F(StopStringEngineTest, SampledAcceptedTelemetryCountsAFullyConfirmedMatchA
   // every proposed draft was confirmed -- even though the round ended via a match, not a bonus.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
 
@@ -1195,13 +1188,9 @@ TEST_F(StopStringEngineTest, NoStopBudgetExhaustedNaturalLastGenuineDraftKeepsVa
   // still count that final draft as accepted -- this request has no stop controller at all.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), std::optional<size_t>{3});  // no stop strings
+  auto request = CreateEngineRequest(engine.engine);
+  // no stop strings
+  request->BeginTurn(Prompt(), SampledOptions({}, std::optional<size_t>{3}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
   ASSERT_EQ(request->TurnGeneratedTokens(), 1u);
@@ -1228,13 +1217,9 @@ TEST_F(StopStringEngineTest, ManualDraftCountFarExceedingTheBudgetStillCountsThe
   // PromoteFinalStageAsAcceptedDraft, never both for the same stage and never zero times.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(5);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), std::optional<size_t>{3});  // no stop strings; budget for 2 more
+  auto request = CreateEngineRequest(engine.engine);
+  // no stop strings; budget for 2 more
+  request->BeginTurn(Prompt(), SampledOptions({}, std::optional<size_t>{3}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
   const auto length_after_prefill = request->CurrentSequenceLength();
@@ -1290,7 +1275,7 @@ TEST_F(StopStringEngineTest, GreedyDraftCountFarExceedingTheBudgetEvaluatesOnlyT
   // the committed outcome, so evaluated is 2 rather than an inferred accepted + 1 = 3.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(5);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), std::optional<size_t>{3});  // no stop strings; budget for 2 more
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -1315,13 +1300,8 @@ TEST_F(StopStringEngineTest, GreedyDraftCountFarExceedingTheBudgetEvaluatesOnlyT
 TEST_F(StopStringEngineTest, DirectRollbackDuringSampledDraftVerificationRestoresControllerAndDrafts) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
   const auto generated_before = request->TurnGeneratedTokens();
@@ -1351,18 +1331,12 @@ TEST_F(StopStringEngineTest, SampledStopTruncationPreservesFutureSampleSequence)
   // more drafts plus a bonus). The retained request's RNG state after rollback must exactly equal
   // a reference request's, which only ever drew the same 2 tokens (1 prefill token, 1 draft) via
   // the very same draft-verification sampling path -- not "advanced as if 4 draws happened".
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-
   // Reference: prefill's own sampled token, then exactly one more draft draw with no bonus (the
   // turn's budget is set to end exactly there), and no stop configured at all.
   auto engine_ref = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine_ref.cache->SetMaxDraftTokensPerStep(3);
-  auto ref = CreateEngineRequest(engine_ref.engine, *params);
-  ref->BeginTurn(Prompt(), std::optional<size_t>{2});
+  auto ref = CreateEngineRequest(engine_ref.engine);
+  ref->BeginTurn(Prompt(), SampledOptions({}, std::optional<size_t>{2}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine_ref.engine->Run(storage), 1u);
 
@@ -1370,8 +1344,8 @@ TEST_F(StopStringEngineTest, SampledStopTruncationPreservesFutureSampleSequence)
   // completes a stop match, discarding 3 later draws made before the match was detected.
   auto engine_spec = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine_spec.cache->SetMaxDraftTokensPerStep(3);
-  auto spec = CreateEngineRequest(engine_spec.engine, *params);
-  spec->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto spec = CreateEngineRequest(engine_spec.engine);
+  spec->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   ASSERT_EQ(engine_spec.engine->Run(storage), 1u);
 
   ref->SetDraftTokens(std::array<int32_t, 1>{7});
@@ -1392,7 +1366,11 @@ TEST_F(StopStringEngineTest, SampledStopTruncationPreservesFutureSampleSequence)
                                        const std::shared_ptr<Request>& request) {
     engine.executor->SetVerifyRowTokens({});
     engine.executor->SetSamplingCandidateTokens({20, 21, 22});
-    request->BeginTurn(std::array<int32_t, 1>{2}, std::optional<size_t>{16});
+    // The same sampled policy again, with no seed so both requests simply continue the streams
+    // their first turns left off at.
+    request->BeginTurn(
+        std::array<int32_t, 1>{2},
+        SampledOptions({}, std::optional<size_t>{16}, std::nullopt));
     std::vector<int32_t> tokens;
     bool done = false;
     while (!done) {
@@ -1424,18 +1402,9 @@ TEST_F(StopStringEngineTest, MixedBatchBothSampledRequestsMatchAtStageZeroTermin
   // observe directly.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  auto make_request = [&](unsigned int seed) {
-    auto p = MakeGreedyParams(*model_);
-    p->search.do_sample = true;
-    p->search.top_k = 3;
-    p->search.temperature = 0.01f;
-    p->search.random_seed = seed;
-    auto r = CreateEngineRequest(engine.engine, *p);
-    r->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto make_request = [&](uint64_t seed) {
+    auto r = CreateEngineRequest(engine.engine);
+    r->BeginTurn(Prompt(), SampledOptions({"STOP"}, std::nullopt, seed));
     return r;
   };
   auto first = make_request(1234);
@@ -1464,7 +1433,7 @@ TEST_F(StopStringEngineTest, StopStringPrecedesTurnLimitForTheSameCompletingDraf
   // token budget; StopString must still be reported, not TurnLimit.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}, std::optional<size_t>{3}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);  // 1 of 3 generated tokens used
@@ -1490,13 +1459,8 @@ TEST_F(StopStringEngineTest, SampledStopStringPrecedesTurnLimitForTheSameComplet
   // disturbing that ordering rather than exercising new precedence logic of its own.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}, std::optional<size_t>{3}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}, std::optional<size_t>{3}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);  // 1 of 3 generated tokens used
 
@@ -1517,9 +1481,9 @@ TEST_F(StopStringEngineTest, SampledStopStringPrecedesTurnLimitForTheSameComplet
 TEST_F(StopStringEngineTest, MixedBatchStopEnabledSpeculativeRequestTruncatesWhileSiblingCommitsNormally) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto stopping = CreateEngineRequest(engine.engine, *model_);
+  auto stopping = CreateEngineRequest(engine.engine);
   stopping->BeginTurn(Prompt(), StopOptions({"STOP"}));
-  auto plain = CreateEngineRequest(engine.engine, *model_);
+  auto plain = CreateEngineRequest(engine.engine);
   plain->BeginTurn(Prompt());
 
   std::array<EngineEvent, 2> prefill;
@@ -1551,7 +1515,7 @@ TEST_F(StopStringEngineTest, MixedBatchStopEnabledSpeculativeRequestTruncatesWhi
 TEST_F(StopStringEngineTest, AcceptedDraftTokenCountAndTelemetryReflectATruncatedGreedyMatch) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -1584,7 +1548,7 @@ TEST_F(StopStringEngineTest, GreedyRejectedDraftReplacementStopTelemetryCountsTh
   // draft to reach it -- evaluated must be accepted + 1 (= 1), not accepted (= 0).
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -1609,13 +1573,8 @@ TEST_F(StopStringEngineTest, SampledRejectedDraftReplacementStopTelemetryCountsT
   // since it falls outside confirmed_draft_counts), so the same accepted + 1 rule applies.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto params = MakeGreedyParams(*model_);
-  params->search.do_sample = true;
-  params->search.top_k = 3;
-  params->search.temperature = 0.01f;
-  params->search.random_seed = 1234;
-  auto request = CreateEngineRequest(engine.engine, *params);
-  request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+  auto request = CreateEngineRequest(engine.engine);
+  request->BeginTurn(Prompt(), SampledOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
 
@@ -1641,7 +1600,7 @@ TEST_F(StopStringEngineTest, SampledRejectedDraftReplacementStopTelemetryCountsT
 TEST_F(StopStringEngineTest, DirectRollbackDuringGreedyDraftVerificationRestoresControllerAndDrafts) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);
@@ -1671,7 +1630,7 @@ TEST_F(StopStringEngineTest, QueuedRollbackDuringGreedyDraftVerificationRestores
   // restore machinery while still exercising Queue*/Complete* (not Restore*) for the draft path.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/5 /* "ST" */);
   engine.cache->SetMaxDraftTokensPerStep(3);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 4> storage;
   ASSERT_EQ(engine.engine->Run(storage), 1u);  // commits "ST"
@@ -1720,9 +1679,9 @@ TEST(StopStringMtpSpeculativeTest, AutomaticMtpDraftsAreProposedForAStopEnabledR
   const int32_t filler = eos == 5 ? 6 : 5;  // never EOS, never matches "UNREACHABLE"
   auto engine = MakeMtpDoublesEngine(model, filler);
 
-  auto stop_request = CreateEngineRequest(engine.engine, *model);
+  auto stop_request = CreateEngineRequest(engine.engine);
   stop_request->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
-  auto plain_request = CreateRequestWithPrompt(engine.engine, *model, Prompt());
+  auto plain_request = CreateRequestWithPrompt(engine.engine, Prompt());
 
   std::array<EngineEvent, 8> storage;
   ASSERT_GT(engine.engine->Run(storage), 0u);
@@ -1737,7 +1696,7 @@ TEST(StopStringMtpSpeculativeTest, StopEnabledRequestThatJustMatchedIsExcludedFr
   auto model = LoadSyntheticPagedMtpModel();
   auto engine = MakeMtpDoublesEngine(model, /*forced_token=*/5 /* "ST" */);
 
-  auto stop_request = CreateEngineRequest(engine.engine, *model);
+  auto stop_request = CreateEngineRequest(engine.engine);
   stop_request->BeginTurn(Prompt(), StopOptions({"STOP"}));
   std::array<EngineEvent, 8> storage;
   ASSERT_GT(engine.engine->Run(storage), 0u);
@@ -1775,7 +1734,7 @@ TEST(StopStringMtpSpeculativeTest, AutomaticMtpProposedDraftItselfCompletesAMidD
   // Every MTP proposal from here on predicts "STOPX" (token 7).
   engine.mtp_executor->SetForcedToken(7);
 
-  auto stop_request = CreateEngineRequest(engine.engine, *model);
+  auto stop_request = CreateEngineRequest(engine.engine);
   stop_request->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 8> storage;
@@ -1826,9 +1785,9 @@ TEST(StopStringMtpSpeculativeTest, PlainSiblingContinuesAutomaticMtpDraftingAcro
   auto engine = MakeMtpDoublesEngine(model, /*forced_token=*/11);
   engine.mtp_executor->SetForcedToken(12);
 
-  auto stop_request = CreateEngineRequest(engine.engine, *model);
+  auto stop_request = CreateEngineRequest(engine.engine);
   stop_request->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
-  auto plain_request = CreateRequestWithPrompt(engine.engine, *model, Prompt());
+  auto plain_request = CreateRequestWithPrompt(engine.engine, Prompt());
 
   std::array<EngineEvent, 8> storage;
   ASSERT_GT(engine.engine->Run(storage), 0u);
@@ -1862,8 +1821,8 @@ TEST_F(StopStringEngineTest, CancelMergesIntoARetainedTokenEventWithoutLeakingAS
   // `plain` is created first so its event drains first (staged_event_order_ follows scheduling
   // order), leaving `stopping`'s token event retained/undrained while `stopping` is still Active.
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/2 /* "A", never matches */);
-  auto plain = CreateEngineRequest(engine.engine, *model_);
-  auto stopping = CreateEngineRequest(engine.engine, *model_);
+  auto plain = CreateEngineRequest(engine.engine);
+  auto stopping = CreateEngineRequest(engine.engine);
   plain->BeginTurn(Prompt());
   stopping->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
 
@@ -1893,7 +1852,7 @@ TEST_F(StopStringEngineTest, CancelMergesIntoARetainedTokenEventWithoutLeakingAS
 // clears an unset (-1) one, which is a no-op.
 TEST_F(StopStringEngineTest, FatalFailurePreservesAnAlreadyCommittedStopMatchOnAnUnrelatedRequest) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/7 /* "STOPX" */);
-  auto completed = CreateEngineRequest(engine.engine, *model_);
+  auto completed = CreateEngineRequest(engine.engine);
   completed->BeginTurn(Prompt(), StopOptions({"STOP"}));
 
   std::array<EngineEvent, 4> storage;
@@ -1905,7 +1864,7 @@ TEST_F(StopStringEngineTest, FatalFailurePreservesAnAlreadyCommittedStopMatchOnA
   ASSERT_EQ(completed->MatchedStopStringIndex(), 0);
 
   // An unrelated request hits a fatal execution failure in a later, separate step.
-  auto executing = CreateEngineRequest(engine.engine, *model_);
+  auto executing = CreateEngineRequest(engine.engine);
   executing->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
   engine.executor->SetForcedToken(2);
   engine.executor->SetNextFailure(ScriptedExecutionFailure::Fatal);
@@ -1923,7 +1882,7 @@ TEST_F(StopStringEngineTest, FatalFailurePreservesAnAlreadyCommittedStopMatchOnA
 
 TEST_F(StopStringEngineTest, UnserviceableStopEnabledRequestPublishesFailure) {
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/2);
-  auto request = CreateEngineRequest(engine.engine, *model_);
+  auto request = CreateEngineRequest(engine.engine);
   request->BeginTurn(Prompt(), StopOptions({"UNREACHABLE"}));
   engine.cache->SetUnserviceableRequest(request);
 

--- a/test/cpp/engine/stop_string_engine_tests.cpp
+++ b/test/cpp/engine/stop_string_engine_tests.cpp
@@ -101,6 +101,7 @@ class NoOpGuidanceProcessor final : public ConstrainedLogitsProcessor {
     committed_tokens.insert(committed_tokens.end(), tokens.begin(), tokens.end());
   }
   void ProcessLogits(DeviceSpan<float>) override {}
+  bool AllowsOnlyTokens(size_t, std::span<const int>) override { return false; }
   void Reset() override {
     committed_tokens.clear();
     ++reset_count;

--- a/test/cpp/engine/turn_policy_tests.cpp
+++ b/test/cpp/engine/turn_policy_tests.cpp
@@ -271,6 +271,53 @@ TEST_F(TurnPolicyTest, GreedyResolutionRejectsContradictoryStochasticScalars) {
   }
 }
 
+TEST_F(TurnPolicyTest, TopKCannotExceedModelVocabulary) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  auto request = CreateEngineRequest(engine.engine);
+  TurnOptions options;
+  options.do_sample = true;
+  options.temperature = 1.0f;
+  options.top_k = model_->config_->model.vocab_size + 1;
+
+  try {
+    request->BeginTurn(Prompt(), options);
+    FAIL() << "Expected top_k above vocab_size to be rejected.";
+  } catch (const std::runtime_error& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("top_k"), std::string::npos) << message;
+    EXPECT_NE(message.find("vocab_size"), std::string::npos) << message;
+  }
+  EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+  EXPECT_EQ(request->CurrentSequenceLength(), 0);
+
+  options.top_k = model_->config_->model.vocab_size;
+  EXPECT_EQ(request->BeginTurn(Prompt(), options), 1u);
+}
+
+TEST_F(TurnPolicyTest, ModelTopKAboveVocabularyNamesTheDefaultAndCanBeOverridden) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  config->search.do_sample = true;
+  config->search.top_k = config->model.vocab_size + 1;
+  auto model = CreateModel(GetOrtEnv(), std::move(config));
+  auto engine = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model));
+  auto request = CreateEngineRequest(engine.engine);
+  TurnOptions options;
+
+  try {
+    request->BeginTurn(Prompt(), options);
+    FAIL() << "Expected a model top_k above vocab_size to be rejected.";
+  } catch (const std::runtime_error& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("model's search.top_k"), std::string::npos) << message;
+    EXPECT_NE(message.find("vocab_size"), std::string::npos) << message;
+  }
+  EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+  EXPECT_EQ(request->CurrentSequenceLength(), 0);
+
+  options.top_k = model->config_->model.vocab_size;
+  EXPECT_EQ(request->BeginTurn(Prompt(), options), 1u);
+}
+
 // A model whose own search defaults resolve to greedy silently overrides an explicit
 // do_sample=true. The caller cannot see those defaults through TurnOptions, so admission rejects
 // the turn and names the model-supplied cause rather than quietly selecting the top logit.
@@ -537,6 +584,67 @@ TEST_F(TurnPolicyTest, OmittedSeedContinuesTheStreamAndAnExplicitSeedRestartsIt)
   EXPECT_EQ(reseeded, seeded_first);
   EXPECT_NE(continued, seeded_first);
 }
+
+#if USE_CUDA
+TEST_F(TurnPolicyTest, CudaGreedyTurnDoesNotAdvanceLaterSampledContinuationRng) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/synthetic-paged");
+  ClearProviders(*config);
+  SetProviderOption(*config, "cuda", {}, {});
+  config->search.random_seed = 1234;
+  auto model = CreateModel(GetOrtEnv(), std::move(config));
+  auto engine = std::make_shared<Engine>(model);
+
+  const auto run_turn = [](Engine& target_engine,
+                           const std::shared_ptr<Request>& request,
+                           std::span<const int32_t> input,
+                           const TurnOptions& options) {
+    request->BeginTurn(input, options);
+    std::vector<int32_t> generated;
+    std::array<EngineEvent, 8> events;
+    for (int step = 0; step < 64 && !request->IsTurnComplete(); ++step) {
+      const size_t count = target_engine.Run(events);
+      for (size_t i = 0; i < count; ++i) {
+        if (events[i].request.get() == request.get() &&
+            (events[i].flags & EngineEventFlagToken)) {
+          generated.push_back(events[i].token);
+        }
+      }
+    }
+    EXPECT_TRUE(request->IsTurnComplete());
+    return generated;
+  };
+
+  const auto original_prompt = Prompt();
+  auto continued_request = CreateEngineRequest(engine);
+  TurnOptions greedy;
+  greedy.max_generated_tokens = 4;
+  const auto greedy_tokens =
+      run_turn(*engine, continued_request, original_prompt, greedy);
+  ASSERT_FALSE(greedy_tokens.empty());
+
+  TurnOptions sampled;
+  sampled.do_sample = true;
+  sampled.top_k = model->config_->model.vocab_size;
+  sampled.temperature = 100.0f;
+  sampled.min_generated_tokens = 12;
+  sampled.max_generated_tokens = 12;
+  constexpr std::array<int32_t, 1> continuation_input{9};
+  const auto continued =
+      run_turn(*engine, continued_request, continuation_input, sampled);
+
+  std::vector<int32_t> equivalent_prompt = original_prompt;
+  equivalent_prompt.insert(equivalent_prompt.end(), greedy_tokens.begin(),
+                           greedy_tokens.end());
+  equivalent_prompt.insert(equivalent_prompt.end(), continuation_input.begin(),
+                           continuation_input.end());
+  auto baseline_request = CreateEngineRequest(engine);
+  const auto baseline =
+      run_turn(*engine, baseline_request, equivalent_prompt, sampled);
+
+  ASSERT_FALSE(continued.empty());
+  EXPECT_EQ(continued, baseline);
+}
+#endif
 
 // A step that is rolled back after the reseed was applied must reseed its retry identically, so the
 // turn's output does not depend on how many times the batch was aborted.

--- a/test/cpp/engine/turn_policy_tests.cpp
+++ b/test/cpp/engine/turn_policy_tests.cpp
@@ -1,0 +1,704 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for the per-turn generation policy: how each turn resolves its own policy from model
+// defaults plus explicit overrides, which combinations admission rejects before mutating anything,
+// and how the turn seed drives the Request's random streams across turns and rollbacks.
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "engine_test_doubles.h"
+#include "engine_test_helpers.h"
+#include "engine/turn_policy.h"
+
+namespace Generators {
+namespace test {
+namespace {
+
+std::vector<int32_t> Prompt() { return {2, 3, 4}; }
+
+// Three equally likely candidates, so a sampled turn's output is decided entirely by the random
+// stream while a greedy turn deterministically takes the lowest-indexed maximum.
+constexpr std::array<int32_t, 3> kSamplingCandidates{20, 21, 22};
+
+// Reports a different scoring device type while delegating every real operation to the model's own
+// device, so a capability keyed by device type can be exercised on a CPU-only machine.
+class ScoringDeviceTypeOverride final : public DeviceInterface {
+ public:
+  ScoringDeviceTypeOverride(DeviceInterface& inner, DeviceType type)
+      : inner_{inner}, type_{type} {}
+
+  DeviceType GetType() const override { return type_; }
+  void InitOrt(const OrtApi& api, Ort::Allocator& allocator) override {
+    inner_.InitOrt(api, allocator);
+  }
+  Ort::Allocator& GetAllocator() override { return inner_.GetAllocator(); }
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return inner_.GetMemoryInfo();
+  }
+  std::string GetExecutionProviderName() const override {
+    return inner_.GetExecutionProviderName();
+  }
+  std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
+    return inner_.AllocateBase(size);
+  }
+  std::shared_ptr<DeviceBuffer> WrapMemoryBase(void* memory, size_t size) override {
+    return inner_.WrapMemoryBase(memory, size);
+  }
+  std::unique_ptr<Search> CreateGreedy(const GeneratorParams& params) override {
+    return inner_.CreateGreedy(params);
+  }
+  std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override {
+    return inner_.CreateBeam(params);
+  }
+  std::unique_ptr<KeyValueCache> CreateKeyValueCache(State& state) override {
+    return inner_.CreateKeyValueCache(state);
+  }
+  void Synchronize() override { inner_.Synchronize(); }
+
+ private:
+  DeviceInterface& inner_;
+  DeviceType type_;
+};
+
+TurnOptions SampledTurn(std::optional<uint64_t> seed, size_t max_generated_tokens) {
+  TurnOptions options;
+  options.do_sample = true;
+  options.top_k = 3;
+  options.temperature = 1.0f;
+  options.seed = seed;
+  options.max_generated_tokens = max_generated_tokens;
+  return options;
+}
+
+class TurnPolicyTest : public ::testing::Test {
+ protected:
+  void SetUp() override { model_ = LoadDummyDecoderModel(); }
+
+  // Runs one whole turn and returns the tokens it generated. The step bound keeps a regression
+  // that stops completing turns from hanging the suite.
+  std::vector<int32_t> RunTurn(DoublesEngine& engine,
+                               const std::shared_ptr<Request>& request,
+                               std::span<const int32_t> tokens,
+                               const TurnOptions& options) {
+    request->BeginTurn(tokens, options);
+    std::vector<int32_t> generated;
+    std::array<EngineEvent, 8> storage;
+    for (int step = 0; step < 64 && !request->IsTurnComplete(); ++step) {
+      const size_t count = engine.engine->Run(storage);
+      for (size_t i = 0; i < count; ++i) {
+        if (storage[i].flags & EngineEventFlagToken) {
+          generated.push_back(storage[i].token);
+        }
+      }
+    }
+    EXPECT_TRUE(request->IsTurnComplete());
+    return generated;
+  }
+
+  std::shared_ptr<Model> model_;
+};
+
+// The capability predicate exists so an unsupported no_repeat_ngram_size is refused at admission
+// instead of throwing after the model has already run. Verifying that means exercising both sides:
+// the CPU search really does suppress a repeated n-gram, and a scoring device whose search does not
+// implement it never gets the chance to try.
+TEST_F(TurnPolicyTest, NoRepeatNgramSuppressesRepeatsOnCpuAndIsRejectedElsewhere) {
+  constexpr int32_t kForcedToken = 5;
+  ASSERT_NE(kForcedToken, EosToken(*model_));
+
+  const auto run_with_ngram_size = [&](std::optional<int> no_repeat_ngram_size) {
+    auto engine = MakeDoublesEngine(model_, /*capacity=*/8, kForcedToken);
+    auto request = CreateEngineRequest(engine.engine);
+    TurnOptions options;
+    options.max_generated_tokens = 3;
+    options.no_repeat_ngram_size = no_repeat_ngram_size;
+    return RunTurn(engine, request, Prompt(), options);
+  };
+
+  // Without it the scripted logits force the same token every step.
+  EXPECT_EQ(run_with_ngram_size(std::nullopt),
+            std::vector<int32_t>(3, kForcedToken));
+
+  // With it the CPU search bans the token that would repeat the trailing bigram, so the third step
+  // has to select something else even though the forced token still has the highest raw logit.
+  const auto suppressed = run_with_ngram_size(2);
+  ASSERT_EQ(suppressed.size(), 3u);
+  EXPECT_EQ(suppressed[0], kForcedToken);
+  EXPECT_EQ(suppressed[1], kForcedToken);
+  EXPECT_NE(suppressed[2], kForcedToken);
+
+  // A scoring device whose Search leaves ApplyNoRepeatNgram unimplemented is rejected at admission,
+  // before the Request is mutated, so the same Request is still usable without the option.
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, kForcedToken);
+  auto request = CreateEngineRequest(engine.engine);
+  ScoringDeviceTypeOverride device{*model_->p_device_scoring_, DeviceType::CUDA};
+  ScopedScoringDevice scoped_device{*model_, device};
+  ASSERT_FALSE(SupportsNoRepeatNgram(DeviceType::CUDA));
+
+  TurnOptions options;
+  options.no_repeat_ngram_size = 2;
+  options.max_generated_tokens = 3;
+  try {
+    request->BeginTurn(Prompt(), options);
+    FAIL() << "Expected no_repeat_ngram_size to be rejected on this scoring device.";
+  } catch (const std::runtime_error& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("no_repeat_ngram_size"), std::string::npos) << message;
+    EXPECT_NE(message.find("scoring device"), std::string::npos) << message;
+  }
+  EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+  EXPECT_EQ(request->CurrentSequenceLength(), 0);
+
+  options.no_repeat_ngram_size.reset();
+  EXPECT_EQ(request->BeginTurn(Prompt(), options), 1u);
+}
+
+// Under any greedy resolution, a scalar that is itself a request for greedy selection, or that
+// restricts nothing, is honored exactly as written rather than rejected.
+TEST_F(TurnPolicyTest, GreedyResolutionAcceptsConsistentAndNeutralScalars) {
+  const auto run_greedy_turn = [&](const TurnOptions& turn_options) {
+    auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+    engine.executor->SetSamplingCandidateTokens(
+        {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+    auto request = CreateEngineRequest(engine.engine);
+    TurnOptions options = turn_options;
+    options.max_generated_tokens = 4;
+    const auto generated = RunTurn(engine, request, Prompt(), options);
+    // Every candidate has the same logit, so only top-logit selection produces the lowest index
+    // four times in a row.
+    EXPECT_EQ(generated, std::vector<int32_t>(4, kSamplingCandidates.front()));
+  };
+
+  {
+    // top_k == 1 on its own asks for greedy selection.
+    TurnOptions options;
+    options.top_k = 1;
+    run_greedy_turn(options);
+  }
+  {
+    // temperature == 0 on its own asks for greedy selection.
+    TurnOptions options;
+    options.temperature = 0.0f;
+    run_greedy_turn(options);
+  }
+  {
+    // Two consistent ways of saying the same thing.
+    TurnOptions options;
+    options.do_sample = false;
+    options.top_k = 1;
+    run_greedy_turn(options);
+  }
+  {
+    TurnOptions options;
+    options.do_sample = false;
+    options.temperature = 0.0f;
+    run_greedy_turn(options);
+  }
+  {
+    // top_p == 1 and top_k == 0 restrict nothing, so neither contradicts top-logit selection.
+    TurnOptions options;
+    options.do_sample = false;
+    options.top_p = 1.0f;
+    options.top_k = 0;
+    run_greedy_turn(options);
+  }
+  {
+    // An explicit sampling request that its own scalars override is still coherent.
+    TurnOptions options;
+    options.do_sample = true;
+    options.top_k = 1;
+    options.temperature = 0.0f;
+    run_greedy_turn(options);
+  }
+}
+
+// A scalar that only makes sense for a distribution the turn will never draw from is a caller
+// mistake, and it is rejected before the Request is touched.
+TEST_F(TurnPolicyTest, GreedyResolutionRejectsContradictoryStochasticScalars) {
+  const auto expect_rejected = [&](const TurnOptions& turn_options,
+                                   std::string_view named_option) {
+    auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+    auto request = CreateEngineRequest(engine.engine);
+    try {
+      request->BeginTurn(Prompt(), turn_options);
+      FAIL() << "Expected a contradictory greedy policy to be rejected.";
+    } catch (const std::runtime_error& error) {
+      const std::string message = error.what();
+      EXPECT_NE(message.find("top logit"), std::string::npos) << message;
+      EXPECT_NE(message.find(named_option), std::string::npos) << message;
+    }
+    EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+    EXPECT_EQ(request->CurrentSequenceLength(), 0);
+
+    // The rejection mutated nothing, so an ordinary turn still admits on the same Request.
+    EXPECT_EQ(request->BeginTurn(Prompt(), TurnOptions{}), 1u);
+  };
+
+  {
+    TurnOptions options;
+    options.do_sample = false;
+    options.temperature = 0.7f;
+    expect_rejected(options, "temperature");
+  }
+  {
+    TurnOptions options;
+    options.do_sample = true;
+    options.top_k = 1;
+    options.top_p = 0.9f;
+    expect_rejected(options, "top_p");
+  }
+  {
+    TurnOptions options;
+    options.do_sample = false;
+    options.top_k = 40;
+    expect_rejected(options, "top_k");
+  }
+  {
+    TurnOptions options;
+    options.do_sample = true;
+    options.temperature = 0.0f;
+    options.top_k = 40;
+    expect_rejected(options, "top_k");
+  }
+}
+
+// A model whose own search defaults resolve to greedy silently overrides an explicit
+// do_sample=true. The caller cannot see those defaults through TurnOptions, so admission rejects
+// the turn and names the model-supplied cause rather than quietly selecting the top logit.
+TEST_F(TurnPolicyTest, ExplicitDoSampleIsRejectedWhenAModelDefaultForcesGreedy) {
+  const auto load_model = [](int top_k, float temperature) {
+    auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+    config->search.top_k = top_k;
+    config->search.temperature = temperature;
+    return CreateModel(GetOrtEnv(), std::move(config));
+  };
+
+  const auto expect_rejected = [&](const std::shared_ptr<Model>& model,
+                                   const std::vector<std::string>& named_defaults) {
+    auto engine = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model));
+    auto request = CreateEngineRequest(engine.engine);
+    TurnOptions options;
+    options.do_sample = true;
+    try {
+      request->BeginTurn(Prompt(), options);
+      FAIL() << "Expected an explicit do_sample=true to be rejected.";
+    } catch (const std::runtime_error& error) {
+      const std::string message = error.what();
+      EXPECT_NE(message.find("do_sample=true"), std::string::npos) << message;
+      for (const auto& named_default : named_defaults) {
+        EXPECT_NE(message.find(named_default), std::string::npos) << message;
+      }
+    }
+    // Nothing was mutated, so the same Request still admits an ordinary turn.
+    EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+    EXPECT_EQ(request->CurrentSequenceLength(), 0);
+    EXPECT_EQ(request->BeginTurn(Prompt(), TurnOptions{}), 1u);
+  };
+
+  // Either model default is enough on its own, and a model that supplies both is named for both.
+  expect_rejected(load_model(/*top_k=*/1, /*temperature=*/1.0f), {"search.top_k = 1"});
+  expect_rejected(load_model(/*top_k=*/50, /*temperature=*/0.0f), {"search.temperature = 0"});
+  expect_rejected(load_model(/*top_k=*/1, /*temperature=*/0.0f),
+                  {"search.top_k = 1", "search.temperature = 0"});
+}
+
+// The way out is to override the field the model set, which is exactly what the rejection asks for.
+TEST_F(TurnPolicyTest, OverridingTheModelGreedyDefaultSamplesTheTurn) {
+  const auto run_sampled_turn = [&](int model_top_k, float model_temperature,
+                                    const TurnOptions& overrides) {
+    auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+    config->search.top_k = model_top_k;
+    config->search.temperature = model_temperature;
+    auto model = CreateModel(GetOrtEnv(), std::move(config));
+    auto engine = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model));
+    engine.executor->SetSamplingCandidateTokens(
+        {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+    auto request = CreateEngineRequest(engine.engine);
+    TurnOptions options = overrides;
+    options.do_sample = true;
+    options.seed = uint64_t{7};
+    options.max_generated_tokens = 8;
+    const auto generated = RunTurn(engine, request, Prompt(), options);
+    // Every candidate has the same logit, so only a sampled turn deviates from the lowest index.
+    EXPECT_EQ(generated.size(), 8u);
+    EXPECT_NE(generated, std::vector<int32_t>(8, kSamplingCandidates.front()));
+  };
+
+  {
+    // The model pins top_k to 1; the turn has to name top_k itself to sample.
+    TurnOptions overrides;
+    overrides.top_k = 3;
+    run_sampled_turn(/*model_top_k=*/1, /*model_temperature=*/1.0f, overrides);
+  }
+  {
+    // The model pins temperature to 0; the turn has to name temperature itself.
+    TurnOptions overrides;
+    overrides.temperature = 1.0f;
+    run_sampled_turn(/*model_top_k=*/3, /*model_temperature=*/0.0f, overrides);
+  }
+}
+
+// A caller who spells greedy out on the turn has chosen it, so do_sample=true alongside it is the
+// same coherent combination it is on a model with ordinary sampling defaults.
+TEST_F(TurnPolicyTest, ExplicitGreedySpellingIsAcceptedOnAGreedyModel) {
+  const auto run_greedy_turn = [&](int model_top_k, float model_temperature,
+                                   const TurnOptions& turn_options) {
+    auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+    config->search.top_k = model_top_k;
+    config->search.temperature = model_temperature;
+    auto model = CreateModel(GetOrtEnv(), std::move(config));
+    auto engine = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model));
+    engine.executor->SetSamplingCandidateTokens(
+        {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+    auto request = CreateEngineRequest(engine.engine);
+    TurnOptions options = turn_options;
+    options.max_generated_tokens = 4;
+    const auto generated = RunTurn(engine, request, Prompt(), options);
+    EXPECT_EQ(generated, std::vector<int32_t>(4, kSamplingCandidates.front()));
+  };
+
+  {
+    // do_sample=true with the caller's own top_k of 1: the model default is not what decided this.
+    TurnOptions options;
+    options.do_sample = true;
+    options.top_k = 1;
+    run_greedy_turn(/*model_top_k=*/1, /*model_temperature=*/1.0f, options);
+  }
+  {
+    TurnOptions options;
+    options.do_sample = true;
+    options.temperature = 0.0f;
+    run_greedy_turn(/*model_top_k=*/50, /*model_temperature=*/0.0f, options);
+  }
+  {
+    // Not asking to sample at all leaves the model's greedy defaults entirely uncontroversial.
+    run_greedy_turn(/*model_top_k=*/1, /*model_temperature=*/1.0f, TurnOptions{});
+    TurnOptions options;
+    options.do_sample = false;
+    run_greedy_turn(/*model_top_k=*/50, /*model_temperature=*/0.0f, options);
+  }
+}
+
+// Temperature 1 rescales nothing, exactly like top_p 1 and top_k 0, so it is neutral under a greedy
+// resolution rather than a request for a distribution the turn will never draw from.
+TEST_F(TurnPolicyTest, GreedyResolutionAcceptsNeutralTemperature) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  engine.executor->SetSamplingCandidateTokens(
+      {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+  auto request = CreateEngineRequest(engine.engine);
+
+  TurnOptions options;
+  options.do_sample = false;
+  options.temperature = 1.0f;
+  options.max_generated_tokens = 4;
+  const auto generated = RunTurn(engine, request, Prompt(), options);
+  EXPECT_EQ(generated, std::vector<int32_t>(4, kSamplingCandidates.front()));
+}
+
+TEST_F(TurnPolicyTest, UnsetOptionsResolveToModelDefaults) {
+  const auto& defaults = model_->config_->search;
+  const auto policy = ResolveTurnPolicy(defaults, TurnOptions{});
+
+  EXPECT_EQ(policy.do_sample, defaults.do_sample);
+  EXPECT_EQ(policy.temperature, defaults.temperature);
+  EXPECT_EQ(policy.top_p, defaults.top_p);
+  EXPECT_EQ(policy.top_k, defaults.top_k);
+  EXPECT_EQ(policy.repetition_penalty, defaults.repetition_penalty);
+  EXPECT_EQ(policy.no_repeat_ngram_size, defaults.no_repeat_ngram_size);
+  // Turn-relative limits have no model default at all.
+  EXPECT_EQ(policy.min_generated_tokens, 0u);
+  EXPECT_FALSE(policy.max_generated_tokens.has_value());
+}
+
+TEST_F(TurnPolicyTest, ResetRestoresEveryOptionToUnset) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  auto request = CreateEngineRequest(engine.engine);
+
+  TurnOptions options;
+  options.request = request;
+  options.do_sample = true;
+  options.temperature = 0.5f;
+  options.top_p = 0.9f;
+  options.top_k = 7;
+  options.repetition_penalty = 1.5f;
+  options.no_repeat_ngram_size = 3;
+  options.min_generated_tokens = 2;
+  options.max_generated_tokens = 5;
+  options.seed = 0u;
+  options.stop_strings = {"STOP"};
+  options.guidance_type = "regex";
+  options.guidance_data = "[0-9]+";
+
+  options.Reset();
+
+  EXPECT_EQ(options.request.lock(), request);
+  EXPECT_FALSE(options.do_sample.has_value());
+  EXPECT_FALSE(options.temperature.has_value());
+  EXPECT_FALSE(options.top_p.has_value());
+  EXPECT_FALSE(options.top_k.has_value());
+  EXPECT_FALSE(options.repetition_penalty.has_value());
+  EXPECT_FALSE(options.no_repeat_ngram_size.has_value());
+  EXPECT_FALSE(options.min_generated_tokens.has_value());
+  EXPECT_FALSE(options.max_generated_tokens.has_value());
+  EXPECT_FALSE(options.seed.has_value());
+  EXPECT_TRUE(options.stop_strings.empty());
+  EXPECT_TRUE(options.guidance_type.empty());
+  EXPECT_TRUE(options.guidance_data.empty());
+}
+
+// Policy never carries over: a turn that overrides nothing decodes with the model's own defaults
+// again, even directly after a turn that overrode everything.
+TEST_F(TurnPolicyTest, PolicyIsResolvedAfreshForEveryTurn) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  engine.executor->SetSamplingCandidateTokens(
+      {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+  auto request = CreateEngineRequest(engine.engine);
+
+  const auto sampled = RunTurn(engine, request, Prompt(),
+                               SampledTurn(/*seed=*/uint64_t{7}, /*max_generated_tokens=*/6));
+  ASSERT_EQ(sampled.size(), 6u);
+  EXPECT_NE(sampled, std::vector<int32_t>(6, kSamplingCandidates.front()));
+
+  TurnOptions defaults;
+  defaults.max_generated_tokens = 6;
+  const auto greedy = RunTurn(engine, request, std::array<int32_t, 1>{5}, defaults);
+
+  // The model's search defaults are greedy, so every step takes the same lowest-indexed maximum.
+  EXPECT_EQ(greedy, std::vector<int32_t>(6, kSamplingCandidates.front()));
+}
+
+TEST_F(TurnPolicyTest, SameSeedReproducesTheSameSampledTurn) {
+  const auto sample_with_seed = [&](uint64_t seed) {
+    auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+    engine.executor->SetSamplingCandidateTokens(
+        {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+    auto request = CreateEngineRequest(engine.engine);
+    return RunTurn(engine, request, Prompt(),
+                   SampledTurn(seed, /*max_generated_tokens=*/8));
+  };
+
+  // Zero is an ordinary deterministic seed, and a seed with a nonzero high half -- which the
+  // classic int seed could never express -- is too.
+  for (const uint64_t seed : {uint64_t{0}, uint64_t{1234},
+                              uint64_t{0x1234'5678'9abc'def0}}) {
+    const auto first = sample_with_seed(seed);
+    ASSERT_EQ(first.size(), 8u);
+    EXPECT_EQ(sample_with_seed(seed), first);
+  }
+}
+
+TEST_F(TurnPolicyTest, FullWidthSeedsAreDistinctFromTheirLowHalf) {
+  const auto sample_with_seed = [&](uint64_t seed) {
+    auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+    engine.executor->SetSamplingCandidateTokens(
+        {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+    auto request = CreateEngineRequest(engine.engine);
+    return RunTurn(engine, request, Prompt(),
+                   SampledTurn(seed, /*max_generated_tokens=*/12));
+  };
+
+  constexpr uint64_t low_half = 0x9abc'def0;
+  EXPECT_NE(sample_with_seed(low_half | (uint64_t{0x1234'5678} << 32)),
+            sample_with_seed(low_half));
+}
+
+// An omitted seed continues the stream the previous turn left off at; reusing an explicitly seeded
+// options object deliberately restarts it.
+TEST_F(TurnPolicyTest, OmittedSeedContinuesTheStreamAndAnExplicitSeedRestartsIt) {
+  const auto run_two_turns = [&](std::optional<uint64_t> second_turn_seed) {
+    auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+    engine.executor->SetSamplingCandidateTokens(
+        {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+    auto request = CreateEngineRequest(engine.engine);
+    auto first = RunTurn(engine, request, Prompt(),
+                         SampledTurn(uint64_t{99}, /*max_generated_tokens=*/8));
+    auto second = RunTurn(engine, request, std::array<int32_t, 1>{5},
+                          SampledTurn(second_turn_seed, /*max_generated_tokens=*/8));
+    return std::pair{std::move(first), std::move(second)};
+  };
+
+  const auto [seeded_first, continued] = run_two_turns(std::nullopt);
+  const auto [reseeded_first, reseeded] = run_two_turns(uint64_t{99});
+
+  ASSERT_EQ(seeded_first.size(), 8u);
+  // Both runs start identically, which is what makes the second turns comparable.
+  EXPECT_EQ(reseeded_first, seeded_first);
+  // Reseeding with the first turn's seed restarts that exact stream, so the reseeded second turn
+  // reproduces the first turn's draws while the continued one does not.
+  EXPECT_EQ(reseeded, seeded_first);
+  EXPECT_NE(continued, seeded_first);
+}
+
+// A step that is rolled back after the reseed was applied must reseed its retry identically, so the
+// turn's output does not depend on how many times the batch was aborted.
+TEST_F(TurnPolicyTest, RolledBackStepReseedsTheRetryIdentically) {
+  const auto run_with_injected_abort = [&](bool inject_abort) {
+    auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+    engine.executor->SetSamplingCandidateTokens(
+        {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+    auto request = CreateEngineRequest(engine.engine);
+    auto options = SampledTurn(uint64_t{31337}, /*max_generated_tokens=*/8);
+    options.request = request;
+    request->BeginTurn(Prompt(), options);
+
+    if (inject_abort) {
+      // Fails inside the transaction's post-processing, after the pending reseed has already been
+      // applied to the Request's stream and before anything is staged.
+      engine.executor->SetNextFailure(ScriptedExecutionFailure::PostProcessing);
+      const auto aborted = RunOne(*engine.engine);
+      EXPECT_EQ(aborted.flags, EngineEventFlagRetryable);
+      EXPECT_EQ(request->TurnGeneratedTokens(), 0u);
+      // Rollback rewound the stream the reseed had already restarted, so the reseed is still
+      // pending and the retry applies it again.
+      EXPECT_TRUE(request->HasPendingTurnSeed());
+    }
+
+    std::vector<int32_t> generated;
+    std::array<EngineEvent, 8> storage;
+    for (int step = 0; step < 64 && !request->IsTurnComplete(); ++step) {
+      const size_t count = engine.engine->Run(storage);
+      for (size_t i = 0; i < count; ++i) {
+        if (storage[i].flags & EngineEventFlagToken) {
+          generated.push_back(storage[i].token);
+        }
+      }
+    }
+    EXPECT_TRUE(request->IsTurnComplete());
+    return generated;
+  };
+
+  const auto without_abort = run_with_injected_abort(false);
+  ASSERT_EQ(without_abort.size(), 8u);
+  EXPECT_EQ(run_with_injected_abort(true), without_abort);
+}
+
+// A turn that ends before a sampling step commits takes its reseed with it: the durable basis is
+// untouched, so the Request continues exactly the stream it was on.
+TEST_F(TurnPolicyTest, CanceledTurnDiscardsItsPendingReseed) {
+  // The model fixes the seed basis so two independent Requests start on the same stream; an
+  // unseeded Request draws a 64-bit basis instead, which is deliberately not reproducible.
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  config->search.random_seed = 4321;
+  auto model = CreateModel(GetOrtEnv(), std::move(config));
+
+  const auto run_after_canceled_turn = [&](std::optional<uint64_t> canceled_turn_seed) {
+    auto engine = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model));
+    engine.executor->SetSamplingCandidateTokens(
+        {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+    auto request = CreateEngineRequest(engine.engine);
+
+    auto canceled = SampledTurn(canceled_turn_seed, /*max_generated_tokens=*/8);
+    canceled.request = request;
+    const uint64_t turn_id = request->BeginTurn(Prompt(), canceled);
+    EXPECT_TRUE(request->Cancel(turn_id));
+    // Drain the cancellation so the Request is ready for another turn. Nothing was sampled.
+    while (engine.engine->HasPendingRequests()) {
+      static_cast<void>(RunOne(*engine.engine));
+    }
+    EXPECT_EQ(request->FinishReason(), GenerationFinishReason::Canceled);
+    EXPECT_EQ(request->TurnGeneratedTokens(), 0u);
+    // The canceled turn took its reseed with it instead of leaving it to be applied, or promoted,
+    // by whatever runs next.
+    EXPECT_FALSE(request->HasPendingTurnSeed());
+
+    return RunTurn(engine, request, std::array<int32_t, 1>{5},
+                   SampledTurn(std::nullopt, /*max_generated_tokens=*/8));
+  };
+
+  const auto after_seeded_cancel = run_after_canceled_turn(uint64_t{99});
+  ASSERT_EQ(after_seeded_cancel.size(), 8u);
+  // Identical to the run where the canceled turn never asked for a seed at all: the discarded
+  // reseed neither advanced nor replaced the Request's durable basis.
+  EXPECT_EQ(after_seeded_cancel, run_after_canceled_turn(std::nullopt));
+
+  // And the Request is still perfectly seedable afterwards.
+  auto engine = MakeDoublesEngine(model, /*capacity=*/8, EosToken(*model));
+  engine.executor->SetSamplingCandidateTokens(
+      {kSamplingCandidates.begin(), kSamplingCandidates.end()});
+  auto request = CreateEngineRequest(engine.engine);
+  const auto seeded = RunTurn(engine, request, Prompt(),
+                              SampledTurn(uint64_t{99}, /*max_generated_tokens=*/8));
+  EXPECT_NE(seeded, after_seeded_cancel);
+}
+
+TEST_F(TurnPolicyTest, MinGeneratedTokensMasksEndOfSequence) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  auto request = CreateEngineRequest(engine.engine);
+
+  TurnOptions options;
+  options.min_generated_tokens = 3;
+  options.max_generated_tokens = 3;
+  // The executor forces the end-of-stream token every step; the floor must keep the turn running
+  // until it has generated three tokens anyway.
+  const auto generated = RunTurn(engine, request, Prompt(), options);
+
+  EXPECT_EQ(generated.size(), 3u);
+  EXPECT_EQ(request->FinishReason(), GenerationFinishReason::TurnLimit);
+  for (const int32_t token : generated) {
+    EXPECT_NE(token, EosToken(*model_));
+  }
+
+  // The floor is turn-scoped: the next turn stops on the very first forced end-of-stream token.
+  const auto next = RunTurn(engine, request, std::array<int32_t, 1>{5}, TurnOptions{});
+  EXPECT_TRUE(next.empty());
+  EXPECT_EQ(request->FinishReason(), GenerationFinishReason::EosToken);
+}
+
+TEST_F(TurnPolicyTest, UnsatisfiableMinimumIsRejectedBeforeMutation) {
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, EosToken(*model_));
+  const auto prompt = Prompt();
+  auto request =
+      CreateEngineRequest(engine.engine, /*max_session_tokens=*/prompt.size() + 2);
+
+  TurnOptions options;
+  options.min_generated_tokens = 3;
+  EXPECT_THROW(request->BeginTurn(prompt, options), std::runtime_error);
+  EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+  EXPECT_EQ(request->CurrentSequenceLength(), 0);
+
+  // The Request is untouched, so a satisfiable minimum still admits normally.
+  options.min_generated_tokens = 2;
+  EXPECT_EQ(request->BeginTurn(prompt, options), 1u);
+}
+
+TEST_F(TurnPolicyTest, StaticEngineRejectsATurnSeedBeforeMutation) {
+  auto config = CreateConfig(GetOrtEnv(), MODEL_PATH "engine/dummy-decoder");
+  config->engine.dynamic_batching.reset();
+  auto model = CreateModel(GetOrtEnv(), std::move(config));
+  auto cache = std::make_shared<RecordingCacheManager>(
+      model, /*capacity=*/8, /*trace=*/nullptr, /*supports_dynamic_batching=*/false);
+  EngineDependencies dependencies{
+      cache, Scheduler::Create(model, cache),
+      std::make_unique<RecordingModelExecutor>(model, cache, EosToken(*model))};
+  auto engine = std::make_shared<Engine>(model, std::move(dependencies));
+  auto request = engine->CreateRequest();
+
+  TurnOptions options;
+  options.seed = 1234u;
+  try {
+    request->BeginTurn(Prompt(), options);
+    FAIL() << "Expected a per-turn seed to be rejected on a static Engine.";
+  } catch (const std::runtime_error& error) {
+    EXPECT_NE(std::string(error.what()).find("dynamic batching"), std::string::npos);
+  }
+  EXPECT_EQ(request->Status(), RequestStatus::Unassigned);
+  EXPECT_EQ(request->CurrentSequenceLength(), 0);
+
+  // Everything the static path does support still admits on the same untouched Request.
+  options.seed.reset();
+  options.max_generated_tokens = 1;
+  EXPECT_EQ(request->BeginTurn(Prompt(), options), 1u);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace Generators

--- a/test/cpp/search_checkpoint_tests.cpp
+++ b/test/cpp/search_checkpoint_tests.cpp
@@ -253,6 +253,43 @@ TEST_F(CudaSearchCheckpointTest, BatchedSamplerRollbackRestoresRequestRandomStat
             std::vector<int32_t>(first.begin(), first.end()));
 }
 
+// A per-turn reseed restarts an existing state's stream in place. The pooled index is not publicly
+// observable, so the contract is checked the way callers experience it: reseeding with the original
+// seed reproduces the original draw on the very same state object.
+TEST_F(CudaSearchCheckpointTest, ReseedStateRestartsTheStreamInPlace) {
+  auto sampler = model->p_device_scoring_->CreateBatchedSampler(
+      1, params->config.model.vocab_size);
+  ASSERT_NE(sampler, nullptr);
+
+  // A seed with a nonzero high half is accepted too; the classic int seed could never express one.
+  constexpr uint64_t seed = 0x1234'5678'9abc'def0ull;
+  auto state = sampler->CreateState(seed);
+  std::array<BatchedSamplerState*, 1> states{state.get()};
+  std::array<BatchedSamplingParams, 1> sampling_params{
+      BatchedSamplingParams{3, 1.0f, 1.0f}};
+
+  auto scores = params->p_device->Allocate<float>(4);
+  const std::array<float, 4> score_values{1.0f, 1.0f, 1.0f, -100.0f};
+  const auto sample_once = [&] {
+    std::copy(score_values.begin(), score_values.end(), scores.CpuSpan().begin());
+    scores.CopyCpuToDevice();
+    std::array<DeviceSpan<float>, 1> rows{scores.subspan(0, 4)};
+    auto tokens = sampler->Sample(
+        rows, sampling_params, states, params->config.model.vocab_size);
+    const auto host = tokens.CopyDeviceToCpu();
+    return std::vector<int32_t>(host.begin(), host.end());
+  };
+
+  const auto first = sample_once();
+  const auto advanced = sample_once();
+
+  sampler->ReseedState(*state, seed);
+  EXPECT_EQ(sample_once(), first);
+
+  // The same state object is still usable and still advances afterwards.
+  EXPECT_EQ(sample_once(), advanced);
+}
+
 TEST_F(CudaSearchCheckpointTest, ExternalSamplingRollbackRestoresSearchTailState) {
   auto external_params = CreateGeneratorParams(*model);
   external_params->search.batch_size = 1;

--- a/test/python/integration/test_integration_engine.py
+++ b/test/python/integration/test_integration_engine.py
@@ -72,20 +72,18 @@ def bundle(device, paged_model_path) -> _Bundle:
     return _Bundle(model=model, tokenizer=tokenizer, config=cfg, device=device)
 
 
-def _greedy_params(model: og.Model, prompt_len: int, max_new_tokens: int, min_new_tokens: int) -> og.GeneratorParams:
-    params = og.GeneratorParams(model)
-    options = {"do_sample": False, "max_length": prompt_len + max_new_tokens}
-    if min_new_tokens:
-        options["min_length"] = prompt_len + min_new_tokens
-    params.set_search_options(**options)
-    return params
-
-
-def _create_request(engine, model, prompt_tokens, max_new_tokens, sink, sinks, *, min_new_tokens=0):
-    params = _greedy_params(model, len(prompt_tokens), max_new_tokens, min_new_tokens)
-    request = engine.create_request(params)
+def _create_request(engine, prompt_tokens, max_new_tokens, sink, sinks, *, min_new_tokens=0):
+    # The session limit is resident-Request policy; the generation floor is per turn.
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(prompt_tokens) + max_new_tokens)
+    request = engine.create_request(options=request_options)
     sinks[request] = sink
-    request.begin_turn(np.asarray(prompt_tokens, dtype=np.int32))
+    turn_options = og.TurnOptions(request)
+    turn_options.set_do_sample(False)
+    turn_options.set_max_generated_tokens(max_new_tokens)
+    if min_new_tokens:
+        turn_options.set_min_generated_tokens(min_new_tokens)
+    request.begin_turn(np.asarray(prompt_tokens, dtype=np.int32), turn_options)
     return request
 
 
@@ -124,7 +122,7 @@ def _generate_isolated(model, prompt_tokens, max_new_tokens, *, min_new_tokens=0
     sink = _Sink()
     engine = og.Engine(model)
     sinks = {}
-    _create_request(engine, model, prompt_tokens, max_new_tokens, sink, sinks, min_new_tokens=min_new_tokens)
+    _create_request(engine, prompt_tokens, max_new_tokens, sink, sinks, min_new_tokens=min_new_tokens)
     _run(engine, sinks)
     del engine
     gc.collect()
@@ -183,7 +181,7 @@ def test_simultaneous_requests(bundle):
     sinks = [_Sink() for _ in _PROMPTS]
     sinks_by_request = {}
     requests = [
-        _create_request(engine, bundle.model, bundle.tokenizer.encode(p), max_new, sink, sinks_by_request)
+        _create_request(engine, bundle.tokenizer.encode(p), max_new, sink, sinks_by_request)
         for p, sink in zip(_PROMPTS, sinks, strict=True)
     ]
     assert engine.has_pending_requests()
@@ -206,7 +204,7 @@ def test_staggered_admission(bundle):
 
     sink_a = _Sink()
     sinks = {}
-    _create_request(engine, bundle.model, prompt_a, max_new, sink_a, sinks)
+    _create_request(engine, prompt_a, max_new, sink_a, sinks)
 
     for _ in range(3):
         if not engine.has_pending_requests():
@@ -217,7 +215,7 @@ def test_staggered_admission(bundle):
     assert len(sink_a.tokens) > 0, "first request produced nothing before staggered admission"
 
     sink_b = _Sink()
-    _create_request(engine, bundle.model, prompt_b, max_new, sink_b, sinks)
+    _create_request(engine, prompt_b, max_new, sink_b, sinks)
 
     _run(engine, sinks)
 
@@ -236,7 +234,7 @@ def test_isolated_matches_batched(bundle):
     sinks = {p: _Sink() for p in _PROMPTS}
     sinks_by_request = {}
     for p, sink in sinks.items():
-        _create_request(engine, bundle.model, bundle.tokenizer.encode(p), max_new, sink, sinks_by_request)
+        _create_request(engine, bundle.tokenizer.encode(p), max_new, sink, sinks_by_request)
     _run(engine, sinks_by_request)
 
     assert sinks[prompt].tokens == isolated, "batched output diverged from the isolated run"
@@ -253,8 +251,8 @@ def test_output_isolation(bundle):
     engine = og.Engine(bundle.model)
     s0, s1 = _Sink(), _Sink()
     sinks = {}
-    _create_request(engine, bundle.model, bundle.tokenizer.encode(p0), max_new, s0, sinks)
-    _create_request(engine, bundle.model, bundle.tokenizer.encode(p1), max_new, s1, sinks)
+    _create_request(engine, bundle.tokenizer.encode(p0), max_new, s0, sinks)
+    _create_request(engine, bundle.tokenizer.encode(p1), max_new, s1, sinks)
     _run(engine, sinks)
 
     assert s0.tokens == isolated0
@@ -272,14 +270,13 @@ def test_completion_isolation(bundle):
     sinks = {}
     _create_request(
         engine,
-        bundle.model,
         bundle.tokenizer.encode(short_prompt),
         short_new,
         short_sink,
         sinks,
         min_new_tokens=short_new,
     )
-    _create_request(engine, bundle.model, bundle.tokenizer.encode(long_prompt), long_new, long_sink, sinks)
+    _create_request(engine, bundle.tokenizer.encode(long_prompt), long_new, long_sink, sinks)
     _run(engine, sinks)
 
     assert len(short_sink.tokens) == short_new, "forced-length request did not stop at its bound"
@@ -329,8 +326,8 @@ def test_close_request_stops_output(bundle):
 
     sink_a, sink_b = _Sink(), _Sink()
     sinks = {}
-    request_a = _create_request(engine, bundle.model, bundle.tokenizer.encode(_PROMPTS[0]), max_new, sink_a, sinks)
-    _create_request(engine, bundle.model, sibling_prompt, max_new, sink_b, sinks)
+    request_a = _create_request(engine, bundle.tokenizer.encode(_PROMPTS[0]), max_new, sink_a, sinks)
+    _create_request(engine, sibling_prompt, max_new, sink_b, sinks)
 
     for _ in range(4):
         if not engine.has_pending_requests():
@@ -357,7 +354,7 @@ def test_engine_teardown_and_recreation(bundle):
     first = og.Engine(bundle.model)
     sink1 = _Sink()
     first_sinks = {}
-    _create_request(first, bundle.model, prompt_tokens, max_new, sink1, first_sinks)
+    _create_request(first, prompt_tokens, max_new, sink1, first_sinks)
     _run(first, first_sinks)
     assert sink1.tokens == expected
     del first
@@ -367,6 +364,6 @@ def test_engine_teardown_and_recreation(bundle):
     assert not second.has_pending_requests()
     sink2 = _Sink()
     second_sinks = {}
-    _create_request(second, bundle.model, prompt_tokens, max_new, sink2, second_sinks)
+    _create_request(second, prompt_tokens, max_new, sink2, second_sinks)
     _run(second, second_sinks)
     assert sink2.tokens == expected

--- a/test/python/test_onnxruntime_genai_engine.py
+++ b/test/python/test_onnxruntime_genai_engine.py
@@ -89,10 +89,10 @@ def draft_model(device):
     return og.Model(config)
 
 
-def _create_request(engine, model, prompt, max_new_tokens, sink, sinks):
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=len(prompt) + max_new_tokens)
-    request = engine.create_request(params)
+def _create_request(engine, prompt, max_new_tokens, sink, sinks):
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(prompt) + max_new_tokens)
+    request = engine.create_request(options=request_options)
     sinks[request] = sink
     request.begin_turn(np.asarray(prompt, dtype=np.int32))
     return request
@@ -154,7 +154,7 @@ def _generate_isolated(model, prompt, max_new_tokens):
     sink = _Sink()
     engine = og.Engine(model)
     sinks = {}
-    _create_request(engine, model, prompt, max_new_tokens, sink, sinks)
+    _create_request(engine, prompt, max_new_tokens, sink, sinks)
     _run(engine, sinks)
     del engine
     gc.collect()
@@ -163,12 +163,9 @@ def _generate_isolated(model, prompt, max_new_tokens):
 
 def test_engine_run_releases_gil(model):
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(
-        do_sample=False,
-        max_length=len(_PROMPT_LONG) + 4,
-    )
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(_PROMPT_LONG) + 4)
+    request = engine.create_request(options=request_options)
     request.begin_turn(np.asarray(_PROMPT_LONG, dtype=np.int32))
     event_buffer = engine.create_event_buffer(1)
 
@@ -231,13 +228,10 @@ def test_strided_request_tokens_are_copied_contiguously(model):
     prompt = prompt_storage[::2]
     assert not prompt.flags.c_contiguous
     max_new_tokens = 4
-    params = og.GeneratorParams(model)
-    params.set_search_options(
-        do_sample=False,
-        max_length=len(prompt) + max_new_tokens,
-    )
     engine = og.Engine(model)
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(prompt) + max_new_tokens)
+    request = engine.create_request(options=request_options)
     request.begin_turn(prompt)
     sink = _Sink()
     sinks = {request: sink}
@@ -261,8 +255,8 @@ def test_model_declares_per_request_fp16_logits():
 def test_run_reuses_buffer_for_zero_one_and_bulk_capacity(model):
     engine = og.Engine(model)
     sinks = {}
-    first = _create_request(engine, model, _PROMPT_A, 1, _Sink(), sinks)
-    second = _create_request(engine, model, _PROMPT_B, 1, _Sink(), sinks)
+    first = _create_request(engine, _PROMPT_A, 1, _Sink(), sinks)
+    second = _create_request(engine, _PROMPT_B, 1, _Sink(), sinks)
 
     zero_buffer = engine.create_event_buffer(0)
     assert engine.run(zero_buffer) is zero_buffer
@@ -291,8 +285,8 @@ def test_run_reuses_buffer_for_zero_one_and_bulk_capacity(model):
     assert len(retained_events) == 1
     assert retained_events[0].request is second
 
-    third = _create_request(engine, model, _PROMPT_A, 1, _Sink(), sinks)
-    fourth = _create_request(engine, model, _PROMPT_B, 1, _Sink(), sinks)
+    third = _create_request(engine, _PROMPT_A, 1, _Sink(), sinks)
+    fourth = _create_request(engine, _PROMPT_B, 1, _Sink(), sinks)
     bulk_buffer = engine.create_event_buffer(8)
     bulk_events = engine.run(bulk_buffer)
     assert len(bulk_events) == 2
@@ -321,12 +315,9 @@ def test_draft_proposal_public_api(draft_model):
     prompt = np.asarray(_PROMPT_A, dtype=np.int32)
     expected = predicted_tokens(_PROMPT_A, 4)
     engine = og.Engine(draft_model)
-    params = og.GeneratorParams(draft_model)
-    params.set_search_options(
-        do_sample=False,
-        max_length=len(prompt) + len(expected),
-    )
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(prompt) + len(expected))
+    request = engine.create_request(options=request_options)
     turn_options = og.TurnOptions(request)
     turn_options.set_max_generated_tokens(len(expected))
     request.begin_turn(prompt, turn_options)
@@ -360,8 +351,8 @@ def test_isolated_matches_simultaneous(model):
     engine = og.Engine(model)
     sink_a, sink_b = _Sink(), _Sink()
     sinks = {}
-    _create_request(engine, model, _PROMPT_A, max_new, sink_a, sinks)
-    _create_request(engine, model, _PROMPT_B, max_new, sink_b, sinks)
+    _create_request(engine, _PROMPT_A, max_new, sink_a, sinks)
+    _create_request(engine, _PROMPT_B, max_new, sink_b, sinks)
     assert engine.has_pending_requests()
     _run(engine, sinks)
 
@@ -377,7 +368,7 @@ def test_staggered_admission(model):
     engine = og.Engine(model)
     sink_a = _Sink()
     sinks = {}
-    _create_request(engine, model, _PROMPT_A, max_new, sink_a, sinks)
+    _create_request(engine, _PROMPT_A, max_new, sink_a, sinks)
 
     for _ in range(3):
         if not engine.has_pending_requests():
@@ -386,7 +377,7 @@ def test_staggered_admission(model):
     assert len(sink_a.tokens) > 0, "first request produced nothing before staggered admission"
 
     sink_b = _Sink()
-    _create_request(engine, model, _PROMPT_B, max_new, sink_b, sinks)
+    _create_request(engine, _PROMPT_B, max_new, sink_b, sinks)
     _run(engine, sinks)
 
     assert sink_a.tokens == expected_a
@@ -419,9 +410,9 @@ def test_eos_terminates_before_max_length(model):
 
 def test_per_turn_budget_is_independent_and_snapshotted(model):
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=32)
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(32)
+    request = engine.create_request(options=request_options)
     sink = _Sink()
     sinks = {request: sink}
     prompt = np.asarray(_PROMPT_LONG, dtype=np.int32)
@@ -447,11 +438,9 @@ def test_per_turn_budget_is_independent_and_snapshotted(model):
 
 def test_request_total_limit_and_cancel_metadata(model):
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=32)
     request_options = og.RequestOptions()
     request_options.set_max_session_tokens(len(_PROMPT_LONG) + 2)
-    request = engine.create_request(params, request_options)
+    request = engine.create_request(options=request_options)
     sink = _Sink()
     sinks = {request: sink}
 
@@ -462,7 +451,7 @@ def test_request_total_limit_and_cancel_metadata(model):
 
     request.close()
 
-    canceled = engine.create_request(params)
+    canceled = engine.create_request(options=request_options)
     turn_id = canceled.begin_turn(np.asarray(_PROMPT_A, dtype=np.int32))
     assert canceled.cancel_turn(turn_id)
     assert not canceled.cancel_turn(turn_id)
@@ -474,9 +463,9 @@ def test_request_total_limit_and_cancel_metadata(model):
 
 def test_zero_turn_budget_uses_default_limit(model):
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=16)
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(16)
+    request = engine.create_request(options=request_options)
     sink = _Sink()
     sinks = {request: sink}
     prompt = np.asarray(_PROMPT_A, dtype=np.int32)
@@ -500,8 +489,8 @@ def test_completion_isolation(model):
     engine = og.Engine(model)
     short_sink, long_sink = _Sink(), _Sink()
     sinks = {}
-    _create_request(engine, model, _PROMPT_A, short_new, short_sink, sinks)
-    _create_request(engine, model, _PROMPT_LONG, long_new, long_sink, sinks)
+    _create_request(engine, _PROMPT_A, short_new, short_sink, sinks)
+    _create_request(engine, _PROMPT_LONG, long_new, long_sink, sinks)
     _run(engine, sinks)
 
     assert short_sink.tokens == predicted_tokens(_PROMPT_A, short_new)
@@ -517,7 +506,7 @@ def test_continuation_while_peer_remains_active(model):
     reference_engine = og.Engine(model)
     reference_sink = _Sink()
     reference_sinks = {}
-    reference = _create_request(reference_engine, model, _PROMPT_A, short_max_new, reference_sink, reference_sinks)
+    reference = _create_request(reference_engine, _PROMPT_A, short_max_new, reference_sink, reference_sinks)
     reference_finished = False
     while not reference_finished:
         event = _next_event(reference_engine)
@@ -529,8 +518,8 @@ def test_continuation_while_peer_remains_active(model):
     engine = og.Engine(model)
     short_sink, long_sink = _Sink(), _Sink()
     sinks = {}
-    short = _create_request(engine, model, _PROMPT_A, short_max_new, short_sink, sinks)
-    _create_request(engine, model, _PROMPT_LONG, long_max_new, long_sink, sinks)
+    short = _create_request(engine, _PROMPT_A, short_max_new, short_sink, sinks)
+    _create_request(engine, _PROMPT_LONG, long_max_new, long_sink, sinks)
 
     short_finished = False
     while not short_finished:
@@ -554,8 +543,8 @@ def test_continuation_while_peer_remains_active(model):
 def test_continuation_waits_for_ready_notification(model):
     engine = og.Engine(model)
     sinks = {}
-    first = _create_request(engine, model, [5, 8, 57], 40, _Sink(), sinks)
-    second = _create_request(engine, model, [6, 8, 56], 40, _Sink(), sinks)
+    first = _create_request(engine, [5, 8, 57], 40, _Sink(), sinks)
+    second = _create_request(engine, [6, 8, 56], 40, _Sink(), sinks)
 
     event = _next_event(engine)
     assert event.request is first
@@ -576,7 +565,7 @@ def test_continuation_waits_for_ready_notification(model):
 def test_request_rejects_second_turn_while_active(model):
     engine = og.Engine(model)
     sinks = {}
-    request = _create_request(engine, model, _PROMPT_A, 8, _Sink(), sinks)
+    request = _create_request(engine, _PROMPT_A, 8, _Sink(), sinks)
 
     with pytest.raises(RuntimeError, match="new request or after the current turn is complete"):
         request.begin_turn(np.asarray([12], dtype=np.int32))
@@ -595,9 +584,9 @@ def test_request_rejects_second_turn_while_active(model):
 def test_begin_turn_copies_non_contiguous_token_views(model, tokens):
     logical_tokens = tokens.tolist()
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=len(logical_tokens) + 3)
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(logical_tokens) + 3)
+    request = engine.create_request(options=request_options)
     sink = _Sink()
     sinks = {request: sink}
 
@@ -609,17 +598,17 @@ def test_begin_turn_copies_non_contiguous_token_views(model, tokens):
 
 def test_begin_turn_accepts_read_only_tokens_and_rejects_multiple_dimensions(model):
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=len(_PROMPT_A) + 1)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(_PROMPT_A) + 1)
 
     read_only_tokens = np.asarray(_PROMPT_A, dtype=np.int32)
     read_only_tokens.setflags(write=False)
-    request = engine.create_request(params)
+    request = engine.create_request(options=request_options)
     request.begin_turn(read_only_tokens)
     assert _next_event(engine).request is request
     request.close()
 
-    invalid_request = engine.create_request(params)
+    invalid_request = engine.create_request(options=request_options)
     with pytest.raises(ValueError, match="one-dimensional"):
         invalid_request.begin_turn(np.asarray([_PROMPT_A, _PROMPT_A], dtype=np.int32))
     invalid_request.close()
@@ -629,7 +618,7 @@ def test_request_lifecycle_operations(model):
     engine = og.Engine(model)
     sink = _Sink()
     sinks = {}
-    request = _create_request(engine, model, _PROMPT_A, 61, sink, sinks)
+    request = _create_request(engine, _PROMPT_A, 61, sink, sinks)
 
     event = _next_event(engine)
     assert event.request is request
@@ -647,15 +636,15 @@ def test_request_lifecycle_operations(model):
     request.close()
 
 
-def test_request_parameters_are_snapshotted(model):
+def test_request_options_are_snapshotted(model):
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=len(_PROMPT_LONG) + 4)
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(_PROMPT_LONG) + 4)
+    request = engine.create_request(options=request_options)
     sink = _Sink()
     sinks = {request: sink}
 
-    params.set_search_options(max_length=len(_PROMPT_LONG) + 12)
+    request_options.set_max_session_tokens(len(_PROMPT_LONG) + 12)
     request.begin_turn(np.asarray(_PROMPT_LONG, dtype=np.int32))
     _run(engine, sinks)
 
@@ -665,9 +654,9 @@ def test_request_parameters_are_snapshotted(model):
 @pytest.mark.parametrize("state", ["created", "active", "turn-complete"])
 def test_close_is_valid_and_idempotent_from_every_state(model, state):
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=len(_PROMPT_LONG) + 8)
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(_PROMPT_LONG) + 8)
+    request = engine.create_request(options=request_options)
     sinks = {request: _Sink()}
 
     if state != "created":
@@ -694,9 +683,9 @@ def test_close_is_valid_and_idempotent_from_every_state(model, state):
 def test_events_deliver_tokens_across_turns(model):
     follow_up = np.asarray([_EOS_TOKEN_ID, 12], dtype=np.int32)
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=64)
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(64)
+    request = engine.create_request(options=request_options)
 
     def run_turn(input_tokens, expected_turn_id):
         assert request.begin_turn(input_tokens) == expected_turn_id
@@ -723,9 +712,7 @@ def test_last_handle_release_reclaims_retained_capacity(model):
     engine = og.Engine(model)
     sinks = [_Sink() for _ in range(8)]
     sinks_by_request = {}
-    requests = [
-        _create_request(engine, model, [5 + index, 9, 13], 1, sinks[index], sinks_by_request) for index in range(8)
-    ]
+    requests = [_create_request(engine, [5 + index, 9, 13], 1, sinks[index], sinks_by_request) for index in range(8)]
 
     completed = set()
     while len(completed) != len(requests):
@@ -743,7 +730,7 @@ def test_last_handle_release_reclaims_retained_capacity(model):
 
     replacement_sink = _Sink()
     replacement_sinks = {}
-    _create_request(engine, model, _PROMPT_A, 4, replacement_sink, replacement_sinks)
+    _create_request(engine, _PROMPT_A, 4, replacement_sink, replacement_sinks)
     _run(engine, replacement_sinks)
 
     assert replacement_sink.tokens == predicted_tokens(_PROMPT_A, 4)
@@ -757,8 +744,8 @@ def test_close_request_freezes_output(model):
     engine = og.Engine(model)
     sink_a, sink_b = _Sink(), _Sink()
     sinks = {}
-    request_a = _create_request(engine, model, _PROMPT_A, max_new, sink_a, sinks)
-    _create_request(engine, model, _PROMPT_B, sibling_new, sink_b, sinks)
+    request_a = _create_request(engine, _PROMPT_A, max_new, sink_a, sinks)
+    _create_request(engine, _PROMPT_B, sibling_new, sink_b, sinks)
 
     for _ in range(4):
         if not engine.has_pending_requests():
@@ -782,7 +769,7 @@ def test_engine_teardown_and_recreation(model):
     first = og.Engine(model)
     sink1 = _Sink()
     first_sinks = {}
-    _create_request(first, model, _PROMPT_A, max_new, sink1, first_sinks)
+    _create_request(first, _PROMPT_A, max_new, sink1, first_sinks)
     _run(first, first_sinks)
     assert sink1.tokens == expected
     del first
@@ -792,7 +779,7 @@ def test_engine_teardown_and_recreation(model):
     assert not second.has_pending_requests()
     sink2 = _Sink()
     second_sinks = {}
-    _create_request(second, model, _PROMPT_A, max_new, sink2, second_sinks)
+    _create_request(second, _PROMPT_A, max_new, sink2, second_sinks)
     _run(second, second_sinks)
     assert sink2.tokens == expected
 
@@ -806,9 +793,9 @@ _STOP_MATCH_PROMPT = [61, 2, 5]
 
 def test_stop_string_matches_across_two_tokens_via_real_inference(model):
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=len(_STOP_MATCH_PROMPT) + 8)
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(_STOP_MATCH_PROMPT) + 8)
+    request = engine.create_request(options=request_options)
     turn_options = og.TurnOptions(request)
     turn_options.set_stop_strings(["STOP"])
     request.begin_turn(np.asarray(_STOP_MATCH_PROMPT, dtype=np.int32), turn_options)
@@ -837,9 +824,9 @@ def test_stop_strings_empty_list_disables_and_ordinary_generation_completes(mode
     # (non-stop) generation exactly as if stop strings had never been configured.
     expected = predicted_tokens(_STOP_MATCH_PROMPT, 8)
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=len(_STOP_MATCH_PROMPT) + 8)
-    request = engine.create_request(params)
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(_STOP_MATCH_PROMPT) + 8)
+    request = engine.create_request(options=request_options)
     turn_options = og.TurnOptions(request)
     turn_options.set_stop_strings(["STOP"])
     turn_options.set_stop_strings([])
@@ -855,8 +842,7 @@ def test_stop_strings_empty_list_disables_and_ordinary_generation_completes(mode
 
 def test_stop_strings_validation_and_embedded_nul_rejection(model):
     engine = og.Engine(model)
-    params = og.GeneratorParams(model)
-    request = engine.create_request(params)
+    request = engine.create_request()
     turn_options = og.TurnOptions(request)
 
     with pytest.raises(RuntimeError):
@@ -871,3 +857,139 @@ def test_stop_strings_validation_and_embedded_nul_rejection(model):
     # A valid configuration still works normally after the rejected attempts above.
     turn_options.set_stop_strings(["STOP"])
     request.close()
+
+
+def _run_turn(engine, request, tokens, turn_options):
+    request.begin_turn(np.asarray(tokens, dtype=np.int32), turn_options)
+    generated = []
+    event_buffer = engine.create_event_buffer(8)
+    for _ in range(64):
+        finished = False
+        for event in engine.run(event_buffer):
+            if event.flags & og.EngineEventFlags.TOKEN:
+                generated.append(event.token)
+            finished = finished or bool(event.flags & og.EngineEventFlags.TURN_FINISHED)
+        if finished:
+            break
+    return generated
+
+
+def test_turn_options_resolve_policy_per_turn(model):
+    engine = og.Engine(model)
+
+    def sampled_request(seed):
+        request_options = og.RequestOptions()
+        request_options.set_max_session_tokens(64)
+        request = engine.create_request(options=request_options)
+        turn_options = og.TurnOptions(request)
+        turn_options.set_do_sample(True)
+        turn_options.set_temperature(0.8)
+        turn_options.set_top_p(0.9)
+        turn_options.set_top_k(4)
+        turn_options.set_repetition_penalty(1.1)
+        turn_options.set_no_repeat_ngram_size(0)
+        turn_options.set_min_generated_tokens(2)
+        turn_options.set_max_generated_tokens(4)
+        turn_options.set_seed(seed)
+        return request, turn_options
+
+    # Zero is a valid deterministic seed, and the same seed on the same prompt reproduces exactly.
+    first, first_options = sampled_request(0)
+    reference = _run_turn(engine, first, _PROMPT_A, first_options)
+    assert 2 <= len(reference) <= 4
+
+    second, second_options = sampled_request(0)
+    assert _run_turn(engine, second, _PROMPT_A, second_options) == reference
+
+    # reset() removes every option, so the following turn is plain model-default generation.
+    third, third_options = sampled_request(0)
+    third_options.reset()
+    third_options.set_max_generated_tokens(4)
+    assert _run_turn(engine, third, _PROMPT_A, third_options) == predicted_tokens(_PROMPT_A, 4)
+
+    for request in (first, second, third):
+        request.close()
+
+
+def test_turn_options_reject_contradictory_sampling_scalars_before_mutation(model):
+    engine = og.Engine(model)
+    request = engine.create_request()
+    turn_options = og.TurnOptions(request)
+    turn_options.set_do_sample(False)
+    turn_options.set_top_k(40)
+
+    # A 40-candidate distribution contradicts top-logit selection.
+    with pytest.raises(RuntimeError, match="contradict it: top_k"):
+        request.begin_turn(np.asarray(_PROMPT_A, dtype=np.int32), turn_options)
+
+    # The rejected attempt left the request untouched, so a corrected policy still admits.
+    turn_options.reset()
+    turn_options.set_max_generated_tokens(1)
+    assert request.begin_turn(np.asarray(_PROMPT_A, dtype=np.int32), turn_options) == 1
+    request.close()
+
+
+def test_turn_options_accept_scalars_consistent_with_greedy_selection(model):
+    """top_k == 1, temperature == 0, and unrestrictive bounds all agree with the top logit."""
+    engine = og.Engine(model)
+    consistent_policies = (
+        {"set_top_k": 1},
+        {"set_temperature": 0.0},
+        {"set_do_sample": False, "set_top_k": 1},
+        {"set_do_sample": False, "set_temperature": 0.0},
+        {"set_do_sample": False, "set_top_p": 1.0, "set_top_k": 0},
+        # Temperature 1 rescales nothing, so it is neutral rather than a request to sample.
+        {"set_do_sample": False, "set_temperature": 1.0},
+        {"set_do_sample": True, "set_top_k": 1, "set_temperature": 0.0},
+    )
+
+    for policy in consistent_policies:
+        request = engine.create_request()
+        turn_options = og.TurnOptions(request)
+        for setter, value in policy.items():
+            getattr(turn_options, setter)(value)
+        turn_options.set_max_generated_tokens(4)
+
+        assert _run_turn(engine, request, _PROMPT_A, turn_options) == predicted_tokens(_PROMPT_A, 4)
+        request.close()
+
+
+@pytest.mark.parametrize(
+    ("search_overlay", "named_default"),
+    (
+        ('{"search": {"top_k": 1}}', "search.top_k = 1"),
+        ('{"search": {"temperature": 0.0}}', "search.temperature = 0"),
+    ),
+)
+def test_turn_options_reject_do_sample_under_model_greedy_defaults(device, search_overlay, named_default):
+    """A model default the caller cannot see must not silently override an explicit do_sample."""
+    config = og.Config(str(_MODEL_DIR))
+    config.clear_providers()
+    if device != "cpu":
+        config.append_provider(device)
+    config.overlay(search_overlay)
+    engine = og.Engine(og.Model(config))
+
+    request = engine.create_request()
+    turn_options = og.TurnOptions(request)
+    turn_options.set_do_sample(True)
+    turn_options.set_max_generated_tokens(2)
+
+    with pytest.raises(RuntimeError, match=named_default):
+        request.begin_turn(np.asarray(_PROMPT_A, dtype=np.int32), turn_options)
+
+    # The rejection mutated nothing, and overriding the named field is what actually asks to sample.
+    turn_options.set_top_k(4)
+    turn_options.set_temperature(0.8)
+    assert request.begin_turn(np.asarray(_PROMPT_A, dtype=np.int32), turn_options) == 1
+    request.close()
+
+
+def test_create_request_rejects_positional_generator_params(model):
+    engine = og.Engine(model)
+    params = og.GeneratorParams(model)
+
+    # The Engine no longer accepts caller generation parameters; the old positional call must fail
+    # loudly rather than silently ignoring them.
+    with pytest.raises(TypeError):
+        engine.create_request(params)

--- a/test/python/test_onnxruntime_genai_hybrid_engine.py
+++ b/test/python/test_onnxruntime_genai_hybrid_engine.py
@@ -34,10 +34,10 @@ def model(request):
     return og.Model(config)
 
 
-def _request(engine, model, prompt, max_new_tokens, sinks):
-    params = og.GeneratorParams(model)
-    params.set_search_options(do_sample=False, max_length=len(prompt) + max_new_tokens)
-    request = engine.create_request(params)
+def _request(engine, prompt, max_new_tokens, sinks):
+    request_options = og.RequestOptions()
+    request_options.set_max_session_tokens(len(prompt) + max_new_tokens)
+    request = engine.create_request(options=request_options)
     sink = _Sink()
     sinks[request] = sink
     request.begin_turn(np.asarray(prompt, dtype=np.int32))
@@ -74,7 +74,7 @@ def test_mixed_unequal_requests_match_isolated_execution(model):
     for prompt in prompts:
         engine = og.Engine(model)
         sinks = {}
-        _, sink = _request(engine, model, prompt, max_new_tokens, sinks)
+        _, sink = _request(engine, prompt, max_new_tokens, sinks)
         _run(engine, sinks)
         expected.append(sink.tokens)
     # The first request's fixed convolution state contributes 0, 6, then 12 to successive scores.
@@ -83,6 +83,6 @@ def test_mixed_unequal_requests_match_isolated_execution(model):
 
     engine = og.Engine(model)
     sinks = {}
-    requests = [_request(engine, model, prompt, max_new_tokens, sinks) for prompt in prompts]
+    requests = [_request(engine, prompt, max_new_tokens, sinks) for prompt in prompts]
     _run(engine, sinks)
     assert [sink.tokens for _, sink in requests] == expected


### PR DESCRIPTION
## Summary

This change completes the public C and C++ Engine API wiring for generation options.

Engine Request creation no longer accepts `OgaGeneratorParams`. A Request now owns only session-level policy, while each Turn carries its own sampling, token-limit, seed, stop-string, and guidance policy.

This makes the API ownership match the Engine lifecycle:

```mermaid
flowchart LR
    M["Model / Engine configuration<br/>scheduler, cache, provider, chunking,<br/>speculative strategy, model defaults"]
    R["RequestOptions<br/>max_session_tokens"]
    T["TurnOptions<br/>sampling, token limits, seed,<br/>stop strings, guidance"]
    E["Engine"]
    Q["Request<br/>resident conversation state"]
    U["Turn<br/>one generation operation"]

    M --> E
    E --> Q
    R --> Q
    Q --> U
    T --> U
```

## Why

The previous Engine Request API required an `OgaGeneratorParams` object even though most of that object belongs to the classic Generator flow or to one generation turn.

The Engine also exposed Turn option setters for temperature, top-p, top-k, seed, and guidance, but those setters were not implemented.

This change removes that mismatch. The classic Generator API remains unchanged.

## Public API change

Request creation changes from:

```c
OgaResult* OgaEngineCreateRequest(
    OgaEngine* engine,
    const OgaGeneratorParams* params,
    const OgaRequestOptions* options,
    OgaRequest** out);
```

to:

```c
OgaResult* OgaEngineCreateRequest(
    OgaEngine* engine,
    const OgaRequestOptions* options,
    OgaRequest** out);
```

`OgaRequestOptions` contains resident Request policy:

```c
OgaRequestOptionsSetMaxSessionTokens(...)
```

`OgaTurnOptions` contains generation policy:

```c
OgaTurnOptionsSetMaxGeneratedTokens(...)
OgaTurnOptionsSetMinGeneratedTokens(...)
OgaTurnOptionsSetDoSample(...)
OgaTurnOptionsSetTemperature(...)
OgaTurnOptionsSetTopP(...)
OgaTurnOptionsSetTopK(...)
OgaTurnOptionsSetRepetitionPenalty(...)
OgaTurnOptionsSetNoRepeatNgramSize(...)
OgaTurnOptionsSetSeed(...)
OgaTurnOptionsClearSeed(...)
OgaTurnOptionsSetStopStrings(...)
OgaTurnOptionsSetGuidance(...)
OgaTurnOptionsClearGuidance(...)
OgaTurnOptionsReset(...)
```

The C++ wrappers and Python bindings mirror this API.

## Request and Turn lifecycle

A Request remains resident across turns so it can reuse its committed sequence and cache. Generation policy is resolved independently for every new Turn.

```mermaid
stateDiagram-v2
    [*] --> Unassigned: Create Request
    Unassigned --> Assigned: Begin first Turn
    Assigned --> Active: Scheduled
    Active --> Active: Commit generation step
    Active --> TurnComplete: EOS, stop string, limit, cancel, or failure
    TurnComplete --> Assigned: Begin continuation Turn
    Unassigned --> Closed: Close
    Assigned --> Closed: Close
    Active --> Closed: Close
    TurnComplete --> Closed: Close
    Closed --> [*]: Destroy handle
```

An omitted scalar Turn option uses the model-configured default. It never inherits the value used by the previous Turn.

Stop strings and guidance are disabled when omitted.

Seed is intentionally different: an omitted seed continues the Request's existing random stream, while an explicit seed reseeds that Turn.

## Turn admission is transactional

The complete Turn policy is resolved and validated before the Request is changed.

Grammar construction and stop-string controller construction also happen before mutation. A bad grammar, invalid sampling combination, unsupported option, or impossible token limit leaves the Request reusable.

```mermaid
flowchart TD
    A["BeginTurn(input, options)"]
    B["Resolve model defaults + explicit Turn overrides"]
    C["Validate sampling, limits, device support, and static-path support"]
    D["Build stop-string controller"]
    E["Compile or acquire guidance grammar"]
    F["Checkpoint Request admission state"]
    G["Append prompt and reserve scheduler/cache state"]
    H["Commit Turn policy and resources"]
    X["Return error<br/>Request remains unchanged"]
    Y["Turn admitted"]

    A --> B --> C
    C -->|invalid| X
    C --> D
    D -->|failure| X
    D --> E
    E -->|failure| X
    E --> F --> G
    G -->|failure| X
    G --> H --> Y
```

## Per-turn sampling policy

`EffectiveTurnPolicy` is the single resolved policy used by ordinary decoding, batched sampling, speculative verification, MTP eligibility, and DFlash2 eligibility.

Greedy selection is classified consistently as:

```cpp
!do_sample || top_k == 1 || temperature == 0
```

Invalid values and contradictory options are rejected at admission instead of being accepted and ignored.

Examples:

- `do_sample=false` with `temperature=0.7` is rejected because the temperature would not affect greedy output.
- `top_k=1` and `temperature=0` are accepted ways to request greedy output.
- `do_sample=true` is rejected if a model default still forces greedy output and the Turn did not override that default.
- A sampled Turn requires a positive top-k or top-p bound.
- No-repeat n-gram is rejected before execution on scoring devices whose Search implementation cannot apply it.

## Session and Turn token limits

`max_session_tokens` is the one Request-level sequence limit. Search storage, static cache sizing, speculative bounds, and the `MaxSessionTokens` finish reason use the same value.

An explicit `max_session_tokens` may lower the model-configured `search.max_length`, but it may not exceed it.

`max_generated_tokens` limits only the current Turn.

`min_generated_tokens` masks EOS until the current Turn has generated the requested number of tokens. It does not override stop strings, cancellation, failure, guidance termination, or maximum limits.

The Engine rejects model configurations that it would otherwise have to reinterpret or silently override:

- Nonzero legacy `search.min_length`; use per-turn `min_generated_tokens`.
- `search.num_beams` other than 1; the Engine batches Requests rather than beam rows.
- Nonpositive `search.max_length`.
- Nonzero `search.chunk_size` with static batching.

The error messages describe the corresponding config overlay when one is available.

## Transactional seed handling

The Request owns a durable 64-bit seed basis.

An explicit Turn seed is applied only inside a rollback-capable generation transaction, after Request and sampler state have been checkpointed and before any host or device RNG consumer runs.

```mermaid
flowchart TD
    A["Turn admits explicit seed"]
    B["Store pending reseed"]
    C["Checkpoint Search, host RNG, and device sampler state"]
    D["Apply pending seed to host and device streams"]
    E["Sample or verify drafts"]
    F{"Step result"}
    G["Commit tokens and sampler state"]
    H["Promote seed to durable Request basis"]
    I["Restore tokens, Search, host RNG, and device RNG"]
    J["Keep pending seed for identical retry"]

    A --> B --> C --> D --> E --> F
    F -->|commit| G --> H
    F -->|rollback| I --> J
    J --> C
```

Seed zero is valid.

Seeds that fit in 32 bits preserve the existing host `std::mt19937` sequence. Wider seeds use both 32-bit halves, and CUDA receives the full 64-bit value.

The CUDA sampler state is reseeded in place so pooled sampler slots are not released and reacquired.

Because the `BatchedSampler` interface crosses the separately loaded CUDA add-on boundary, the internal device interface version is increased from 4 to 5. Core and CUDA add-on artifacts must come from matching builds.

## Turn-scoped guidance

Guidance is compiled or acquired before admission mutation and installed only when the Turn commits.

The grammar cursor participates in step rollback.

Every terminal path releases the Turn's guidance state.

This supports a guided tool-call Turn followed by an unguided tool-result Turn on the same Request:

```mermaid
sequenceDiagram
    participant App
    participant Request
    participant Engine

    App->>Request: BeginTurn(prompt, guidance)
    Request->>Engine: Admit guided Turn
    Engine-->>App: Tool-call tokens and terminal event
    App->>Request: BeginTurn(tool result, no guidance)
    Request->>Engine: Admit unguided continuation
    Engine-->>App: Normal generated tokens
```

Guided turns do not use speculative drafts because draft rows cannot reproduce the grammar processor. A later unguided Turn becomes draft-eligible again.

## Stop strings and speculative decoding

The decoded UTF-8 stop-string behavior already present in the Engine is preserved.

Stop strings remain Turn-scoped and transactional.

Speculative verification stops at the first matching accepted prefix while keeping token history, cache state, usage, finish reason, and matched stop-string index consistent.

Draft proposals are cleared at every terminal Turn boundary so a proposal validated under one Turn's policy cannot cross into a later Turn with different guidance, minimum-token, repetition, or n-gram settings.

## DFlash2 interaction

DFlash2 drafting remains greedy-only, but greediness now comes from the resolved Turn policy.

An untracked Request can join the DFlash2 ring pool only on a draft-eligible position-zero step.

Once a Request owns a ring, sampled turns continue feeding committed context without requesting drafts. This preserves cache continuity and allows a later greedy Turn to resume drafting.

DFlash2 forward-pass statistics increment only when the drafter session actually runs.

## Static batching

Static batching keeps its existing non-transactional execution path.

Options that require transactional state are rejected before Request mutation on this path:

- Per-turn seed.
- Stop strings.

Static Engine construction also rejects model-configured prefill chunking.

Other supported Turn sampling controls use the same resolved policy as dynamic batching.

## Classic Generator impact

The classic Generator public API and generation behavior are unchanged.

`OgaGeneratorParams`, `OgaCreateGenerator`, `OgaGenerator`, and MTP Generator continue to work as before.

The only shared operational impact is the CUDA add-on interface version change. A mismatched older CUDA add-on is rejected instead of being loaded with an incompatible sampler vtable.

## Caller migration

Before:

```cpp
auto params = OgaGeneratorParams::Create(*model);
params->SetSearchOption("do_sample", false);
params->SetSearchOption("max_length", 4096);
auto request = engine->CreateRequest(*params);
request->BeginTurn(tokens);
```

After:

```cpp
auto request_options = OgaRequestOptions::Create();
request_options->SetMaxSessionTokens(4096);
auto request = engine->CreateRequest(request_options.get());

auto turn_options = request->CreateTurnOptions();
turn_options->SetDoSample(false);
request->BeginTurn(tokens, turn_options.get());
```

Python `Engine.create_request` now accepts only the optional keyword argument `options`. Passing the old positional `GeneratorParams` fails clearly instead of being reinterpreted.

Examples, existing benchmark scenarios, C API tests, C++ tests, and Python tests are migrated to the new ownership model.

The benchmark changes are API migrations only. This PR does not add benchmark scenarios or metrics.