### PR TITLE
Update Extensions for Marian byte-fallback casing fixes

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -14,7 +14,7 @@ pybind11;https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.zip;f78029
 googletest;https://github.com/google/googletest/archive/530d5c8c84abd2a46f38583ee817743c9b3a42b4.zip;5e3a61db2aa975cfd0f97ba92c818744e7fa7034
 microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.zip;e4a542a323c070376f7c2d1973d0f7ddbc1d2fa5
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
-onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;543e968c4fedd2a71a6cca2537d873f77ed60f78
+onnxruntime_extensions;https://github.com/microsoft/onnxruntime-extensions.git;75129dc9da91f95c22d3f83087571a0759ed0d5c
 
 # These two dependencies are for the optional constrained decoding feature (USE_GUIDANCE)
 llguidance;https://github.com/microsoft/llguidance.git;94fa39128ef184ffeda33845f6d333f332a34b4d


### PR DESCRIPTION
## Summary

Update the ONNX Runtime Extensions pin from `543e968c4fedd2a71a6cca2537d873f77ed60f78` to `75129dc9da91f95c22d3f83087571a0759ed0d5c` to consume https://github.com/microsoft/onnxruntime-extensions/pull/1118.

This fixes Marian Unicode case restoration when a code point spans byte-fallback tokens. The merged change also isolates full-decoding state between batch rows, advances the row input pointer, and validates malformed UTF-8 before applying casing.

The repository URL remains the official Microsoft upstream. The new pin is a direct descendant of the current pin and retains the tool-schema changes from #2537. No model weights, tokenizer vocabulary, or search settings change.

## Validation

- Verified the commit is reachable from Extensions `main` and advances the previous pin.
- Verified the merged decoder and regression-test files are byte-identical to the tested PR head.
- All 18 selected Extensions tokenizer tests passed on Windows x64 Release, covering byte-fallback casing, invalid UTF-8, batch/stream isolation, unknown IDs, and neighboring unigram/BPE paths.
- GenAI's dependency parser input remains valid; `git diff --check` passes.

A full GenAI build on this refreshed branch has not been run locally. GenAI CI should validate this dependency update across supported platforms.