### PR TITLE
Fix DFlash target hidden-state taps

### DIFF
--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -313,16 +313,16 @@ python builder.py -i path_to_local_folder_on_disk -o path_to_output_folder -p fp
 
 #### Build a DFlash 2 Block Drafter
 
-Set `dflash2_path` to a DFlash 2 checkpoint to export an auxiliary `dflash2.onnx` block drafter beside a Qwen3.5 MoE target model. The target must use paged attention, and `aux_hidden_state_layers` must exactly match the drafter checkpoint's `target_layer_ids`. The drafter reuses the target's embedding and LM-head initializers, so both checkpoints must use compatible tensors.
+Set `dflash2_path` to a DFlash 2 checkpoint to export an auxiliary `dflash2.onnx` block drafter beside a Qwen3.5 MoE target model. The target must use paged attention. SpecForge identifies the target layers whose outputs are tapped, while `aux_hidden_state_layers` identifies residual streams entering layers, so each configured auxiliary layer must be one greater than the corresponding `target_layer_ids` entry in the DFlash checkpoint. The drafter reuses the target's embedding and LM-head initializers, so both checkpoints must use compatible tensors.
 
 `dflash2_num_draft_tokens` optionally overrides how many tokens the drafter proposes per step. It must be a positive integer no greater than the draft checkpoint's block size minus the anchor token; that checkpoint limit is also the default.
 
 ```bash
 # From wheel:
-python -m onnxruntime_genai.models.builder -i path_to_target_model -o path_to_output_folder -p fp16 -e cuda -c cache_dir_for_hf_files --extra_options use_paged_attention=true aux_hidden_state_layers=1,11,21 dflash2_path=path_to_dflash2_checkpoint dflash2_num_draft_tokens=4
+python -m onnxruntime_genai.models.builder -i path_to_target_model -o path_to_output_folder -p fp16 -e cuda -c cache_dir_for_hf_files --extra_options use_paged_attention=true aux_hidden_state_layers=2,12,22 dflash2_path=path_to_dflash2_checkpoint dflash2_num_draft_tokens=4
 
 # From source:
-python builder.py -i path_to_target_model -o path_to_output_folder -p fp16 -e cuda -c cache_dir_for_hf_files --extra_options use_paged_attention=true aux_hidden_state_layers=1,11,21 dflash2_path=path_to_dflash2_checkpoint dflash2_num_draft_tokens=4
+python builder.py -i path_to_target_model -o path_to_output_folder -p fp16 -e cuda -c cache_dir_for_hf_files --extra_options use_paged_attention=true aux_hidden_state_layers=2,12,22 dflash2_path=path_to_dflash2_checkpoint dflash2_num_draft_tokens=4
 ```
 
 #### Build a DSpark Block Drafter

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -753,8 +753,9 @@ def get_args():
                     layer i, so indices must lie in [1, num_hidden_layers). Default is empty (disabled).
                 dflash2_path = Path to a DFlash 2 draft checkpoint. Exports an auxiliary `dflash2.onnx`
                     block drafter beside the target model and adds a `dflash2` section to
-                    genai_config.json. Requires use_paged_attention=true, and requires
-                    aux_hidden_state_layers to match the drafter's `target_layer_ids`. Default is unset (disabled).
+                    genai_config.json. Requires use_paged_attention=true. SpecForge taps each target
+                    layer's output, so aux_hidden_state_layers must be the drafter's
+                    `target_layer_ids` each plus one. Default is unset (disabled).
                 dflash2_num_draft_tokens = Override the number of draft tokens the DFlash 2 block
                     drafter proposes per step. Must be positive and no greater than the draft checkpoint's
                     block size minus its anchor token. That checkpoint limit is the default.

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -1062,6 +1062,26 @@ class Qwen35MoEModel(MTPModel):
     def save_processing(self, model_name_or_path, extra_kwargs, out_dir):
         self.decoder.save_processing(model_name_or_path, extra_kwargs, out_dir)
 
+    def require_specforge_aux_taps(self, target_layer_ids, drafter_name):
+        if not target_layer_ids:
+            raise ValueError(f"The {drafter_name} checkpoint must define at least one target_layer_ids entry.")
+
+        aux_layers = [layer_id + 1 for layer_id in target_layer_ids]
+        untappable = [layer_id - 1 for layer_id in aux_layers if not 1 <= layer_id < self.decoder.num_layers]
+        if untappable:
+            raise ValueError(
+                f"The {drafter_name} checkpoint targets decoder layers {untappable}, whose outputs the exporter "
+                f"cannot expose; target_layer_ids must lie in [0, {self.decoder.num_layers - 1})."
+            )
+
+        expected = ",".join(str(layer_id) for layer_id in aux_layers)
+        actual = ",".join(str(layer_id) for layer_id in self.decoder.aux_hidden_state_layers)
+        if actual != expected:
+            raise ValueError(
+                f"The {drafter_name} drafter needs aux_hidden_state_layers={expected} on the main model, "
+                f"got '{actual}'."
+            )
+
     def make_dflash2_init(self, io_dtype, extra_options):
         """DFlash 2 block drafter, exported as an auxiliary ``dflash2.onnx``.
 
@@ -1099,12 +1119,7 @@ class Qwen35MoEModel(MTPModel):
                 f"dflash2_num_draft_tokens must not exceed the drafter checkpoint limit ({checkpoint_draft_limit})."
             )
         target_layer_ids = dflash_config["target_layer_ids"]
-        expected = ",".join(str(i + 1) for i in target_layer_ids)
-        actual = ",".join(str(i) for i in self.decoder.aux_hidden_state_layers)
-        if actual != expected:
-            raise ValueError(
-                f"The DFlash 2 drafter needs aux_hidden_state_layers={expected} on the main model, got '{actual}'."
-            )
+        self.require_specforge_aux_taps(target_layer_ids, "DFlash 2")
 
     def make_dflash2_model(self, input_path):
         if not self.dflash2_path:
@@ -1204,12 +1219,7 @@ class Qwen35MoEModel(MTPModel):
         }
 
         target_layer_ids = draft_config["dflash_config"]["target_layer_ids"]
-        expected = ",".join(str(i + 1) for i in target_layer_ids)
-        actual = ",".join(str(i) for i in self.decoder.aux_hidden_state_layers)
-        if actual != expected:
-            raise ValueError(
-                f"The DSpark drafter needs aux_hidden_state_layers={expected} on the main model, got '{actual}'."
-            )
+        self.require_specforge_aux_taps(target_layer_ids, "DSpark")
 
     def make_dspark_model(self, input_path):
         if not self.dspark_path:

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -1066,7 +1066,9 @@ class Qwen35MoEModel(MTPModel):
         """DFlash 2 block drafter, exported as an auxiliary ``dflash2.onnx``.
 
         ``dflash2_path`` points at the draft checkpoint. The drafter has no embedding and no
-        LM head of its own, so both come from the target and are shared on disk.
+        LM head of its own, so both come from the target and are shared on disk. SpecForge taps
+        the output of each ``target_layer_ids`` entry, which is the residual stream entering the
+        following layer.
         """
         self.dflash2_path = extra_options.get("dflash2_path")
         if not self.dflash2_path:
@@ -1097,7 +1099,7 @@ class Qwen35MoEModel(MTPModel):
                 f"dflash2_num_draft_tokens must not exceed the drafter checkpoint limit ({checkpoint_draft_limit})."
             )
         target_layer_ids = dflash_config["target_layer_ids"]
-        expected = ",".join(str(i) for i in target_layer_ids)
+        expected = ",".join(str(i + 1) for i in target_layer_ids)
         actual = ",".join(str(i) for i in self.decoder.aux_hidden_state_layers)
         if actual != expected:
             raise ValueError(

--- a/test/python/builder/test_qwen_dflash2_export.py
+++ b/test/python/builder/test_qwen_dflash2_export.py
@@ -55,6 +55,7 @@ def _composite(aux_layers=AUX_LAYERS, use_paged_attention=True):
         aux_hidden_state_layers=list(aux_layers),
         num_kv_heads=2,
         head_size=128,
+        num_layers=32,
         filename="model.onnx",
         attention_attrs={"paged_block_size": 256},
         context_length=32768,
@@ -95,6 +96,26 @@ def test_matching_tap_layers_are_accepted(tmp_path):
     model.make_dflash2_init(io_dtype=None, extra_options={"dflash2_path": _draft_checkpoint(tmp_path)})
 
     assert model.dflash2_attrs["num_draft_tokens"] is None
+
+
+def test_checkpoint_must_define_target_layers(tmp_path):
+    model = _composite(aux_layers=[])
+
+    with pytest.raises(ValueError, match="at least one target_layer_ids entry"):
+        model.make_dflash2_init(
+            io_dtype=None,
+            extra_options={"dflash2_path": _draft_checkpoint(tmp_path, target_layer_ids=[])},
+        )
+
+
+def test_checkpoint_cannot_target_an_unexposable_layer(tmp_path):
+    model = _composite(aux_layers=[32])
+
+    with pytest.raises(ValueError, match=r"target_layer_ids must lie in \[0, 31\)"):
+        model.make_dflash2_init(
+            io_dtype=None,
+            extra_options={"dflash2_path": _draft_checkpoint(tmp_path, target_layer_ids=[31])},
+        )
 
 
 def test_draft_token_count_can_be_overridden(tmp_path):

--- a/test/python/builder/test_qwen_dflash2_export.py
+++ b/test/python/builder/test_qwen_dflash2_export.py
@@ -15,6 +15,7 @@ from models.builders.mtp import MTPModel
 from models.builders.qwen import Qwen35MoEModel
 
 TARGET_LAYER_IDS = [1, 11, 21]
+AUX_LAYERS = [layer_id + 1 for layer_id in TARGET_LAYER_IDS]
 
 
 def _draft_checkpoint(tmp_path, target_layer_ids=TARGET_LAYER_IDS):
@@ -45,7 +46,7 @@ def _draft_checkpoint(tmp_path, target_layer_ids=TARGET_LAYER_IDS):
     return str(draft_dir)
 
 
-def _composite(aux_layers=TARGET_LAYER_IDS, use_paged_attention=True):
+def _composite(aux_layers=AUX_LAYERS, use_paged_attention=True):
     model = object.__new__(Qwen35MoEModel)
     model.dflash2 = None
     model.dflash2_shared_initializers = []
@@ -78,9 +79,9 @@ def test_drafter_requires_paged_attention(tmp_path):
         model.make_dflash2_init(io_dtype=None, extra_options={"dflash2_path": _draft_checkpoint(tmp_path)})
 
 
-# The drafter reads the target's residual streams by position, so a tap set that does not match
-# the checkpoint's target_layer_ids silently feeds it the wrong tensors.
-@pytest.mark.parametrize("aux_layers", [[1, 11], [1, 11, 22], [21, 11, 1], []])
+# SpecForge target_layer_ids name layer outputs, while aux_hidden_state_layers names the residual
+# entering a layer. Passing the checkpoint IDs through unchanged silently selects the prior outputs.
+@pytest.mark.parametrize("aux_layers", [TARGET_LAYER_IDS, [2, 12], [2, 12, 23], [22, 12, 2], []])
 def test_mismatched_tap_layers_are_rejected(tmp_path, aux_layers):
     model = _composite(aux_layers=aux_layers)
 
@@ -142,7 +143,7 @@ def test_genai_config_gains_the_drafter_and_the_target_tap(tmp_path):
     config = json.loads(config_path.read_text())
     assert config["model"]["decoder"]["outputs"]["aux_hidden_states"] == "aux_hidden_states"
     assert config["model"]["dflash2"]["filename"] == "dflash2.onnx"
-    assert config["model"]["dflash2"]["aux_hidden_state_layers"] == TARGET_LAYER_IDS
+    assert config["model"]["dflash2"]["aux_hidden_state_layers"] == AUX_LAYERS
 
 
 def test_shared_initializers_are_recorded_once_on_both_sides(tmp_path):

--- a/test/python/builder/test_qwen_dspark_export.py
+++ b/test/python/builder/test_qwen_dspark_export.py
@@ -53,6 +53,7 @@ def _composite(aux_layers=AUX_LAYERS, use_paged_attention=True, dflash2_path=Non
     model.decoder = types.SimpleNamespace(
         use_paged_attention=use_paged_attention,
         aux_hidden_state_layers=list(aux_layers),
+        num_layers=32,
         filename="model.onnx",
         attention_attrs={"paged_block_size": 256},
         context_length=32768,
@@ -108,6 +109,26 @@ def test_tap_layers_one_past_each_target_layer_are_accepted(tmp_path):
 
     assert model.dspark_attrs["num_draft_tokens"] is None
     assert model.dspark_attrs["top_k"] == 16
+
+
+def test_checkpoint_must_define_target_layers(tmp_path):
+    model = _composite(aux_layers=[])
+
+    with pytest.raises(ValueError, match="at least one target_layer_ids entry"):
+        model.make_dspark_init(
+            io_dtype=None,
+            extra_options={"dspark_path": _draft_checkpoint(tmp_path, target_layer_ids=[])},
+        )
+
+
+def test_checkpoint_cannot_target_an_unexposable_layer(tmp_path):
+    model = _composite(aux_layers=[32])
+
+    with pytest.raises(ValueError, match=r"target_layer_ids must lie in \[0, 31\)"):
+        model.make_dspark_init(
+            io_dtype=None,
+            extra_options={"dspark_path": _draft_checkpoint(tmp_path, target_layer_ids=[31])},
+        )
 
 
 def test_lattice_width_and_draft_count_can_be_overridden(tmp_path):


### PR DESCRIPTION
## Summary
- translate SpecForge DFlash `target_layer_ids` to the following `aux_hidden_state_layers` entry
- reject unshifted tap configurations that would feed the drafter the preceding layer outputs
- update model-builder help, documentation, examples, and exporter coverage

## Why
SpecForge capture layer `L` is the output of target layer `L` (`hidden_states[L + 1]`). The model builder names auxiliary taps by the residual stream entering a layer, so the equivalent tap is `L + 1`. Matching the IDs directly supplied the previous layer's output and could materially reduce DFlash acceptance.

## Validation
- `python -m pytest -q test\python\builder\test_qwen_dflash2_export.py`
- repository-configured `lintrunner`
- targeted Ruff lint and format checks for the changed linted Python files