### PR TITLE
Expose terminal EOS tokens to Engine continuation hosts

### DIFF
--- a/docs/engine_c_api_spec.md
+++ b/docs/engine_c_api_spec.md
@@ -346,10 +346,13 @@ typedef uint32_t OgaEngineEventFlags;
 #define OgaEngineEventFlag_CapacityBlocked ((OgaEngineEventFlags)(1u << 2))
 #define OgaEngineEventFlag_Failed ((OgaEngineEventFlags)(1u << 3))
 #define OgaEngineEventFlag_Retryable ((OgaEngineEventFlags)(1u << 4))
+#define OgaEngineEventFlag_TerminalToken ((OgaEngineEventFlags)(1u << 5))
 ```
 
 `OgaEngineEventFlags` is a bitmask, not a mutually exclusive type. In particular, a final model step
-may emit one event with both `Token` and `TurnFinished`.
+may emit one event with both `Token` and `TurnFinished`. EOS completion instead emits a distinct
+`TerminalToken | TurnFinished` event because a speculative step can also make visible tokens
+available before selecting EOS.
 
 The public types are fixed-width integer typedefs rather than C enums. Adding a constant therefore
 cannot change a field or parameter's ABI width under compiler enum-size options.
@@ -413,8 +416,10 @@ Payload validity is determined by flags:
 | --- | --- |
 | `None` | Reserved zero value; no-work is represented by Buffer count zero |
 | `Token` | `request`, `turn_id`, and `token` |
+| `TerminalToken` | `request`, `turn_id`, and the selected EOS `token`; always combined with `TurnFinished` |
 | `TurnFinished` | `request`, `turn_id`, `finish_reason`, `usage`, and `matched_stop_string_index` (-1 unless `finish_reason` is `StopString`) |
 | `Token \| TurnFinished` | Final visible token and terminal payload from the same committed step |
+| `TerminalToken \| TurnFinished` | EOS selected without appending it to the retained sequence or generated-token usage |
 | `CapacityBlocked` | `error_code` is `CapacityDeferred` or `ExecutionCapacityExceeded`; Engine and Request remain reusable |
 | `Retryable` | `error_code` is `RetryableExecution`; no progress committed and the Engine remains reusable |
 | `TurnFinished \| Failed` | Request/Turn failure; finish reason is `Failed` |
@@ -771,8 +776,10 @@ delivery does not remove tokens from that state. Because token and Turn ID are c
 commit, no `GeneratedTokenRecord` or per-Turn token range is required.
 
 Callers must never consume the token getter merely because an event was returned. They check
-`flags & OgaEngineEventFlag_Token`; the same event can also carry
-`OgaEngineEventFlag_TurnFinished`.
+`flags & OgaEngineEventFlag_Token` for visible output or
+`flags & OgaEngineEventFlag_TerminalToken` for an unappended EOS boundary. A host may pass the
+terminal token before the next Turn's continuation tokens when required by the model's chat
+template, but must not display or count it as assistant output.
 
 ## Failure and capacity behavior
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -17,6 +17,7 @@ static_assert(kMaxDraftTokensPerStep < kSpeculativeAcceptanceLengthBins);
 namespace {
 
 constexpr size_t kFatalEventOverhead = 2;
+constexpr size_t kMaxEventsPerRequestStep = kMaxGeneratedTokensPerStep + 1;
 constexpr size_t kMtpFailureDisableThreshold = 3;
 constexpr size_t kDflash2FailureDisableThreshold = 3;
 
@@ -174,12 +175,12 @@ Engine::Engine(std::shared_ptr<Model> model, EngineDependencies dependencies)
   const size_t max_batch_size = cache_manager_->MaxBatchSize();
   if (fatal_events_.max_size() < kFatalEventOverhead ||
       max_batch_size > (fatal_events_.max_size() - kFatalEventOverhead) /
-                           kMaxGeneratedTokensPerStep) {
+                           kMaxEventsPerRequestStep) {
     throw std::overflow_error(
         "Engine event capacity exceeds the supported size.");
   }
   max_step_event_count_ =
-      max_batch_size * kMaxGeneratedTokensPerStep;
+      max_batch_size * kMaxEventsPerRequestStep;
   step_plan_.requests.reserve(max_batch_size);
   step_results_.reserve(max_batch_size);
   staged_event_order_.reserve(max_batch_size);
@@ -2027,22 +2028,32 @@ void Engine::AppendEventsFromStep(
         0};
   };
 
+  const bool has_terminal_token =
+      result.done &&
+      !result.token_appended &&
+      result.finish_reason == GenerationFinishReason::EosToken;
   for (size_t i = 0; i < result.visible_token_count; ++i) {
     EngineEvent event;
     event.request = request;
     event.turn_id = request->CurrentTurnId();
     event.flags = EngineEventFlagToken;
     event.token = result.visible_tokens[i];
-    if (result.done && i + 1 == result.visible_token_count) {
+    if (result.done && !has_terminal_token &&
+        i + 1 == result.visible_token_count) {
       finish_turn(event);
     }
     staged_events_.push_back(std::move(event));
   }
 
-  if (result.done && result.visible_token_count == 0) {
+  if (result.done &&
+      (result.visible_token_count == 0 || has_terminal_token)) {
     EngineEvent event;
     event.request = request;
     event.turn_id = request->CurrentTurnId();
+    if (has_terminal_token) {
+      event.flags |= EngineEventFlagTerminalToken;
+      event.token = result.token;
+    }
     finish_turn(event);
     staged_events_.push_back(std::move(event));
   }

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -42,6 +42,7 @@ enum EngineEventFlag : uint32_t {
   EngineEventFlagCapacityBlocked = 1u << 2,
   EngineEventFlagFailed = 1u << 3,
   EngineEventFlagRetryable = 1u << 4,
+  EngineEventFlagTerminalToken = 1u << 5,
 };
 
 struct TurnUsage {

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -910,7 +910,9 @@ RequestStepResult Request::StageDraftCompletionForTransaction() {
     }
   }
   RequestStepResult result{
-      0,
+      finish_reason == GenerationFinishReason::EosToken
+          ? search_->GetNextTokens().CpuSpan().back()
+          : 0,
       false,
       true,
       finish_reason,
@@ -1245,6 +1247,7 @@ RequestStepResult Request::CompleteGeneration() {
     if (search_->IsDone() && !next_tokens.empty() &&
         contains(params_->config.model.eos_token_id, next_tokens.back())) {
       finish_reason_ = GenerationFinishReason::EosToken;
+      token = next_tokens.back();
     } else if (turn_limit_reached) {
       finish_reason_ = GenerationFinishReason::TurnLimit;
     } else {

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -71,6 +71,8 @@ struct TurnOptions {
 };
 
 struct RequestStepResult {
+  // The sampled token for this step. For EOS completion this is the selected terminal token even
+  // though Search does not append it to the retained sequence or include it in visible_tokens.
   int32_t token{};
   bool token_appended{};
   bool done{};

--- a/src/ort_genai.h
+++ b/src/ort_genai.h
@@ -979,6 +979,20 @@ struct OgaEngineEvent : OgaAbstract {
     return value;
   }
 
+  std::optional<int32_t> VisibleToken() const {
+    if ((Flags() & OgaEngineEventFlag_Token) == 0) {
+      return std::nullopt;
+    }
+    return Token();
+  }
+
+  std::optional<int32_t> TerminalToken() const {
+    if ((Flags() & OgaEngineEventFlag_TerminalToken) == 0) {
+      return std::nullopt;
+    }
+    return Token();
+  }
+
   OgaFinishReason FinishReason() const {
     OgaFinishReason value{};
     OgaCheckResult(OgaEngineEventGetFinishReason(this, &value));

--- a/src/ort_genai_c.h
+++ b/src/ort_genai_c.h
@@ -107,6 +107,14 @@ typedef uint32_t OgaEngineEventFlags;
 #define OgaEngineEventFlag_CapacityBlocked ((OgaEngineEventFlags)(1u << 2))
 #define OgaEngineEventFlag_Failed ((OgaEngineEventFlags)(1u << 3))
 #define OgaEngineEventFlag_Retryable ((OgaEngineEventFlags)(1u << 4))
+/**
+ * \brief The event's token is the EOS token selected to finish the Turn.
+ *
+ * Unlike OgaEngineEventFlag_Token, this token was not appended to the retained sequence and is not
+ * included in generated-token usage. A host may pass it before the next Turn's continuation tokens
+ * when required by the model's chat template, but should not display it as assistant output.
+ */
+#define OgaEngineEventFlag_TerminalToken ((OgaEngineEventFlags)(1u << 5))
 
 /** \brief Stable behavioral classification for an Engine event. */
 typedef uint32_t OgaErrorCode;
@@ -1301,7 +1309,8 @@ OGA_EXPORT const OgaEngineEvent* OGA_API_CALL OgaEngineEventBufferGet(
  *
  * Each getter below returns an owned OgaResult on a null event or output pointer and null on
  * success. Scalar outputs are initialized to zero and pointer outputs to null before a null event
- * is rejected. Payload meaning is selected by OgaEngineEventFlags.
+ * is rejected. Payload meaning is selected by OgaEngineEventFlags. OgaEngineEventGetToken is valid
+ * when either OgaEngineEventFlag_Token or OgaEngineEventFlag_TerminalToken is present.
  *
  * OgaEngineEventGetRequest returns a const borrowed Request alias that must not be destroyed.
  * OgaEngineEventGetUsage returns a borrowed usage view. Both have the event view's lifetime.

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -32,6 +32,7 @@ enum class PyEngineEventFlags : uint32_t {
   CapacityBlocked = OgaEngineEventFlag_CapacityBlocked,
   Failed = OgaEngineEventFlag_Failed,
   Retryable = OgaEngineEventFlag_Retryable,
+  TerminalToken = OgaEngineEventFlag_TerminalToken,
 };
 
 enum class PyEngineErrorCode : uint32_t {
@@ -800,6 +801,7 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       .value("CAPACITY_BLOCKED", PyEngineEventFlags::CapacityBlocked)
       .value("FAILED", PyEngineEventFlags::Failed)
       .value("RETRYABLE", PyEngineEventFlags::Retryable)
+      .value("TERMINAL_TOKEN", PyEngineEventFlags::TerminalToken)
       .def(
           "__and__",
           [](PyEngineEventFlags lhs, PyEngineEventFlags rhs) {
@@ -938,9 +940,16 @@ PYBIND11_MODULE(onnxruntime_genai, m) {
       })
       .def_property_readonly("turn_id", &OgaEngineEvent::TurnId)
       .def_property_readonly("token", [](const OgaEngineEvent& event) -> pybind11::object {
-        if ((event.Flags() & OgaEngineEventFlag_Token) == 0)
+        const auto token = event.VisibleToken();
+        if (!token)
           return pybind11::none();
-        return pybind11::int_(event.Token());
+        return pybind11::int_(*token);
+      })
+      .def_property_readonly("terminal_token", [](const OgaEngineEvent& event) -> pybind11::object {
+        const auto token = event.TerminalToken();
+        if (!token)
+          return pybind11::none();
+        return pybind11::int_(*token);
       })
       .def_property_readonly("finish_reason", [](const OgaEngineEvent& event) {
         return static_cast<PyFinishReason>(event.FinishReason());

--- a/test/cpp/c_api_tests.cpp
+++ b/test/cpp/c_api_tests.cpp
@@ -30,6 +30,8 @@
 
 namespace {
 
+static_assert(OgaEngineEventFlag_TerminalToken == (1u << 5));
+
 struct EngineEventSnapshot {
   OgaEngineEventFlags flags{};
   const OgaRequest* request{};

--- a/test/cpp/engine/engine_run_tests.cpp
+++ b/test/cpp/engine/engine_run_tests.cpp
@@ -1135,6 +1135,29 @@ TEST_F(EngineRunTest, StaticBatchingPreservesOrderingAndReusesResidentContinuati
   EXPECT_EQ(cache_observer->allocate_calls, allocations_before);
 }
 
+TEST_F(EngineRunTest, StaticBatchingEmitsSelectedEosAsTerminalToken) {
+  model_->config_->engine.dynamic_batching.reset();
+  const int32_t eos = EosToken(*model_);
+  auto cache = std::make_shared<RecordingCacheManager>(
+      model_, /*capacity=*/4, nullptr, /*supports_dynamic_batching=*/false);
+  auto scheduler = Scheduler::Create(model_, cache);
+  auto executor = std::make_unique<RecordingModelExecutor>(model_, cache, eos);
+  EngineDependencies dependencies{cache, std::move(scheduler), std::move(executor)};
+  auto engine = std::make_shared<Engine>(model_, std::move(dependencies));
+  const auto prompt = Prompt(10);
+  auto request = CreateEngineRequest(engine);
+  request->BeginTurn(prompt);
+
+  const auto event = RunOne(*engine);
+
+  EXPECT_EQ(event.request, request);
+  EXPECT_EQ(event.flags, EngineEventFlagTerminalToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(event.token, eos);
+  EXPECT_EQ(event.finish_reason, GenerationFinishReason::EosToken);
+  EXPECT_EQ(event.usage.generated_tokens, 0u);
+  EXPECT_EQ(request->CurrentSequenceLength(), static_cast<int64_t>(prompt.size()));
+}
+
 TEST_F(EngineRunTest, StaticBatchReturnsAllRowEventsWhenCapacitySuffices) {
   model_->config_->engine.dynamic_batching.reset();
   auto cache = std::make_shared<RecordingCacheManager>(
@@ -2267,9 +2290,9 @@ TEST_F(EngineRunTest, SampledSpeculativeRunRespectsTurnTokenLimit) {
   EXPECT_EQ(request->TurnGeneratedTokens(), 3u);
 }
 
-// The bonus row predicting EOS ends the turn without appending it, so the step's only visible
-// tokens are the accepted drafts.
-TEST_F(EngineRunTest, SpeculativeRunWithEosBonusTokenEmitsOnlyAcceptedDrafts) {
+// The bonus row predicting EOS ends the turn without appending it. Accepted drafts remain visible
+// token events, followed by a distinct terminal-token event carrying the selected EOS.
+TEST_F(EngineRunTest, SpeculativeRunWithEosBonusTokenEmitsAcceptedDraftsThenTerminalToken) {
   const int32_t eos = EosToken(*model_);
   const int32_t filler = eos == 5 ? 6 : 5;
   auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
@@ -2285,17 +2308,18 @@ TEST_F(EngineRunTest, SpeculativeRunWithEosBonusTokenEmitsOnlyAcceptedDrafts) {
   engine.executor->SetVerifyRowTokens({11, 12, 13, eos});
 
   std::array<EngineEvent, 4> events;
-  ASSERT_EQ(engine.engine->Run(events), 3u);
+  ASSERT_EQ(engine.engine->Run(events), 4u);
 
   EXPECT_EQ(events[0].token, 11);
   EXPECT_EQ(events[1].token, 12);
   EXPECT_EQ(events[2].token, 13);
+  EXPECT_EQ(events[3].token, eos);
   EXPECT_EQ(events[0].flags, EngineEventFlagToken);
   EXPECT_EQ(events[1].flags, EngineEventFlagToken);
-  EXPECT_EQ(
-      events[2].flags,
-      EngineEventFlagToken | EngineEventFlagTurnFinished);
-  EXPECT_EQ(events[2].finish_reason, GenerationFinishReason::EosToken);
+  EXPECT_EQ(events[2].flags, EngineEventFlagToken);
+  EXPECT_EQ(events[3].flags,
+            EngineEventFlagTerminalToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(events[3].finish_reason, GenerationFinishReason::EosToken);
   EXPECT_EQ(request->status_, RequestStatus::TurnComplete);
   EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 3);
   EXPECT_EQ(request->TurnGeneratedTokens(), generated_after_prefill + 3);
@@ -2460,14 +2484,17 @@ TEST_F(EngineRunTest, SpeculativeRunStopsAtAcceptedEos) {
   request->SetDraftTokens(std::vector<int32_t>{11, eos, 13});
   engine.executor->SetVerifyRowTokens({11, eos, 13, 25});
 
-  const auto event = RunOne(*engine.engine);
+  const auto visible = RunOne(*engine.engine);
+  EXPECT_EQ(visible.request, request);
+  EXPECT_EQ(visible.flags, EngineEventFlagToken);
+  EXPECT_EQ(visible.token, 11);
 
-  EXPECT_EQ(event.request, request);
-  EXPECT_EQ(
-      event.flags,
-      EngineEventFlagToken | EngineEventFlagTurnFinished);
-  EXPECT_EQ(event.token, 11);
-  EXPECT_EQ(event.finish_reason, GenerationFinishReason::EosToken);
+  const auto terminal = RunOne(*engine.engine);
+  EXPECT_EQ(terminal.request, request);
+  EXPECT_EQ(terminal.flags,
+            EngineEventFlagTerminalToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(terminal.token, eos);
+  EXPECT_EQ(terminal.finish_reason, GenerationFinishReason::EosToken);
   EXPECT_EQ(request->status_, RequestStatus::TurnComplete);
   EXPECT_EQ(request->FinishReason(), GenerationFinishReason::EosToken);
   EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 1);

--- a/test/cpp/engine/engine_run_tests.cpp
+++ b/test/cpp/engine/engine_run_tests.cpp
@@ -2504,6 +2504,36 @@ TEST_F(EngineRunTest, SpeculativeRunStopsAtAcceptedEos) {
   EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 2u);
 }
 
+TEST_F(EngineRunTest, SpeculativeRunReportsEosThatReplacesRejectedDraft) {
+  const int32_t eos = EosToken(*model_);
+  const int32_t filler = eos == 5 ? 6 : 5;
+  auto engine = MakeDoublesEngine(model_, /*capacity=*/8, filler);
+  engine.cache->SetMaxDraftTokensPerStep(3);
+
+  auto request =
+      CreateRequestWithPrompt(engine.engine, Prompt(10));
+  ASSERT_EQ(RunOne(*engine.engine).request, request);
+  const int64_t length_after_prefill = request->CurrentSequenceLength();
+  const size_t generated_after_prefill = request->TurnGeneratedTokens();
+
+  request->SetDraftTokens(std::vector<int32_t>{11, 12, 13});
+  engine.executor->SetVerifyRowTokens({11, eos, 21, 22});
+
+  const auto visible = RunOne(*engine.engine);
+  EXPECT_EQ(visible.request, request);
+  EXPECT_EQ(visible.flags, EngineEventFlagToken);
+  EXPECT_EQ(visible.token, 11);
+
+  const auto terminal = RunOne(*engine.engine);
+  EXPECT_EQ(terminal.request, request);
+  EXPECT_EQ(terminal.flags,
+            EngineEventFlagTerminalToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(terminal.token, eos);
+  EXPECT_EQ(terminal.finish_reason, GenerationFinishReason::EosToken);
+  EXPECT_EQ(request->CurrentSequenceLength(), length_after_prefill + 1);
+  EXPECT_EQ(request->TurnGeneratedTokens(), generated_after_prefill + 1);
+}
+
 TEST_F(EngineRunTest, RolledBackSpeculativeRunLeavesProposalPendingAndRetryable) {
   const int32_t eos = EosToken(*model_);
   const int32_t filler = eos == 5 ? 6 : 5;
@@ -2729,13 +2759,18 @@ TEST_F(EngineRunTest, ContinuationDropsTheMtpShadowFromThePreviousTurn) {
 
   engine.executor->SetForcedToken(eos);
   bool turn_finished = false;
+  std::optional<int32_t> terminal_token;
   for (int attempt = 0; attempt < 8 && !turn_finished; ++attempt) {
     const size_t count = engine.engine->Run(storage);
     for (size_t i = 0; i < count; ++i) {
+      if ((storage[i].flags & EngineEventFlagTerminalToken) != 0) {
+        terminal_token = storage[i].token;
+      }
       turn_finished |= (storage[i].flags & EngineEventFlagTurnFinished) != 0;
     }
   }
   ASSERT_TRUE(turn_finished);
+  EXPECT_EQ(terminal_token, eos);
   ASSERT_EQ(engine.mtp_cache->AllocatedCount(), 1u);
 
   // The new turn appends a prompt the shadow never sees, so keeping it would leave the shadow a

--- a/test/cpp/engine/request_lifecycle_tests.cpp
+++ b/test/cpp/engine/request_lifecycle_tests.cpp
@@ -1306,7 +1306,9 @@ TEST_F(RequestLifecycleTest, TerminalGuidanceTakesPrecedenceOverMinimumGenerated
   const auto terminal = RunOne(*guidance_engine.engine);
   ASSERT_EQ(terminal.request, request);
   EXPECT_EQ(terminal.flags & EngineEventFlagToken, 0u);
+  EXPECT_NE(terminal.flags & EngineEventFlagTerminalToken, 0u);
   EXPECT_NE(terminal.flags & EngineEventFlagTurnFinished, 0u);
+  EXPECT_EQ(terminal.token, EosToken(*guidance_model));
   EXPECT_EQ(terminal.finish_reason, GenerationFinishReason::EosToken);
   EXPECT_EQ(terminal.usage.generated_tokens, 1u);
   EXPECT_TRUE(request->IsTurnComplete());
@@ -1335,7 +1337,9 @@ TEST_F(RequestLifecycleTest, ExtendableGuidanceHonorsMinimumGeneratedTokens) {
   const auto terminal = RunOne(*guidance_engine.engine);
   ASSERT_EQ(terminal.request, request);
   EXPECT_EQ(terminal.flags & EngineEventFlagToken, 0u);
+  EXPECT_NE(terminal.flags & EngineEventFlagTerminalToken, 0u);
   EXPECT_NE(terminal.flags & EngineEventFlagTurnFinished, 0u);
+  EXPECT_EQ(terminal.token, EosToken(*guidance_model));
   EXPECT_EQ(terminal.finish_reason, GenerationFinishReason::EosToken);
   EXPECT_EQ(terminal.usage.generated_tokens, options.min_generated_tokens);
 }

--- a/test/cpp/engine/stop_string_engine_tests.cpp
+++ b/test/cpp/engine/stop_string_engine_tests.cpp
@@ -942,11 +942,14 @@ TEST_F(StopStringEngineTest, GreedyDraftVerificationNeverObservesAnAcceptedEosDr
   request->SetDraftTokens(std::array<int32_t, 3>{11, eos, 12});
   engine.executor->SetVerifyRowTokens({11, eos, 12, 13});  // argmax accepts all three positions
 
-  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
   EXPECT_EQ(storage[0].token, 11);
-  EXPECT_EQ(storage[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
-  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::EosToken);
-  EXPECT_EQ(storage[0].matched_stop_string_index, -1);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken);
+  EXPECT_EQ(storage[1].token, eos);
+  EXPECT_EQ(storage[1].flags,
+            EngineEventFlagTerminalToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::EosToken);
+  EXPECT_EQ(storage[1].matched_stop_string_index, -1);
   EXPECT_EQ(request->FinishReason(), GenerationFinishReason::EosToken);
   EXPECT_EQ(request->MatchedStopStringIndex(), -1);
 
@@ -1080,11 +1083,14 @@ TEST_F(StopStringEngineTest, SampledDraftVerificationNeverObservesAnAcceptedEosD
   request->SetDraftTokens(std::array<int32_t, 3>{11, eos, 12});
   engine.executor->SetVerifyRowTokens({11, eos, 12, 13});
 
-  ASSERT_EQ(engine.engine->Run(storage), 1u);
+  ASSERT_EQ(engine.engine->Run(storage), 2u);
   EXPECT_EQ(storage[0].token, 11);
-  EXPECT_EQ(storage[0].flags, EngineEventFlagToken | EngineEventFlagTurnFinished);
-  EXPECT_EQ(storage[0].finish_reason, GenerationFinishReason::EosToken);
-  EXPECT_EQ(storage[0].matched_stop_string_index, -1);
+  EXPECT_EQ(storage[0].flags, EngineEventFlagToken);
+  EXPECT_EQ(storage[1].token, eos);
+  EXPECT_EQ(storage[1].flags,
+            EngineEventFlagTerminalToken | EngineEventFlagTurnFinished);
+  EXPECT_EQ(storage[1].finish_reason, GenerationFinishReason::EosToken);
+  EXPECT_EQ(storage[1].matched_stop_string_index, -1);
   ASSERT_EQ(engine.cache->prefix_commits.size(), 1u);
   EXPECT_EQ(engine.cache->prefix_commits[0].kept_tokens, 2u);  // 1 base + 1 appended draft
 }

--- a/test/python/test_onnxruntime_genai_engine.py
+++ b/test/python/test_onnxruntime_genai_engine.py
@@ -105,6 +105,10 @@ def _drain(event, sinks):
     sink = sinks[ready]
     if event.flags & og.EngineEventFlags.TOKEN:
         sink.tokens.append(event.token)
+        assert event.terminal_token is None
+    if event.flags & og.EngineEventFlags.TERMINAL_TOKEN:
+        assert event.token is None
+        assert event.terminal_token == _EOS_TOKEN_ID
     if event.flags & og.EngineEventFlags.TURN_FINISHED:
         sink.finish_reason = event.finish_reason
         sink.usage = _UsageSnapshot(
@@ -690,6 +694,7 @@ def test_events_deliver_tokens_across_turns(model):
     def run_turn(input_tokens, expected_turn_id):
         assert request.begin_turn(input_tokens) == expected_turn_id
         tokens = []
+        terminal_token = None
         finished = False
         while not finished:
             event = _next_event(engine)
@@ -697,14 +702,18 @@ def test_events_deliver_tokens_across_turns(model):
             assert event.turn_id == expected_turn_id
             if event.token is not None:
                 tokens.append(event.token)
+            if event.terminal_token is not None:
+                terminal_token = event.terminal_token
             finished = bool(event.flags & og.EngineEventFlags.TURN_FINISHED)
-        return tokens
+        return tokens, terminal_token
 
-    first_turn_tokens = run_turn(np.asarray(_PROMPT_A, dtype=np.int32), 1)
-    second_turn_tokens = run_turn(follow_up, 2)
+    first_turn_tokens, first_terminal_token = run_turn(np.asarray(_PROMPT_A, dtype=np.int32), 1)
+    second_turn_tokens, second_terminal_token = run_turn(follow_up, 2)
 
     assert first_turn_tokens
     assert second_turn_tokens
+    assert first_terminal_token == _EOS_TOKEN_ID
+    assert second_terminal_token == _EOS_TOKEN_ID
     request.close()
 
 


### PR DESCRIPTION
## Summary

- add a distinct `TerminalToken` Engine event flag for the EOS token selected to finish a turn
- keep EOS separate from visible `Token` events, retained sequence length, and generated-token usage
- expose flag-gated C++ and Python accessors and document how continuation hosts should consume the boundary
- cover dynamic, speculative, static-batching, capacity-one delivery, C ABI, and Python behavior

## Motivation

ONNX Runtime GenAI selects EOS to end an assistant turn but deliberately does not append that token to the retained request sequence or publish it as a visible token. A continuation host therefore cannot know the exact model-selected assistant boundary. Foundry Local currently reconstructs that boundary with a synthetic `__foundry_engine_assistant_boundary_` marker rendered through the model chat template.

Publishing the unappended EOS as `TerminalToken | TurnFinished` lets a host prepend the exact boundary token to the next `BeginTurn` input while suppressing it from assistant text. A separate flag avoids changing the established meaning of `Token`, and a separate event preserves both accepted speculative draft tokens and EOS when they occur in one step.

This does not introduce a default per-turn output limit. Hosts can continue leaving `max_generated_tokens` unset unless the user explicitly supplies a maximum; the request remains bounded by its configured session/context limit.

## Validation

- repository lint (`lintrunner -a`)
- full Engine C++ suite on Windows/VS 2026 and WSL/Linux: 606 tests per platform
- full Python Engine suite on Windows and WSL/Linux: 40 tests per platform
- public Engine C/C++ API tests on Windows and WSL/Linux: 8 tests per platform