### PR TITLE
Fix accepted draft EOS classification after sampler slot reuse

### DIFF
--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -324,6 +324,7 @@ void Request::MarkClosedFromEngine(const Engine& engine) noexcept {
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_eos_ = false;
   draft_verification_stop_match_index_ = -1;
 }
 
@@ -369,6 +370,7 @@ void Request::ReleaseTurnResources() noexcept {
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_eos_ = false;
   draft_verification_stop_match_index_ = -1;
   // The turn's reseed dies with the turn. A reseed that a sampling step already committed was
   // promoted to current_seed_basis_ by CommitStateForTransaction(), which runs before any terminal
@@ -428,6 +430,7 @@ void Request::CompleteClose() noexcept {
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_eos_ = false;
   draft_verification_stop_match_index_ = -1;
   std::vector<int32_t>{}.swap(tokens_host_);
 }
@@ -552,6 +555,7 @@ void Request::AppendDraftsForTransaction(size_t draft_count) {
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_eos_ = false;
   draft_verification_stop_match_index_ = -1;
 }
 
@@ -568,6 +572,7 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_eos_ = false;
   draft_verification_stop_match_index_ = -1;
 
   for (size_t offset = 0; offset < accepted_count; ++offset) {
@@ -606,6 +611,8 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
             *turn_policy_.max_generated_tokens;
     if (search_->IsDone() || turn_limit_reached) {
       draft_verification_completed_generation_ = true;
+      draft_verification_eos_ =
+          search_->IsDone() && contains(params_->config.model.eos_token_id, token);
       break;
     }
   }
@@ -673,6 +680,7 @@ void Request::DiscardStagedDrafts() noexcept {
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_eos_ = false;
   draft_verification_stop_match_index_ = -1;
 }
 
@@ -901,12 +909,8 @@ RequestStepResult Request::StageDraftCompletionForTransaction() {
             *turn_policy_.max_generated_tokens;
     if (turn_limit_reached) {
       finish_reason = GenerationFinishReason::TurnLimit;
-    } else {
-      const auto next_tokens = search_->GetNextTokens().CpuSpan();
-      if (search_->IsDone() && !next_tokens.empty() &&
-          contains(params_->config.model.eos_token_id, next_tokens.back())) {
-        finish_reason = GenerationFinishReason::EosToken;
-      }
+    } else if (draft_verification_eos_) {
+      finish_reason = GenerationFinishReason::EosToken;
     }
   }
   RequestStepResult result{
@@ -930,6 +934,7 @@ void Request::RestoreStateForTransaction() {
   evaluated_draft_count_ = 0;
   scheduled_token_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_eos_ = false;
   draft_verification_stop_match_index_ = -1;
   // The pending reseed itself is deliberately kept so the retry reseeds identically; only its
   // "already applied to the live streams" marker is undone, because rng_ was just rolled back.
@@ -955,6 +960,7 @@ void Request::QueueStateRestoreForTransaction() {
   evaluated_draft_count_ = 0;
   scheduled_token_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_eos_ = false;
   draft_verification_stop_match_index_ = -1;
   pending_reseed_applied_ = false;
   // Deliberately does not replay the stop controller yet: like the guidance checkpoint swap below,
@@ -1013,6 +1019,7 @@ void Request::CommitStep(const RequestStepPlan& plan,
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
   draft_verification_completed_generation_ = false;
+  draft_verification_eos_ = false;
   draft_verification_stop_match_index_ = -1;
 }
 

--- a/src/engine/request.cpp
+++ b/src/engine/request.cpp
@@ -323,9 +323,7 @@ void Request::MarkClosedFromEngine(const Engine& engine) noexcept {
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
-  draft_verification_completed_generation_ = false;
-  draft_verification_eos_ = false;
-  draft_verification_stop_match_index_ = -1;
+  draft_verification_.Reset();
 }
 
 void Request::CompleteCloseFromEngine(const Engine& engine) noexcept {
@@ -369,9 +367,7 @@ void Request::ReleaseTurnResources() noexcept {
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
-  draft_verification_completed_generation_ = false;
-  draft_verification_eos_ = false;
-  draft_verification_stop_match_index_ = -1;
+  draft_verification_.Reset();
   // The turn's reseed dies with the turn. A reseed that a sampling step already committed was
   // promoted to current_seed_basis_ by CommitStateForTransaction(), which runs before any terminal
   // boundary; anything still pending here belongs to a turn that ended before it sampled (or whose
@@ -429,9 +425,7 @@ void Request::CompleteClose() noexcept {
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
-  draft_verification_completed_generation_ = false;
-  draft_verification_eos_ = false;
-  draft_verification_stop_match_index_ = -1;
+  draft_verification_.Reset();
   std::vector<int32_t>{}.swap(tokens_host_);
 }
 
@@ -554,9 +548,7 @@ void Request::AppendDraftsForTransaction(size_t draft_count) {
   staged_draft_count_ = draft_count;
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
-  draft_verification_completed_generation_ = false;
-  draft_verification_eos_ = false;
-  draft_verification_stop_match_index_ = -1;
+  draft_verification_.Reset();
 }
 
 void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
@@ -571,9 +563,7 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
-  draft_verification_completed_generation_ = false;
-  draft_verification_eos_ = false;
-  draft_verification_stop_match_index_ = -1;
+  draft_verification_.Reset();
 
   for (size_t offset = 0; offset < accepted_count; ++offset) {
     // Every iteration examines exactly one proposed draft position's target acceptance, whether or
@@ -595,8 +585,8 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
       // so its bytes must never reach the controller or be able to produce a StopString result.
       if (stop_controller_) {
         if (const auto& match = stop_controller_->ObserveToken(token)) {
-          draft_verification_stop_match_index_ = static_cast<int32_t>(match->index);
-          draft_verification_completed_generation_ = true;
+          draft_verification_.stop_match_index = static_cast<int32_t>(match->index);
+          draft_verification_.completed_generation = true;
           break;
         }
       }
@@ -610,8 +600,8 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
         turn_generated_tokens_ + accepted_draft_count_ >=
             *turn_policy_.max_generated_tokens;
     if (search_->IsDone() || turn_limit_reached) {
-      draft_verification_completed_generation_ = true;
-      draft_verification_eos_ =
+      draft_verification_.completed_generation = true;
+      draft_verification_.eos =
           search_->IsDone() && contains(params_->config.model.eos_token_id, token);
       break;
     }
@@ -623,7 +613,7 @@ void Request::CommitAcceptedDraftsForTransaction(size_t accepted_count) {
   // turn/context limit interrupted it) and the caller proposed more drafts than were confirmed,
   // that rejected position was examined (compared against the target's own argmax and found not to
   // match) even though it is not processed here, so it counts too.
-  if (!draft_verification_completed_generation_ && accepted_count < proposed_count) {
+  if (!draft_verification_.completed_generation && accepted_count < proposed_count) {
     ++evaluated_draft_count_;
   }
 }
@@ -679,9 +669,7 @@ void Request::DiscardStagedDrafts() noexcept {
   }
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
-  draft_verification_completed_generation_ = false;
-  draft_verification_eos_ = false;
-  draft_verification_stop_match_index_ = -1;
+  draft_verification_.Reset();
 }
 
 RequestStateSnapshot Request::Snapshot() const {
@@ -889,7 +877,7 @@ RequestStepResult Request::StageGenerationForTransaction(
 }
 
 RequestStepResult Request::StageDraftCompletionForTransaction() {
-  if (!draft_verification_completed_generation_) {
+  if (!draft_verification_.completed_generation) {
     throw std::logic_error(
         "Draft completion was staged before verification completed generation.");
   }
@@ -899,17 +887,19 @@ RequestStepResult Request::StageDraftCompletionForTransaction() {
   // Stop-string precedence over the turn/context limit was already decided when this token was
   // observed, immediately after it was accepted in CommitAcceptedDraftsForTransaction()'s loop --
   // mirroring StageGeneration()'s identical precedence for the ordinary one-token path.
-  if (draft_verification_stop_match_index_ >= 0) {
+  if (draft_verification_.stop_match_index >= 0) {
     finish_reason = GenerationFinishReason::StopString;
-    matched_stop_string_index = draft_verification_stop_match_index_;
+    matched_stop_string_index = draft_verification_.stop_match_index;
   } else {
     const bool turn_limit_reached =
         turn_policy_.max_generated_tokens &&
         turn_generated_tokens_ + accepted_draft_count_ >=
             *turn_policy_.max_generated_tokens;
+    // An accepted EOS does not append, so it cannot newly reach the turn limit at the same
+    // position. The order here is therefore deliberate but unobservable for a valid turn.
     if (turn_limit_reached) {
       finish_reason = GenerationFinishReason::TurnLimit;
-    } else if (draft_verification_eos_) {
+    } else if (draft_verification_.eos) {
       finish_reason = GenerationFinishReason::EosToken;
     }
   }
@@ -933,9 +923,7 @@ void Request::RestoreStateForTransaction() {
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
   scheduled_token_count_ = 0;
-  draft_verification_completed_generation_ = false;
-  draft_verification_eos_ = false;
-  draft_verification_stop_match_index_ = -1;
+  draft_verification_.Reset();
   // The pending reseed itself is deliberately kept so the retry reseeds identically; only its
   // "already applied to the live streams" marker is undone, because rng_ was just rolled back.
   pending_reseed_applied_ = false;
@@ -959,9 +947,7 @@ void Request::QueueStateRestoreForTransaction() {
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
   scheduled_token_count_ = 0;
-  draft_verification_completed_generation_ = false;
-  draft_verification_eos_ = false;
-  draft_verification_stop_match_index_ = -1;
+  draft_verification_.Reset();
   pending_reseed_applied_ = false;
   // Deliberately does not replay the stop controller yet: like the guidance checkpoint swap below,
   // that work is deferred to CompleteStateRestoreForTransaction() so this stays lightweight
@@ -1018,9 +1004,7 @@ void Request::CommitStep(const RequestStepPlan& plan,
   staged_draft_count_ = 0;
   accepted_draft_count_ = 0;
   evaluated_draft_count_ = 0;
-  draft_verification_completed_generation_ = false;
-  draft_verification_eos_ = false;
-  draft_verification_stop_match_index_ = -1;
+  draft_verification_.Reset();
 }
 
 // Records the tokens this step makes externally visible, in sequence order. Accepted drafts are

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -607,12 +607,6 @@ struct Request : std::enable_shared_from_this<Request>,
   // MarkFinalStageAsEvaluatedNonAcceptedDraft/CommitAcceptedDraftsForTransaction for how each path
   // advances it.
   size_t evaluated_draft_count_{};
-  // Capture terminal EOS before another request can reuse the batched sampler's next-token slot.
-  // CommitAcceptedDraftsForTransaction() also records a stop-string match when one ends greedy
-  // draft verification early, giving StopString precedence over the turn/context limit for the
-  // same completing token. The sampled/batched path observes stop matches through the same
-  // StageGenerationForTransaction()/StageGeneration() path the ordinary one-token step uses, one
-  // stage at a time, so it needs no separate bookkeeping here.
   struct DraftVerificationState {
     bool completed_generation{};
     bool eos{};
@@ -620,6 +614,12 @@ struct Request : std::enable_shared_from_this<Request>,
 
     void Reset() noexcept { *this = DraftVerificationState{}; }
   };
+  // Capture terminal EOS before another request can reuse the batched sampler's next-token slot.
+  // CommitAcceptedDraftsForTransaction() also records a stop-string match when one ends greedy
+  // draft verification early, giving StopString precedence over the turn/context limit for the
+  // same completing token. The sampled/batched path observes stop matches through the same
+  // StageGenerationForTransaction()/StageGeneration() path the ordinary one-token step uses, one
+  // stage at a time, so it needs no separate bookkeeping here.
   //
   // StageDraftCompletionForTransaction() only ever reads this state (and accepted_draft_count_)
   // to compute its result; it never resets or otherwise mutates it. Only transaction/turn-lifecycle
@@ -629,7 +629,7 @@ struct Request : std::enable_shared_from_this<Request>,
   // transaction also uses the batched sampler (once from the batched-sampling setup loop, once
   // unconditionally from the final per-request loop), and both calls must produce the exact same
   // result.
-  DraftVerificationState draft_verification_;
+  DraftVerificationState draft_verification_{};
   std::shared_ptr<GeneratorParams> params_;
   // Durable seed basis every RNG stream of this Request starts from. Initialized once from the
   // model-configured seed (a generated 64-bit value when the model leaves it unset) and advanced

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -608,6 +608,9 @@ struct Request : std::enable_shared_from_this<Request>,
   // advances it.
   size_t evaluated_draft_count_{};
   bool draft_verification_completed_generation_{};
+  // Capture terminal EOS before another request can reuse the batched sampler's next-token slot.
+  // Like the stop match below, this is immutable until the transaction is committed or reset.
+  bool draft_verification_eos_{};
   // Set by CommitAcceptedDraftsForTransaction() when a stop-string match ends greedy draft
   // verification early, giving StopString precedence over the turn/context limit for the same
   // completing token. -1 when verification completed generation for any other reason (or has not
@@ -615,8 +618,8 @@ struct Request : std::enable_shared_from_this<Request>,
   // the same StageGenerationForTransaction()/StageGeneration() path the ordinary one-token step
   // uses, one stage at a time, so it needs no separate bookkeeping here.
   //
-  // StageDraftCompletionForTransaction() only ever reads this field (and accepted_draft_count_,
-  // and Search's own state) to compute its result; it never resets or otherwise mutates it. Only
+  // StageDraftCompletionForTransaction() only ever reads these fields (and accepted_draft_count_)
+  // to compute its result; it never resets or otherwise mutates them. Only
   // CommitStep()/RestoreStateForTransaction()/QueueStateRestoreForTransaction()/
   // DiscardStagedDrafts()/AppendDraftsForTransaction() reset it, at their own well-defined
   // transaction boundaries -- never in response to StageDraftCompletionForTransaction() being

--- a/src/engine/request.h
+++ b/src/engine/request.h
@@ -316,7 +316,7 @@ struct Request : std::enable_shared_from_this<Request>,
   std::span<const int32_t> StagedDraftTokens() const;
   void CommitAcceptedDraftsForTransaction(size_t accepted_count);
   bool DraftVerificationCompletedGeneration() const noexcept {
-    return draft_verification_completed_generation_;
+    return draft_verification_.completed_generation;
   }
   bool IsStopToken(int32_t token) const;
   void RewindDraftsForTransaction(size_t accepted_count);
@@ -607,28 +607,29 @@ struct Request : std::enable_shared_from_this<Request>,
   // MarkFinalStageAsEvaluatedNonAcceptedDraft/CommitAcceptedDraftsForTransaction for how each path
   // advances it.
   size_t evaluated_draft_count_{};
-  bool draft_verification_completed_generation_{};
   // Capture terminal EOS before another request can reuse the batched sampler's next-token slot.
-  // Like the stop match below, this is immutable until the transaction is committed or reset.
-  bool draft_verification_eos_{};
-  // Set by CommitAcceptedDraftsForTransaction() when a stop-string match ends greedy draft
-  // verification early, giving StopString precedence over the turn/context limit for the same
-  // completing token. -1 when verification completed generation for any other reason (or has not
-  // completed yet). The sampled/batched path never sets this: it observes stop matches through
-  // the same StageGenerationForTransaction()/StageGeneration() path the ordinary one-token step
-  // uses, one stage at a time, so it needs no separate bookkeeping here.
+  // CommitAcceptedDraftsForTransaction() also records a stop-string match when one ends greedy
+  // draft verification early, giving StopString precedence over the turn/context limit for the
+  // same completing token. The sampled/batched path observes stop matches through the same
+  // StageGenerationForTransaction()/StageGeneration() path the ordinary one-token step uses, one
+  // stage at a time, so it needs no separate bookkeeping here.
+  struct DraftVerificationState {
+    bool completed_generation{};
+    bool eos{};
+    int32_t stop_match_index{-1};
+
+    void Reset() noexcept { *this = DraftVerificationState{}; }
+  };
   //
-  // StageDraftCompletionForTransaction() only ever reads these fields (and accepted_draft_count_)
-  // to compute its result; it never resets or otherwise mutates them. Only
-  // CommitStep()/RestoreStateForTransaction()/QueueStateRestoreForTransaction()/
-  // DiscardStagedDrafts()/AppendDraftsForTransaction() reset it, at their own well-defined
-  // transaction boundaries -- never in response to StageDraftCompletionForTransaction() being
-  // called. This is deliberate: ScheduledRequests::GenerateNextTokensForTransaction() can call
+  // StageDraftCompletionForTransaction() only ever reads this state (and accepted_draft_count_)
+  // to compute its result; it never resets or otherwise mutates it. Only transaction/turn-lifecycle
+  // boundaries reset it -- never StageDraftCompletionForTransaction() itself. This is deliberate:
+  // ScheduledRequests::GenerateNextTokensForTransaction() can call
   // StageDraftCompletionForTransaction() for the same request twice in one step when the
   // transaction also uses the batched sampler (once from the batched-sampling setup loop, once
   // unconditionally from the final per-request loop), and both calls must produce the exact same
   // result.
-  int32_t draft_verification_stop_match_index_{-1};
+  DraftVerificationState draft_verification_;
   std::shared_ptr<GeneratorParams> params_;
   // Durable seed basis every RNG stream of this Request starts from. Initialized once from the
   // model-configured seed (a generated 64-bit value when the model leaves it unset) and advanced

--- a/test/cpp/engine/stop_string_engine_tests.cpp
+++ b/test/cpp/engine/stop_string_engine_tests.cpp
@@ -133,6 +133,143 @@ class StopStringEngineTest : public ::testing::Test {
   std::shared_ptr<Model> model_;
 };
 
+// Exercise CUDA's shared next-token-slot lifetime with real CPU EOS/search semantics.
+class SharedSlotSearch final : public GreedySearch_Cpu {
+ public:
+  using GreedySearch_Cpu::GreedySearch_Cpu;
+  bool BindNextTokensSlot(DeviceSpan<int32_t> slot) override {
+    if (slot.size() != 1)
+      return false;
+    next_tokens_ptr_ = slot;
+    next_tokens_ = cpu_span<int32_t>(slot.Span());
+    return true;
+  }
+};
+
+class SharedSlotDevice final : public DeviceInterface {
+ public:
+  explicit SharedSlotDevice(DeviceInterface& inner) : inner_{inner} {}
+  DeviceType GetType() const override { return inner_.GetType(); }
+  void InitOrt(const OrtApi& api, Ort::Allocator& allocator) override {
+    inner_.InitOrt(api, allocator);
+  }
+  Ort::Allocator& GetAllocator() override { return inner_.GetAllocator(); }
+  std::unique_ptr<OrtMemoryInfo> GetMemoryInfo() const override {
+    return inner_.GetMemoryInfo();
+  }
+  std::string GetExecutionProviderName() const override {
+    return inner_.GetExecutionProviderName();
+  }
+  std::shared_ptr<DeviceBuffer> AllocateBase(size_t size) override {
+    return inner_.AllocateBase(size);
+  }
+  std::shared_ptr<DeviceBuffer> WrapMemoryBase(void* memory, size_t size) override {
+    return inner_.WrapMemoryBase(memory, size);
+  }
+  std::unique_ptr<Search> CreateGreedy(const GeneratorParams& params) override {
+    return std::make_unique<SharedSlotSearch>(params);
+  }
+  std::unique_ptr<Search> CreateBeam(const GeneratorParams& params) override {
+    return inner_.CreateBeam(params);
+  }
+  std::unique_ptr<KeyValueCache> CreateKeyValueCache(State&) override { return {}; }
+  void Synchronize() override { inner_.Synchronize(); }
+
+ private:
+  DeviceInterface& inner_;
+};
+
+TEST_F(StopStringEngineTest, AcceptedDraftEosSurvivesCompactedSharedSlotAndRollback) {
+  SharedSlotDevice device{*model_->p_device_scoring_};
+  ScopedScoringDevice scoring{*model_, device};
+  for (const size_t eos_position : {size_t{0}, size_t{1}}) {
+    for (const bool queued_restore : {false, true}) {
+      SCOPED_TRACE(::testing::Message() << "EOS position " << eos_position
+                                      << ", queued restore " << queued_restore);
+      auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
+      engine.cache->SetMaxDraftTokensPerStep(3);
+      auto request = CreateEngineRequest(engine.engine);
+      auto survivor = CreateEngineRequest(engine.engine);
+      request->BeginTurn(Prompt(), StopOptions({"STOP"}));
+      survivor->BeginTurn(Prompt());
+      std::array<EngineEvent, 8> storage;
+      ASSERT_EQ(engine.engine->Run(storage), 2u);
+
+      auto slots = model_->p_device_scoring_->Allocate<int32_t>(2);
+      ASSERT_TRUE(request->BindNextTokensSlot(slots.subspan(0, 1)));
+      ASSERT_TRUE(survivor->BindNextTokensSlot(slots.subspan(1, 1)));
+      std::array<int32_t, 3> drafts{11, 12, 13};
+      drafts[eos_position] = EosToken(*model_);
+      request->SetDraftTokens(drafts);
+      RequestStepPlan plan;
+      plan.request = request;
+      plan.request_id = request.get();
+      plan.sequence_length_before = request->CurrentSequenceLength();
+      plan.target_cache_slots = static_cast<size_t>(plan.sequence_length_before) + drafts.size();
+      plan.draft_token_count = drafts.size();
+      PrepareRequestStep(model_, plan);
+
+      for (int attempt = 0; attempt < 2; ++attempt) {
+        request->SaveStateForTransaction();
+        request->AppendDraftsForTransaction(drafts.size());
+        request->CommitAcceptedDraftsForTransaction(drafts.size());
+        ASSERT_TRUE(request->DraftVerificationCompletedGeneration());
+        EXPECT_EQ(request->AcceptedDraftTokenCount(), eos_position);
+        EXPECT_EQ(request->StageDraftCompletionForTransaction().finish_reason,
+                  GenerationFinishReason::EosToken);
+        EXPECT_EQ(slots.CpuSpan()[0], EosToken(*model_));
+
+        // The finished first row is removed; the surviving second row reuses its slot before
+        // ScheduledRequests stages the finished request a second time.
+        survivor->SaveStateForTransaction();
+        ASSERT_TRUE(survivor->BindNextTokensSlot(slots.subspan(0, 1)));
+        const auto surviving = survivor->ApplyLogitsForTransaction(LogitsForToken(*model_, 12));
+        EXPECT_TRUE(surviving.token_appended);
+        EXPECT_FALSE(surviving.done);
+        ASSERT_EQ(slots.CpuSpan()[0], 12);
+        const auto completed = request->StageDraftCompletionForTransaction();
+        EXPECT_EQ(completed.finish_reason, GenerationFinishReason::EosToken);
+        EXPECT_FALSE(completed.token_appended);
+        EXPECT_EQ(completed.matched_stop_string_index, -1);
+        survivor->RestoreStateForTransaction();
+
+        if (attempt == 0) {
+          if (queued_restore) {
+            request->QueueStateRestoreForTransaction();
+            request->CompleteStateRestoreForTransaction();
+          } else {
+            request->RestoreStateForTransaction();
+          }
+          EXPECT_FALSE(request->DraftVerificationCompletedGeneration());
+          EXPECT_EQ(request->AcceptedDraftTokenCount(), 0u);
+          EXPECT_EQ(request->PendingDraftTokenCount(), drafts.size());
+        } else {
+          request->CommitStateForTransaction();
+          request->CommitStep(plan, completed);
+        }
+      }
+      EXPECT_EQ(request->FinishReason(), GenerationFinishReason::EosToken);
+      EXPECT_FALSE(request->DraftVerificationCompletedGeneration());
+
+      // A new non-EOS turn must not inherit the previous transaction's terminal EOS.
+      request->BeginTurn(std::array<int32_t, 1>{11}, StopOptions({"UNREACHABLE"}, 2));
+      ASSERT_GT(engine.engine->Run(storage), 0u);
+      request->SetDraftTokens(std::array<int32_t, 1>{12});
+      plan.sequence_length_before = request->CurrentSequenceLength();
+      plan.target_cache_slots = static_cast<size_t>(plan.sequence_length_before) + 1;
+      plan.draft_token_count = 1;
+      PrepareRequestStep(model_, plan);
+      request->SaveStateForTransaction();
+      request->AppendDraftsForTransaction(1);
+      request->CommitAcceptedDraftsForTransaction(1);
+      ASSERT_TRUE(request->DraftVerificationCompletedGeneration());
+      EXPECT_EQ(request->StageDraftCompletionForTransaction().finish_reason,
+                GenerationFinishReason::TurnLimit);
+      request->RestoreStateForTransaction();
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------------------------
 // Request-level transactional behavior (direct Search/logits driving, no Engine::Run involved).
 // ---------------------------------------------------------------------------------------------

--- a/test/cpp/engine/stop_string_engine_tests.cpp
+++ b/test/cpp/engine/stop_string_engine_tests.cpp
@@ -185,7 +185,7 @@ TEST_F(StopStringEngineTest, AcceptedDraftEosSurvivesCompactedSharedSlotAndRollb
   for (const size_t eos_position : {size_t{0}, size_t{1}}) {
     for (const bool queued_restore : {false, true}) {
       SCOPED_TRACE(::testing::Message() << "EOS position " << eos_position
-                                      << ", queued restore " << queued_restore);
+                                        << ", queued restore " << queued_restore);
       auto engine = MakeDoublesEngine(model_, /*capacity=*/8, /*forced_token=*/11);
       engine.cache->SetMaxDraftTokensPerStep(3);
       auto request = CreateEngineRequest(engine.engine);

--- a/test/cpp/engine/stop_string_engine_tests.cpp
+++ b/test/cpp/engine/stop_string_engine_tests.cpp
@@ -133,12 +133,16 @@ class StopStringEngineTest : public ::testing::Test {
   std::shared_ptr<Model> model_;
 };
 
+// ---------------------------------------------------------------------------------------------
+// Request-level transactional behavior (direct Search/logits driving, no Engine::Run involved).
+// ---------------------------------------------------------------------------------------------
+
 // Exercise CUDA's shared next-token-slot lifetime with real CPU EOS/search semantics.
 class SharedSlotSearch final : public GreedySearch_Cpu {
  public:
   using GreedySearch_Cpu::GreedySearch_Cpu;
   bool BindNextTokensSlot(DeviceSpan<int32_t> slot) override {
-    if (slot.size() != 1)
+    if (params_->BatchBeamSize() != 1 || slot.size() != 1)
       return false;
     next_tokens_ptr_ = slot;
     next_tokens_ = cpu_span<int32_t>(slot.Span());
@@ -269,10 +273,6 @@ TEST_F(StopStringEngineTest, AcceptedDraftEosSurvivesCompactedSharedSlotAndRollb
     }
   }
 }
-
-// ---------------------------------------------------------------------------------------------
-// Request-level transactional behavior (direct Search/logits driving, no Engine::Run involved).
-// ---------------------------------------------------------------------------------------------
 
 TEST_F(StopStringEngineTest, NoStopStringsPreserveOrdinaryGenerationBehavior) {
   // Exercise the no-stop path entirely through the public request and event contract.


### PR DESCRIPTION
Fix Engine completion classification when an accepted speculative draft is EOS and batched-sampler compaction reuses its next-token slot.
 
 ## Problem
 
 Accepted draft processing previously checked EOS through `Search::GetNextTokens()` during completion staging. That storage is shared by the batched sampler and can be rebound to another request after slot compaction. As a result, an accepted EOS could be overwritten before the request classified its completion, causing the request to miss EOS termination.
 
 ## Changes
 
 - Capture whether an accepted draft is EOS while committing the draft, before sampler-slot reuse can occur.
 - Store that result in request-owned transactional state and use it during completion staging.
 - Reset the state across commit, rollback, discard, retry, and turn lifecycle boundaries.
 - Add a regression test covering shared-slot overwrite, repeated completion staging, immediate and queued rollback, deterministic retry, and a subsequent non-EOS turn.