### PR TITLE
Fix get_logits after generator rewind

### DIFF
--- a/src/generator/generators.cpp
+++ b/src/generator/generators.cpp
@@ -994,7 +994,15 @@ DeviceSpan<float> Generator::GetLogits() {
     return strategy_logits;
   }
   if (!computed_logits_) {
-    ComputeLogits(search_->GetNextTokens());
+    auto next_tokens = search_->GetNextTokens();
+    if (last_action_ == Action::rewound) {
+      if (search_->GetSequenceLength() == 0)
+        throw std::runtime_error(
+            "GetLogits called with no prior state. Please call AppendTokens, SetLogits, or SetInputs "
+            "before calling GetLogits.");
+      search_->AppendTokens(next_tokens);
+    }
+    ComputeLogits(next_tokens);
   }
   return search_->GetLogits();
 }

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -243,10 +243,23 @@ def test_rewind_cuda(test_data_path, relative_model_path):
     while not generator.is_done():
         generator.generate_next_token()
 
-    assert generator.get_sequence(0) is not None
+    expected_sequence = np.copy(generator.get_sequence(0))
+    rewind_length = 3
+    boundary_prefix = expected_sequence[: rewind_length + 1]
+    control = og.Generator(model, search_params)
+    control.append_tokens(boundary_prefix[np.newaxis, :])
+    control_logits = np.copy(control.get_logits())
 
-    generator.rewind_to(3)
+    generator.rewind_to(rewind_length)
+    actual_logits = np.copy(generator.get_logits())
+    assert np.allclose(control_logits, actual_logits, rtol=0, atol=1e-6)
+    assert np.array_equal(boundary_prefix, generator.get_sequence(0))
 
+    control.generate_next_token()
+    generator.generate_next_token()
+    assert np.array_equal(control.get_sequence(0), generator.get_sequence(0))
+
+    generator.rewind_to(rewind_length)
     generator.append_tokens(np.array([[731, 731]], dtype=np.int32))
     while not generator.is_done():
         generator.generate_next_token()

--- a/test/python/test_onnxruntime_genai_api.py
+++ b/test/python/test_onnxruntime_genai_api.py
@@ -306,12 +306,36 @@ def test_rewind(test_data_path, relative_model_path):
 
     assert np.array_equal(expected_sequence, generator.get_sequence(0))
 
-    generator.rewind_to(3)
+    rewind_length = 3
+    boundary_prefix = expected_sequence[: rewind_length + 1]
+    control = og.Generator(model, search_params)
+    control.append_tokens(boundary_prefix[np.newaxis, :])
+    control_logits = np.copy(control.get_logits())
 
+    generator.rewind_to(rewind_length)
+    actual_logits = np.copy(generator.get_logits())
+    assert np.allclose(control_logits, actual_logits, rtol=0, atol=1e-6)
+    assert np.array_equal(boundary_prefix, generator.get_sequence(0))
+
+    control.generate_next_token()
+    generator.generate_next_token()
+    assert np.array_equal(control.get_sequence(0), generator.get_sequence(0))
+
+    generator.rewind_to(rewind_length)
     generator.append_tokens(np.array([[731, 731]], dtype=np.int32))
     while not generator.is_done():
         generator.generate_next_token()
 
+    assert np.array_equal(expected_sequence, generator.get_sequence(0))
+
+    generator.rewind_to(0)
+    with pytest.raises(RuntimeError, match="no prior state"):
+        generator.get_logits()
+    assert len(generator.get_sequence(0)) == 0
+
+    generator.append_tokens(np.array([[0, 0, 195, 731]], dtype=np.int32))
+    while not generator.is_done():
+        generator.generate_next_token()
     assert np.array_equal(expected_sequence, generator.get_sequence(0))
 
 


### PR DESCRIPTION
## Description
After `Generator.rewind_to(N)`, search keeps the boundary token queued so generation can replay it. Standard `get_logits()` skipped that replay and called the model with inconsistent sequence and attention-mask state, causing continuous decoding to fail in `GptAttention_0`.

Replay the queued token before computing logits after a nonzero rewind. For `rewind_to(0)`, reject `get_logits()` before mutation so the generator remains reusable. Fresh issue and PR searches found no matching work.

## Tests
- CPU `RelWithDebInfo` build with `--parallel 2`
- `test_onnxruntime_genai_api.py::test_rewind` — 1 passed
- `test_onnxruntime_genai_api.py::test_rewind_cuda` — CPU fixture passed locally; existing fp32/fp16 CUDA fixtures run when CUDA is available
- Runnable API module — 11 passed, 45 skipped, 8 unavailable-fixture cases deselected
- clang-format 20.1.8 and Ruff 0.12.12 checks
