### PR TITLE
Add opt-in DFlash2 gate/up projection fusion

### DIFF
--- a/src/python/py/models/README.md
+++ b/src/python/py/models/README.md
@@ -339,6 +339,21 @@ python -m onnxruntime_genai.models.builder -i path_to_target_model -o path_to_ou
 python builder.py -i path_to_target_model -o path_to_output_folder -p fp16 -e cuda -c cache_dir_for_hf_files --extra_options use_paged_attention=true aux_hidden_state_layers=2,12,22 dflash2_path=path_to_dflash2_checkpoint dflash2_num_draft_tokens=4 dflash2_precision=int4
 ```
 
+Set `dflash2_fuse_gate_up=true` to experimentally combine each DFlash 2 MLP's gate and up
+projections into one `MatMul` or `MatMulNBits`, followed by `Split`. The default is `false`.
+This export-time option requires `dflash2_path` and supports all three `dflash2_precision`
+values. It preserves BF16 body activations and the existing quantization scheme; the target,
+attention projections, and LM head are unchanged. Re-export the drafter to apply it and
+validate latency and quality on the deployment workload before enabling it in production.
+
+```bash
+# From wheel:
+python -m onnxruntime_genai.models.builder -i path_to_target_model -o path_to_output_folder -p bf16 -e cuda --extra_options use_paged_attention=true aux_hidden_state_layers=6,20,34,48,62 dflash2_path=path_to_dflash2_checkpoint dflash2_precision=int4 dflash2_fuse_gate_up=true
+
+# From source:
+python builder.py -i path_to_target_model -o path_to_output_folder -p bf16 -e cuda --extra_options use_paged_attention=true aux_hidden_state_layers=6,20,34,48,62 dflash2_path=path_to_dflash2_checkpoint dflash2_precision=int4 dflash2_fuse_gate_up=true
+```
+
 #### Build a DSpark Block Drafter
 
 Set `dspark_path` to a DSpark checkpoint to export an auxiliary `dspark.onnx` block drafter beside a Qwen3.5 or Qwen3.8 target model. The target must use paged attention. SpecForge identifies the target layers whose outputs are tapped, while `aux_hidden_state_layers` identifies residual streams entering layers, so each configured auxiliary layer must be one greater than the corresponding `target_layer_ids` entry in the DSpark checkpoint. The drafter reuses the target's embedding and LM-head initializers. `dspark_path` and `dflash2_path` are mutually exclusive, and selecting DSpark replaces rather than accompanies the target's MTP head.

--- a/src/python/py/models/builder.py
+++ b/src/python/py/models/builder.py
@@ -785,6 +785,11 @@ def get_args():
                 dflash2_num_draft_tokens = Override the number of draft tokens the DFlash 2 block
                     drafter proposes per step. Must be positive and no greater than the draft checkpoint's
                     block size minus its anchor token. That checkpoint limit is the default.
+                dflash2_fuse_gate_up = Experimental DFlash 2 MLP gate/up projection fusion.
+                    Accepts true or false (default). Requires dflash2_path. Combines gate/up
+                    weights into one MatMul or MatMulNBits followed by Split. Preserves BF16
+                    activations and body quantization; does not change the target or LM head.
+                    Requires re-export and workload-specific performance/quality validation.
                 dflash2_precision = Weight precision for the DFlash 2 drafter body: bf16 (default),
                     int4, or int8. bf16 keeps every projection dense. int4/int8 emit `MatMulNBits`
                     at the target's block size for the attention and MLP projections, leaving the

--- a/src/python/py/models/builders/dflash2.py
+++ b/src/python/py/models/builders/dflash2.py
@@ -57,6 +57,7 @@ class DFlash2Builder(BlockDrafterBuilder):
         filename="dflash2.onnx",
         num_draft_tokens=None,
         quant=None,
+        fuse_gate_up=False,
     ):
         self.draft_dir = draft_dir
         self.target_dir = target_dir
@@ -73,6 +74,7 @@ class DFlash2Builder(BlockDrafterBuilder):
             self.lm_head_quant = quant["lm_head"]
         self.filename = filename
         self.paged_block_size = paged_block_size
+        self.mlp_attrs = {"fuse_gate_up": fuse_gate_up}
 
         with open(os.path.join(draft_dir, "config.json")) as f:
             cfg = json.load(f)
@@ -502,22 +504,42 @@ class DFlash2Builder(BlockDrafterBuilder):
 
     def _make_mlp(self, i, x, w, rows_q):
         p = f"/dflash2/layers.{i}/mlp"
-        gate = self.matmul(
-            f"{p}/gate_proj/MatMul",
-            x,
-            w[f"layers.{i}.mlp.gate_proj.weight"],
-            self.hidden_size,
-            self.intermediate_size,
-            rows_q,
-        )
-        up = self.matmul(
-            f"{p}/up_proj/MatMul",
-            x,
-            w[f"layers.{i}.mlp.up_proj.weight"],
-            self.hidden_size,
-            self.intermediate_size,
-            rows_q,
-        )
+        if self.mlp_attrs["fuse_gate_up"]:
+            gate_up = self.matmul(
+                f"{p}/gate_up_proj/MatMul",
+                x,
+                torch.cat((w[f"layers.{i}.mlp.gate_proj.weight"], w[f"layers.{i}.mlp.up_proj.weight"]), dim=0),
+                self.hidden_size,
+                2 * self.intermediate_size,
+                rows_q,
+            )
+            gate, up = self.out(f"{p}/gate_proj/MatMul"), self.out(f"{p}/up_proj/MatMul")
+            self.make_node(
+                "Split",
+                [gate_up, self.const([self.intermediate_size, self.intermediate_size])],
+                [gate, up],
+                name=f"{p}/gate_up_proj/Split",
+                axis=-1,
+            )
+            self.make_value(gate, self.io_dtype, [rows_q, self.intermediate_size])
+            self.make_value(up, self.io_dtype, [rows_q, self.intermediate_size])
+        else:
+            gate = self.matmul(
+                f"{p}/gate_proj/MatMul",
+                x,
+                w[f"layers.{i}.mlp.gate_proj.weight"],
+                self.hidden_size,
+                self.intermediate_size,
+                rows_q,
+            )
+            up = self.matmul(
+                f"{p}/up_proj/MatMul",
+                x,
+                w[f"layers.{i}.mlp.up_proj.weight"],
+                self.hidden_size,
+                self.intermediate_size,
+                rows_q,
+            )
         sig = self.unary("Sigmoid", f"{p}/act/Sigmoid", gate, self.io_dtype, [rows_q, self.intermediate_size])
         silu = self.binary("Mul", f"{p}/act/Mul", gate, sig, self.io_dtype, [rows_q, self.intermediate_size])
         prod = self.binary("Mul", f"{p}/act/MulUp", silu, up, self.io_dtype, [rows_q, self.intermediate_size])

--- a/src/python/py/models/builders/qwen.py
+++ b/src/python/py/models/builders/qwen.py
@@ -1182,10 +1182,14 @@ class Qwen35MoEModel(MTPModel):
             if num_draft_tokens < 1:
                 raise ValueError("dflash2_num_draft_tokens must be a positive integer.")
 
+        fuse_gate_up = str(extra_options.get("dflash2_fuse_gate_up", False)).lower()
+        if fuse_gate_up not in ("true", "false"):
+            raise ValueError("dflash2_fuse_gate_up must be true or false.")
         self.dflash2_attrs = {
             "io_dtype": io_dtype,
             "num_draft_tokens": num_draft_tokens,
             "precision": self.block_drafter_precision(extra_options, "dflash2_precision"),
+            "fuse_gate_up": fuse_gate_up == "true",
         }
 
         with open(os.path.join(self.dflash2_path, "config.json"), encoding="utf-8") as handle:
@@ -1214,6 +1218,7 @@ class Qwen35MoEModel(MTPModel):
             self.decoder.context_length,
             num_draft_tokens=self.dflash2_attrs["num_draft_tokens"],
             quant=self.block_drafter_quant(self.dflash2_attrs["precision"]),
+            fuse_gate_up=self.dflash2_attrs["fuse_gate_up"],
         )
         self.dflash2.make_model()
 

--- a/test/python/builder/test_qwen_dflash2_export.py
+++ b/test/python/builder/test_qwen_dflash2_export.py
@@ -6,7 +6,10 @@ import json
 import os
 import types
 
+import numpy as np
+import onnx
 import onnx_ir as ir
+import onnxruntime as ort
 import pytest
 import torch
 
@@ -240,9 +243,7 @@ def _quant_composite(
     model.decoder.exclude_lm_head = exclude_lm_head
     model.decoder.onnx_dtype = onnx_dtype
     model.decoder.quantization_algo = "default"
-    model.decoder.matmul_mixed_precision = (
-        {"last_matmul": last_matmul_type} if last_matmul_type is not None else {}
-    )
+    model.decoder.matmul_mixed_precision = {"last_matmul": last_matmul_type} if last_matmul_type is not None else {}
     model.decoder.quant_attrs = {
         "matmul_block_size": 32,
         "is_symmetric": True,
@@ -387,6 +388,105 @@ def test_bf16_body_never_prepacks_even_when_the_target_does(tmp_path):
     assert "weight_prepacked" not in node.attributes
 
 
+@pytest.mark.parametrize("bits", [None, 4, 8])
+@pytest.mark.parametrize("fuse_gate_up", [False, True])
+def test_mlp_gate_up_fusion_preserves_weight_rows(tmp_path, bits, fuse_gate_up):
+    quant = {"bits": bits, "block_size": 8, "prepack": 0, "lm_head": None} if bits else None
+    builder = DFlash2Builder(
+        _draft_checkpoint(tmp_path),
+        str(tmp_path),
+        ir.DataType.BFLOAT16,
+        paged_block_size=256,
+        max_position_embeddings=128,
+        quant=quant,
+        fuse_gate_up=fuse_gate_up,
+    )
+    generator = torch.Generator().manual_seed(42)
+    weights = {
+        f"layers.0.mlp.{projection}.weight": torch.randn(shape, generator=generator).to(torch.bfloat16)
+        for projection, shape in (
+            ("gate_proj", (16, 8)),
+            ("up_proj", (16, 8)),
+            ("down_proj", (8, 16)),
+        )
+    }
+
+    builder._make_mlp(0, "hidden_states", weights, "num_block")
+
+    projections = [node for node in builder.graph if node.op_type in ("MatMul", "MatMulNBits")]
+    assert len(projections) == (2 if fuse_gate_up else 3)
+    if not fuse_gate_up:
+        assert not any(node.op_type == "Split" for node in builder.graph)
+        assert projections[0].name == "/dflash2/layers.0/mlp/gate_proj/MatMul"
+        assert projections[1].name == "/dflash2/layers.0/mlp/up_proj/MatMul"
+        return
+
+    projection = next(node for node in builder.graph if node.name == "/dflash2/layers.0/mlp/gate_up_proj/MatMul")
+    assert projection.op_type == ("MatMulNBits" if bits else "MatMul")
+    assert "weight_prepacked" not in projection.attributes
+    split = next(node for node in builder.graph if node.op_type == "Split")
+    assert split.inputs[0] is projection.outputs[0]
+    assert split.attributes["axis"].value == -1
+    assert all(output.shape == ir.Shape(["num_block", 16]) for output in split.outputs)
+
+    reference = DFlash2Builder(
+        builder.draft_dir,
+        str(tmp_path),
+        ir.DataType.BFLOAT16,
+        paged_block_size=256,
+        max_position_embeddings=128,
+        quant=quant,
+    )
+    for name in ("gate_proj", "up_proj"):
+        reference.matmul(f"/{name}/MatMul", "hidden_states", weights[f"layers.0.mlp.{name}.weight"], 8, 16, "num_block")
+    reference_nodes = list(reference.graph)
+    for input_index in range(1, len(projection.inputs)):
+        combined = projection.inputs[input_index].const_value.numpy()
+        separate = [node.inputs[input_index].const_value.numpy() for node in reference_nodes]
+        axis = 0 if bits else 1
+        np.testing.assert_array_equal(combined, np.concatenate(separate, axis=axis))
+
+
+@pytest.mark.parametrize("bits", [None, 4, 8])
+def test_mlp_gate_up_fusion_execution_matches_unfused(tmp_path, bits):
+    draft_dir = _draft_checkpoint(tmp_path)
+    generator = torch.Generator().manual_seed(123)
+    weights = {
+        f"layers.0.mlp.{projection}.weight": torch.randn(shape, generator=generator) / shape[1] ** 0.5
+        for projection, shape in (
+            ("gate_proj", (64, 32)),
+            ("up_proj", (64, 32)),
+            ("down_proj", (32, 64)),
+        )
+    }
+    sessions = []
+    for fused in (False, True):
+        builder = DFlash2Builder(
+            draft_dir,
+            str(tmp_path),
+            ir.DataType.FLOAT,
+            paged_block_size=256,
+            max_position_embeddings=128,
+            quant={"bits": bits, "block_size": 32, "prepack": 0, "lm_head": None} if bits else None,
+            fuse_gate_up=fused,
+        )
+        builder.io_dtype = ir.DataType.FLOAT
+        builder.hidden_size = 32
+        builder.intermediate_size = 64
+        builder.graph.inputs.append(builder.make_value("hidden_states", ir.DataType.FLOAT, ["num_block", 32]))
+        output = builder._make_mlp(0, "hidden_states", weights, "num_block")
+        builder.graph.outputs.append(builder.values[output])
+        model = ir.serde.serialize_model(builder.model)
+        onnx.checker.check_model(model)
+        sessions.append(ort.InferenceSession(model.SerializeToString(), providers=["CPUExecutionProvider"]))
+
+    for rows in (1, 8, 16, 32):
+        inputs = {"hidden_states": torch.randn((rows, 32), generator=generator).numpy()}
+        expected = sessions[0].run(None, inputs)[0]
+        actual = sessions[1].run(None, inputs)[0]
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
 def test_quantized_lm_head_matches_the_targets_initializer_names(tmp_path):
     builder = DFlash2Builder(
         _draft_checkpoint(tmp_path),
@@ -497,12 +597,14 @@ def test_five_uniformly_windowed_layers_accept_total_layer_count(tmp_path):
     assert builder.sliding_window == 2048
 
 
-def test_drafter_uses_target_context_length(tmp_path, monkeypatch):
+@pytest.mark.parametrize("fuse_gate_up", [False, True, "true", "false"])
+def test_drafter_uses_target_context_length(tmp_path, monkeypatch, fuse_gate_up):
     captured = {}
 
     class StubDFlash2Builder:
         def __init__(self, _draft_dir, _target_dir, _io_dtype, _paged_block_size, max_position, **_kwargs):
             captured["max_position"] = max_position
+            captured["fuse_gate_up"] = _kwargs["fuse_gate_up"]
 
         def make_model(self):
             pass
@@ -510,12 +612,34 @@ def test_drafter_uses_target_context_length(tmp_path, monkeypatch):
     dflash2_module = importlib.import_module("models.builders.dflash2")
     monkeypatch.setattr(dflash2_module, "DFlash2Builder", StubDFlash2Builder)
     model = _composite()
-    model.dflash2_path = _draft_checkpoint(tmp_path)
-    model.dflash2_attrs = {"io_dtype": None, "num_draft_tokens": None, "precision": "bf16"}
+    model.make_dflash2_init(
+        io_dtype=None,
+        extra_options={"dflash2_path": _draft_checkpoint(tmp_path), "dflash2_fuse_gate_up": fuse_gate_up},
+    )
 
     model.make_dflash2_model(str(tmp_path))
 
     assert captured["max_position"] == model.decoder.context_length
+    assert captured["fuse_gate_up"] is (str(fuse_gate_up).lower() == "true")
+
+
+def test_gate_up_fusion_defaults_off(tmp_path):
+    model = _composite()
+    model.make_dflash2_init(io_dtype=None, extra_options={"dflash2_path": _draft_checkpoint(tmp_path)})
+
+    assert model.dflash2_attrs["fuse_gate_up"] is False
+    builder = DFlash2Builder(model.dflash2_path, str(tmp_path), ir.DataType.BFLOAT16, 256, 128)
+    assert builder.mlp_attrs["fuse_gate_up"] is False
+
+
+@pytest.mark.parametrize("value", ["yes", "", 1, None])
+def test_gate_up_fusion_rejects_invalid_option(tmp_path, value):
+    model = _composite()
+    with pytest.raises(ValueError, match="dflash2_fuse_gate_up must be true or false"):
+        model.make_dflash2_init(
+            io_dtype=None,
+            extra_options={"dflash2_path": _draft_checkpoint(tmp_path), "dflash2_fuse_gate_up": value},
+        )
 
 
 def test_failed_save_preserves_existing_dflash2_files(tmp_path, monkeypatch):


### PR DESCRIPTION
## Description

Add an experimental, opt-in DFlash 2 MLP gate/up projection fusion to reduce projection overhead during speculative decoding. The new export option `dflash2_fuse_gate_up=true` combines the two projections while retaining BF16 body activations and existing quantization; the default remains `false` and existing model packages are unchanged.

## Summary of Changes

- Emit one gate/up `MatMul` or `MatMulNBits` followed by `Split`, preserving the existing activation and down-projection graph.
- Support dense BF16, INT4, and INT8 drafter bodies through the existing quantizer. Attention projections, context-weight sharing, the target model, and LM head are unchanged.
- Validate and forward the export option, and document usage in builder CLI help and the model-builder README. Applying the option requires re-exporting the drafter.
- Add coverage for default-off behavior, option parsing/forwarding, projection structure, exact weight/scale concatenation, and executable fused/unfused numerical parity.

## Testing

After rebasing onto `main` (`a1c73fba`):

```bash
lintrunner
PYTHONPATH=src/python/py python -m pytest -q \
  test/python/builder/test_qwen_dflash2_export.py \
  test/python/builder/test_aux_hidden_states.py \
  test/python/builder/test_qwen_dspark_export.py
```

- Lintrunner passes; **145 tests pass**.
- Dense BF16 and INT4/INT8 packed gate/up weights and scales match concatenated unfused initializers exactly.
- CPU FP32 execution tests cover dense, INT4, and INT8 graphs at 1, 8, 16, and 32 rows, including ONNX model validation.
- Separate H200 validation covers real-size BF16 input/output and INT4 block-32 weights at 1, 8, 16, and 32 rows, in eager and CUDA Graph modes, with three input scales. All 24 fused/unfused comparisons were bitwise identical; maximum absolute difference was zero. Graph replay also matched eager execution.

### Isolated H200 Measurement

Whole-MLP CUDA-event latency, including `Split`, activation, and down projection. Input width 5120, intermediate width 17408; synthetic seeded weights; BF16 activations, INT4 block-32 weights, no prepacking. ORT 1.31.0 Release at `a7df32cf60`, H200 driver 580.159.04. Each arm has 500 samples per shape/mode from five alternating-order paired rounds, after warmup.

| Rows | Eager separate / fused (us, p50) | Reduction | CUDA Graph separate / fused (us, p50) | Reduction |
|---:|---:|---:|---:|---:|
| 1 | 112.096 / 107.504 | 4.10% | 106.720 / 102.608 | 3.85% |
| 8 | 228.800 / 217.728 | 4.84% | 222.848 / 212.768 | 4.52% |
| 16 | 415.040 / 395.904 | 4.61% | 406.688 / 387.072 | 4.82% |
| 32 | 358.656 / 352.736 | 1.65% | 346.592 / 342.368 | 1.22% |

**Limitations:** these are isolated synthetic MLP measurements, not full-drafter or end-to-end decoding speedups. Both arms used `ORT_ENABLE_ALL` with `QuickGeluFusion` disabled to retain the literal Sigmoid/Mul/Mul sequence; production-default optimizer behavior was not benchmarked. Session creation, quantization, graph capture, and transfers were excluded. Real-checkpoint acceptance, generation quality, and full-model latency remain unvalidated, so the feature stays experimental and disabled by default. This PR does not enable CUDA Graph capture in the DFlash2 runtime.

## Checklist

- [x] Tests added and passing
- [x] Existing default behavior preserved
- [x] Documentation updated
- [ ] Full-model performance and quality validation before considering a default change