### PR TITLE
[WebGPU] Support paged attention models

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2188,11 +2188,11 @@ void SetProviderOption(Config& config, std::string_view provider_name, std::stri
   }
 
   // JSON-escape all caller-supplied string fragments before concatenating them into the
-  // JSON document. Without escaping, quote/backslash characters in provider_name,
+  // JSON document. Without escaping, quote/backslash characters in the provider name,
   // option_name, or option_value would let a caller inject arbitrary JSON structure
   // (sibling keys, new provider entries, etc.) into the parsed configuration.
   std::ostringstream json;
-  json << R"({")" << EscapeJsonString(provider_name) << R"(":{)";
+  json << R"({")" << EscapeJsonString(normalized_provider) << R"(":{)";
   if (!option_name.empty()) {
     json << R"(")" << EscapeJsonString(option_name) << R"(":")" << EscapeJsonString(option_value) << R"(")";
   }

--- a/src/ep/webgpu/interface.cpp
+++ b/src/ep/webgpu/interface.cpp
@@ -226,6 +226,12 @@ struct InterfaceImpl : DeviceInterface {
 
   void Synchronize() override {}  // Nothing to do?
 
+  void GetAvailableMemory(size_t& /*free_bytes*/, size_t& /*total_bytes*/) override {
+    throw std::runtime_error(
+        "WebGPU does not expose available device memory. Set "
+        "engine.dynamic_batching.num_blocks explicitly for PagedAttention models.");
+  }
+
   bool UpdateAttentionMask([[maybe_unused]] void* next_mask_data, void* mask_data, int batch_beam_size, [[maybe_unused]] int new_kv_length, int total_length, [[maybe_unused]] int max_length, bool update_only, ONNXTensorElementDataType type) override {
     if (batch_beam_size != 1 || !update_only) {
       return false;  // Fall back to CPU for multi-beam or non-static mask
@@ -326,8 +332,9 @@ struct InterfaceImpl : DeviceInterface {
     // excluded because they are meaningless for the trivial initialization model.
     // Keep this list in sync with ParseWebGpuContextConfig in
     // onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc.
-    constexpr std::array<std::string_view, 14> kWebGpuGlobalOptions = {
+    constexpr std::array<std::string_view, 15> kWebGpuGlobalOptions = {
         "deviceId",
+        "adapterIndex",
         "webgpuInstance",
         "webgpuDevice",
         "dawnProcTable",

--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -298,7 +298,7 @@ python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p pr
 
 This scenario is for when you want to build a model that uses the `PagedAttention` operator so it can be served by ONNX Runtime GenAI's continuous-batching engine. When enabled, the builder replaces `GroupQueryAttention` with `PagedAttention`, packs all sequences of the batch into a single flattened token axis (`input_ids` becomes 1D), stores the KV-cache in paged `[num_blocks, block_size, num_key_value_heads, head_size]` buffers, and removes the `attention_mask` input in favor of the `block_table`, `cumulative_sequence_lengths`, and `past_sequence_lengths` metadata inputs. It also removes `position_ids` when RoPE is fused into attention; architectures that require an external MRoPE op retain packed position IDs (for example, Qwen3.5/3.8 uses `[3, num_tokens]`). Set `prune_lm_head=true` to select the final packed hidden state for each sequence before the LM head and output `[batch_size, vocab_size]` logits. By default, it projects every packed hidden state and outputs `[num_tokens, vocab_size]` logits.
 
-Paged attention supports CUDA with `fp16` or `bf16` precision and WebGPU with `fp16` precision. Paged exports include the CPU `attention_metadata` input used by the runtime to provide stable query and KV bounds without downloading device sequence lengths in every attention layer. Paged attention cannot be combined with `exclude_embeds` or `exclude_lm_head`. `paged_block_size` defaults to `256` and must be a positive multiple of `256`; for models with short and long rotary caches, it must evenly divide `original_max_position_embeddings`. `gpu_utilization_factor` defaults to `0.6` and must be greater than `0` and at most `1`. `max_batch_size` defaults to `100` and must be a positive integer no greater than `256`. `paged_chunk_size` defaults to `paged_block_size`, must be a positive integer, and is written to `search.chunk_size`; it applies only to models whose sliding-window layers are served from a ring of blocks, which hold `paged_chunk_size + window_size - 1` positions and therefore require chunked prefill.
+Paged attention supports CUDA with `fp16` or `bf16` precision and WebGPU with `fp16` precision. CUDA paged exports include the CPU-resident `attention_metadata` input used by the runtime to provide stable query and KV bounds without downloading device sequence lengths in every attention layer; WebGPU exports omit it. Paged attention cannot be combined with `exclude_embeds` or `exclude_lm_head`. `paged_block_size` defaults to `256` and must be a positive multiple of `256`; for models with short and long rotary caches, it must evenly divide `original_max_position_embeddings`. `gpu_utilization_factor` defaults to `0.6` and must be greater than `0` and at most `1`. Set the positive integer `num_blocks` to use a fixed global-cache capacity instead; this is required for providers such as WebGPU that do not expose available device memory. `max_batch_size` defaults to `100` and must be a positive integer no greater than `256`. `paged_chunk_size` defaults to `paged_block_size`, must be a positive integer, and is written to `search.chunk_size`; it applies only to models whose sliding-window layers are served from a ring of blocks, which hold `paged_chunk_size + window_size - 1` positions and therefore require chunked prefill.
 
 Paged builds can describe non-legacy decoder state in `model.decoder.state_groups`. The Qwen hybrid builder emits exact logical layer IDs for sparse paged KV, fixed convolution state, and fixed recurrent state. Tensor name templates are emitted once under the decoder's `inputs` and `outputs`. Legacy models whose every decoder layer uses paged KV omit the manifest and preserve the existing implicit contract. The hybrid state manifest is experimental and its schema is not yet stable. It requires coordinated Engine runtime work beyond the current onnxruntime-genai#2454 head and is not compatible with the merged runtime on its own. In particular, the runtime must supply packed multimodal position IDs with shape `[3, num_tokens]`; the current `VarlenDecoderIO` does not create that input.
 
@@ -308,6 +308,16 @@ python -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o pa
 
 # From source:
 python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p fp16 -e cuda -c cache_dir_to_store_temp_files --extra_options use_paged_attention=true prune_lm_head=true
+```
+
+WebGPU requires a fixed cache capacity:
+
+```bash
+# From wheel:
+python -m onnxruntime_genai.models.builder -i path_to_local_folder_on_disk -o path_to_output_folder -p fp16 -e webgpu -c cache_dir_to_store_temp_files --extra_options use_paged_attention=true num_blocks=1024
+
+# From source:
+python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p fp16 -e webgpu -c cache_dir_to_store_temp_files --extra_options use_paged_attention=true num_blocks=1024
 ```
 
 #### Build a DFlash 2 Block Drafter

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -207,7 +207,7 @@ def check_extra_options(
                 "use_paged_attention cannot be combined with " + ", ".join(incompatible_options) + "."
             )
 
-        for key in ("paged_block_size", "paged_chunk_size", "max_batch_size"):
+        for key in ("paged_block_size", "paged_chunk_size", "num_blocks", "max_batch_size"):
             if key not in extra_options:
                 continue
             try:
@@ -780,8 +780,8 @@ def get_args():
                     cumulative_sequence_lengths, and past_sequence_lengths metadata inputs are added. With
                     prune_lm_head=true, selects the final packed hidden state for each sequence so the model outputs
                     [batch_size, vocab_size] logits. By default, the model outputs [num_tokens, vocab_size] logits.
-                    Currently only supported for the CUDA execution provider with fp16 or bf16 precision. Cannot be
-                    combined with exclude_embeds or exclude_lm_head.
+                    Supports CUDA with fp16 or bf16 precision and WebGPU with fp16 precision. Cannot be combined with
+                    exclude_embeds or exclude_lm_head.
                 paged_block_size = 256/512/768/...: Paged KV-cache block size used when use_paged_attention is set.
                     Must be a positive multiple of 256 (required by the ONNX Runtime PagedAttention CUDA kernel).
                     Default is 256. Also written to the `engine.dynamic_batching` section of genai_config.json.
@@ -789,6 +789,9 @@ def get_args():
                     Only used when use_paged_attention is set and the model's sliding-window layers are served
                     from a ring of blocks; those layers hold only `paged_chunk_size + window_size - 1` positions,
                     so prefill must be chunked. Must be a positive integer. Default is paged_block_size.
+                num_blocks = Fixed global paged KV-cache capacity. Must be a positive integer. When set, it replaces
+                    gpu_utilization_factor in genai_config.json. Required for providers such as WebGPU that do not
+                    expose available device memory.
                 windowed_kv_cache = Use a reduced KV cache for sliding-window layers. Default is true.
                     With paged attention, eligible local layers use a ring of blocks while at least one full-context
                     layer remains. Without paged attention, supported execution providers use their windowed-cache

--- a/src/python/py/models/builders/base.py
+++ b/src/python/py/models/builders/base.py
@@ -593,6 +593,8 @@ class Model:
                 del self.input_names["attention_mask"]
             if not self.has_windowed_paged_layers():
                 del self.input_names["block_table_windowed"]
+            if self.ep == "webgpu":
+                del self.input_names["attention_metadata"]
         else:
             for name in [
                 "block_table",
@@ -1171,7 +1173,8 @@ class Model:
                 inputs["block_table_windowed"] = self.input_names["block_table_windowed"]
             inputs["cumulative_sequence_lengths"] = self.input_names["cumulative_sequence_lengths"]
             inputs["past_sequence_lengths"] = self.input_names["past_sequence_lengths"]
-            inputs["attention_metadata"] = self.input_names["attention_metadata"]
+            if "attention_metadata" in self.input_names:
+                inputs["attention_metadata"] = self.input_names["attention_metadata"]
         if "past_key_values.key" in self.input_names:
             inputs["past_key_names"] = "past_key_values.%d.key"
         if "past_key_values.value" in self.input_names:
@@ -1296,13 +1299,17 @@ class Model:
             genai_config["model"]["decoder"]["session_options"]["provider_options"].append(ep_options)
 
         if self.use_paged_attention:
-            genai_config["engine"] = {
-                "dynamic_batching": {
-                    "block_size": self.attention_attrs["paged_block_size"],
-                    "gpu_utilization_factor": float(self.extra_options.get("gpu_utilization_factor", 0.6)),
-                    "max_batch_size": int(self.extra_options.get("max_batch_size", 100)),
-                },
+            dynamic_batching = {
+                "block_size": self.attention_attrs["paged_block_size"],
+                "max_batch_size": int(self.extra_options.get("max_batch_size", 100)),
             }
+            if "num_blocks" in self.extra_options:
+                dynamic_batching["num_blocks"] = int(self.extra_options["num_blocks"])
+            else:
+                dynamic_batching["gpu_utilization_factor"] = float(
+                    self.extra_options.get("gpu_utilization_factor", 0.6)
+                )
+            genai_config["engine"] = {"dynamic_batching": dynamic_batching}
 
         state_groups = self.make_decoder_state_groups(inputs, outputs)
         if state_groups:
@@ -3740,7 +3747,7 @@ class Model:
                 cumulative_sequence_lengths=self.input_names["cumulative_sequence_lengths"],
                 past_sequence_lengths=self.input_names["past_sequence_lengths"],
                 block_table=block_table,
-                attention_metadata=self.input_names["attention_metadata"],
+                attention_metadata=self.input_names.get("attention_metadata", ""),
                 **kwargs,
             )
         else:

--- a/test/cpp/model_tests.cpp
+++ b/test/cpp/model_tests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <algorithm>
 #include <cstring>  // for memcmp
 #include <iostream>
 #include <random>
@@ -20,6 +21,27 @@
 
 // External global variable from main.cpp for custom model path
 extern std::string g_custom_model_path;
+
+TEST(ConfigTests, FullProviderNameUpdatesCanonicalOptions) {
+  Generators::Config config;
+  Generators::SetProviderOption(config, "webgpu", "validationMode", "basic");
+  Generators::SetProviderOption(config, "WebGpuExecutionProvider", "adapterIndex", "3");
+
+  ASSERT_EQ(config.model.decoder.session_options.provider_options.size(), 1u);
+  const auto& provider_options = config.model.decoder.session_options.provider_options.front();
+  EXPECT_EQ(provider_options.name, "WebGPU");
+  ASSERT_EQ(provider_options.options.size(), 2u);
+  const auto find_option = [&provider_options](std::string_view name) {
+    return std::find_if(provider_options.options.begin(), provider_options.options.end(),
+                        [name](const auto& option) { return option.first == name; });
+  };
+  const auto validation_mode = find_option("validationMode");
+  ASSERT_NE(validation_mode, provider_options.options.end());
+  EXPECT_EQ(validation_mode->second, "basic");
+  const auto adapter_index = find_option("adapterIndex");
+  ASSERT_NE(adapter_index, provider_options.options.end());
+  EXPECT_EQ(adapter_index->second, "3");
+}
 
 // To generate this file:
 // python convert_generation.py --model_type gpt2 -m hf-internal-testing/tiny-random-gpt2 --output tiny_gpt2_greedysearch_fp16.onnx --use_gpu --max_length 20

--- a/test/python/builder/test_paged_windowed_kv_cache.py
+++ b/test/python/builder/test_paged_windowed_kv_cache.py
@@ -207,6 +207,7 @@ def test_all_local_layers_keep_the_shared_block_count():
 
 def _make_inputs_model(use_paged_attention, use_ring):
     model = _new_model()
+    model.ep = "cuda"
     model.extra_options = {}
     model.use_paged_attention = use_paged_attention
     model.context_length_attrs["window_kv_cache"] = use_ring
@@ -252,13 +253,15 @@ def test_paged_model_without_a_ring_drops_the_windowed_block_table():
     assert "block_table" in model.input_names
 
 
-def test_webgpu_paged_model_keeps_attention_metadata():
-    model = _make_inputs_model(use_paged_attention=True, use_ring=False)
+def test_webgpu_paged_model_drops_attention_metadata():
+    model = _make_inputs_model(use_paged_attention=True, use_ring=True)
     model.ep = "webgpu"
 
     model.make_inputs_init()
 
-    assert "attention_metadata" in model.input_names
+    assert "attention_metadata" not in model.input_names
+    assert "block_table" in model.input_names
+    assert "block_table_windowed" in model.input_names
 
 
 def test_non_paged_model_drops_every_paged_input():
@@ -469,6 +472,14 @@ def test_genai_config_honours_paged_chunk_size(monkeypatch, tmp_path):
     config = _write_genai_config(monkeypatch, tmp_path, window_size=128, extra_options={"paged_chunk_size": "64"})
 
     assert config["search"]["chunk_size"] == 64
+
+
+def test_genai_config_honours_explicit_block_capacity(monkeypatch, tmp_path):
+    config = _write_genai_config(monkeypatch, tmp_path, window_size=128, extra_options={"num_blocks": "1024"})
+
+    dynamic_batching = config["engine"]["dynamic_batching"]
+    assert dynamic_batching["num_blocks"] == 1024
+    assert "gpu_utilization_factor" not in dynamic_batching
 
 
 def test_genai_config_omits_the_ring_when_it_is_off(monkeypatch, tmp_path):

--- a/test/python/builder/test_precision.py
+++ b/test/python/builder/test_precision.py
@@ -731,6 +731,8 @@ def test_paged_attention_lm_head_pruning(monkeypatch, tmp_path, prune_lm_head, l
         ({"use_paged_attention": "true", "paged_chunk_size": "0"}, "paged_chunk_size"),
         ({"use_paged_attention": "true", "paged_chunk_size": "-1"}, "paged_chunk_size"),
         ({"use_paged_attention": "true", "paged_chunk_size": "abc"}, "paged_chunk_size"),
+        ({"use_paged_attention": "true", "num_blocks": "0"}, "num_blocks"),
+        ({"use_paged_attention": "true", "num_blocks": "abc"}, "num_blocks"),
         ({"use_paged_attention": "true", "max_batch_size": "-1"}, "max_batch_size"),
         ({"use_paged_attention": "true", "max_batch_size": "257"}, "max_batch_size"),
         ({"use_paged_attention": "true", "gpu_utilization_factor": "0"}, "gpu_utilization_factor"),
@@ -747,12 +749,14 @@ def test_paged_attention_normalizes_engine_options(monkeypatch):
         "use_paged_attention": "true",
         "paged_block_size": "512",
         "paged_chunk_size": "64",
+        "num_blocks": "1024",
         "gpu_utilization_factor": "0.75",
         "max_batch_size": "32",
     }
     _run_check_extra_options(monkeypatch, extra_options, precision="bf16", execution_provider="cuda")
     assert extra_options["paged_block_size"] == 512
     assert extra_options["paged_chunk_size"] == 64
+    assert extra_options["num_blocks"] == 1024
     assert extra_options["gpu_utilization_factor"] == 0.75
     assert extra_options["max_batch_size"] == 32
 


### PR DESCRIPTION
## Summary

Enable model-builder and runtime support for running paged-attention models with the WebGPU execution provider. WebGPU cannot query available device memory and its PagedAttention kernel does not consume the CPU-only `attention_metadata` input, so these models need an explicit cache capacity and a provider-specific input contract.

## Key changes

- Add and validate the `num_blocks` model-builder option, emitting it instead of `gpu_utilization_factor` for fixed-capacity paged KV caches.
- Omit `attention_metadata` from WebGPU paged models while preserving the remaining paged inputs.
- Fail with an actionable message if runtime memory-based cache sizing is attempted on WebGPU.
- Normalize full WebGPU provider names and forward `adapterIndex` to the initialization session.
- Document the WebGPU export command and add focused C++ and Python regression coverage.

## Testing

- `python -m pytest -q test/python/builder/test_paged_windowed_kv_cache.py test/python/builder/test_precision.py` (`108 passed`)
- `clang-format --dry-run --Werror src/config.cpp src/ep/webgpu/interface.cpp test/cpp/model_tests.cpp`

C++ build/tests were not run locally because CMake Tools has no configured build targets in this workspace and could not configure the project.