### PR TITLE
Preserve exact generated prompt length in benchmark

### DIFF
--- a/benchmark/c/main.cpp
+++ b/benchmark/c/main.cpp
@@ -256,7 +256,16 @@ void RunBenchmark(const benchmark::Options& opts) {
     }
     const auto output_sequence_length = gen->TokenCount();
     const auto* output_sequence_data = gen->GetSequenceData(0);
-    prompt = std::string{tokenizer->Decode(output_sequence_data, output_sequence_length)};
+    if (output_sequence_length < num_prompt_tokens) {
+      throw std::runtime_error(
+          "Generated prompt has fewer tokens than requested by -l/--prompt_length.");
+    }
+
+    // Keep the generated token IDs instead of decoding and re-encoding them.
+    // Tokenizer round trips are not token-count preserving, so re-encoding can
+    // produce more than the exact prompt length requested with -l.
+    std::vector<int32_t> prompt_tokens(output_sequence_data, output_sequence_data + num_prompt_tokens);
+    prompt = std::string{tokenizer->Decode(prompt_tokens.data(), prompt_tokens.size())};
   }
 
   auto prompt_sequences = OgaSequences::Create();


### PR DESCRIPTION
* preserve generated prompt token IDs instead of decode/re-encoding them
* guarantee bare -l/--prompt_length benchmarks use the requested input length
