### PR TITLE
Fix explicit cache budgeting for windowed block drafters

### DIFF
--- a/docs/paged_attention_engine.md
+++ b/docs/paged_attention_engine.md
@@ -1364,13 +1364,15 @@ Automatic block drafting is greedy-only. A request that uses random sampling (`d
 drafter and never claims cache blocks.
 
 A windowed block drafter (DFlash 2) owns a fixed ring of cache blocks per maximum batch row, so its
-pool is sized for `max_batch_size` rings and is allocated before the target pool measures free
-memory; its footprint is independent of context length. A full-attention block drafter (DSpark)
-instead mirrors the target pool: its bytes per target block and its fixed query-spill bytes are
-charged against free memory before target capacity is selected, using the cache element type
-reported by the graph. That trade is explicit -- a DSpark drafter with the same layer geometry as
-the target roughly halves the target's paged-cache capacity for the same GPU memory budget, and it
-attends the whole resident sequence on every step rather than a window.
+pool is sized for `max_batch_size` rings and its footprint is independent of context length. With
+automatic sizing, that pool is allocated before the target measures free memory. When `num_blocks`
+is explicit, its fixed footprint is instead validated and deducted from the byte budget represented
+by that baseline target block count before either cache pool is allocated. A full-attention block
+drafter (DSpark) instead mirrors the target pool: its bytes per target block and its fixed
+query-spill bytes are charged against the same budget before target capacity is selected, using the
+cache element type reported by the graph. That trade is explicit -- a DSpark drafter with the same
+layer geometry as the target roughly halves the target's paged-cache capacity for the same GPU
+memory budget, and it attends the whole resident sequence on every step rather than a window.
 
 A request joins the drafter on its first decode step and holds its blocks until it is closed, so
 both pools are only sufficient while at most `max_batch_size` requests are tracked. A request that

--- a/src/config.h
+++ b/src/config.h
@@ -636,8 +636,9 @@ struct Config {
 
   struct Engine {
     struct DynamicBatching {
-      size_t block_size{256};                       // Total number of slots per block.
-      std::optional<size_t> num_blocks;             // Total number of blocks per layer.
+      size_t block_size{256};  // Total number of slots per block.
+      // Baseline target blocks; Engine auxiliary caches share the equivalent byte budget.
+      std::optional<size_t> num_blocks;
       std::optional<float> gpu_utilization_factor;  // Fraction of free GPU memory to use for key-value cache.
       size_t max_batch_size{16};                    // Maximum batch size for dynamically batching requests.
       size_t max_scheduled_tokens{2048};            // Maximum tokens in one dynamically batched model run.

--- a/src/dflash2_drafter.cpp
+++ b/src/dflash2_drafter.cpp
@@ -363,6 +363,12 @@ size_t Dflash2Drafter::PoolBlocks(const Config& config, size_t paged_block_size,
                          "DFlash 2 cache block count");
 }
 
+size_t Dflash2Drafter::PoolBytes(const Config& config, size_t paged_block_size,
+                                 size_t pool_blocks, ONNXTensorElementDataType cache_type) {
+  return CheckedMultiply(pool_blocks, BytesPerBlock(config, paged_block_size, cache_type),
+                         "Block-drafter cache bytes");
+}
+
 size_t Dflash2Drafter::FullAttentionPoolBlocks(size_t target_blocks, size_t paged_block_size,
                                                size_t query_block_size,
                                                size_t max_batch_size) {

--- a/src/dflash2_drafter.h
+++ b/src/dflash2_drafter.h
@@ -100,6 +100,10 @@ struct Dflash2Drafter {
   // be sized against the target pool. A windowed drafter only needs a fixed ring per request.
   static size_t PoolBlocks(const Config& config, size_t paged_block_size, size_t max_batch_size);
 
+  // Total K/V bytes occupied by a pool of `pool_blocks`.
+  static size_t PoolBytes(const Config& config, size_t paged_block_size, size_t pool_blocks,
+                          ONNXTensorElementDataType cache_type);
+
   // A full-attention drafter mirrors the target's committed blocks and reserves enough extra
   // blocks for every active request's query rows.
   static size_t FullAttentionPoolBlocks(size_t target_blocks, size_t paged_block_size,

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -309,6 +309,17 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
       // windowed drafter's footprint depends on the batch size, not the context length.
       dflash2_drafter = std::make_unique<Dflash2Drafter>(
           dflash2_model, paged_block_size, pool_blocks, dflash2_max_batch_size);
+      // Explicit num_blocks bypasses the free-memory probe, so deduct the already allocated fixed
+      // pool from that configured target-only budget.
+      if (batching.num_blocks.has_value()) {
+        const size_t dflash2_bytes_per_pool_block =
+            Dflash2Drafter::BytesPerBlock(*model->config_, paged_block_size, dflash2_cache_type);
+        if (pool_blocks >
+            std::numeric_limits<size_t>::max() / dflash2_bytes_per_pool_block) {
+          throw std::runtime_error("DFlash 2 windowed cache bytes overflow size_t.");
+        }
+        dflash2_reserved_memory_bytes = pool_blocks * dflash2_bytes_per_pool_block;
+      }
     } else {
       // A full-attention drafter mirrors the target pool, so it is billed per target block instead
       // and built below once the target pool's block count is known.

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -316,7 +316,7 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
             Dflash2Drafter::BytesPerBlock(*model->config_, paged_block_size, dflash2_cache_type);
         if (pool_blocks >
             std::numeric_limits<size_t>::max() / dflash2_bytes_per_pool_block) {
-          throw std::runtime_error("DFlash 2 windowed cache bytes overflow size_t.");
+          throw std::runtime_error("Windowed block-drafter cache bytes overflow size_t.");
         }
         dflash2_reserved_memory_bytes = pool_blocks * dflash2_bytes_per_pool_block;
       }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -275,6 +275,7 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
   size_t dflash2_bytes_per_block = 0;
   size_t dflash2_reserved_memory_bytes = 0;
   size_t dflash2_max_batch_size = 0;
+  size_t dflash2_pool_blocks = 0;
   if (!model->config_->model.dflash2.filename.empty()) {
     if (!model->config_->engine.dynamic_batching) {
       throw std::runtime_error("An Engine-hosted DFlash 2 drafter requires dynamic batching.");
@@ -302,23 +303,18 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
     const auto dflash2_cache_type = ValidateDflash2ModelCompatibility(
         *model->config_, model->session_info_, dflash2_model->session_info_, paged_block_size);
     model->config_->engine.aux_hidden_states_output_required = true;
-    const size_t pool_blocks = Dflash2Drafter::PoolBlocks(
+    dflash2_pool_blocks = Dflash2Drafter::PoolBlocks(
         *model->config_, paged_block_size, dflash2_max_batch_size);
-    if (pool_blocks != 0) {
-      // Built before the main pool so the pool's free-memory measurement already excludes it. A
-      // windowed drafter's footprint depends on the batch size, not the context length.
-      dflash2_drafter = std::make_unique<Dflash2Drafter>(
-          dflash2_model, paged_block_size, pool_blocks, dflash2_max_batch_size);
-      // Explicit num_blocks bypasses the free-memory probe, so deduct the already allocated fixed
-      // pool from that configured target-only budget.
+    if (dflash2_pool_blocks != 0) {
       if (batching.num_blocks.has_value()) {
-        const size_t dflash2_bytes_per_pool_block =
-            Dflash2Drafter::BytesPerBlock(*model->config_, paged_block_size, dflash2_cache_type);
-        if (pool_blocks >
-            std::numeric_limits<size_t>::max() / dflash2_bytes_per_pool_block) {
-          throw std::runtime_error("Windowed block-drafter cache bytes overflow size_t.");
-        }
-        dflash2_reserved_memory_bytes = pool_blocks * dflash2_bytes_per_pool_block;
+        // Explicit num_blocks bypasses the free-memory probe. CacheManager validates and deducts
+        // this fixed pool before either cache pool is allocated.
+        dflash2_reserved_memory_bytes = Dflash2Drafter::PoolBytes(
+            *model->config_, paged_block_size, dflash2_pool_blocks, dflash2_cache_type);
+      } else {
+        // Automatic sizing measures free memory after allocating the fixed drafter pool.
+        dflash2_drafter = std::make_unique<Dflash2Drafter>(
+            dflash2_model, paged_block_size, dflash2_pool_blocks, dflash2_max_batch_size);
       }
     } else {
       // A full-attention drafter mirrors the target pool, so it is billed per target block instead
@@ -338,15 +334,20 @@ EngineDependencies Engine::CreateDependencies(std::shared_ptr<Model> model) {
       CacheManager::Create(model, mtp_bytes_per_block + dflash2_bytes_per_block,
                            dflash2_reserved_memory_bytes);
   if (dflash2_model && !dflash2_drafter) {
-    const auto& dflash2 = model->config_->model.dflash2;
     const size_t paged_block_size =
         static_cast<size_t>(model->config_->engine.dynamic_batching->block_size);
-    dflash2_drafter = std::make_unique<Dflash2Drafter>(
-        dflash2_model, paged_block_size,
-        Dflash2Drafter::FullAttentionPoolBlocks(
-            cache_manager->Snapshot().total_blocks, paged_block_size,
-            static_cast<size_t>(dflash2.block_size), dflash2_max_batch_size),
-        dflash2_max_batch_size);
+    if (dflash2_pool_blocks != 0) {
+      dflash2_drafter = std::make_unique<Dflash2Drafter>(
+          dflash2_model, paged_block_size, dflash2_pool_blocks, dflash2_max_batch_size);
+    } else {
+      const auto& dflash2 = model->config_->model.dflash2;
+      dflash2_drafter = std::make_unique<Dflash2Drafter>(
+          dflash2_model, paged_block_size,
+          Dflash2Drafter::FullAttentionPoolBlocks(
+              cache_manager->Snapshot().total_blocks, paged_block_size,
+              static_cast<size_t>(dflash2.block_size), dflash2_max_batch_size),
+          dflash2_max_batch_size);
+    }
   }
   auto scheduler = Scheduler::Create(model, cache_manager);
   auto model_executor = ModelExecutor::Create(model, cache_manager);

--- a/test/cpp/dflash2_config_test.cpp
+++ b/test/cpp/dflash2_config_test.cpp
@@ -392,6 +392,18 @@ TEST(Dflash2ConfigTest, AccountsForWindowedPagedCache) {
                 config, 16, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
             3072u);
   EXPECT_EQ(Dflash2Drafter::PoolBlocks(config, 8, 3), 15u);
+  EXPECT_EQ(Dflash2Drafter::PoolBytes(
+                config, 8, 15, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            23040u);
+}
+
+TEST(Dflash2ConfigTest, RejectsWindowedPoolByteOverflow) {
+  const auto config = MakeDflash2Config();
+  EXPECT_THROW(
+      Dflash2Drafter::PoolBytes(
+          config, 8, std::numeric_limits<size_t>::max(),
+          ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+      std::runtime_error);
 }
 
 TEST(Dflash2ConfigTest, BillsFullAttentionCachePerTargetBlock) {

--- a/test/cpp/engine/paged_key_value_cache_tests.cpp
+++ b/test/cpp/engine/paged_key_value_cache_tests.cpp
@@ -491,6 +491,16 @@ TEST(PagedKeyValueCacheManifestTest, ExplicitBlockCountCoversBothPools) {
           /*auxiliary_reserved_memory_bytes=*/1024),
       std::runtime_error);
 
+  // Fixed auxiliary state, including a preallocated windowed drafter pool, also consumes the
+  // configured budget when there is no per-block head.
+  EXPECT_EQ(
+      ResolveConfiguredPagedBlockCount(
+          /*configured_num_blocks=*/100,
+          /*primary_bytes_per_block=*/64,
+          /*auxiliary_bytes_per_block=*/0,
+          /*auxiliary_reserved_memory_bytes=*/64),
+      99u);
+
   // A budget too small to leave a block for each pool is rejected rather than silently allocating
   // an extra head pool outside the configured sizing contract.
   EXPECT_THROW(
@@ -505,6 +515,21 @@ TEST(PagedKeyValueCacheManifestTest, ExplicitBlockCountCoversBothPools) {
           /*configured_num_blocks=*/std::numeric_limits<size_t>::max(),
           /*primary_bytes_per_block=*/64,
           /*auxiliary_bytes_per_block=*/32),
+      std::runtime_error);
+
+  EXPECT_THROW(
+      ResolveConfiguredPagedBlockCount(
+          /*configured_num_blocks=*/1,
+          /*primary_bytes_per_block=*/64,
+          /*auxiliary_bytes_per_block=*/0,
+          /*auxiliary_reserved_memory_bytes=*/64),
+      std::runtime_error);
+
+  EXPECT_THROW(
+      ResolveConfiguredPagedBlockCount(
+          /*configured_num_blocks=*/1,
+          /*primary_bytes_per_block=*/64,
+          /*auxiliary_bytes_per_block=*/std::numeric_limits<size_t>::max()),
       std::runtime_error);
 }
 

--- a/test/cpp/engine/paged_key_value_cache_tests.cpp
+++ b/test/cpp/engine/paged_key_value_cache_tests.cpp
@@ -524,13 +524,6 @@ TEST(PagedKeyValueCacheManifestTest, ExplicitBlockCountCoversBothPools) {
           /*auxiliary_bytes_per_block=*/0,
           /*auxiliary_reserved_memory_bytes=*/64),
       std::runtime_error);
-
-  EXPECT_THROW(
-      ResolveConfiguredPagedBlockCount(
-          /*configured_num_blocks=*/1,
-          /*primary_bytes_per_block=*/64,
-          /*auxiliary_bytes_per_block=*/std::numeric_limits<size_t>::max()),
-      std::runtime_error);
 }
 
 TEST(PagedKeyValueCacheManifestTest, AllocatesSparseSlidingAndFullLayerCaches) {


### PR DESCRIPTION
## Summary

Fix explicit paged-cache budgeting for windowed DFlash 2 block drafters.

When `engine.dynamic_batching.num_blocks` was configured, the Engine allocated the drafter's fixed KV-cache pool but still assigned the target model the full configured block budget. Total cache allocation therefore exceeded the intended budget by the size of the drafter pool.

## Changes

- Compute the windowed drafter pool's exact byte footprint from its block count, cache geometry, element type, and layer count.
- Deduct that fixed footprint from the byte budget represented by explicit `num_blocks`.
- Validate arithmetic and budget capacity before allocating either KV-cache pool.
- Preserve automatic `gpu_utilization_factor` sizing by allocating the fixed drafter pool before probing free device memory.
- Keep full-attention DSpark sizing unchanged.
- Clarify that Engine-hosted auxiliary caches share the byte budget represented by the baseline target block count.

## Failure behavior

An explicit budget that cannot retain at least one target block after reserving the drafter pool is rejected during Engine construction. Pool-size arithmetic overflow is also rejected before allocation.

## Validation

- C++ build: `unit_tests` and `engine_unit_tests`
- Core unit tests: 240 passed, 22 skipped
- Engine unit tests: 581 passed
- Focused cache tests: 63 passed
- Clang-format and `git diff --check`

The complete change was reviewed independently by defect-focused, design-focused, and continuous-batching reviewers. Their common allocation-order finding was addressed by deferring the windowed drafter allocation until after explicit-budget validation.
